### PR TITLE
🏗 Stop running visual diff tests on Travis

### DIFF
--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -26,6 +26,7 @@ const {
   timedExecOrDie,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
+const {isTravisBuild} = require('../common/ci');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'visual-diff-tests.js';
@@ -52,4 +53,12 @@ function prBuildWorkflow() {
   }
 }
 
+// TODO(rsimha): Remove this block once Travis is shut off.
+if (isTravisBuild()) {
+  printSkipMessage(
+    jobName,
+    'this is a Travis build. Sizes will be reported from CircleCI'
+  );
+  return;
+}
 runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow);

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -57,7 +57,7 @@ function prBuildWorkflow() {
 if (isTravisBuild()) {
   printSkipMessage(
     jobName,
-    'this is a Travis build. Sizes will be reported from CircleCI'
+    'this is a Travis build. Visual diff tests will be run on CircleCI'
   );
   return;
 }


### PR DESCRIPTION
They're already being run on CircleCI, and we're shutting off Travis soon.