### PR TITLE
🏗 E2E test improvements

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -28,10 +28,6 @@ const {
   installBrowserAssertions,
 } = require('./expect');
 const {
-  getCoverageObject,
-  mergeClientCoverage,
-} = require('istanbul-middleware/lib/core');
-const {
   SeleniumWebDriverController,
 } = require('./selenium-webdriver-controller');
 const {AmpDriver, AmpdocEnvironment} = require('./amp-driver');
@@ -49,6 +45,12 @@ const SETUP_RETRIES = 3;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
 const COV_REPORT_PATH = '/coverage/client';
 const supportedBrowsers = new Set(['chrome', 'firefox', 'safari']);
+
+/**
+ * Used to lazily load coverage middleware.
+ */
+let istanbulMiddleware;
+
 /**
  * TODO(cvializ): Firefox now experimentally supports puppeteer.
  * When it's more mature we might want to support it.
@@ -367,7 +369,7 @@ class ItConfig {
 async function updateCoverage(env) {
   const coverage = await env.controller.evaluate(() => window.__coverage__);
   if (coverage) {
-    mergeClientCoverage(coverage);
+    istanbulMiddleware.mergeClientCoverage(coverage);
   }
 }
 
@@ -376,7 +378,7 @@ async function updateCoverage(env) {
  * @return {Promise<void>}
  */
 async function reportCoverage() {
-  const coverage = getCoverageObject();
+  const coverage = istanbulMiddleware.getCoverageObject();
   await fetch(`https://${HOST}:${PORT}${COV_REPORT_PATH}`, {
     method: 'POST',
     body: JSON.stringify(coverage),
@@ -483,6 +485,12 @@ function describeEnv(factory) {
         // don't install for CI
         if (!isCiBuild()) {
           installRepl(global, env);
+        }
+      });
+
+      before(() => {
+        if (argv.coverage) {
+          istanbulMiddleware = require('istanbul-middleware/lib/core');
         }
       });
 

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -47,9 +47,12 @@ const COV_REPORT_PATH = '/coverage/client';
 const supportedBrowsers = new Set(['chrome', 'firefox', 'safari']);
 
 /**
- * Used to lazily load coverage middleware.
+ * Load coverage middleware only if needed.
  */
 let istanbulMiddleware;
+if (argv.coverage) {
+  istanbulMiddleware = require('istanbul-middleware/lib/core');
+}
 
 /**
  * TODO(cvializ): Firefox now experimentally supports puppeteer.
@@ -485,12 +488,6 @@ function describeEnv(factory) {
         // don't install for CI
         if (!isCiBuild()) {
           installRepl(global, env);
-        }
-      });
-
-      before(() => {
-        if (argv.coverage) {
-          istanbulMiddleware = require('istanbul-middleware/lib/core');
         }
       });
 

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -30,6 +30,10 @@ const {
   getFilesFromArgv,
   installPackages,
 } = require('../../common/utils');
+const {
+  createCtrlcHandler,
+  exitCtrlcHandler,
+} = require('../../common/ctrlcHandler');
 const {cyan} = require('kleur/colors');
 const {execOrDie} = require('../../common/exec');
 const {HOST, PORT, startServer, stopServer} = require('../serve');
@@ -200,11 +204,12 @@ async function runWatch_() {
 
 /**
  * Entry-point to run e2e tests.
- * @return {!Promise}
  */
 async function e2e() {
+  const handlerProcess = createCtrlcHandler('e2e');
   await setUpTesting_();
-  return argv.watch ? runWatch_() : runTests_();
+  argv.watch ? await runWatch_() : await runTests_();
+  exitCtrlcHandler(handlerProcess);
 }
 
 module.exports = {


### PR DESCRIPTION
**Two changes:**
- Conditionally load `istanbul-middleware` (its circular dependency warning can be avoided during non-coverage builds)
- Add a Ctrl+C handler (so E2E tests can be canceled if needed during local dev)

![image](https://user-images.githubusercontent.com/26553114/107293407-8ca16680-6a39-11eb-8ffa-300b9f651d58.png)
