### PR TITLE
Fix extensions loading integration tests in Experiment C

### DIFF
--- a/test/integration/test-extensions-loading.js
+++ b/test/integration/test-extensions-loading.js
@@ -48,9 +48,14 @@ function testLoadOrderFixture(fixtureName, testElements) {
         const testElement = fixture.doc.querySelectorAll(testElements[i])[0];
         checkElementUpgrade(testElement);
         if (testElement.tagName == 'AMP-FIT-TEXT') {
-          expect(
-            fixture.doc.getElementsByClassName('i-amphtml-fit-text-content')
-          ).to.have.length(1);
+          // TODO(#32523) Remove this when Bento experiment is done.
+          if (BENTO_AUTO_UPGRADE) {
+            expect(testElement.shadowRoot).to.be.defined;
+          } else {
+            expect(
+              fixture.doc.getElementsByClassName('i-amphtml-fit-text-content')
+            ).to.have.length(1);
+          }
         }
       }
     });


### PR DESCRIPTION
The tests touched in this PR are [failing consistently in master](https://app.circleci.com/pipelines/github/ampproject/amphtml/1632/workflows/b015c46e-7d72-44d2-b858-03d61ce0d6a0/jobs/15686), due to `.i-amphtml-fit-text-content` not existing in the Bento version path. 

Note: If this PR is merged first we will not need #32581