### PR TITLE
Disable layout-aspect-ratio-css due to visual diff flakes

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,6 +13,6 @@
   "ios-fixed-no-transfer": 0,
   "fie-resources": 1,
   "visibility-trigger-improvements": 1,
-  "layout-aspect-ratio-css": 0.1,
+  "layout-aspect-ratio-css": 0,
   "sticky-ad-transition": 0.02
 }


### PR DESCRIPTION
Disable "layout-aspect-ratio-css" in visual tests to avoid skew with non-aspect-ratio-supporting FF. Ok to revert as soon as FF launches the feature. See https://bugzilla.mozilla.org/show_bug.cgi?id=1528375 for details.

Related to #30291.