### PR TITLE
♻️ Allow dynamically setting 3p bootstrap script

### DIFF
--- a/3p/frame.max.html
+++ b/3p/frame.max.html
@@ -2,7 +2,13 @@
 <head>
 <meta charset="utf-8">
 <meta name="robots" content="noindex">
-<script src="./integration.js"></script>
+<script>
+var url = './integration.js';
+try {
+  url = JSON.parse(window.name).bootstrap; 
+} catch (e) {}
+document.write('<script src="' + url + '"><' + '/script>');
+</script>
 </head>
 <body style="margin:0">
 <div id="c" style="position:absolute;top:0;left:0;bottom:0;right:0;">

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -69,6 +69,10 @@ describes.realWin(
     let registryBackup;
     const whenFirstVisible = Promise.resolve();
 
+    function mockMode(mode) {
+      env.sandbox.stub(win.parent, '__AMP_MODE').value(mode);
+    }
+
     beforeEach(() => {
       registryBackup = Object.create(null);
       Object.keys(adConfig).forEach((k) => {
@@ -323,19 +327,19 @@ describes.realWin(
 
     describe('preconnectCallback', () => {
       it('should add preconnect and prefetch to DOM header', () => {
+        mockMode({});
         ad3p.buildCallback();
         ad3p.preconnectCallback();
         return whenFirstVisible.then(() => {
           const fetches = win.document.querySelectorAll('link[rel=preload]');
           expect(fetches).to.have.length(2);
-          expect(
-            Array.from(fetches)
-              .map((link) => link.href)
-              .sort()
-          ).to.jsonEqual([
-            'http://ads.localhost:9876/dist.3p/current/frame.max.html',
-            'http://ads.localhost:9876/dist.3p/current/integration.js',
-          ]);
+          expect(fetches[0].href).to.match(
+            /^https:\/\/d-\d+\.ampproject\.net\/\$internalRuntimeVersion\$\/frame\.html$/
+          );
+          expect(fetches[1]).to.have.property(
+            'href',
+            'https://3p.ampproject.net/$internalRuntimeVersion$/f.js'
+          );
 
           const preconnects = win.document.querySelectorAll(
             'link[rel=preconnect]'

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -125,6 +125,7 @@ export function getIframe(
   const name = JSON.stringify(
     dict({
       'host': host,
+      'bootstrap': getBootstrapUrl(),
       'type': attributes['type'],
       // https://github.com/ampproject/amphtml/pull/2955
       'count': count[attributes['type']],
@@ -204,6 +205,17 @@ export function addDataAndJsonAttributes_(element, attributes) {
 }
 
 /**
+ * Get the bootstrap script URL for iframe.
+ * @return {string}
+ */
+export function getBootstrapUrl() {
+  if (getMode().localDev || getMode().test) {
+    return getMode().minified ? './f.js' : './integration.js';
+  }
+  return `${urls.thirdParty}/${internalRuntimeVersion()}/f.js`;
+}
+
+/**
  * Preloads URLs related to the bootstrap iframe.
  * @param {!Window} win
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
@@ -216,10 +228,7 @@ export function preloadBootstrap(win, ampdoc, preconnect, opt_disallowCustom) {
 
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.
-  const scriptUrl = getMode().localDev
-    ? getAdsLocalhost(win) + '/dist.3p/current/integration.js'
-    : `${urls.thirdParty}/${internalRuntimeVersion()}/f.js`;
-  preconnect.preload(ampdoc, scriptUrl, 'script');
+  preconnect.preload(ampdoc, getBootstrapUrl(), 'script');
 }
 
 /**

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -424,20 +424,19 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
       });
 
       it('should prefetch bootstrap frame and JS', () => {
-        mockMode({localDev: true});
+        mockMode({});
         const ampdoc = Services.ampdoc(window.document);
         preloadBootstrap(window, ampdoc, preconnect);
         // Wait for visible promise.
         return ampdoc.whenFirstVisible().then(() => {
           const fetches = document.querySelectorAll('link[rel=preload]');
           expect(fetches).to.have.length(2);
-          expect(fetches[0]).to.have.property(
-            'href',
-            'http://ads.localhost:9876/dist.3p/current/frame.max.html'
+          expect(fetches[0].href).to.match(
+            /^https:\/\/d-\d+\.ampproject\.net\/\$internalRuntimeVersion\$\/frame\.html$/
           );
           expect(fetches[1]).to.have.property(
             'href',
-            'http://ads.localhost:9876/dist.3p/current/integration.js'
+            'https://3p.ampproject.net/$internalRuntimeVersion$/f.js'
           );
         });
       });


### PR DESCRIPTION
This PR gets rid of the hard coded `integration.js`/`f.js`, and replace it with a URL that is assigned by AMP runtime. In addition, it moves script calls from HTML to the Javascript.

The risk here is that some 3p script might depend on `draw3p()` being ran within the container div or a specific script tag, but I see no sign any 3p integration actually does that. Tested several ads and 3p (facebook and twitter extensions) and all worked fine.

Pulling in @dvoytenko  do you see this being a problems with this?