### PR TITLE
🏗 Pin the Chromium version used by visual diff to 78.0.3904.0

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -146,15 +146,16 @@ function usesFilesOrLocalChanges(taskName) {
  * Runs 'npm install' to install packages in a given directory.
  *
  * @param {string} dir
+ * @param {NodeJS.ProcessEnv} options
  */
-function installPackages(dir) {
+function installPackages(dir, options = {}) {
   log(
     'Running',
     cyan('npm install'),
     'to install packages in',
     cyan(path.relative(ROOT_DIR, dir)) + '...'
   );
-  execOrDie(`npm install --prefix ${dir}`, {'stdio': 'ignore'});
+  execOrDie(`npm install --prefix ${dir}`, {'stdio': 'ignore', ...options});
 }
 
 module.exports = {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -57,6 +57,10 @@ const percyCss = [
   '.i-amphtml-new-loader * { animation: none !important; }',
 ].join('\n');
 
+// Fix Chromium version to 78.0.3904.0, same as the one running on Percy.
+// Use https://omahaproxy.appspot.com/ to convert version<->revision numbers.
+const INSTALL_PACKAGE_OPTIONS = {'PUPPETEER_CHROMIUM_REVISION': '693954'};
+
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {
   widths: [375],
 };
@@ -789,7 +793,7 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
 
 function installPercy_() {
   if (!argv.noinstall) {
-    installPackages(__dirname);
+    installPackages(__dirname, INSTALL_PACKAGE_OPTIONS);
   }
 
   puppeteer = require('puppeteer');

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -57,8 +57,10 @@ const percyCss = [
   '.i-amphtml-new-loader * { animation: none !important; }',
 ].join('\n');
 
-// Fix Chromium version to 78.0.3904.0, same as the one running on Percy.
+// Pin the version of Chromium to 78.0.3904.0, same as the one running on Percy.
 // Use https://omahaproxy.appspot.com/ to convert version<->revision numbers.
+// REPEATING TODO(@ampproject/wg-infra): keep this pinned with Percy whenever we
+// update the version of Chrome in the project settings.
 const INSTALL_PACKAGE_OPTIONS = {'PUPPETEER_CHROMIUM_REVISION': '693954'};
 
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {


### PR DESCRIPTION
This is the same (or close enough) version as the one used on Percy. Pinning this version of Chromium used on our CI to the same as the one used on Percy would help us avoid subtle visual bugs caused by lack of support for newer versions on either end

Related to #32461