### PR TITLE
Revert owner lifecycle control from the amp-iframe

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -645,8 +645,7 @@ export class AmpIframe extends AMP.BaseElement {
       return;
     }
     this.isDisplayed_ = isDisplayed;
-    const hasOwner = !!this.element.getOwner();
-    if (!isDisplayed && !hasOwner && this.iframe_) {
+    if (!isDisplayed && this.iframe_) {
       this.getVsync().mutate(() => this.unload());
     }
   }

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -631,11 +631,6 @@ export class AmpIframe extends AMP.BaseElement {
     }
   }
 
-  /** @override */
-  unlayoutOnPause() {
-    return true;
-  }
-
   /**
    * @param {boolean} isDisplayed
    * @private

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -1101,26 +1101,6 @@ describes.realWin(
       expect(impl.unload).to.be.calledOnce;
     });
 
-    it('should not unlayout on pause if has owner', async () => {
-      const ampIframe = createAmpIframe(env, {
-        src: iframeSrc,
-        width: 100,
-        height: 100,
-      });
-      const impl = await ampIframe.getImpl(false);
-      impl.element.getOwner = () => ({});
-      await waitForAmpIframeLayoutPromise(doc, ampIframe);
-      expect(ampIframe.querySelector('iframe')).to.exist;
-      expect(ampIframe.unlayoutOnPause()).to.be.true;
-
-      setDisplay(ampIframe, true);
-      setDisplay(ampIframe, false);
-      env.sandbox.stub(impl, 'unload');
-
-      await new Promise(setTimeout);
-      expect(impl.unload).not.called;
-    });
-
     it('should now need pausing before displayed', async () => {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -1089,7 +1089,7 @@ describes.realWin(
       const impl = await ampIframe.getImpl(false);
       await waitForAmpIframeLayoutPromise(doc, ampIframe);
       expect(ampIframe.querySelector('iframe')).to.exist;
-      expect(ampIframe.unlayoutOnPause()).to.be.true;
+      expect(ampIframe.unlayoutOnPause()).to.be.false;
 
       // The element should become visible before pause is necessary.
       setDisplay(ampIframe, true);
@@ -1110,7 +1110,7 @@ describes.realWin(
       const impl = await ampIframe.getImpl(false);
       await waitForAmpIframeLayoutPromise(doc, ampIframe);
       expect(ampIframe.querySelector('iframe')).to.exist;
-      expect(ampIframe.unlayoutOnPause()).to.be.true;
+      expect(ampIframe.unlayoutOnPause()).to.be.false;
 
       // The element was never visible.
       env.sandbox./*OK*/ stub(impl, 'unload');
@@ -1128,7 +1128,7 @@ describes.realWin(
       });
       const impl = await ampIframe.getImpl(false);
       expect(ampIframe.querySelector('iframe')).to.not.exist;
-      expect(ampIframe.unlayoutOnPause()).to.be.true;
+      expect(ampIframe.unlayoutOnPause()).to.be.false;
 
       env.sandbox./*OK*/ stub(impl, 'unload');
       setDisplay(ampIframe, true);


### PR DESCRIPTION
Should no longer be needed with the #32478 fix.

Revert #32459.
Revert #32466.

Partial for #31915.

Blocked by #32722 and #32701.