### PR TITLE
🏗 Add fail-fast behavior to CircleCI builds

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -16,7 +16,7 @@
 #
 # This script checks if a PR branch is using the most recent CircleCI config.
 #
-# Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
+# Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 
 set -e
 err=0

--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -13,9 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the license.
-#
+
 # This script checks if a PR branch is using the most recent CircleCI config.
-#
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 
 set -e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,12 @@ commands:
     steps:
       - browser-tools/install-chrome:
           replace-existing: true
+  fail_fast:
+    steps:
+      - run:
+          name: 'Fail Fast'
+          when: on_fail
+          command: ./.circleci/fail_fast.sh
 
 jobs:
   'Checks':
@@ -84,6 +90,7 @@ jobs:
       - run:
           name: 'Checks'
           command: node build-system/pr-check/checks.js
+      - fail_fast
   'Unminified Build':
     executor:
       name: amphtml-xlarge-executor
@@ -92,6 +99,7 @@ jobs:
       - run:
           name: 'Unminified Build'
           command: node build-system/pr-check/unminified-build.js
+      - fail_fast
   'Nomodule Build':
     executor:
       name: amphtml-xlarge-executor
@@ -100,6 +108,7 @@ jobs:
       - run:
           name: 'Nomodule Build'
           command: node build-system/pr-check/nomodule-build.js
+      - fail_fast
   'Module Build':
     executor:
       name: amphtml-xlarge-executor
@@ -108,6 +117,7 @@ jobs:
       - run:
           name: 'Module Build'
           command: node build-system/pr-check/module-build.js
+      - fail_fast
   'Bundle Size':
     executor:
       name: amphtml-medium-executor
@@ -116,6 +126,7 @@ jobs:
       - run:
           name: 'Bundle Size'
           command: node build-system/pr-check/bundle-size.js
+      - fail_fast
   'Validator Tests':
     executor:
       name: amphtml-medium-executor
@@ -127,6 +138,7 @@ jobs:
       - run:
           name: 'Validator Tests'
           command: node build-system/pr-check/validator-tests.js
+      - fail_fast
   'Visual Diff Tests':
     executor:
       name: amphtml-large-executor
@@ -136,6 +148,7 @@ jobs:
       - run:
           name: 'Visual Diff Tests'
           command: node build-system/pr-check/visual-diff-tests.js
+      - fail_fast
   'Unit Tests':
     executor:
       name: amphtml-large-executor
@@ -149,6 +162,7 @@ jobs:
           command: node build-system/pr-check/unit-tests.js
       - save_karma_cache:
           cache_name: unit
+      - fail_fast
   'Unminified Tests':
     executor:
       name: amphtml-large-executor
@@ -162,6 +176,7 @@ jobs:
           command: node build-system/pr-check/unminified-tests.js
       - save_karma_cache:
           cache_name: unminified
+      - fail_fast
   'Nomodule Tests':
     executor:
       name: amphtml-large-executor
@@ -175,6 +190,7 @@ jobs:
           command: node build-system/pr-check/nomodule-tests.js
       - save_karma_cache:
           cache_name: nomodule
+      - fail_fast
   'Module Tests':
     executor:
       name: amphtml-large-executor
@@ -188,6 +204,7 @@ jobs:
           command: node build-system/pr-check/module-tests.js
       - save_karma_cache:
           cache_name: module
+      - fail_fast
   'End-to-End Tests':
     executor:
       name: amphtml-large-executor
@@ -197,6 +214,7 @@ jobs:
       - run:
           name: 'End-to-End Tests'
           command: node build-system/pr-check/e2e-tests.js
+      - fail_fast
   'Performance Tests':
     executor:
       name: amphtml-xlarge-executor
@@ -206,6 +224,7 @@ jobs:
       - run:
           name: 'Performance Tests'
           command: node build-system/pr-check/performance-tests.js
+      - fail_fast
   'Experiment A Tests':
     executor:
       name: amphtml-xlarge-executor
@@ -215,6 +234,7 @@ jobs:
       - run:
           name: 'Experiment A Tests'
           command: node build-system/pr-check/experiment-tests.js --experiment=experimentA
+      - fail_fast
   'Experiment B Tests':
     executor:
       name: amphtml-xlarge-executor
@@ -224,6 +244,7 @@ jobs:
       - run:
           name: 'Experiment B Tests'
           command: node build-system/pr-check/experiment-tests.js --experiment=experimentB
+      - fail_fast
   'Experiment C Tests':
     executor:
       name: amphtml-xlarge-executor
@@ -233,6 +254,7 @@ jobs:
       - run:
           name: 'Experiment C Tests'
           command: node build-system/pr-check/experiment-tests.js --experiment=experimentC
+      - fail_fast
 
 workflows:
   'CircleCI':

--- a/.circleci/fail_fast.sh
+++ b/.circleci/fail_fast.sh
@@ -13,9 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the license.
-#
+
 # This script early-exits the CircleCI workflow when a single job fails.
-#
 # Reference: https://support.circleci.com/hc/en-us/articles/360052058811-Exit-build-early-if-any-test-fails
 
 set -e

--- a/.circleci/fail_fast.sh
+++ b/.circleci/fail_fast.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+# This script early-exits the CircleCI workflow when a single job fails.
+#
+# Reference: https://support.circleci.com/hc/en-us/articles/360052058811-Exit-build-early-if-any-test-fails
+
+set -e
+
+RED() { echo -e "\n\033[0;31m$1\033[0m"; }
+
+echo $(RED "Exiting workflow because a job failed.")
+curl -X POST \
+--header "Content-Type: application/json" \
+"https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLE_TOKEN}"

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -17,7 +17,7 @@
 # This script fetches the merge commit of a PR branch with master to make sure
 # PRs are tested against all the latest changes on CircleCI.
 #
-# Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables.
+# Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 
 set -e
 err=0

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -13,10 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the license.
-#
+
 # This script fetches the merge commit of a PR branch with master to make sure
 # PRs are tested against all the latest changes on CircleCI.
-#
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 
 set -e

--- a/.circleci/install_dependencies.sh
+++ b/.circleci/install_dependencies.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the license.
-#
+
 # Script used by AMP's CI builds to install project dependencies on CircleCI.
 
 set -e

--- a/.circleci/setup_storage.sh
+++ b/.circleci/setup_storage.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the license.
-#
+
 # Script used by AMP's CI builds to authenticate with GCP storage on CircleCI.
 # TODO(rsimha, ampproject/amp-github-apps#1110): Update storage details.
 

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the license.
-#
+
 # Script used by AMP's CI builds to install project dependencies on GH Actions.
 
 set -e

--- a/build-system/common/enable-git-pre-push.sh
+++ b/build-system/common/enable-git-pre-push.sh
@@ -13,10 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the license.
-#
+
 # This script adds a pre-push hook to .git/hooks/, which runs some basic tests
 # before running "git push".
-#
 # To enable it, run this script: "./build-system/common/enable-git-pre-push.sh"
 
 


### PR DESCRIPTION
This PR adds a step that early-exits the entire CircleCI workflow if a single job fails.

E.g. if an early step in the `Checks` job were to fail, we no longer spend several minutes building and testing the runtime in parallel jobs.

**Pros:**
- Workflow view makes it clear which job failed
- Logs from the failing job will show the error that caused the job to fail
- Unrelated parallel / subsequent jobs will be terminated early (significant savings of CPU minutes)

**Cons:**
- After fail-fast, the top-level workflow status is "canceled", not "failed" (by design, according to [this](https://support.circleci.com/hc/en-us/articles/360052058811-Exit-build-early-if-any-test-fails))
- Fail-fast behavior requires the use of an API token (set as a secure project-level environment variable)

**[Workflow view:](https://app.circleci.com/pipelines/github/ampproject/amphtml/1643/workflows/471abfd9-a91d-4e65-92b2-c16bf7bef737)**

![image](https://user-images.githubusercontent.com/26553114/107462722-c00fee00-6b2a-11eb-8e15-006649c9da0a.png)

**[Fail-fast example:](https://app.circleci.com/pipelines/github/ampproject/amphtml/1643/workflows/471abfd9-a91d-4e65-92b2-c16bf7bef737/jobs/15803)**

![image](https://user-images.githubusercontent.com/26553114/107463028-5cd28b80-6b2b-11eb-9b43-c0fe7494d47f.png)


**Reference:** https://support.circleci.com/hc/en-us/articles/360052058811-Exit-build-early-if-any-test-fails