### PR TITLE
amp-form: enable detached analytics & fix error flow

### DIFF
--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1222,7 +1222,9 @@ export class AmpForm {
    * @private
    */
   analyticsEvent_(eventType, opt_vars) {
-    triggerAnalyticsEvent(this.form_, eventType, opt_vars);
+    // Use cached `this.doc_` to trigger analytics since analytics
+    // may be called after the <form> has been removed from the DOM.
+    triggerAnalyticsEvent(this.doc_, eventType, opt_vars);
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -504,7 +504,11 @@ export class AmpForm {
     }
     formDataForAnalytics['formId'] = this.form_.id;
 
-    this.analyticsEvent_(eventType, formDataForAnalytics);
+    try {
+      this.analyticsEvent_(eventType, formDataForAnalytics);
+    } catch (err) {
+      dev().error(TAG, 'Sending analytics failed:', err);
+    }
   }
 
   /**
@@ -1222,9 +1226,9 @@ export class AmpForm {
    * @private
    */
   analyticsEvent_(eventType, opt_vars) {
-    // Use cached `this.doc_` to trigger analytics since analytics
+    // Use cached `this.ampdoc_` to trigger analytics since analytics
     // may be called after the <form> has been removed from the DOM.
-    triggerAnalyticsEvent(this.doc_, eventType, opt_vars);
+    triggerAnalyticsEvent(this.ampdoc_, eventType, opt_vars);
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1228,7 +1228,7 @@ export class AmpForm {
   analyticsEvent_(eventType, opt_vars) {
     // Use cached `this.ampdoc_` to trigger analytics since analytics
     // may be called after the <form> has been removed from the DOM.
-    triggerAnalyticsEvent(this.ampdoc_, eventType, opt_vars);
+    triggerAnalyticsEvent(this.form_, eventType, opt_vars);
   }
 
   /**

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1042,8 +1042,8 @@ export class AmpForm {
       promise = Promise.resolve(null);
     }
     return promise.then((responseJson) => {
-      this.triggerFormSubmitInAnalytics_('amp-form-submit-error');
       this.handleSubmitFailure_(e, responseJson, incomingTrust);
+      this.triggerFormSubmitInAnalytics_('amp-form-submit-error');
       this.maybeHandleRedirect_(e.response);
     });
   }

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1226,8 +1226,6 @@ export class AmpForm {
    * @private
    */
   analyticsEvent_(eventType, opt_vars) {
-    // Use cached `this.ampdoc_` to trigger analytics since analytics
-    // may be called after the <form> has been removed from the DOM.
     triggerAnalyticsEvent(this.form_, eventType, opt_vars);
   }
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -1144,7 +1144,7 @@ describes.repeated(
             env.sandbox.stub(ampForm.xhr_, 'fetch').rejects({
               response: {
                 json: () => {
-                  return Promise.resolve({'name': 'Tim Apple'});
+                  return Promise.resolve({'name': 'John Doe'});
                 },
               },
             });
@@ -1152,7 +1152,7 @@ describes.repeated(
               .stub(ampForm, 'analyticsEvent_')
               .throws('Test.');
             const renderedTemplate = createElement('div');
-            renderedTemplate.innerText = 'Hello, Tim Apple';
+            renderedTemplate.innerText = 'Hello, John Doe';
             env.sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
               .resolves(renderedTemplate);
@@ -1172,7 +1172,7 @@ describes.repeated(
                 expect(ampForm.templates_.findAndRenderTemplate).to.be.called;
                 expect(
                   ampForm.templates_.findAndRenderTemplate
-                ).calledWith(messageContainer, {'name': 'Tim Apple'});
+                ).calledWith(messageContainer, {'name': 'John Doe'});
                 expect(mutateElementStub).to.have.been.calledOnce;
                 expect(messageContainer.firstChild).to.equal(renderedTemplate);
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -33,6 +33,7 @@ import {DIRTINESS_INDICATOR_CLASS} from '../form-dirtiness';
 import {Services} from '../../../../src/services';
 import {cidServiceForDocForTesting} from '../../../../src/service/cid-impl';
 import {createCustomEvent} from '../../../../src/event-helper';
+import {createElementWithAttributes} from '../../../../src/dom';
 import {
   createFormDataWrapper,
   isFormDataWrapper,
@@ -45,7 +46,6 @@ import {
 } from '../form-validators';
 import {user} from '../../../../src/log';
 import {whenCalled} from '../../../../testing/test-helper.js';
-import {createElementWithAttributes} from '../../../../src/dom';
 
 describes.repeated(
   '',
@@ -103,6 +103,7 @@ describes.repeated(
           env.sandbox
             .stub(ampForm.ssrTemplateHelper_, 'isEnabled')
             .returns(false);
+          env.sandbox.stub(ampForm, 'analyticsEvent_');
           return Promise.resolve(ampForm);
         }
 
@@ -247,7 +248,6 @@ describes.repeated(
               ampForm.method_ = 'GET';
               env.sandbox.stub(form, 'submit');
               env.sandbox.stub(form, 'checkValidity').returns(true);
-              env.sandbox.stub(ampForm, 'analyticsEvent_');
               ampForm.ssrTemplateHelper_.isEnabled.restore();
               env.sandbox
                 .stub(ampForm.ssrTemplateHelper_, 'isEnabled')
@@ -1122,6 +1122,7 @@ describes.repeated(
 
         it('should render responses even if analytics throws', () => {
           expectAsyncConsoleError(/Form submission failed/);
+          expectAsyncConsoleError(/Sending analytics failed/, 2);
 
           return getAmpForm(getForm()).then((ampForm) => {
             const form = ampForm.form_;
@@ -1148,11 +1149,9 @@ describes.repeated(
                 },
               },
             });
-            env.sandbox
-              .stub(ampForm, 'analyticsEvent_')
-              .throws('Test.');
+            ampForm.analyticsEvent_.throws('Test.');
             const renderedTemplate = createElement('div');
-            renderedTemplate.innerText = 'Hello, John Doe';
+            renderedTemplate.innerText = 'Sorry, John Doe';
             env.sandbox
               .stub(ampForm.templates_, 'findAndRenderTemplate')
               .resolves(renderedTemplate);
@@ -1441,7 +1440,6 @@ describes.repeated(
             env.sandbox.stub(ampForm.xhr_, 'fetch').resolves({
               json: () => Promise.resolve({}),
             });
-            env.sandbox.stub(ampForm, 'analyticsEvent_');
 
             const event = {
               stopImmediatePropagation: env.sandbox.spy(),
@@ -1500,7 +1498,6 @@ describes.repeated(
             });
             env.sandbox.spy(ampForm.urlReplacement_, 'expandInputValueAsync');
             env.sandbox.stub(ampForm.urlReplacement_, 'expandInputValueSync');
-            env.sandbox.stub(ampForm, 'analyticsEvent_');
 
             // Setup some Promises
             const submitPromise = ampForm.submit_(ActionTrust.HIGH);
@@ -1641,7 +1638,6 @@ describes.repeated(
                 fetchResolver = resolve;
               })
             );
-            env.sandbox.stub(ampForm, 'analyticsEvent_');
             env.sandbox.stub(ampForm.actions_, 'trigger');
             const form = ampForm.form_;
             const event = {
@@ -1694,7 +1690,6 @@ describes.repeated(
           return getAmpForm(getForm(/*button1*/ true, /*button2*/ true)).then(
             (ampForm) => {
               let fetchRejecter;
-              env.sandbox.stub(ampForm, 'analyticsEvent_');
               env.sandbox.stub(ampForm.xhr_, 'fetch').returns(
                 new Promise((unusedResolve, reject) => {
                   fetchRejecter = reject;
@@ -2821,7 +2816,6 @@ describes.repeated(
             env.sandbox.stub(form, 'submit');
             env.sandbox.stub(form, 'checkValidity').returns(true);
             env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
-            env.sandbox.stub(ampForm, 'analyticsEvent_');
 
             env.sandbox.stub(ampForm, 'handleXhrSubmitSuccess_').resolves();
             const submitActionPromise = ampForm.handleSubmitAction_(
@@ -2865,7 +2859,6 @@ describes.repeated(
                 fetchResolver = resolve;
               })
             );
-            env.sandbox.stub(ampForm, 'analyticsEvent_');
             const event = {
               stopImmediatePropagation: env.sandbox.spy(),
               target: form,
@@ -2919,7 +2912,6 @@ describes.repeated(
                 fetchRejecter = reject;
               })
             );
-            env.sandbox.stub(ampForm, 'analyticsEvent_');
             const event = {
               stopImmediatePropagation: env.sandbox.spy(),
               target: form,
@@ -2977,7 +2969,6 @@ describes.repeated(
             env.sandbox.stub(ampForm.xhr_, 'fetch').resolves();
             env.sandbox.stub(ampForm.urlReplacement_, 'expandInputValueAsync');
             env.sandbox.spy(ampForm.urlReplacement_, 'expandInputValueSync');
-            env.sandbox.stub(ampForm, 'analyticsEvent_');
             ampForm.handleSubmitAction_(/* invocation */ {});
 
             const expectedFormData = {


### PR DESCRIPTION
**summary**
Fixes: https://github.com/ampproject/amphtml/issues/32577

Changelog:
- Surround call to analytics with try/catch s.t. an error with analytics won't get in the way of updating `<form>` state
- Analytics call to use cached ampdoc s.t. if the `<form>` is detached from DOM, it'll still function 
- Swap order of error flow so that form state is updated prior to analytics event
- Add unit test that fakes an analytics failure 