### PR TITLE
🏗 Remove and prevent unused eslint directives

### DIFF
--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -66,6 +66,7 @@ function runLinter(stream) {
   const options = {
     fix: argv.fix,
     quiet: argv.quiet,
+    reportUnusedDisableDirectives: true,
   };
   const fixedFiles = {};
   return stream

--- a/src/ini-load.js
+++ b/src/ini-load.js
@@ -41,7 +41,6 @@ export function whenContentIniLoad(
   rect,
   opt_prerenderableOnly
 ) {
-  // eslint-disable-next-line no-undef
   if (INI_LOAD_INOB) {
     return whenContentIniLoadInOb(elementOrAmpDoc, opt_prerenderableOnly);
   }


### PR DESCRIPTION
This PR enables the detection of `eslint` directives that have become unnecessary, and cleans up the one such instance in our code.

**Reference:** https://eslint.org/docs/developer-guide/nodejs-api#cliengine

Addresses https://github.com/ampproject/amphtml/pull/32397/files#r572619849