### PR TITLE
♻️ amp-subscriptions*: Consistently refers to subscription platforms as "platforms" internally

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/amp-subscriptions-google.js
@@ -185,14 +185,14 @@ export class GoogleSubscriptionsPlatform {
     this.runtime_.setOnLinkComplete(() => {
       this.onLinkComplete_();
       this.subscriptionAnalytics_.actionEvent(
-        this.getServiceId(),
+        this.getPlatformKey(),
         Action.LINK,
         ActionStatus.SUCCESS
       );
       // TODO(dvoytenko): deprecate separate "link" events.
       this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.LINK_COMPLETE,
-        this.getServiceId()
+        this.getPlatformKey()
       );
     });
     this.runtime_.setOnFlowStarted((e) => {
@@ -218,7 +218,7 @@ export class GoogleSubscriptionsPlatform {
         e.flow == Action.SHOW_OFFERS
       ) {
         this.subscriptionAnalytics_.actionEvent(
-          this.getServiceId(),
+          this.getPlatformKey(),
           e.flow,
           ActionStatus.STARTED,
           params
@@ -229,14 +229,14 @@ export class GoogleSubscriptionsPlatform {
       if (e.flow == 'linkAccount') {
         this.onLinkComplete_();
         this.subscriptionAnalytics_.actionEvent(
-          this.getServiceId(),
+          this.getPlatformKey(),
           Action.LINK,
           ActionStatus.REJECTED
         );
         // TODO(dvoytenko): deprecate separate "link" events.
         this.subscriptionAnalytics_.serviceEvent(
           SubscriptionAnalyticsEvents.LINK_CANCELED,
-          this.getServiceId()
+          this.getPlatformKey()
         );
       } else if (
         e.flow == Action.SUBSCRIBE ||
@@ -245,7 +245,7 @@ export class GoogleSubscriptionsPlatform {
         e.flow == Action.SHOW_OFFERS
       ) {
         this.subscriptionAnalytics_.actionEvent(
-          this.getServiceId(),
+          this.getPlatformKey(),
           e.flow,
           ActionStatus.REJECTED
         );
@@ -360,14 +360,14 @@ export class GoogleSubscriptionsPlatform {
     if (linkRequested && this.isGoogleViewer_) {
       this.loginWithAmpReaderId_();
       this.subscriptionAnalytics_.actionEvent(
-        this.getServiceId(),
+        this.getPlatformKey(),
         Action.LINK,
         ActionStatus.STARTED
       );
       // TODO(dvoytenko): deprecate separate "link" events.
       this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.LINK_REQUESTED,
-        this.getServiceId()
+        this.getPlatformKey()
       );
     } else {
       this.maybeComplete_(
@@ -488,7 +488,7 @@ export class GoogleSubscriptionsPlatform {
     });
 
     this.subscriptionAnalytics_.actionEvent(
-      this.getServiceId(),
+      this.getPlatformKey(),
       eventType,
       ActionStatus.SUCCESS,
       params
@@ -621,7 +621,7 @@ export class GoogleSubscriptionsPlatform {
   }
 
   /** @override */
-  getServiceId() {
+  getPlatformKey() {
     return PLATFORM_ID;
   }
 

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -640,7 +640,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, (env) => {
   describe('should reauthorize on complete subscribe', () => {
     let productId;
     let entitlements;
-    const serviceId = 'serviceId';
+    const platformKey = 'platformKey';
 
     afterEach(() => {
       analyticsMock
@@ -678,7 +678,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, (env) => {
     it('should work with poorly formatted entitlements', () => {
       productId = 'unknown subscriptionToken';
       entitlements = new Entitlements(
-        serviceId,
+        platformKey,
         null,
         [new SwgEntitlement(null, [productId], null)],
         productId
@@ -691,7 +691,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, (env) => {
         productId,
       });
       entitlements = new Entitlements(
-        serviceId,
+        platformKey,
         null,
         [new SwgEntitlement('google', [productId], token)],
         productId

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -126,7 +126,7 @@ export class SubscriptionService {
     this.cid_ = Services.cidForDoc(ampdoc);
 
     /** @private {!Object<string, ?Promise<string>>} */
-    this.serviceIdToReaderIdPromiseMap_ = {};
+    this.platformKeyToReaderIdPromiseMap_ = {};
 
     /** @private {!CryptoHandler} */
     this.cryptoHandler_ = new CryptoHandler(ampdoc);
@@ -154,11 +154,11 @@ export class SubscriptionService {
         'Services not configured in service config'
       );
 
-      const serviceIds = this.platformConfig_['services'].map(
+      const platformKeys = this.platformConfig_['services'].map(
         (service) => service['serviceId'] || 'local'
       );
 
-      this.initializePlatformStore_(serviceIds);
+      this.initializePlatformStore_(platformKeys);
 
       /** @type {!Array} */ (this.platformConfig_['services']).forEach(
         (service) => {
@@ -212,12 +212,12 @@ export class SubscriptionService {
    * Returns encrypted document key if it exists.
    * This key is needed for requesting a different key
    * that decrypts locked content on the page.
-   * @param {string} serviceId Who you want to decrypt the key.
-   *                           For example: 'google.com'
+   * @param {string} platformKey Who you want to decrypt the key.
+   *                             For example: 'google.com'
    * @return {?string}
    */
-  getEncryptedDocumentKey(serviceId) {
-    return this.cryptoHandler_.getEncryptedDocumentKey(serviceId);
+  getEncryptedDocumentKey(platformKey) {
+    return this.cryptoHandler_.getEncryptedDocumentKey(platformKey);
   }
 
   /**
@@ -233,21 +233,21 @@ export class SubscriptionService {
   }
 
   /**
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @return {!Promise<string>}
    */
-  getReaderId(serviceId) {
-    let readerIdPromise = this.serviceIdToReaderIdPromiseMap_[serviceId];
+  getReaderId(platformKey) {
+    let readerIdPromise = this.platformKeyToReaderIdPromiseMap_[platformKey];
     if (!readerIdPromise) {
       const consent = Promise.resolve();
       // Scope is kept "amp-access" by default to avoid unnecessary CID
       // rotation.
       const scope =
-        'amp-access' + (serviceId == 'local' ? '' : '-' + serviceId);
+        'amp-access' + (platformKey == 'local' ? '' : '-' + platformKey);
       readerIdPromise = this.cid_.then((cid) =>
         cid.get({scope, createCookieIfNotPresent: true}, consent)
       );
-      this.serviceIdToReaderIdPromiseMap_[serviceId] = readerIdPromise;
+      this.platformKeyToReaderIdPromiseMap_[platformKey] = readerIdPromise;
     }
     return readerIdPromise;
   }
@@ -264,17 +264,17 @@ export class SubscriptionService {
    * This method registers an auto initialized subcription platform with this
    * service.
    *
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {function(!JsonObject, !ServiceAdapter):!SubscriptionPlatformInterface} subscriptionPlatformFactory
    * @return {!Promise}
    */
-  registerPlatform(serviceId, subscriptionPlatformFactory) {
+  registerPlatform(platformKey, subscriptionPlatformFactory) {
     return this.initialize_().then(() => {
       if (this.doesViewerProvideAuth_) {
         return; // External platforms should not register if viewer provides auth
       }
       const matchedServices = this.platformConfig_['services'].filter(
-        (service) => (service.serviceId || 'local') === serviceId
+        (service) => (service.serviceId || 'local') === platformKey
       );
 
       const matchedServiceConfig = userAssert(
@@ -390,12 +390,12 @@ export class SubscriptionService {
   }
 
   /**
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {!./entitlement.Entitlement} entitlement
    * @private
    */
-  resolveEntitlementsToStore_(serviceId, entitlement) {
-    this.platformStore_.resolveEntitlement(serviceId, entitlement);
+  resolveEntitlementsToStore_(platformKey, entitlement) {
+    this.platformStore_.resolveEntitlement(platformKey, entitlement);
     if (entitlement.decryptedDocumentKey) {
       this.cryptoHandler_.tryToDecryptDocument(
         entitlement.decryptedDocumentKey
@@ -403,7 +403,7 @@ export class SubscriptionService {
     }
     this.subscriptionAnalytics_.serviceEvent(
       SubscriptionAnalyticsEvents.ENTITLEMENT_RESOLVED,
-      serviceId
+      platformKey
     );
   }
 
@@ -466,10 +466,10 @@ export class SubscriptionService {
           return entitlement;
         })
         .catch((reason) => {
-          const serviceId = subscriptionPlatform.getServiceId();
-          this.platformStore_.reportPlatformFailureAndFallback(serviceId);
+          const platformKey = subscriptionPlatform.getServiceId();
+          this.platformStore_.reportPlatformFailureAndFallback(platformKey);
           throw user().createError(
-            `fetch entitlements failed for ${serviceId}`,
+            `fetch entitlements failed for ${platformKey}`,
             reason
           );
         })
@@ -477,15 +477,15 @@ export class SubscriptionService {
   }
 
   /**
-   * Initializes the PlatformStore with the service ids.
-   * @param {!Array<string>} serviceIds
+   * Initializes the PlatformStore with a list of platform keys.
+   * @param {!Array<string>} platformKeys
    */
-  initializePlatformStore_(serviceIds) {
+  initializePlatformStore_(platformKeys) {
     const fallbackEntitlement = this.platformConfig_['fallbackEntitlement']
       ? Entitlement.parseFromJson(this.platformConfig_['fallbackEntitlement'])
       : Entitlement.empty('local');
     this.platformStore_ = new PlatformStore(
-      serviceIds,
+      platformKeys,
       this.platformConfig_['score'],
       fallbackEntitlement
     );
@@ -496,9 +496,9 @@ export class SubscriptionService {
    * Delegates authentication to viewer
    */
   delegateAuthToViewer_() {
-    const serviceIds = ['local'];
+    const platformKeys = ['local'];
     const origin = getWinOrigin(this.ampdoc_.win);
-    this.initializePlatformStore_(serviceIds);
+    this.initializePlatformStore_(platformKeys);
 
     /** @type {!Array} */ (this.platformConfig_['services']).forEach(
       (service) => {
@@ -667,19 +667,19 @@ export class SubscriptionService {
   /**
    * Delegates an action to specified platform.
    * @param {string} action
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {?string} sourceId
    * @return {!Promise<boolean>}
    */
-  delegateActionToService(action, serviceId, sourceId = null) {
+  delegateActionToService(action, platformKey, sourceId = null) {
     return new Promise((resolve) => {
-      this.platformStore_.onPlatformResolves(serviceId, (platform) => {
+      this.platformStore_.onPlatformResolves(platformKey, (platform) => {
         devAssert(platform, 'Platform is not registered');
         this.subscriptionAnalytics_.event(
           SubscriptionAnalyticsEvents.ACTION_DELEGATED,
           dict({
             'action': action,
-            'serviceId': serviceId,
+            'serviceId': platformKey,
           }),
           dict({
             'action': action,
@@ -694,12 +694,12 @@ export class SubscriptionService {
   /**
    * Delegate UI decoration to another service.
    * @param {!Element} element
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {string} action
    * @param {?JsonObject} options
    */
-  decorateServiceAction(element, serviceId, action, options) {
-    this.platformStore_.onPlatformResolves(serviceId, (platform) => {
+  decorateServiceAction(element, platformKey, action, options) {
+    this.platformStore_.onPlatformResolves(platformKey, (platform) => {
       devAssert(platform, 'Platform is not registered');
       platform.decorateUI(element, action, options);
     });

--- a/extensions/amp-subscriptions/0.1/amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/amp-subscriptions.js
@@ -288,17 +288,17 @@ export class SubscriptionService {
       );
 
       this.platformStore_.resolvePlatform(
-        subscriptionPlatform.getServiceId(),
+        subscriptionPlatform.getPlatformKey(),
         subscriptionPlatform
       );
       this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.PLATFORM_REGISTERED,
-        subscriptionPlatform.getServiceId()
+        subscriptionPlatform.getPlatformKey()
       );
       // Deprecated event fired for backward compatibility
       this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.PLATFORM_REGISTERED_DEPRECATED,
-        subscriptionPlatform.getServiceId()
+        subscriptionPlatform.getPlatformKey()
       );
       this.fetchEntitlements_(subscriptionPlatform);
     });
@@ -421,10 +421,11 @@ export class SubscriptionService {
         this.cryptoHandler_.isDocumentEncrypted() &&
         !entitlements.decryptedDocumentKey
       ) {
-        const logChannel = platform.getServiceId() == 'local' ? user() : dev();
+        const logChannel =
+          platform.getPlatformKey() == 'local' ? user() : dev();
         logChannel.error(
           TAG,
-          `${platform.getServiceId()}: Subscription granted and encryption enabled, ` +
+          `${platform.getPlatformKey()}: Subscription granted and encryption enabled, ` +
             'but no decrypted document key returned.'
         );
         return null;
@@ -458,15 +459,15 @@ export class SubscriptionService {
         .then((entitlement) => {
           entitlement =
             entitlement ||
-            Entitlement.empty(subscriptionPlatform.getServiceId());
+            Entitlement.empty(subscriptionPlatform.getPlatformKey());
           this.resolveEntitlementsToStore_(
-            subscriptionPlatform.getServiceId(),
+            subscriptionPlatform.getPlatformKey(),
             entitlement
           );
           return entitlement;
         })
         .catch((reason) => {
-          const platformKey = subscriptionPlatform.getServiceId();
+          const platformKey = subscriptionPlatform.getPlatformKey();
           this.platformStore_.reportPlatformFailureAndFallback(platformKey);
           throw user().createError(
             `fetch entitlements failed for ${platformKey}`,
@@ -559,7 +560,7 @@ export class SubscriptionService {
       const selectedPlatform = resolvedValues[1];
       const grantEntitlement = resolvedValues[2];
       const selectedEntitlement = this.platformStore_.getResolvedEntitlementFor(
-        selectedPlatform.getServiceId()
+        selectedPlatform.getPlatformKey()
       );
       const bestEntitlement = grantEntitlement || selectedEntitlement;
 
@@ -567,12 +568,12 @@ export class SubscriptionService {
 
       this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED,
-        selectedPlatform.getServiceId()
+        selectedPlatform.getPlatformKey()
       );
       // Deprecated events are fire for backwards compatibility
       this.subscriptionAnalytics_.serviceEvent(
         SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED_DEPRECATED,
-        selectedPlatform.getServiceId()
+        selectedPlatform.getPlatformKey()
       );
       if (bestEntitlement.granted) {
         this.subscriptionAnalytics_.serviceEvent(
@@ -582,11 +583,11 @@ export class SubscriptionService {
       } else {
         this.subscriptionAnalytics_.serviceEvent(
           SubscriptionAnalyticsEvents.PAYWALL_ACTIVATED,
-          selectedPlatform.getServiceId()
+          selectedPlatform.getPlatformKey()
         );
         this.subscriptionAnalytics_.serviceEvent(
           SubscriptionAnalyticsEvents.ACCESS_DENIED,
-          selectedPlatform.getServiceId()
+          selectedPlatform.getPlatformKey()
         );
       }
     });

--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -96,16 +96,16 @@ export class SubscriptionAnalytics {
 
   /**
    * @param {!SubscriptionAnalyticsEvents|string} eventType
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {!JsonObject=} opt_vars
    * @param {!JsonObject=} internalVars
    */
-  serviceEvent(eventType, serviceId, opt_vars, internalVars) {
+  serviceEvent(eventType, platformKey, opt_vars, internalVars) {
     this.event(
       eventType,
       /** @type {!JsonObject} */ (Object.assign(
         dict({
-          'serviceId': serviceId,
+          'serviceId': platformKey,
         }),
         opt_vars
       )),
@@ -142,15 +142,15 @@ export class SubscriptionAnalytics {
   }
 
   /**
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {!Action|string} action
    * @param {!ActionStatus|string} status
    * @param {!JsonObject=} opt_vars
    */
-  actionEvent(serviceId, action, status, opt_vars) {
+  actionEvent(platformKey, action, status, opt_vars) {
     this.serviceEvent(
       SubscriptionAnalyticsEvents.SUBSCRIPTIONS_ACTION,
-      serviceId,
+      platformKey,
       opt_vars,
       dict({
         'action': action,

--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -76,17 +76,17 @@ export class CryptoHandler {
    * Returns encrypted document key if it exists.
    * This key is needed for requesting a different key
    * that decrypts locked content on the page.
-   * @param {string} serviceId Who you want to decrypt the key.
-   *                           For example: 'google.com'
+   * @param {string} platformKey Who you want to decrypt the key.
+   *                             For example: 'google.com'
    * @return {?string}
    */
-  getEncryptedDocumentKey(serviceId) {
+  getEncryptedDocumentKey(platformKey) {
     // Doing this for testing.
     const encryptedKeys = this.getEncryptedKeys();
     if (!encryptedKeys) {
       return null;
     }
-    return encryptedKeys[serviceId] || null;
+    return encryptedKeys[platformKey] || null;
   }
 
   /**

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -89,7 +89,7 @@ export class LocalSubscriptionBasePlatform {
   /**
    * @override
    */
-  getServiceId() {
+  getPlatformKey() {
     return 'local';
   }
 
@@ -154,7 +154,7 @@ export class LocalSubscriptionBasePlatform {
           const platform = this.serviceAdapter_.selectPlatformForLogin();
           this.serviceAdapter_.delegateActionToService(
             action,
-            platform.getServiceId(),
+            platform.getPlatformKey(),
             element.id
           );
         } else {

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -21,7 +21,7 @@ import {Observable} from '../../../src/observable';
 import {devAssert, user} from '../../../src/log';
 import {dict, hasOwn} from '../../../src/utils/object';
 
-/** @typedef {{serviceId: string, entitlement: (!./entitlement.Entitlement|undefined)}} */
+/** @typedef {{platformKey: string, entitlement: (!./entitlement.Entitlement|undefined)}} */
 export let EntitlementChangeEventDef;
 
 /** @const */
@@ -36,26 +36,21 @@ const TAG = 'amp-subscriptions';
 let PlatformWeightDef;
 
 /**
- * Manages platforms. Has a list of platforms it instantiates and manages.
+ * Manages subscription platforms.
  */
 export class PlatformStore {
   /**
-   * @param {!Array<string>} expectedServiceIds
+   * @param {!Array<string>} platformKeys
    * @param {!JsonObject|Object<string, number>} scoreConfig
    * @param {!./entitlement.Entitlement} fallbackEntitlement
    * @param {Object<string, !./subscription-platform.SubscriptionPlatform>=} opt_Platforms
    */
-  constructor(
-    expectedServiceIds,
-    scoreConfig,
-    fallbackEntitlement,
-    opt_Platforms
-  ) {
+  constructor(platformKeys, scoreConfig, fallbackEntitlement, opt_Platforms) {
     /** @private @const {!Object<string, !./subscription-platform.SubscriptionPlatform>} */
     this.subscriptionPlatforms_ = opt_Platforms || dict();
 
     /** @private @const {!Array<string>} */
-    this.serviceIds_ = expectedServiceIds;
+    this.platformKeys_ = platformKeys;
 
     /** @private @const {!Object<string, !./entitlement.Entitlement>} */
     this.entitlements_ = {};
@@ -65,14 +60,14 @@ export class PlatformStore {
      * {!Object<string, !Deferred<!./entitlement.Entitlement>>}
      */
     this.entitlementDeferredMap_ = {};
-    expectedServiceIds.forEach((serviceId) => {
-      this.entitlementDeferredMap_[serviceId] = new Deferred();
+    platformKeys.forEach((platformKey) => {
+      this.entitlementDeferredMap_[platformKey] = new Deferred();
     });
 
     /** @private @const {!Observable<!EntitlementChangeEventDef>} */
     this.onEntitlementResolvedCallbacks_ = new Observable();
 
-    /** @private @const {!Observable<{serviceId: string}>} */
+    /** @private @const {!Observable<{platformKey: string}>} */
     this.onPlatformResolvedCallbacks_ = new Observable();
 
     /** @private {?Deferred} */
@@ -99,13 +94,13 @@ export class PlatformStore {
 
   /**
    * Resolves a platform in the store
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {!./subscription-platform.SubscriptionPlatform} platform
    */
-  resolvePlatform(serviceId, platform) {
-    this.subscriptionPlatforms_[serviceId] = platform;
+  resolvePlatform(platformKey, platform) {
+    this.subscriptionPlatforms_[platformKey] = platform;
     this.onPlatformResolvedCallbacks_.fire({
-      serviceId,
+      platformKey,
     });
   }
 
@@ -121,7 +116,7 @@ export class PlatformStore {
     }
     // Then create new platform store withe the newply reset platforms in it.
     return new PlatformStore(
-      this.serviceIds_,
+      this.platformKeys_,
       this.scoreConfig_,
       this.fallbackEntitlement_,
       this.subscriptionPlatforms_
@@ -130,17 +125,17 @@ export class PlatformStore {
 
   /**
    * Calls a callback for when a platform is resolved.
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {!Function} callback
    */
-  onPlatformResolves(serviceId, callback) {
-    const platform = this.subscriptionPlatforms_[serviceId];
+  onPlatformResolves(platformKey, callback) {
+    const platform = this.subscriptionPlatforms_[platformKey];
     if (platform) {
       callback(platform);
     } else {
       this.onPlatformResolvedCallbacks_.add((e) => {
-        if (e.serviceId === serviceId) {
-          callback(this.getPlatform(serviceId));
+        if (e.platformKey === platformKey) {
+          callback(this.getPlatform(platformKey));
         }
       });
     }
@@ -148,20 +143,21 @@ export class PlatformStore {
 
   /**
    * Returns the platform for the given id
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @return {!./subscription-platform.SubscriptionPlatform}
    */
-  getPlatform(serviceId) {
-    const platform = this.subscriptionPlatforms_[serviceId];
-    devAssert(platform, `Platform for id ${serviceId} is not resolved`);
+  getPlatform(platformKey) {
+    const platform = this.subscriptionPlatforms_[platformKey];
+    devAssert(platform, `Platform for id ${platformKey} is not resolved`);
     return platform;
   }
 
   /**
    * Returns the local platform
+   * @private
    * @return {!./subscription-platform.SubscriptionPlatform}
    */
-  getLocalPlatform() {
+  getLocalPlatform_() {
     const localPlatform =
       /** @type {!./subscription-platform.SubscriptionPlatform} */
       (this.getPlatform('local'));
@@ -183,7 +179,7 @@ export class PlatformStore {
   }
 
   /**
-   * This registers a callback which is called whenever a service id is resolved
+   * This registers a callback which is called whenever a platform key is resolved
    * with an entitlement.
    * @param {function(!EntitlementChangeEventDef):void} callback
    */
@@ -192,54 +188,57 @@ export class PlatformStore {
   }
 
   /**
-   * This resolves the entitlement to a serviceId
-   * @param {string} serviceId
+   * This resolves the entitlement to a platformKey
+   * @param {string} platformKey
    * @param {!./entitlement.Entitlement} entitlement
    */
-  resolveEntitlement(serviceId, entitlement) {
+  resolveEntitlement(platformKey, entitlement) {
     if (entitlement) {
-      entitlement.service = serviceId;
+      entitlement.service = platformKey;
     }
-    this.entitlements_[serviceId] = entitlement;
-    const deferred = this.entitlementDeferredMap_[serviceId];
+    this.entitlements_[platformKey] = entitlement;
+    const deferred = this.entitlementDeferredMap_[platformKey];
     if (deferred) {
       deferred.resolve(entitlement);
     }
-    // Remove this serviceId as a failed platform now
-    if (this.failedPlatforms_.indexOf(serviceId) != -1) {
-      this.failedPlatforms_.splice(this.failedPlatforms_.indexOf(serviceId));
+    // Remove this platformKey from the failed platforms list
+    if (this.failedPlatforms_.indexOf(platformKey) != -1) {
+      this.failedPlatforms_.splice(this.failedPlatforms_.indexOf(platformKey));
     }
     // Call all onChange callbacks.
     if (entitlement.granted) {
       this.saveGrantEntitlement_(entitlement);
     }
-    this.onEntitlementResolvedCallbacks_.fire({serviceId, entitlement});
+    this.onEntitlementResolvedCallbacks_.fire({
+      platformKey,
+      entitlement,
+    });
   }
 
   /**
    * Returns entitlement for a platform.
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @return {!./entitlement.Entitlement} entitlement
    */
-  getResolvedEntitlementFor(serviceId) {
+  getResolvedEntitlementFor(platformKey) {
     devAssert(
-      this.entitlements_[serviceId],
-      `Platform ${serviceId} has not yet resolved with entitlements`
+      this.entitlements_[platformKey],
+      `Platform ${platformKey} has not yet resolved with entitlements`
     );
-    return this.entitlements_[serviceId];
+    return this.entitlements_[platformKey];
   }
 
   /**
    * Returns entitlement for a platform once it's resolved.
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @return {!Promise<!./entitlement.Entitlement>} entitlement
    */
-  getEntitlementPromiseFor(serviceId) {
+  getEntitlementPromiseFor(platformKey) {
     devAssert(
-      this.entitlementDeferredMap_[serviceId],
-      `Platform ${serviceId} is not declared`
+      this.entitlementDeferredMap_[platformKey],
+      `Platform ${platformKey} is not declared`
     );
-    return this.entitlementDeferredMap_[serviceId].promise;
+    return this.entitlementDeferredMap_[platformKey].promise;
   }
 
   /**
@@ -261,7 +260,7 @@ export class PlatformStore {
   getScoreFactorStates() {
     const states = dict({});
     return Promise.all(
-      this.serviceIds_.map((platformId) => {
+      this.platformKeys_.map((platformId) => {
         states[platformId] = dict();
         return Promise.all(
           Object.values(SubscriptionsScoreFactor).map((scoreFactor) =>
@@ -278,15 +277,15 @@ export class PlatformStore {
 
   /**
    * Return a score factor for a platform once it's resolved
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {string} scoreFactor
    * @return {!Promise<number>}
    * @private
    */
-  getScoreFactorPromiseFor_(serviceId, scoreFactor) {
+  getScoreFactorPromiseFor_(platformKey, scoreFactor) {
     // Make sure the platform is ready
-    return this.getEntitlementPromiseFor(serviceId).then(() => {
-      return this.subscriptionPlatforms_[serviceId].getSupportedScoreFactor(
+    return this.getEntitlementPromiseFor(platformKey).then(() => {
+      return this.subscriptionPlatforms_[platformKey].getSupportedScoreFactor(
         scoreFactor
       );
     });
@@ -387,7 +386,7 @@ export class PlatformStore {
   }
 
   /**
-   * Returns entitlements when all services are done fetching them.
+   * Returns entitlements when all platforms are done fetching them.
    * @return {!Promise<!Array<!./entitlement.Entitlement>>}
    */
   getAllPlatformsEntitlements() {
@@ -429,7 +428,7 @@ export class PlatformStore {
   }
 
   /**
-   * Returns entitlements when all services are done fetching them.
+   * Returns platform after all platforms fetch entitlements.
    * @return {!Promise<!./subscription-platform.SubscriptionPlatform>}
    */
   selectPlatform() {
@@ -447,7 +446,7 @@ export class PlatformStore {
    */
   areAllPlatformsResolved_() {
     const entitlementsResolved = Object.keys(this.entitlements_).length;
-    return entitlementsResolved === this.serviceIds_.length;
+    return entitlementsResolved === this.platformKeys_.length;
   }
 
   /**
@@ -527,7 +526,7 @@ export class PlatformStore {
     // Start with base score
     const weight = platform.getBaseScore();
 
-    // Iterate score factors checking service support
+    // Iterate score factors checking platform support
     for (const factor in this.scoreConfig_) {
       if (hasOwn(this.scoreConfig_, factor)) {
         factorWeights.push(this.getSupportedFactorWeight_(factor, platform));
@@ -548,7 +547,7 @@ export class PlatformStore {
    * @private
    */
   rankPlatformsByWeight_(platformWeights) {
-    const localPlatform = this.getLocalPlatform();
+    const localPlatform = this.getLocalPlatform_();
     platformWeights.sort((platform1, platform2) => {
       // Force local platform to win ties
       if (
@@ -585,15 +584,15 @@ export class PlatformStore {
    * Records a platform failure
    * logs error if all platforms have failed
    * uses fallback if there is one.
-   * @param {string} serviceId
+   * @param {string} platformKey
    */
-  reportPlatformFailureAndFallback(serviceId) {
+  reportPlatformFailureAndFallback(platformKey) {
     if (
-      serviceId === this.getLocalPlatform().getServiceId() &&
+      platformKey === this.getLocalPlatform_().getServiceId() &&
       this.fallbackEntitlement_
     ) {
       this.resolveEntitlement(
-        this.getLocalPlatform().getServiceId(),
+        this.getLocalPlatform_().getServiceId(),
         this.fallbackEntitlement_
       );
       user().warn(
@@ -601,10 +600,10 @@ export class PlatformStore {
         'Local platform has failed to resolve,  ' +
           'using fallback entitlement.'
       );
-    } else if (this.failedPlatforms_.indexOf(serviceId) == -1) {
-      const entitlement = Entitlement.empty(serviceId);
-      this.resolveEntitlement(serviceId, entitlement);
-      this.failedPlatforms_.push(serviceId);
+    } else if (this.failedPlatforms_.indexOf(platformKey) == -1) {
+      const entitlement = Entitlement.empty(platformKey);
+      this.resolveEntitlement(platformKey, entitlement);
+      this.failedPlatforms_.push(platformKey);
     }
   }
 

--- a/extensions/amp-subscriptions/0.1/platform-store.js
+++ b/extensions/amp-subscriptions/0.1/platform-store.js
@@ -489,7 +489,7 @@ export class PlatformStore {
     while (availablePlatforms.length) {
       const platform = availablePlatforms.pop();
       const entitlement = this.getResolvedEntitlementFor(
-        platform.getServiceId()
+        platform.getPlatformKey()
       );
       if (entitlement.isSubscriber()) {
         return platform;
@@ -588,11 +588,11 @@ export class PlatformStore {
    */
   reportPlatformFailureAndFallback(platformKey) {
     if (
-      platformKey === this.getLocalPlatform_().getServiceId() &&
+      platformKey === this.getLocalPlatform_().getPlatformKey() &&
       this.fallbackEntitlement_
     ) {
       this.resolveEntitlement(
-        this.getLocalPlatform_().getServiceId(),
+        this.getLocalPlatform_().getPlatformKey(),
         this.fallbackEntitlement_
       );
       user().warn(

--- a/extensions/amp-subscriptions/0.1/service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/service-adapter.js
@@ -42,11 +42,11 @@ export class ServiceAdapter {
 
   /**
    * Returns the encrypted document key for the specified service.
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @return {?string}
    */
-  getEncryptedDocumentKey(serviceId) {
-    return this.subscriptionService_.getEncryptedDocumentKey(serviceId);
+  getEncryptedDocumentKey(platformKey) {
+    return this.subscriptionService_.getEncryptedDocumentKey(platformKey);
   }
 
   /**
@@ -59,11 +59,11 @@ export class ServiceAdapter {
 
   /**
    * Returns the reader ID for the specified service.
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @return {!Promise<string>}
    */
-  getReaderId(serviceId) {
-    return this.subscriptionService_.getReaderId(serviceId);
+  getReaderId(platformKey) {
+    return this.subscriptionService_.getReaderId(platformKey);
   }
 
   /**
@@ -87,14 +87,14 @@ export class ServiceAdapter {
   /**
    * Delegates actions to a given service.
    * @param {string} action
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {?string} sourceId
    * @return {!Promise<boolean>}
    */
-  delegateActionToService(action, serviceId, sourceId) {
+  delegateActionToService(action, platformKey, sourceId) {
     return this.subscriptionService_.delegateActionToService(
       action,
-      serviceId,
+      platformKey,
       sourceId
     );
   }
@@ -102,14 +102,14 @@ export class ServiceAdapter {
   /**
    * Delegate UI decoration to another service.
    * @param {!Element} element
-   * @param {string} serviceId
+   * @param {string} platformKey
    * @param {string} action
    * @param {?JsonObject} options
    */
-  decorateServiceAction(element, serviceId, action, options) {
+  decorateServiceAction(element, platformKey, action, options) {
     this.subscriptionService_.decorateServiceAction(
       element,
-      serviceId,
+      platformKey,
       action,
       options
     );

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -22,7 +22,7 @@
  */
 export class SubscriptionPlatform {
   /**
-   * Returns the service Id.
+   * Returns the platform key.
    * @return {string}
    */
   getServiceId() {}

--- a/extensions/amp-subscriptions/0.1/subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/subscription-platform.js
@@ -25,7 +25,7 @@ export class SubscriptionPlatform {
    * Returns the platform key.
    * @return {string}
    */
-  getServiceId() {}
+  getPlatformKey() {}
 
   /**
    * Requests entitlement for a subscription platform.

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -314,7 +314,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
     platform.getEntitlements = env.sandbox
       .stub()
       .callsFake(() => Promise.resolve(entitlement));
-    platform.getServiceId = env.sandbox.stub().callsFake(() => 'local');
+    platform.getPlatformKey = env.sandbox.stub().callsFake(() => 'local');
 
     subscriptionService.platformConfig_ = platformConfig;
     subscriptionService.registerPlatform(serviceData.serviceId, factoryStub);
@@ -814,7 +814,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
   describe('registerPlatform', () => {
     it('should work on free pages', async () => {
       const platformFactoryStub = env.sandbox.stub().callsFake(() => ({
-        getServiceId: () => 'platform1',
+        getPlatformKey: () => 'platform1',
       }));
       env.sandbox.stub(subscriptionService, 'initialize_').callsFake(() => {
         subscriptionService.platformConfig_ = freePlatformConfig;
@@ -1132,7 +1132,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
       const element = document.createElement('div');
       element.setAttribute('subscriptions-service', 'swg-google');
       const platform = new SubscriptionPlatform();
-      platform.getServiceId = () => 'swg-google';
+      platform.getPlatformKey = () => 'swg-google';
       subscriptionService.platformStore_ = new PlatformStore([
         'local',
         'swg-google',
@@ -1142,7 +1142,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
         .callsFake((platformKey, callback) => callback(platform));
       const decorateUIStub = env.sandbox.stub(platform, 'decorateUI');
       subscriptionService.decorateServiceAction(element, 'swg-google', 'login');
-      expect(whenResolveStub).to.be.calledWith(platform.getServiceId());
+      expect(whenResolveStub).to.be.calledWith(platform.getPlatformKey());
       expect(decorateUIStub).to.be.calledWith(element);
     });
   });

--- a/extensions/amp-subscriptions/0.1/test/test-analytics.js
+++ b/extensions/amp-subscriptions/0.1/test/test-analytics.js
@@ -25,7 +25,7 @@ import {user} from '../../../../src/log';
 //--> env.sandbox.stub(ServiceUrl, 'adsUrl', url => serverUrl + url);
 
 const TAG = 'amp-subscriptions';
-const OPT_VARS = {'serviceId': 'service1'};
+const OPT_VARS = {'serviceId': 'platform1'};
 const INT_VARS = {
   'action': 'action1',
   'status': ActionStatus.SUCCESS,
@@ -43,7 +43,7 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, (env) => {
   it('should not fail', () => {
     analytics.event('event1');
     analytics.serviceEvent('event1', 'serviceId');
-    analytics.actionEvent('service1', 'action1', ActionStatus.SUCCESS);
+    analytics.actionEvent('platform1', 'action1', ActionStatus.SUCCESS);
   });
 
   describe('internal routing', () => {
@@ -54,12 +54,12 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, (env) => {
     });
 
     it('should trigger a service event', () => {
-      analytics.serviceEvent('event1', 'service1');
+      analytics.serviceEvent('event1', 'platform1');
       expect(eventStub).to.be.calledOnce.calledWith('event1', OPT_VARS);
     });
 
     it('should trigger an action event', () => {
-      analytics.actionEvent('service1', 'action1', ActionStatus.SUCCESS);
+      analytics.actionEvent('platform1', 'action1', ActionStatus.SUCCESS);
       expect(eventStub).to.be.calledOnce.calledWith(
         SubscriptionAnalyticsEvents.SUBSCRIPTIONS_ACTION,
         OPT_VARS,
@@ -92,7 +92,7 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, (env) => {
     });
 
     it('should log an action event', () => {
-      analytics.actionEvent('service1', 'action1', ActionStatus.SUCCESS);
+      analytics.actionEvent('platform1', 'action1', ActionStatus.SUCCESS);
       expect(userLogStub).to.be.calledOnce.calledWith(
         TAG,
         'subscriptions-action-action1-success',
@@ -108,7 +108,7 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, (env) => {
     it('should log a service event', () => {
       analytics.serviceEvent(
         SubscriptionAnalyticsEvents.PLATFORM_ACTIVATED,
-        'service1'
+        'platform1'
       );
       expect(userLogStub).to.be.calledOnce.calledWith(
         TAG,
@@ -144,14 +144,14 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, (env) => {
     });
 
     it('should notify about service events', () => {
-      analytics.serviceEvent('servEvent', 'service1');
+      analytics.serviceEvent('servEvent', 'platform1');
       expect(eventStr).to.equal('servEvent');
       expect(optParams).to.deep.equal(OPT_VARS);
       expect(intParams).to.deep.equal({});
     });
 
     it('should notify about action events', () => {
-      analytics.actionEvent('service1', 'action1', ActionStatus.SUCCESS);
+      analytics.actionEvent('platform1', 'action1', ActionStatus.SUCCESS);
       expect(eventStr).to.equal(
         SubscriptionAnalyticsEvents.SUBSCRIPTIONS_ACTION
       );

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
@@ -38,9 +38,9 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, (env) => {
       dialog,
       serviceAdapter
     );
-    const serviceIds = ['service1', 'service2'];
+    const platformKeys = ['platformKey1', 'platformKey2'];
     entitlementsForService1 = new Entitlement({
-      service: serviceIds[0],
+      service: platformKeys[0],
       granted: false,
       grantReason: null,
     });

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -307,8 +307,8 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
         element.setAttribute('subscriptions-action', Action.LOGIN);
         element.removeAttribute('subscriptions-service');
         const platform = {};
-        const serviceId = 'serviceId';
-        platform.getServiceId = env.sandbox.stub().callsFake(() => serviceId);
+        const platformKey = 'platformKey';
+        platform.getServiceId = env.sandbox.stub().callsFake(() => platformKey);
         const loginStub = env.sandbox
           .stub(
             localSubscriptionPlatform.serviceAdapter_,
@@ -321,7 +321,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
         );
         localSubscriptionPlatform.handleClick_(element);
         expect(loginStub).to.be.called;
-        expect(delegateStub).to.be.calledWith(Action.LOGIN, serviceId);
+        expect(delegateStub).to.be.calledWith(Action.LOGIN, platformKey);
       }
     );
 
@@ -342,11 +342,11 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
           'delegateActionToService'
         );
         const platform = {};
-        const serviceId = 'serviceId';
-        platform.getServiceId = env.sandbox.stub().callsFake(() => serviceId);
+        const platformKey = 'platformKey';
+        platform.getServiceId = env.sandbox.stub().callsFake(() => platformKey);
         localSubscriptionPlatform.handleClick_(element);
         expect(loginStub).to.be.called;
-        expect(delegateStub).to.be.calledWith(Action.LOGIN, serviceId);
+        expect(delegateStub).to.be.calledWith(Action.LOGIN, platformKey);
       }
     );
 
@@ -366,8 +366,8 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
         'delegateActionToService'
       );
       const platform = {};
-      const serviceId = 'serviceId';
-      platform.getServiceId = env.sandbox.stub().callsFake(() => serviceId);
+      const platformKey = 'platformKey';
+      platform.getServiceId = env.sandbox.stub().callsFake(() => platformKey);
       localSubscriptionPlatform.handleClick_(element);
       expect(loginStub).to.not.be.called;
       expect(delegateStub).to.not.be.called;

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -308,7 +308,9 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
         element.removeAttribute('subscriptions-service');
         const platform = {};
         const platformKey = 'platformKey';
-        platform.getServiceId = env.sandbox.stub().callsFake(() => platformKey);
+        platform.getPlatformKey = env.sandbox
+          .stub()
+          .callsFake(() => platformKey);
         const loginStub = env.sandbox
           .stub(
             localSubscriptionPlatform.serviceAdapter_,
@@ -343,7 +345,9 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
         );
         const platform = {};
         const platformKey = 'platformKey';
-        platform.getServiceId = env.sandbox.stub().callsFake(() => platformKey);
+        platform.getPlatformKey = env.sandbox
+          .stub()
+          .callsFake(() => platformKey);
         localSubscriptionPlatform.handleClick_(element);
         expect(loginStub).to.be.called;
         expect(delegateStub).to.be.calledWith(Action.LOGIN, platformKey);
@@ -367,7 +371,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
       );
       const platform = {};
       const platformKey = 'platformKey';
-      platform.getServiceId = env.sandbox.stub().callsFake(() => platformKey);
+      platform.getPlatformKey = env.sandbox.stub().callsFake(() => platformKey);
       localSubscriptionPlatform.handleClick_(element);
       expect(loginStub).to.not.be.called;
       expect(delegateStub).to.not.be.called;

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -221,13 +221,15 @@ describes.realWin('Platform store', {}, (env) => {
     const anotherPlatformBaseScore = 0;
     beforeEach(() => {
       localPlatform = new SubscriptionPlatform();
-      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox
+        .stub(localPlatform, 'getPlatformKey')
+        .callsFake(() => 'local');
       env.sandbox
         .stub(localPlatform, 'getBaseScore')
         .callsFake(() => localPlatformBaseScore);
       anotherPlatform = new SubscriptionPlatform();
       env.sandbox
-        .stub(anotherPlatform, 'getServiceId')
+        .stub(anotherPlatform, 'getPlatformKey')
         .callsFake(() => 'another');
       env.sandbox
         .stub(anotherPlatform, 'getBaseScore')
@@ -293,13 +295,15 @@ describes.realWin('Platform store', {}, (env) => {
     let anotherPlatformBaseScore = 0;
     beforeEach(() => {
       localPlatform = new SubscriptionPlatform();
-      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox
+        .stub(localPlatform, 'getPlatformKey')
+        .callsFake(() => 'local');
       env.sandbox
         .stub(localPlatform, 'getBaseScore')
         .callsFake(() => localPlatformBaseScore);
       anotherPlatform = new SubscriptionPlatform();
       env.sandbox
-        .stub(anotherPlatform, 'getServiceId')
+        .stub(anotherPlatform, 'getPlatformKey')
         .callsFake(() => 'another');
       env.sandbox
         .stub(anotherPlatform, 'getBaseScore')
@@ -334,9 +338,9 @@ describes.realWin('Platform store', {}, (env) => {
           service: 'another',
         })
       );
-      expect(platformStore.selectApplicablePlatform_().getServiceId()).to.equal(
-        localPlatform.getServiceId()
-      );
+      expect(
+        platformStore.selectApplicablePlatform_().getPlatformKey()
+      ).to.equal(localPlatform.getPlatformKey());
       platformStore.resolveEntitlement(
         'local',
         new Entitlement({
@@ -355,9 +359,9 @@ describes.realWin('Platform store', {}, (env) => {
           grantReason: GrantReason.SUBSCRIBER,
         })
       );
-      expect(platformStore.selectApplicablePlatform_().getServiceId()).to.equal(
-        anotherPlatform.getServiceId()
-      );
+      expect(
+        platformStore.selectApplicablePlatform_().getPlatformKey()
+      ).to.equal(anotherPlatform.getPlatformKey());
     });
 
     it('should choose local platform if all other conditions are same', () => {
@@ -384,9 +388,9 @@ describes.realWin('Platform store', {}, (env) => {
           service: 'another',
         })
       );
-      expect(platformStore.selectApplicablePlatform_().getServiceId()).to.equal(
-        localPlatform.getServiceId()
-      );
+      expect(
+        platformStore.selectApplicablePlatform_().getPlatformKey()
+      ).to.equal(localPlatform.getPlatformKey());
     });
 
     it('should chose platform based on score weight', () => {
@@ -416,9 +420,9 @@ describes.realWin('Platform store', {}, (env) => {
           service: 'another',
         })
       );
-      expect(platformStore.selectApplicablePlatform_().getServiceId()).to.equal(
-        anotherPlatform.getServiceId()
-      );
+      expect(
+        platformStore.selectApplicablePlatform_().getPlatformKey()
+      ).to.equal(anotherPlatform.getPlatformKey());
     });
 
     it('should chose platform based on multiple factors', () => {
@@ -451,9 +455,9 @@ describes.realWin('Platform store', {}, (env) => {
           service: 'another',
         })
       );
-      expect(platformStore.selectApplicablePlatform_().getServiceId()).to.equal(
-        localPlatform.getServiceId()
-      );
+      expect(
+        platformStore.selectApplicablePlatform_().getPlatformKey()
+      ).to.equal(localPlatform.getPlatformKey());
     });
 
     it('should chose platform specified factors', () => {
@@ -487,8 +491,10 @@ describes.realWin('Platform store', {}, (env) => {
         })
       );
       expect(
-        platformStore.selectApplicablePlatform_('supporsViewer').getServiceId()
-      ).to.equal(localPlatform.getServiceId());
+        platformStore
+          .selectApplicablePlatform_('supporsViewer')
+          .getPlatformKey()
+      ).to.equal(localPlatform.getPlatformKey());
     });
 
     it('should chose platform handle negative factor values', () => {
@@ -521,9 +527,9 @@ describes.realWin('Platform store', {}, (env) => {
           service: 'another',
         })
       );
-      expect(platformStore.selectApplicablePlatform_().getServiceId()).to.equal(
-        anotherPlatform.getServiceId()
-      );
+      expect(
+        platformStore.selectApplicablePlatform_().getPlatformKey()
+      ).to.equal(anotherPlatform.getPlatformKey());
     });
 
     it('should use baseScore', () => {
@@ -551,9 +557,9 @@ describes.realWin('Platform store', {}, (env) => {
           service: 'another',
         })
       );
-      expect(platformStore.selectApplicablePlatform_().getServiceId()).to.equal(
-        anotherPlatform.getServiceId()
-      );
+      expect(
+        platformStore.selectApplicablePlatform_().getPlatformKey()
+      ).to.equal(anotherPlatform.getPlatformKey());
     });
     it('getScoreFactorStates should return promised score', async () => {
       env.sandbox
@@ -608,7 +614,9 @@ describes.realWin('Platform store', {}, (env) => {
     beforeEach(() => {
       localFactors = {};
       localPlatform = new SubscriptionPlatform();
-      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox
+        .stub(localPlatform, 'getPlatformKey')
+        .callsFake(() => 'local');
       // Base score does not matter.
       env.sandbox.stub(localPlatform, 'getBaseScore').callsFake(() => 10000);
       env.sandbox
@@ -617,7 +625,7 @@ describes.realWin('Platform store', {}, (env) => {
       anotherFactors = {};
       anotherPlatform = new SubscriptionPlatform();
       env.sandbox
-        .stub(anotherPlatform, 'getServiceId')
+        .stub(anotherPlatform, 'getPlatformKey')
         .callsFake(() => 'another');
       env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 0);
       env.sandbox
@@ -660,7 +668,7 @@ describes.realWin('Platform store', {}, (env) => {
         'local with fallbackEntitlement',
       () => {
         const platform = new SubscriptionPlatform();
-        env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
+        env.sandbox.stub(platform, 'getPlatformKey').callsFake(() => 'local');
         env.sandbox
           .stub(platformStore, 'getLocalPlatform_')
           .callsFake(() => platform);
@@ -680,12 +688,12 @@ describes.realWin('Platform store', {}, (env) => {
       async () => {
         const platform = new SubscriptionPlatform();
         const anotherPlatform = new SubscriptionPlatform();
-        env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
+        env.sandbox.stub(platform, 'getPlatformKey').callsFake(() => 'local');
         env.sandbox
           .stub(platformStore, 'getLocalPlatform_')
           .callsFake(() => platform);
         env.sandbox
-          .stub(anotherPlatform, 'getServiceId')
+          .stub(anotherPlatform, 'getPlatformKey')
           .callsFake(() => platformKeys[0]);
         env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
         platformStore.resolvePlatform(platformKeys[0], anotherPlatform);
@@ -701,7 +709,7 @@ describes.realWin('Platform store', {}, (env) => {
           fallbackEntitlement
         );
         // falbackEntitlement has Reason as SUBSCRIBER so it should win
-        expect(selectedPlatform.getServiceId()).to.equal('local');
+        expect(selectedPlatform.getPlatformKey()).to.equal('local');
       }
     );
 
@@ -711,12 +719,12 @@ describes.realWin('Platform store', {}, (env) => {
       async () => {
         const platform = new SubscriptionPlatform();
         const anotherPlatform = new SubscriptionPlatform();
-        env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
+        env.sandbox.stub(platform, 'getPlatformKey').callsFake(() => 'local');
         env.sandbox
           .stub(platformStore, 'getLocalPlatform_')
           .callsFake(() => platform);
         env.sandbox
-          .stub(anotherPlatform, 'getServiceId')
+          .stub(anotherPlatform, 'getPlatformKey')
           .callsFake(() => platformKeys[0]);
         env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
         platformStore.resolvePlatform(platformKeys[0], anotherPlatform);
@@ -733,7 +741,7 @@ describes.realWin('Platform store', {}, (env) => {
           fallbackEntitlement
         );
         // falbackEntitlement has Reason as SUBSCRIBER so it should win
-        expect(selectedPlatform.getServiceId()).to.equal(platformKeys[0]);
+        expect(selectedPlatform.getPlatformKey()).to.equal(platformKeys[0]);
       }
     );
   });
@@ -741,9 +749,9 @@ describes.realWin('Platform store', {}, (env) => {
   describe('getPlatform', () => {
     it('should return the platform for a given platform key', () => {
       const platform = new SubscriptionPlatform();
-      platform.getServiceId = () => 'test';
+      platform.getPlatformKey = () => 'test';
       platformStore.subscriptionPlatforms_['test'] = platform;
-      expect(platformStore.getPlatform('test').getServiceId()).to.be.equal(
+      expect(platformStore.getPlatform('test').getPlatformKey()).to.be.equal(
         'test'
       );
     });
@@ -866,7 +874,9 @@ describes.realWin('Platform store', {}, (env) => {
 
     beforeEach(() => {
       localPlatform = new SubscriptionPlatform();
-      env.sandbox.stub(localPlatform, 'getServiceId').callsFake(() => 'local');
+      env.sandbox
+        .stub(localPlatform, 'getPlatformKey')
+        .callsFake(() => 'local');
     });
 
     it(
@@ -877,7 +887,7 @@ describes.realWin('Platform store', {}, (env) => {
 
         platformStore.resolvePlatform('local', localPlatform);
         platformStore.onPlatformResolves('local', (platform) => {
-          platformKey = platform.getServiceId();
+          platformKey = platform.getPlatformKey();
         });
 
         expect(platformKey).to.be.equal('local');
@@ -891,7 +901,7 @@ describes.realWin('Platform store', {}, (env) => {
         let platformKey;
 
         platformStore.onPlatformResolves('local', (platform) => {
-          platformKey = platform.getServiceId();
+          platformKey = platform.getPlatformKey();
         });
         platformStore.resolvePlatform('local', localPlatform);
 

--- a/extensions/amp-subscriptions/0.1/test/test-platform-store.js
+++ b/extensions/amp-subscriptions/0.1/test/test-platform-store.js
@@ -22,17 +22,17 @@ import {user} from '../../../../src/log';
 
 describes.realWin('Platform store', {}, (env) => {
   let platformStore;
-  const serviceIds = ['service1', 'service2'];
+  const platformKeys = ['platform1', 'platform2'];
   const entitlementsForService1 = new Entitlement({
-    source: serviceIds[0],
+    source: platformKeys[0],
     raw: '',
-    service: serviceIds[0],
+    service: platformKeys[0],
     granted: true,
   });
   const entitlementsForService2 = new Entitlement({
-    source: serviceIds[1],
+    source: platformKeys[1],
     raw: '',
-    service: serviceIds[1],
+    service: platformKeys[1],
     granted: false,
   });
   const fallbackEntitlement = new Entitlement({
@@ -55,7 +55,7 @@ describes.realWin('Platform store', {}, (env) => {
 
   beforeEach(() => {
     platformStore = new PlatformStore(
-      serviceIds,
+      platformKeys,
       {
         supportsViewer: 9,
         testFactor1: 10,
@@ -65,32 +65,32 @@ describes.realWin('Platform store', {}, (env) => {
     );
   });
 
-  it('should instantiate with the service ids', () => {
-    expect(platformStore.serviceIds_).to.be.equal(serviceIds);
+  it('should instantiate with the platform keys', () => {
+    expect(platformStore.platformKeys_).to.be.equal(platformKeys);
   });
 
   it('should resolve entitlement', async () => {
     // Request entitlement promise even before it's resolved.
-    const p = platformStore.getEntitlementPromiseFor('service2');
+    const p = platformStore.getEntitlementPromiseFor('platform2');
 
     // Resolve once.
     const ent = new Entitlement({
-      service: 'service2',
+      service: 'platform2',
       granted: false,
     });
-    platformStore.resolveEntitlement('service2', ent);
-    expect(platformStore.getResolvedEntitlementFor('service2')).to.equal(ent);
-    expect(platformStore.getEntitlementPromiseFor('service2')).to.equal(p);
+    platformStore.resolveEntitlement('platform2', ent);
+    expect(platformStore.getResolvedEntitlementFor('platform2')).to.equal(ent);
+    expect(platformStore.getEntitlementPromiseFor('platform2')).to.equal(p);
 
     // Additional resolution doesn't change anything without reset.
     platformStore.resolveEntitlement(
-      'service2',
+      'platform2',
       new Entitlement({
-        service: 'service2',
+        service: 'platform2',
         granted: true,
       })
     );
-    expect(platformStore.getEntitlementPromiseFor('service2')).to.equal(p);
+    expect(platformStore.getEntitlementPromiseFor('platform2')).to.equal(p);
     await expect(p).to.eventually.equal(ent);
   });
 
@@ -101,9 +101,9 @@ describes.realWin('Platform store', {}, (env) => {
     );
     platformStore.onChange(cb);
     platformStore.resolveEntitlement(
-      'service2',
+      'platform2',
       new Entitlement({
-        service: 'service2',
+        service: 'platform2',
         granted: false,
       })
     );
@@ -119,13 +119,19 @@ describes.realWin('Platform store', {}, (env) => {
           throw new Error('Incorrect entitlement resolved');
         }
       });
-      platformStore.resolveEntitlement(serviceIds[1], entitlementsForService2);
-      platformStore.resolveEntitlement(serviceIds[0], entitlementsForService1);
+      platformStore.resolveEntitlement(
+        platformKeys[1],
+        entitlementsForService2
+      );
+      platformStore.resolveEntitlement(
+        platformKeys[0],
+        entitlementsForService1
+      );
     });
 
     it('should resolve true for existing positive entitlement', (done) => {
-      platformStore.entitlements_[serviceIds[0]] = entitlementsForService1;
-      platformStore.entitlements_[serviceIds[1]] = entitlementsForService2;
+      platformStore.entitlements_[platformKeys[0]] = entitlementsForService1;
+      platformStore.entitlements_[platformKeys[1]] = entitlementsForService2;
       platformStore.getGrantStatus().then((entitlements) => {
         if (entitlements === true) {
           done();
@@ -137,12 +143,12 @@ describes.realWin('Platform store', {}, (env) => {
 
     it('should resolve false for negative entitlement', (done) => {
       const negativeEntitlements = new Entitlement({
-        source: serviceIds[0],
+        source: platformKeys[0],
         raw: '',
-        service: serviceIds[0],
+        service: platformKeys[0],
       });
-      platformStore.entitlements_[serviceIds[0]] = negativeEntitlements;
-      platformStore.entitlements_[serviceIds[1]] = entitlementsForService2;
+      platformStore.entitlements_[platformKeys[0]] = negativeEntitlements;
+      platformStore.entitlements_[platformKeys[1]] = entitlementsForService2;
       platformStore.getGrantStatus().then((entitlements) => {
         if (entitlements === false) {
           done();
@@ -154,11 +160,11 @@ describes.realWin('Platform store', {}, (env) => {
 
     it('should resolve false if all future entitlement are also negative ', (done) => {
       const negativeEntitlements = new Entitlement({
-        source: serviceIds[0],
+        source: platformKeys[0],
         raw: '',
-        service: serviceIds[0],
+        service: platformKeys[0],
       });
-      platformStore.entitlements_[serviceIds[0]] = negativeEntitlements;
+      platformStore.entitlements_[platformKeys[0]] = negativeEntitlements;
       platformStore.getGrantStatus().then((entitlements) => {
         if (entitlements === false) {
           done();
@@ -166,26 +172,41 @@ describes.realWin('Platform store', {}, (env) => {
           throw new Error('Incorrect entitlement resolved');
         }
       });
-      platformStore.resolveEntitlement(serviceIds[1], entitlementsForService2);
+      platformStore.resolveEntitlement(
+        platformKeys[1],
+        entitlementsForService2
+      );
     });
   });
 
   describe('areAllPlatformsResolved_', () => {
     it('should return true if all entitlements are present', () => {
-      platformStore.resolveEntitlement(serviceIds[1], entitlementsForService2);
+      platformStore.resolveEntitlement(
+        platformKeys[1],
+        entitlementsForService2
+      );
       expect(platformStore.areAllPlatformsResolved_()).to.be.equal(false);
-      platformStore.resolveEntitlement(serviceIds[0], entitlementsForService1);
+      platformStore.resolveEntitlement(
+        platformKeys[0],
+        entitlementsForService1
+      );
       expect(platformStore.areAllPlatformsResolved_()).to.be.equal(true);
     });
   });
 
   describe('getAvailablePlatformsEntitlements_', () => {
     it('should return all available entitlements', () => {
-      platformStore.resolveEntitlement(serviceIds[1], entitlementsForService2);
+      platformStore.resolveEntitlement(
+        platformKeys[1],
+        entitlementsForService2
+      );
       expect(platformStore.getAvailablePlatformsEntitlements_()).to.deep.equal([
         entitlementsForService2,
       ]);
-      platformStore.resolveEntitlement(serviceIds[0], entitlementsForService1);
+      platformStore.resolveEntitlement(
+        platformKeys[0],
+        entitlementsForService1
+      );
       expect(platformStore.getAvailablePlatformsEntitlements_()).to.deep.equal([
         entitlementsForService2,
         entitlementsForService1,
@@ -641,9 +662,9 @@ describes.realWin('Platform store', {}, (env) => {
         const platform = new SubscriptionPlatform();
         env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
         env.sandbox
-          .stub(platformStore, 'getLocalPlatform')
+          .stub(platformStore, 'getLocalPlatform_')
           .callsFake(() => platform);
-        platformStore.reportPlatformFailureAndFallback('service1');
+        platformStore.reportPlatformFailureAndFallback('platform1');
         expect(errorSpy).to.not.be.called;
         platformStore.reportPlatformFailureAndFallback('local');
         expect(errorSpy).to.be.calledOnce;
@@ -661,17 +682,17 @@ describes.realWin('Platform store', {}, (env) => {
         const anotherPlatform = new SubscriptionPlatform();
         env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
         env.sandbox
-          .stub(platformStore, 'getLocalPlatform')
+          .stub(platformStore, 'getLocalPlatform_')
           .callsFake(() => platform);
         env.sandbox
           .stub(anotherPlatform, 'getServiceId')
-          .callsFake(() => serviceIds[0]);
+          .callsFake(() => platformKeys[0]);
         env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
-        platformStore.resolvePlatform(serviceIds[0], anotherPlatform);
+        platformStore.resolvePlatform(platformKeys[0], anotherPlatform);
         platformStore.resolvePlatform('local', platform);
         platformStore.reportPlatformFailureAndFallback('local');
         platformStore.resolveEntitlement(
-          serviceIds[0],
+          platformKeys[0],
           entitlementsForService1
         );
 
@@ -692,18 +713,18 @@ describes.realWin('Platform store', {}, (env) => {
         const anotherPlatform = new SubscriptionPlatform();
         env.sandbox.stub(platform, 'getServiceId').callsFake(() => 'local');
         env.sandbox
-          .stub(platformStore, 'getLocalPlatform')
+          .stub(platformStore, 'getLocalPlatform_')
           .callsFake(() => platform);
         env.sandbox
           .stub(anotherPlatform, 'getServiceId')
-          .callsFake(() => serviceIds[0]);
+          .callsFake(() => platformKeys[0]);
         env.sandbox.stub(anotherPlatform, 'getBaseScore').callsFake(() => 10);
-        platformStore.resolvePlatform(serviceIds[0], anotherPlatform);
+        platformStore.resolvePlatform(platformKeys[0], anotherPlatform);
         platformStore.resolvePlatform('local', platform);
         fallbackEntitlement.grantReason = GrantReason.METERING;
         platformStore.reportPlatformFailureAndFallback('local');
         platformStore.resolveEntitlement(
-          serviceIds[0],
+          platformKeys[0],
           entitlementsForService1
         );
 
@@ -712,13 +733,13 @@ describes.realWin('Platform store', {}, (env) => {
           fallbackEntitlement
         );
         // falbackEntitlement has Reason as SUBSCRIBER so it should win
-        expect(selectedPlatform.getServiceId()).to.equal(serviceIds[0]);
+        expect(selectedPlatform.getServiceId()).to.equal(platformKeys[0]);
       }
     );
   });
 
   describe('getPlatform', () => {
-    it('should return the platform for the serviceId', () => {
+    it('should return the platform for a given platform key', () => {
       const platform = new SubscriptionPlatform();
       platform.getServiceId = () => 'test';
       platformStore.subscriptionPlatforms_['test'] = platform;
@@ -754,7 +775,7 @@ describes.realWin('Platform store', {}, (env) => {
     });
 
     it('should resolve with first entitlement with subscriptions', async () => {
-      platformStore.resolveEntitlement('service1', subscribedEntitlement);
+      platformStore.resolveEntitlement('platform1', subscribedEntitlement);
       const entitlement = await platformStore.getGrantEntitlement();
       expect(entitlement).to.equal(subscribedEntitlement);
     });
@@ -763,23 +784,23 @@ describes.realWin('Platform store', {}, (env) => {
       'should resolve with metered entitlement when no ' +
         'platform is subscribed',
       async () => {
-        platformStore.resolveEntitlement('service1', noEntitlement);
-        platformStore.resolveEntitlement('service2', meteringEntitlement);
+        platformStore.resolveEntitlement('platform1', noEntitlement);
+        platformStore.resolveEntitlement('platform2', meteringEntitlement);
         const entitlement = await platformStore.getGrantEntitlement();
         expect(entitlement).to.equal(meteringEntitlement);
       }
     );
 
     it('should override metering with subscription', async () => {
-      platformStore.resolveEntitlement('service1', meteringEntitlement);
-      platformStore.resolveEntitlement('service2', subscribedEntitlement);
+      platformStore.resolveEntitlement('platform1', meteringEntitlement);
+      platformStore.resolveEntitlement('platform2', subscribedEntitlement);
       const entitlement = await platformStore.getGrantEntitlement();
       expect(entitlement).to.equal(subscribedEntitlement);
     });
 
     it('should resolve to null if nothing matched', async () => {
-      platformStore.resolveEntitlement('service1', noEntitlement);
-      platformStore.resolveEntitlement('service2', noEntitlement);
+      platformStore.resolveEntitlement('platform1', noEntitlement);
+      platformStore.resolveEntitlement('platform2', noEntitlement);
       const entitlement = await platformStore.getGrantEntitlement();
       expect(entitlement).to.be.null;
     });
@@ -852,14 +873,14 @@ describes.realWin('Platform store', {}, (env) => {
       'should return a promise resolving the requested platform ' +
         'if it is already registered',
       () => {
-        let serviceId;
+        let platformKey;
 
         platformStore.resolvePlatform('local', localPlatform);
         platformStore.onPlatformResolves('local', (platform) => {
-          serviceId = platform.getServiceId();
+          platformKey = platform.getServiceId();
         });
 
-        expect(serviceId).to.be.equal('local');
+        expect(platformKey).to.be.equal('local');
       }
     );
 
@@ -867,14 +888,14 @@ describes.realWin('Platform store', {}, (env) => {
       'should return a promise resolving when the requested platform ' +
         'gets registered',
       () => {
-        let serviceId;
+        let platformKey;
 
         platformStore.onPlatformResolves('local', (platform) => {
-          serviceId = platform.getServiceId();
+          platformKey = platform.getServiceId();
         });
         platformStore.resolvePlatform('local', localPlatform);
 
-        expect(serviceId).to.be.equal('local');
+        expect(platformKey).to.be.equal('local');
       }
     );
   });

--- a/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
+++ b/extensions/amp-subscriptions/0.1/test/test-service-adapter.js
@@ -60,9 +60,9 @@ describes.realWin(
           subscriptionService,
           'getEncryptedDocumentKey'
         );
-        serviceAdapter.getEncryptedDocumentKey('serviceId');
+        serviceAdapter.getEncryptedDocumentKey('platformKey');
         expect(stub).to.be.calledOnce;
-        expect(stub).to.be.calledWith('serviceId');
+        expect(stub).to.be.calledWith('platformKey');
       });
     });
 
@@ -119,13 +119,13 @@ describes.realWin(
     describe('decorateServiceAction', () => {
       it('should call decorateServiceAction of subscription service', () => {
         const element = win.document.createElement('div');
-        const serviceId = 'local';
+        const platformKey = 'local';
         const stub = env.sandbox.stub(
           subscriptionService,
           'decorateServiceAction'
         );
-        serviceAdapter.decorateServiceAction(element, serviceId, 'action');
-        expect(stub).to.be.calledWith(element, serviceId, 'action');
+        serviceAdapter.decorateServiceAction(element, platformKey, 'action');
+        expect(stub).to.be.calledWith(element, platformKey, 'action');
       });
     });
 

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
@@ -354,12 +354,12 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, (env) => {
   });
 
   describe('proxy methods', () => {
-    it('should delegate getServiceId', () => {
+    it('should delegate getPlatformKey', () => {
       const proxyStub = env.sandbox.stub(
         viewerPlatform.platform_,
-        'getServiceId'
+        'getPlatformKey'
       );
-      viewerPlatform.getServiceId();
+      viewerPlatform.getPlatformKey();
       expect(proxyStub).to.be.called;
     });
 

--- a/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
+++ b/extensions/amp-subscriptions/0.1/viewer-subscription-platform.js
@@ -232,8 +232,8 @@ export class ViewerSubscriptionPlatform {
   }
 
   /** @override */
-  getServiceId() {
-    return this.platform_.getServiceId();
+  getPlatformKey() {
+    return this.platform_.getPlatformKey();
   }
 
   /** @override */


### PR DESCRIPTION
This PR updates the `amp-subscriptions` and `amp-subscriptions-google` extensions to consistently refer to subscription platforms as "platforms" internally. After the this PR, subscription platforms would only be called "services" externally in configuration JSON, templates, etc

Context: I found the interchangeable use of "platform" and "service" in the code was pretty confusing. Between the two terms, "platform" seems much more descriptive, in my opinion