### PR TITLE
Output sizer with aspect-ratio to ensure correct visual diff in FF

### DIFF
--- a/src/layout.js
+++ b/src/layout.js
@@ -516,21 +516,24 @@ export function applyStaticLayout(element, fixIeIntrinsic = false) {
   } else if (layout == Layout.FIXED_HEIGHT) {
     setStyle(element, 'height', dev().assertString(height));
   } else if (layout == Layout.RESPONSIVE) {
+    // TODO(#30291): do not output <i-amphtml-sizer> at all once FF launches
+    // the aspect-ratio support. This is mainly to avoid flakes with visual
+    // tests. See https://bugzilla.mozilla.org/show_bug.cgi?id=1528375.
+    const sizer = element.ownerDocument.createElement('i-amphtml-sizer');
+    sizer.setAttribute('slot', 'i-amphtml-svc');
+    setStyles(sizer, {
+      paddingTop:
+        (getLengthNumeral(height) / getLengthNumeral(width)) * 100 + '%',
+    });
+    element.insertBefore(sizer, element.firstChild);
+    element.sizerElement = sizer;
     if (shouldUseAspectRatioCss(toWin(element.ownerDocument.defaultView))) {
       setStyle(
         element,
         'aspect-ratio',
         `${getLengthNumeral(width)}/${getLengthNumeral(height)}`
       );
-    } else {
-      const sizer = element.ownerDocument.createElement('i-amphtml-sizer');
-      sizer.setAttribute('slot', 'i-amphtml-svc');
-      setStyles(sizer, {
-        paddingTop:
-          (getLengthNumeral(height) / getLengthNumeral(width)) * 100 + '%',
-      });
-      element.insertBefore(sizer, element.firstChild);
-      element.sizerElement = sizer;
+      sizer.classList.add('i-amphtml-disable-ar');
     }
   } else if (layout == Layout.INTRINSIC) {
     // Intrinsic uses an svg inside the sizer element rather than the padding

--- a/test/unit/test-layout.js
+++ b/test/unit/test-layout.js
@@ -695,8 +695,13 @@ describes.realWin('Layout: aspect-ratio CSS', {amp: true}, function (env) {
         expect(element.style.height).to.equal('');
         expect(element).to.have.class('i-amphtml-layout-responsive');
         expect(element).to.have.class('i-amphtml-layout-size-defined');
-        // No sizer added.
-        expect(element.querySelector('i-amphtml-sizer')).to.be.null;
+        // TODO(#30291): do not output <i-amphtml-sizer> at all once FF launches
+        // the aspect-ratio support. This is mainly to avoid flakes with visual
+        // tests. See https://bugzilla.mozilla.org/show_bug.cgi?id=1528375.
+        const sizer = element.querySelector('i-amphtml-sizer');
+        expect(sizer).to.exist;
+        expect(sizer).to.have.class('i-amphtml-disable-ar');
+        expect(getComputedStyle(sizer).display).to.equal('none');
       });
 
       it('should disable SSR sizer for responsive layout', () => {


### PR DESCRIPTION
Outputs both `aspect-ratio` styling and `i-amphtml-sizer`. The sizer is configured as `display:none` using `@supports (aspect-ratio)`.

Needed to avoid visual diff flakes until FF launches aspect-ratio. See https://bugzilla.mozilla.org/show_bug.cgi?id=1528375 for details.

Related to #30291.