### PR TITLE
🏗 Fix skip logic for E2E tests on FF / Safari

### DIFF
--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -114,6 +114,7 @@ async function prBuildWorkflow() {
     !buildTargetsInclude(
       Targets.RUNTIME,
       Targets.UNIT_TEST,
+      Targets.E2E_TEST,
       Targets.INTEGRATION_TEST
     )
   ) {


### PR DESCRIPTION
Another follow up to #32443 that I should've done there. Hopefully third time lucky!
