### PR TITLE
Remove all (user|dev).fine/info/warn

### DIFF
--- a/3p/frame-metadata.js
+++ b/3p/frame-metadata.js
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import {dev} from '../src/log';
 import {dict} from '../src/utils/object.js';
-import {getMode} from '../src/mode';
 import {once} from '../src/utils/function.js';
 import {parseJson} from '../src/json';
 import {parseUrlDeprecated} from '../src/url';
@@ -64,9 +62,6 @@ const allMetadata = once(() => {
     //    to make it less terrible.
     return parseJson(iframeName);
   } catch (err) {
-    if (!getMode().test) {
-      dev().info('INTEGRATION', 'Could not parse context from:', iframeName);
-    }
     return FALLBACK;
   }
 });

--- a/ads/inabox/inabox-host.js
+++ b/ads/inabox/inabox-host.js
@@ -46,7 +46,6 @@ export class InaboxHost {
   constructor(win) {
     // Prevent double initialization
     if (win[AMP_INABOX_INITIALIZED]) {
-      dev().info(TAG, 'Skip a 2nd attempt of initializing AMP inabox host.');
       return;
     }
 
@@ -56,7 +55,6 @@ export class InaboxHost {
     setReportError(reportError);
 
     if (win[INABOX_IFRAMES] && !Array.isArray(win[INABOX_IFRAMES])) {
-      dev().info(TAG, 'Invalid %s. %s', INABOX_IFRAMES, win[INABOX_IFRAMES]);
       win[INABOX_IFRAMES] = [];
     }
     const host = new InaboxMessagingHost(win, win[INABOX_IFRAMES]);
@@ -64,7 +62,6 @@ export class InaboxHost {
     if (win.AMP[INABOX_UNREGISTER_IFRAME]) {
       // It's already defined; log a debug message and assume the existing
       // implmentation is good.
-      dev().info(TAG, `win.AMP[${INABOX_UNREGISTER_IFRAME}] already defined}`);
     } else {
       win.AMP[INABOX_UNREGISTER_IFRAME] = host.unregisterIframe.bind(host);
     }
@@ -86,8 +83,6 @@ export class InaboxHost {
           }
           processMessageFn(message);
         });
-      } else {
-        dev().info(TAG, 'Invalid %s %s', PENDING_MESSAGES, queuedMsgs);
       }
     }
     // Empty and ensure that future messages are no longer stored in the array.

--- a/ads/inabox/inabox-messaging-host.js
+++ b/ads/inabox/inabox-messaging-host.js
@@ -20,14 +20,11 @@ import {
   serializeMessage,
 } from '../../src/3p-frame-messaging';
 import {canInspectWindow} from '../../src/iframe-helper';
-import {dev, devAssert} from '../../src/log';
+import {devAssert} from '../../src/log';
 import {dict} from '../../src/utils/object';
 import {getData} from '../../src/event-helper';
 import {getFrameOverlayManager} from './frame-overlay-manager';
 import {getPositionObserver} from './position-observer';
-
-/** @const */
-const TAG = 'InaboxMessagingHost';
 
 /** @const */
 const READ_ONLY_MESSAGES = [MessageType.SEND_POSITIONS];
@@ -47,9 +44,6 @@ class NamedObservable {
    * @param {!Function} callback
    */
   listen(key, callback) {
-    if (key in this.map_) {
-      dev().fine(TAG, `Overriding message callback [${key}]`);
-    }
     this.map_[key] = callback;
   }
 
@@ -128,13 +122,11 @@ export class InaboxMessagingHost {
   processMessage(message) {
     const request = deserializeMessage(getData(message));
     if (!request || !request['sentinel']) {
-      dev().fine(TAG, 'Ignored non-AMP message:', message);
       return false;
     }
 
     const adFrame = this.getFrameElement_(message.source, request['sentinel']);
     if (!adFrame) {
-      dev().info(TAG, 'Ignored message from untrusted iframe:', message);
       return false;
     }
 
@@ -143,7 +135,6 @@ export class InaboxMessagingHost {
       ? allowedTypes.split(/\s*,\s*/)
       : READ_ONLY_MESSAGES;
     if (allowedTypesList.indexOf(request['type']) === -1) {
-      dev().info(TAG, 'Message type ignored:', message);
       return false;
     }
 
@@ -155,7 +146,6 @@ export class InaboxMessagingHost {
         message.origin,
       ])
     ) {
-      dev().warn(TAG, 'Unprocessed AMP message:', message);
       return false;
     }
 
@@ -197,7 +187,6 @@ export class InaboxMessagingHost {
    * @param {?JsonObject} data
    */
   sendPosition_(request, source, data) {
-    dev().fine(TAG, 'Sent position data to [%s] %s', request.sentinel, data);
     source./*OK*/ postMessage(
       serializeMessage(MessageType.POSITION, request.sentinel, data),
       // We don't need to restrict what origin we send the data to because (a)

--- a/ads/vendors/_ping_.js
+++ b/ads/vendors/_ping_.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {dev, devAssert, userAssert} from '../../src/log';
+import {devAssert, userAssert} from '../../src/log';
 import {validateData} from '../../3p/3p';
 
 /**
@@ -64,34 +64,9 @@ export function _ping_(global, data) {
     }
     if (data.enableIo) {
       global.context.observeIntersection(function (changes) {
-        /** @type {!Array} */ (changes).forEach(function (c) {
-          dev().info(
-            'AMP-AD',
-            'Intersection: (WxH)' +
-              `${c.intersectionRect.width}x${c.intersectionRect.height}`
-          );
-        });
         // store changes to global.lastIO for testing purpose
         global.ping.lastIO = changes[changes.length - 1];
       });
-    }
-    global.context.getHtml('a', ['href'], function (html) {
-      dev().info('GET-HTML', html);
-    });
-    global.context.getConsentState(function (consentState) {
-      dev().info('GET-CONSENT-STATE', consentState);
-    });
-    if (global.context.consentSharedData) {
-      const TAG = 'consentSharedData';
-      dev().info(TAG, global.context.consentSharedData);
-    }
-    if (global.context.initialConsentValue) {
-      const TAG = 'consentStringValue';
-      dev().info(TAG, global.context.initialConsentValue);
-    }
-    if (global.context.initialConsentMetadata) {
-      const TAG = 'consentMetadata';
-      dev().info(TAG, global.context.initialConsentMetadata);
     }
   } else {
     global.setTimeout(() => {

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
@@ -20,21 +20,21 @@ const {resolve, dirname, relative, join} = require('path').posix;
 // key is a valid callee name to potentially remove.
 // value.detected indicates if the callee name (key) was imported into the current module.
 // value.removeable is the array of property names that can be removed.
-// Example: ['dev', {detected: false, removeable: ['fine']}] would mean ... `dev().info(...)` can be removed.
+// Example: ['dev', {detected: false, removeable: ['fine']}] would mean ... `dev().fine(...)` can be removed.
 function defaultCalleeToPropertiesMap() {
   return new Map([
     [
       'dev',
       {
         detected: false,
-        removeable: ['info', 'warn'],
+        removeable: ['info', 'fine', 'warn'],
       },
     ],
     [
       'user',
       {
         detected: false,
-        removeable: ['info', 'warn'],
+        removeable: ['info', 'fine', 'warn'],
       },
     ],
   ]);

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/index.js
@@ -20,21 +20,21 @@ const {resolve, dirname, relative, join} = require('path').posix;
 // key is a valid callee name to potentially remove.
 // value.detected indicates if the callee name (key) was imported into the current module.
 // value.removeable is the array of property names that can be removed.
-// Example: ['dev', {detected: false, removeable: ['fine']}] would mean ... `dev().fine(...)` can be removed.
+// Example: ['dev', {detected: false, removeable: ['fine']}] would mean ... `dev().info(...)` can be removed.
 function defaultCalleeToPropertiesMap() {
   return new Map([
     [
       'dev',
       {
         detected: false,
-        removeable: ['info', 'fine', 'warn'],
+        removeable: ['info', 'warn'],
       },
     ],
     [
       'user',
       {
         detected: false,
-        removeable: ['info', 'fine', 'warn'],
+        removeable: ['info', 'warn'],
       },
     ],
   ]);

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/input.js
@@ -22,8 +22,6 @@ dev().info(
   fromLocation.search
 );
 dev().info;
-user().fine(TAG, 'fine');
-user().fine;
 user().info('Should not be removed');
 
 function hello() {
@@ -32,8 +30,6 @@ function hello() {
     'Removing iframe query string before navigation:',
     fromLocation.search
   );
-  dev().fine(TAG, 'fine');
-  user().fine(TAG, 'fine');
   user().info('Should be removed');
   user().error('Should not be removed');
   return false;
@@ -45,7 +41,6 @@ export function helloAgain() {
     'Removing iframe query string before navigation:',
     fromLocation.search
   );
-  dev().fine(TAG, 'fine');
   user().warn(TAG, 'warn');
   user().error('Should not be removed');
   return false;
@@ -58,8 +53,6 @@ class Foo {
       'Removing iframe query string before navigation:',
       fromLocation.search
     );
-    dev().fine(TAG, 'fine');
-    user().fine(TAG, 'fine');
     dev().error(TAG, 'Should not be removed');
     user().error('Should not be removed');
   }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/input.js
@@ -22,6 +22,8 @@ dev().info(
   fromLocation.search
 );
 dev().info;
+user().fine(TAG, 'fine');
+user().fine;
 user().info('Should not be removed');
 
 function hello() {
@@ -30,6 +32,8 @@ function hello() {
     'Removing iframe query string before navigation:',
     fromLocation.search
   );
+  dev().fine(TAG, 'fine');
+  user().fine(TAG, 'fine');
   user().info('Should be removed');
   user().error('Should not be removed');
   return false;
@@ -41,6 +45,7 @@ export function helloAgain() {
     'Removing iframe query string before navigation:',
     fromLocation.search
   );
+  dev().fine(TAG, 'fine');
   user().warn(TAG, 'warn');
   user().error('Should not be removed');
   return false;
@@ -53,6 +58,8 @@ class Foo {
       'Removing iframe query string before navigation:',
       fromLocation.search
     );
+    dev().fine(TAG, 'fine');
+    user().fine(TAG, 'fine');
     dev().error(TAG, 'Should not be removed');
     user().error('Should not be removed');
   }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/output.mjs
@@ -15,7 +15,6 @@
  */
 import { dev, user } from '../../../../../../../src/log';
 dev().info;
-user().fine;
 
 function hello() {
   user().error('Should not be removed');

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-both-usage/output.mjs
@@ -15,6 +15,7 @@
  */
 import { dev, user } from '../../../../../../../src/log';
 dev().info;
+user().fine;
 
 function hello() {
   user().error('Should not be removed');

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/input.js
@@ -16,20 +16,25 @@
 
 import {user} from '../../../../../../../src/log';
 
+user().fine(TAG, 'fine');
+user().fine;
 user().error('Should not be removed');
 
 function hello() {
+  user().fine(TAG, 'fine');
   user().info('Should be removed');
   return false;
 }
 
 export function helloAgain() {
+  user().fine(TAG, 'fine');
   user().error('Should not be removed');
   return false;
 }
 
 class Foo {
   method() {
+    user().fine(TAG, 'fine');
     user().info('Should be removed');
   }
 }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/input.js
@@ -16,25 +16,20 @@
 
 import {user} from '../../../../../../../src/log';
 
-user().fine(TAG, 'fine');
-user().fine;
 user().error('Should not be removed');
 
 function hello() {
-  user().fine(TAG, 'fine');
   user().info('Should be removed');
   return false;
 }
 
 export function helloAgain() {
-  user().fine(TAG, 'fine');
   user().error('Should not be removed');
   return false;
 }
 
 class Foo {
   method() {
-    user().fine(TAG, 'fine');
     user().info('Should be removed');
   }
 }

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/output.mjs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { user } from '../../../../../../../src/log';
-user().fine;
 user().error('Should not be removed');
 
 function hello() {

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/imported-user-usage/output.mjs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { user } from '../../../../../../../src/log';
+user().fine;
 user().error('Should not be removed');
 
 function hello() {

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/input.js
@@ -23,6 +23,3 @@ dev().info;
 
 dev().fine(TAG, 'fine');
 dev().fine;
-
-user().fine(TAG, 'user fine');
-user().fine;

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/input.js
@@ -23,3 +23,6 @@ dev().info;
 
 dev().fine(TAG, 'fine');
 dev().fine;
+
+user().fine(TAG, 'user fine');
+user().fine;

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/output.js
@@ -17,5 +17,3 @@ dev().info(TAG, 'Removing iframe query string before navigation:', fromLocation.
 dev().info;
 dev().fine(TAG, 'fine');
 dev().fine;
-user().fine(TAG, 'user fine');
-user().fine;

--- a/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-dev-methods/test/fixtures/transform-assertions/no-import/output.js
@@ -17,3 +17,5 @@ dev().info(TAG, 'Removing iframe query string before navigation:', fromLocation.
 dev().info;
 dev().fine(TAG, 'fine');
 dev().fine;
+user().fine(TAG, 'user fine');
+user().fine;

--- a/builtins/amp-pixel.js
+++ b/builtins/amp-pixel.js
@@ -61,7 +61,6 @@ export class AmpPixel extends BaseElement {
       this.element.hasAttribute('i-amphtml-ssr') &&
       this.element.querySelector('img')
     ) {
-      dev().info(TAG, 'inabox img already present');
       return;
     }
     // Trigger, but only when visible.
@@ -95,7 +94,6 @@ export class AmpPixel extends BaseElement {
               return;
             }
             const pixel = createPixel(this.win, src, this.referrerPolicy_);
-            dev().info(TAG, 'pixel triggered: ', src);
             return pixel;
           });
       });

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -615,11 +615,6 @@ export class AmpA4A extends AMP.BaseElement {
       // TODO(levitzky): May need additional checks for other display:hidden cases.
       this.element.classList.contains('i-amphtml-hidden-by-media-query')
     ) {
-      dev().fine(
-        TAG,
-        'onLayoutMeasure canceled due height/width 0',
-        this.element
-      );
       return false;
     }
     if (!isAdPositionAllowed(this.element, this.win)) {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -418,12 +418,6 @@ export class AmpA4A extends AMP.BaseElement {
       width: this.element.getAttribute('width'),
       height: this.element.getAttribute('height'),
     };
-    const upgradeDelayMs = Math.round(this.getResource().getUpgradeDelayMs());
-    dev().info(
-      TAG,
-      `upgradeDelay ${this.element.getAttribute('type')}: ${upgradeDelayMs}`
-    );
-
     this.uiHandler = new AMP.AmpAdUIHandler(this);
 
     const verifier = signatureVerifierFor(this.win);
@@ -836,7 +830,6 @@ export class AmpA4A extends AMP.BaseElement {
             this.win.location.search
           );
           if (match && match[1]) {
-            dev().info(TAG, `Using debug exp features: ${match[1]}`);
             this.populatePostAdResponseExperimentFeatures_(
               tryDecodeUriComponent(match[1])
             );
@@ -1622,19 +1615,6 @@ export class AmpA4A extends AMP.BaseElement {
     );
   }
 
-  /**
-   * @param {!Element} iframe that was just created.  To be overridden for
-   * testing.
-   * @visibleForTesting
-   */
-  onCrossDomainIframeCreated(iframe) {
-    dev().info(
-      TAG,
-      this.element.getAttribute('type'),
-      `onCrossDomainIframeCreated ${iframe}`
-    );
-  }
-
   /** @return {boolean} whether html creatives should be sandboxed. */
   sandboxHTMLCreativeFrame() {
     return true;
@@ -1672,10 +1652,6 @@ export class AmpA4A extends AMP.BaseElement {
         if (networkFailureHandlerResult.frameGetDisabled) {
           // Reset adUrl to null which will cause layoutCallback to not
           // fetch via frame GET.
-          dev().info(
-            TAG,
-            'frame get disabled as part of network failure handler'
-          );
           this.resetAdUrl();
         } else {
           this.adUrl_ = networkFailureHandlerResult.adUrl || this.adUrl_;

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1193,7 +1193,6 @@ export class AmpA4A extends AMP.BaseElement {
       }
       const parts = line.split('=');
       if (parts.length != 2 || !parts[0]) {
-        dev().warn(TAG, `invalid experiment feature ${line}`);
         return;
       }
       this.postAdResponseExperimentFeatures[parts[0]] = parts[1];
@@ -1421,11 +1420,10 @@ export class AmpA4A extends AMP.BaseElement {
         .then(() => {
           this.originalSlotSize_ = null;
         })
-        .catch((err) => {
+        .catch(() => {
           // TODO(keithwrightbos): if we are unable to revert size, on next
           // trigger of promise chain the ad request may fail due to invalid
           // slot size.  Determine how to handle this case.
-          dev().warn(TAG, 'unable to revert to original size', err);
         });
     }
 
@@ -1724,8 +1722,6 @@ export class AmpA4A extends AMP.BaseElement {
       );
       return Promise.resolve(false);
     }
-    // TODO(keithwrightbos): remove when no longer needed.
-    dev().warn(TAG, 'fallback to 3p');
     // Haven't rendered yet, so try rendering via one of our
     // cross-domain iframe solutions.
     const method = this.experimentalNonAmpCreativeRenderMethod_;
@@ -2196,23 +2192,11 @@ export class AmpA4A extends AMP.BaseElement {
     }
     if (metadataStart < 0) {
       // Couldn't find a metadata blob.
-      dev().warn(
-        TAG,
-        this.element.getAttribute('type'),
-        'Could not locate start index for amp meta data in: %s',
-        creative
-      );
       return null;
     }
     const metadataEnd = creative.lastIndexOf('</script>');
     if (metadataEnd < 0) {
       // Couldn't find a metadata blob.
-      dev().warn(
-        TAG,
-        this.element.getAttribute('type'),
-        'Could not locate closing script tag for amp meta data in: %s',
-        creative
-      );
       return null;
     }
     try {
@@ -2287,12 +2271,6 @@ export class AmpA4A extends AMP.BaseElement {
         creative.slice(metadataEnd + '</script>'.length);
       return metaData;
     } catch (err) {
-      dev().warn(
-        TAG,
-        this.element.getAttribute('type'),
-        'Invalid amp metadata: %s',
-        creative.slice(metadataStart + metadataString.length, metadataEnd)
-      );
       if (this.isSinglePageStoryAd) {
         throw err;
       }

--- a/extensions/amp-a4a/0.1/amp-ad-network-base.js
+++ b/extensions/amp-a4a/0.1/amp-ad-network-base.js
@@ -81,7 +81,7 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
     return this.adResponsePromise_
       .then((response) => this.invokeValidator_(response))
       .then((validatorResult) => this.invokeRenderer_(validatorResult))
-      .catch((error) => this.handleFailure_(error.type, error.msg));
+      .catch((error) => this.handleFailure_(error.type));
   }
 
   /**
@@ -90,12 +90,6 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
    * @final
    */
   onFailure(failure, recovery) {
-    if (this.recoveryModes_[failure]) {
-      dev().warn(
-        TAG,
-        `Recovery mode for failure type ${failure} already registered!`
-      );
-    }
     this.recoveryModes_[failure] = recovery;
   }
 
@@ -105,9 +99,6 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
    * @final
    */
   registerValidator(validator, type = 'default') {
-    if (this.validators_[type]) {
-      dev().warn(TAG, `${type} validator already registered.`);
-    }
     this.validators_[type] = validator;
   }
 
@@ -117,9 +108,6 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
    * @final
    */
   registerRenderer(renderer, type) {
-    if (this.renderers_[type]) {
-      dev().warn(TAG, `Rendering mode already registered for type '${type}'`);
-    }
     this.renderers_[type] = renderer;
   }
 
@@ -196,14 +184,10 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
 
   /**
    * @param {FailureType} failureType
-   * @param {*=} error
    * @private
    */
-  handleFailure_(failureType, error) {
+  handleFailure_(failureType) {
     const recoveryMode = this.recoveryModes_[failureType];
-    if (error) {
-      dev().warn(TAG, error);
-    }
     switch (recoveryMode) {
       case RecoveryModeType.COLLAPSE:
         this.forceCollapse_();

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
 import {isArray, isObject} from '../../../src/types';
 import {isSecureUrlDeprecated} from '../../../src/url';
 import {parseJson} from '../../../src/json';
-
-const TAG = 'amp-ad-util';
 
 /**
  * Sends a CORS XHR request to the given URL.
@@ -64,20 +61,11 @@ export function getAmpAdMetadata(creative) {
   }
   if (metadataStart < 0) {
     // Couldn't find a metadata blob.
-    dev().warn(
-      TAG,
-      `Could not locate start index for amp meta data in: ${creative}`
-    );
     return null;
   }
   const metadataEnd = creative.lastIndexOf('</script>');
   if (metadataEnd < 0) {
     // Couldn't find a metadata blob.
-    dev().warn(
-      TAG,
-      'Could not locate closing script tag for amp meta data in: %s',
-      creative
-    );
     return null;
   }
   try {
@@ -152,11 +140,6 @@ export function getAmpAdMetadata(creative) {
       creative.slice(metadataEnd + '</script>'.length);
     return metaData;
   } catch (err) {
-    dev().warn(
-      TAG,
-      'Invalid amp metadata: %s',
-      creative.slice(metadataStart + metadataString.length, metadataEnd)
-    );
     return null;
   }
 }

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -245,7 +245,6 @@ export class LaterpayVendor {
         return this.accessSource_.getLoginUrl(url);
       })
       .then((url) => {
-        dev().info(TAG, 'Authorization URL: ', url);
         return this.timer_
           .timeoutPromise(
             AUTHORIZATION_TIMEOUT,

--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -557,7 +557,6 @@ export class LaterpayVendor {
       /* useAuthData */ false
     );
     return urlPromise.then((url) => {
-      dev().fine(TAG, 'Authorization URL: ', url);
       this.accessSource_.loginWithUrl(url, purchaseType);
     });
   }

--- a/extensions/amp-access-laterpay/0.2/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.2/laterpay-impl.js
@@ -281,7 +281,6 @@ export class LaterpayVendor {
         return this.accessSource_.getLoginUrl(url);
       })
       .then((url) => {
-        dev().info(TAG, 'Authorization URL: ', url);
         return this.timer_
           .timeoutPromise(
             AUTHORIZATION_TIMEOUT,

--- a/extensions/amp-access-laterpay/0.2/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.2/laterpay-impl.js
@@ -616,7 +616,6 @@ export class LaterpayVendor {
       /* useAuthData */ false
     );
     return urlPromise.then((url) => {
-      dev().fine(TAG, 'Authorization URL: ', url);
       this.accessSource_.loginWithUrl(url, purchaseType);
     });
   }

--- a/extensions/amp-access-poool/0.1/poool-impl.js
+++ b/extensions/amp-access-poool/0.1/poool-impl.js
@@ -15,13 +15,11 @@
  */
 import {Services} from '../../../src/services';
 import {addParamToUrl, addParamsToUrl} from '../../../src/url';
-import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {listenFor} from '../../../src/iframe-helper';
 import {resetStyles, setStyle, setStyles} from '../../../src/style';
-
-const TAG = 'amp-access-poool';
+import {user, userAssert} from '../../../src/log';
 
 const ACCESS_CONFIG = {
   'authorization': 'https://api.poool.fr/api/v3/amp/access?rid=READER_ID',
@@ -169,7 +167,6 @@ export class PooolVendor {
         return this.accessSource_.getLoginUrl(url);
       })
       .then((url) => {
-        dev().info(TAG, 'Authorization URL: ', url);
         return this.timer_
           .timeoutPromise(AUTHORIZATION_TIMEOUT, this.xhr_.fetchJson(url))
           .then((res) => res.json());

--- a/extensions/amp-access/0.1/amp-access-client.js
+++ b/extensions/amp-access/0.1/amp-access-client.js
@@ -16,12 +16,9 @@
 
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, devAssert, userAssert} from '../../../src/log';
+import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
-
-/** @const {string} */
-const TAG = 'amp-access-client';
 
 /** @const {number} */
 const DEFAULT_AUTHORIZATION_TIMEOUT = 3000;
@@ -120,13 +117,11 @@ export class AccessClientAdapter {
 
   /** @override */
   authorize() {
-    dev().fine(TAG, 'Start authorization via ', this.authorizationUrl_);
     const urlPromise = this.context_.buildUrl(
       this.authorizationUrl_,
       /* useAuthData */ false
     );
     return urlPromise.then((url) => {
-      dev().fine(TAG, 'Authorization URL: ', url);
       return this.timer_
         .timeoutPromise(
           this.authorizationTimeout_,
@@ -150,7 +145,6 @@ export class AccessClientAdapter {
       /* useAuthData */ true
     );
     return promise.then((url) => {
-      dev().fine(TAG, 'Pingback URL: ', url);
       return this.xhr_.sendSignal(url, {
         method: 'POST',
         credentials: 'include',

--- a/extensions/amp-access/0.1/amp-access-other.js
+++ b/extensions/amp-access/0.1/amp-access-other.js
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-import {dev, devAssert} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {isProxyOrigin} from '../../../src/url';
-
-/** @const {string} */
-const TAG = 'amp-access-other';
 
 /** @implements {./amp-access-source.AccessTypeAdapterDef} */
 export class AccessOtherAdapter {
@@ -58,7 +55,6 @@ export class AccessOtherAdapter {
 
   /** @override */
   authorize() {
-    dev().fine(TAG, 'Use the authorization fallback for type=other');
     // Disallow authorization for proxy origin (`cdn.ampproject.org`).
     devAssert(!this.isProxyOrigin_, 'Cannot authorize for proxy origin');
     const response = devAssert(this.authorizationResponse_);
@@ -72,7 +68,6 @@ export class AccessOtherAdapter {
 
   /** @override */
   pingback() {
-    dev().fine(TAG, 'Ignore pingback');
     return Promise.resolve();
   }
 

--- a/extensions/amp-access/0.1/amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/amp-access-server-jwt.js
@@ -344,7 +344,6 @@ export class AccessServerJwtAdapter {
             `[i-amphtml-access-id="${escapeCssSelectorIdent(sectionId)}"]`
           );
         if (!target) {
-          dev().warn(TAG, 'Section not found: ', sectionId);
           continue;
         }
         target.parentElement.replaceChild(

--- a/extensions/amp-access/0.1/amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/amp-access-server-jwt.js
@@ -158,13 +158,6 @@ export class AccessServerJwtAdapter {
 
   /** @override */
   authorize() {
-    dev().fine(
-      TAG,
-      'Start authorization with ',
-      this.isProxyOrigin_ ? 'proxy' : 'non-proxy',
-      this.serverState_,
-      this.clientAdapter_.getAuthorizationUrl()
-    );
     if (!this.isProxyOrigin_ || !this.serverState_) {
       return this.authorizeOnClient_();
     }
@@ -197,7 +190,6 @@ export class AccessServerJwtAdapter {
     );
     let jwtPromise = urlPromise
       .then((url) => {
-        dev().fine(TAG, 'Authorization URL: ', url);
         return this.timer_.timeoutPromise(
           AUTHORIZATION_TIMEOUT,
           this.xhr_.fetchText(url, {
@@ -296,11 +288,6 @@ export class AccessServerJwtAdapter {
    * @private
    */
   authorizeOnClient_() {
-    dev().fine(
-      TAG,
-      'Proceed via client protocol via ',
-      this.clientAdapter_.getAuthorizationUrl()
-    );
     return this.fetchJwt_().then((resp) => {
       return resp.jwt['amp_authdata'];
     });
@@ -311,7 +298,6 @@ export class AccessServerJwtAdapter {
    * @private
    */
   authorizeOnServer_() {
-    dev().fine(TAG, 'Proceed via server protocol');
     return this.fetchJwt_().then((resp) => {
       const {encoded, jwt} = resp;
       const accessData = jwt['amp_authdata'];
@@ -322,8 +308,6 @@ export class AccessServerJwtAdapter {
           'jwt': encoded,
         })
       );
-      dev().fine(TAG, 'Authorization request: ', this.serviceUrl_, request);
-      dev().fine(TAG, '- access data: ', accessData);
       // Note that `application/x-www-form-urlencoded` is used to avoid
       // CORS preflight request.
       return this.timer_
@@ -338,7 +322,6 @@ export class AccessServerJwtAdapter {
           })
         )
         .then((response) => {
-          dev().fine(TAG, 'Authorization response: ', response);
           return this.replaceSections_(response);
         })
         .then(() => accessData);
@@ -351,7 +334,6 @@ export class AccessServerJwtAdapter {
    */
   replaceSections_(doc) {
     const sections = doc.querySelectorAll('[i-amphtml-access-id]');
-    dev().fine(TAG, '- access sections: ', sections);
     return this.vsync_.mutatePromise(() => {
       for (let i = 0; i < sections.length; i++) {
         const section = sections[i];

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -114,19 +114,9 @@ export class AccessServerAdapter {
 
   /** @override */
   authorize() {
-    dev().fine(
-      TAG,
-      'Start authorization with ',
-      this.isProxyOrigin_ ? 'proxy' : 'non-proxy',
-      this.serverState_,
-      this.clientAdapter_.getAuthorizationUrl()
-    );
     if (!this.isProxyOrigin_ || !this.serverState_) {
-      dev().fine(TAG, 'Proceed via client protocol');
       return this.clientAdapter_.authorize();
     }
-
-    dev().fine(TAG, 'Proceed via server protocol');
 
     const varsPromise = this.context_.collectUrlVars(
       this.clientAdapter_.getAuthorizationUrl(),
@@ -145,7 +135,6 @@ export class AccessServerAdapter {
           'state': this.serverState_,
           'vars': requestVars,
         });
-        dev().fine(TAG, 'Authorization request: ', this.serviceUrl_, request);
         // Note that `application/x-www-form-urlencoded` is used to avoid
         // CORS preflight request.
         return this.timer_.timeoutPromise(
@@ -160,13 +149,11 @@ export class AccessServerAdapter {
         );
       })
       .then((responseDoc) => {
-        dev().fine(TAG, 'Authorization response: ', responseDoc);
         const accessDataString = devAssert(
           responseDoc.querySelector('script[id="amp-access-data"]'),
           'No authorization data available'
         ).textContent;
         const accessData = parseJson(accessDataString);
-        dev().fine(TAG, '- access data: ', accessData);
 
         return this.replaceSections_(responseDoc).then(() => {
           return accessData;
@@ -195,7 +182,6 @@ export class AccessServerAdapter {
    */
   replaceSections_(doc) {
     const sections = doc.querySelectorAll('[i-amphtml-access-id]');
-    dev().fine(TAG, '- access sections: ', sections);
     return this.vsync_.mutatePromise(() => {
       for (let i = 0; i < sections.length; i++) {
         const section = sections[i];

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -16,16 +16,13 @@
 
 import {AccessClientAdapter} from './amp-access-client';
 import {Services} from '../../../src/services';
-import {dev, devAssert} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {fetchDocument} from '../../../src/document-fetcher';
 import {isExperimentOn} from '../../../src/experiments';
 import {isProxyOrigin, removeFragment} from '../../../src/url';
 import {parseJson} from '../../../src/json';
-
-/** @const {string} */
-const TAG = 'amp-access-server';
 
 /**
  * This class implements server-side authorization protocol. In this approach
@@ -192,7 +189,6 @@ export class AccessServerAdapter {
             `[i-amphtml-access-id="${escapeCssSelectorIdent(sectionId)}"]`
           );
         if (!target) {
-          dev().warn(TAG, 'Section not found: ', sectionId);
           continue;
         }
         target.parentElement.replaceChild(

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -224,7 +224,6 @@ export class AccessSource {
       type = AccessType.CLIENT;
     }
     if (type == AccessType.CLIENT && this.isServerEnabled_) {
-      user().info(TAG, 'Forcing access type: SERVER');
       type = AccessType.SERVER;
     }
     return type;

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -283,14 +283,6 @@ export class AccessSource {
    * Do some initial setup.
    */
   start() {
-    dev().fine(
-      TAG,
-      'config:',
-      this.type_,
-      this.loginConfig_,
-      this.adapter_.getConfig()
-    );
-
     // Calculate login URLs right away.
     this.buildLoginUrls_();
   }
@@ -348,7 +340,6 @@ export class AccessSource {
    */
   runAuthorization(opt_disableFallback) {
     if (!this.adapter_.isAuthorizationEnabled()) {
-      dev().fine(TAG, 'Ignore authorization for type=', this.type_);
       this.firstAuthorizationResolver_();
       return Promise.resolve();
     }
@@ -367,7 +358,6 @@ export class AccessSource {
 
     const promise = responsePromise
       .then((response) => {
-        dev().fine(TAG, 'Authorization response: ', response);
         this.setAuthResponse_(response);
         this.buildLoginUrls_();
         return response;
@@ -397,7 +387,6 @@ export class AccessSource {
     return this.adapter_
       .pingback()
       .then(() => {
-        dev().fine(TAG, 'Pingback complete');
         this.analyticsEvent_('access-pingback-sent');
       })
       .catch((error) => {
@@ -472,13 +461,10 @@ export class AccessSource {
       return this.loginPromise_;
     }
 
-    dev().fine(TAG, 'Start login: ', loginUrl, eventLabel);
-
     this.loginAnalyticsEvent_(eventLabel, 'started');
     const dialogPromise = this.openLoginDialog_(loginUrl);
     const loginPromise = dialogPromise
       .then((result) => {
-        dev().fine(TAG, 'Login dialog completed: ', eventLabel, result);
         this.loginPromise_ = null;
         const query = parseQueryString(result);
         const s = query['success'];
@@ -504,7 +490,6 @@ export class AccessSource {
         }
       })
       .catch((reason) => {
-        dev().fine(TAG, 'Login dialog failed: ', eventLabel, reason);
         this.loginAnalyticsEvent_(eventLabel, 'failed');
         if (this.loginPromise_ == loginPromise) {
           this.loginPromise_ = null;

--- a/extensions/amp-access/0.1/amp-access-vendor.js
+++ b/extensions/amp-access/0.1/amp-access-vendor.js
@@ -16,10 +16,7 @@
 
 import './access-vendor';
 import {Deferred} from '../../../src/utils/promise';
-import {dev, userAssert} from '../../../src/log';
-
-/** @const {string} */
-const TAG = 'amp-access-vendor';
+import {userAssert} from '../../../src/log';
 
 /**
  * The adapter for a vendor implementation that implements `AccessVendor`
@@ -84,7 +81,6 @@ export class AccessVendorAdapter {
 
   /** @override */
   authorize() {
-    dev().fine(TAG, 'Start authorization via ', this.vendorName_);
     return this.vendorPromise_.then((vendor) => {
       return vendor.authorize();
     });
@@ -97,7 +93,6 @@ export class AccessVendorAdapter {
 
   /** @override */
   pingback() {
-    dev().fine(TAG, 'Pingback via ', this.vendorName_);
     return this.vendorPromise_.then((vendor) => {
       return vendor.pingback();
     });

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -599,7 +599,6 @@ export class AccessService {
     if (this.reportViewPromise_) {
       return this.reportViewPromise_;
     }
-    dev().fine(TAG, 'start view monitoring');
     this.reportViewPromise_ = this.whenViewed_(timeToView)
       .then(() => {
         // Wait for the most recent authorization flow to complete.
@@ -612,7 +611,6 @@ export class AccessService {
       })
       .catch((reason) => {
         // Ignore - view has been canceled.
-        dev().fine(TAG, 'view cancelled:', reason);
         this.reportViewPromise_ = null;
         throw reason;
       });

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -312,7 +312,6 @@ export class AccessService {
    */
   start_() {
     if (!this.enabled_) {
-      user().info(TAG, 'Access is disabled - no "id=amp-access" element');
       return this;
     }
     this.startInternal_();

--- a/extensions/amp-access/0.1/login-dialog.js
+++ b/extensions/amp-access/0.1/login-dialog.js
@@ -15,16 +15,13 @@
  */
 
 import {Services} from '../../../src/services';
-import {dev, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getData, listen} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
 import {openWindowDialog} from '../../../src/dom';
 import {parseUrlDeprecated} from '../../../src/url';
 import {urls} from '../../../src/config';
-
-/** @const */
-const TAG = 'amp-access-login';
+import {userAssert} from '../../../src/log';
 
 /** @const {!RegExp} */
 const RETURN_URL_REGEX = new RegExp('RETURN_URL');
@@ -104,7 +101,6 @@ class ViewerLoginDialog {
    */
   open() {
     return this.getLoginUrl().then((loginUrl) => {
-      dev().fine(TAG, 'Open viewer dialog: ', loginUrl);
       return this.viewer.sendMessageAwaitResponse(
         'openDialog',
         dict({
@@ -232,19 +228,16 @@ export class WebLoginDialog {
     this.dialogReadyPromise_ = null;
     if (typeof this.urlOrPromise == 'string') {
       const loginUrl = buildLoginUrl(this.urlOrPromise, returnUrl);
-      dev().fine(TAG, 'Open dialog: ', loginUrl, returnUrl, w, h, x, y);
       this.dialog_ = openWindowDialog(this.win, loginUrl, '_blank', options);
       if (this.dialog_) {
         this.dialogReadyPromise_ = Promise.resolve();
       }
     } else {
-      dev().fine(TAG, 'Open dialog: ', 'about:blank', returnUrl, w, h, x, y);
       this.dialog_ = openWindowDialog(this.win, '', '_blank', options);
       if (this.dialog_) {
         this.dialogReadyPromise_ = this.urlOrPromise.then(
           (url) => {
             const loginUrl = buildLoginUrl(url, returnUrl);
-            dev().fine(TAG, 'Set dialog url: ', loginUrl);
             this.dialog_.location.replace(loginUrl);
           },
           (error) => {
@@ -288,14 +281,12 @@ export class WebLoginDialog {
     }, 500);
 
     this.messageUnlisten_ = listen(this.win, 'message', (e) => {
-      dev().fine(TAG, 'MESSAGE:', e);
       if (e.origin != returnOrigin) {
         return;
       }
       if (!getData(e) || getData(e)['sentinel'] != 'amp') {
         return;
       }
-      dev().fine(TAG, 'Received message from dialog: ', getData(e));
       if (getData(e)['type'] == 'result') {
         if (this.dialog_) {
           this.dialog_./*OK*/ postMessage(
@@ -320,7 +311,6 @@ export class WebLoginDialog {
     if (!this.resolve_) {
       return;
     }
-    dev().fine(TAG, 'Login done: ', result, opt_error);
     if (opt_error) {
       this.reject_(opt_error);
     } else {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -246,12 +246,6 @@ class AmpAccordion extends AMP.BaseElement {
           ))
         : dict();
     } catch (e) {
-      dev().fine(
-        'AMP-ACCORDION',
-        'Error setting session state: %s, %s',
-        e.message,
-        e.stack
-      );
       return dict();
     }
   }
@@ -270,14 +264,7 @@ class AmpAccordion extends AMP.BaseElement {
         dev().assertString(this.sessionId_),
         sessionStr
       );
-    } catch (e) {
-      dev().fine(
-        'AMP-ACCORDION',
-        'Error setting session state: %s, %s',
-        e.message,
-        e.stack
-      );
-    }
+    } catch (e) {}
   }
 
   /**

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -305,7 +305,6 @@ export class AmpAdExit extends AMP.BaseElement {
   filter_(filters, event) {
     return filters.every((filter) => {
       const result = filter.filter(event);
-      user().info(TAG, `Filter '${filter.name}': ${result ? 'pass' : 'fail'}`);
       return result;
     });
   }

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -151,7 +151,6 @@ export class AmpAdExit extends AMP.BaseElement {
         .then((exitService) => exitService.openUrl(finalUrl))
         .catch((error) => {
           // TODO: reporting on errors
-          dev().fine(TAG, 'ExitServiceError - fallback=' + error.fallback);
           if (error.fallback) {
             openWindowDialog(this.win, finalUrl, '_blank');
           }
@@ -282,7 +281,6 @@ export class AmpAdExit extends AMP.BaseElement {
    * @param {string} url
    */
   pingTrackingUrl_(url) {
-    user().fine(TAG, `pinging ${url}`);
     if (
       this.transport_.beacon &&
       this.win.navigator.sendBeacon &&

--- a/extensions/amp-ad-exit/0.1/filters/click-delay.js
+++ b/extensions/amp-ad-exit/0.1/filters/click-delay.js
@@ -15,10 +15,7 @@
  */
 
 import {Filter, FilterType} from './filter';
-import {dev, userAssert} from '../../../../src/log';
-
-/** @type {string} */
-const TAG = 'amp-ad-exit';
+import {userAssert} from '../../../../src/log';
 
 export class ClickDelayFilter extends Filter {
   /**
@@ -49,19 +46,9 @@ export class ClickDelayFilter extends Filter {
 
     if (spec.startTimingEvent) {
       if (!win['performance'] || !win['performance']['timing']) {
-        dev().warn(
-          TAG,
-          'Browser does not support performance timing, ' +
-            'falling back to now'
-        );
       } else if (
         win['performance']['timing'][spec.startTimingEvent] == undefined
       ) {
-        dev().warn(
-          TAG,
-          `Invalid performance timing event type ${spec.startTimingEvent}` +
-            ', falling back to now'
-        );
       } else {
         this.intervalStart =
           win['performance']['timing'][spec.startTimingEvent];

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -52,7 +52,7 @@ import {
   isInManualExperiment,
 } from '../../../ads/google/a4a/traffic-experiments';
 import {computedStyle, setStyles} from '../../../src/style';
-import {dev, devAssert, user} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {domFingerprintPlain} from '../../../src/utils/dom-fingerprint';
 import {getAmpAdRenderOutsideViewport} from '../../amp-ad/0.1/concurrent-load';
 import {getData} from '../../../src/event-helper';
@@ -289,7 +289,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       consentState == CONSENT_POLICY_STATE.UNKNOWN &&
       this.element.getAttribute('data-npa-on-unknown-consent') != 'true'
     ) {
-      user().info(TAG, 'Ad request suppressed due to unknown consent');
       return Promise.resolve('');
     }
     // TODO: Check for required and allowed parameters. Probably use

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -424,7 +424,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
 
   /** @override */
   onNetworkFailure(error, adUrl) {
-    dev().info(TAG, 'network error, attempt adding of error parameter', error);
     return {adUrl: maybeAppendErrorParameter(adUrl, 'n')};
   }
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -137,7 +137,6 @@ export class ResponsiveState {
         })
         // Do nothing if we fail to read localstorage.
         .catch(() => {
-          dev().warn(TAG, 'Failed to look up publisher ad size settings.');
           return null;
         })
     );
@@ -262,9 +261,7 @@ export class ResponsiveState {
             })
         )
         // Do nothing if we fail to write to localstorage.
-        .catch(() => {
-          dev().warn(TAG, 'Failed to persist publisher auto ad size setting.');
-        });
+        .catch(() => {});
     };
     win.addEventListener('message', listener);
     return savePromise;

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -253,10 +253,6 @@ export class ResponsiveState {
               autoAdSizeStatus
             )
             .then(() => {
-              dev().info(
-                TAG,
-                `Saved publisher auto ad size setting: ${autoAdSizeStatus}`
-              );
               promiseResolver();
             })
         )
@@ -443,16 +439,16 @@ export class ResponsiveState {
     // Attempt to resize to the correct height. The width should already be
     // 100vw, but is fixed here so that future resizes of the viewport don't
     // affect it.
-    return this.element_.getImpl(/* waitForBuild= */ false).then((impl) =>
-      impl
-        .attemptChangeSize(
-          this.getResponsiveHeight_(viewportSize),
-          viewportSize.width
-        )
-        .catch(() => {
-          dev().info(TAG, `Change size attempt failed.`);
-        })
-    );
+    return this.element_
+      .getImpl(/* waitForBuild= */ false)
+      .then((impl) =>
+        impl
+          .attemptChangeSize(
+            this.getResponsiveHeight_(viewportSize),
+            viewportSize.width
+          )
+          .catch(() => {})
+      );
   }
 
   /**

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -21,14 +21,11 @@ import {
 } from '../../amp-a4a/0.1/amp-a4a';
 import {AmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
 import {AmpTemplateCreativeDef} from '../../amp-a4a/0.1/amp-ad-type-defs';
-import {dev, devAssert} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {tryParseJson} from '../../../src/json';
 import {tryResolve} from '../../../src/utils/promise';
 import {utf8Decode, utf8Encode} from '../../../src/utils/bytes';
-
-/** @type {string} */
-const TAG = 'amp-ad-network-adzerk-impl';
 
 /** @visibleForTesting @type {string} */
 export const AMP_TEMPLATED_CREATIVE_HEADER_NAME = 'AMP-template-amp-creative';
@@ -115,13 +112,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
         .then((parsedTemplate) => {
           return utf8Encode(this.parseMetadataFromCreative(parsedTemplate));
         })
-        .catch((error) => {
-          dev().warn(
-            TAG,
-            'Error fetching/expanding template',
-            this.ampCreativeJson_,
-            error
-          );
+        .catch(() => {
           this.forceCollapse();
           return Promise.reject(NO_CONTENT_RESPONSE);
         });

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -758,7 +758,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       consentTuple.consentState == CONSENT_POLICY_STATE.UNKNOWN &&
       this.element.getAttribute('data-npa-on-unknown-consent') != 'true'
     ) {
-      user().info(TAG, 'Ad request suppressed due to unknown consent');
       this.getAdUrlDeferred.resolve('');
       return Promise.resolve('');
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1042,7 +1042,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @override */
   onNetworkFailure(error, adUrl) {
-    dev().info(TAG, 'network error, attempt adding of error parameter', error);
     return {adUrl: maybeAppendErrorParameter(adUrl, 'n')};
   }
 
@@ -1690,14 +1689,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               const typeInstances = /** @type {!Array<!AmpAdNetworkDoubleclickImpl>}*/ (instances).filter(
                 (instance) => {
                   const isValid = instance.hasAdPromise();
-                  if (!isValid) {
-                    dev().info(
-                      TAG,
-                      'Ignoring instance without ad promise as ' +
-                        'likely invalid',
-                      instance.element
-                    );
-                  }
                   return isValid;
                 }
               );
@@ -1710,7 +1701,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
               // promise which results in sending as non-SRA request (benefit
               // is it allows direct cache method).
               if (!noFallbackExp && typeInstances.length == 1) {
-                dev().info(TAG, `single block in network ${networkId}`);
                 // Ensure deferred exists, may not if getAdUrl did not yet
                 // execute.
                 typeInstances[0].sraDeferred =

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -763,7 +763,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       return Promise.resolve('');
     }
     if (this.iframe && !this.isRefreshing) {
-      dev().warn(TAG, `Frame already exists, sra: ${this.useSra}`);
       this.getAdUrlDeferred.resolve('');
       return Promise.resolve('');
     }
@@ -793,9 +792,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     const targetingExpansionPromise = timerService
       .timeoutPromise(1000, this.expandJsonTargeting_(rtcParamsPromise))
-      .catch(() => {
-        dev().warn(TAG, 'JSON Targeting expansion failed/timed out.');
-      });
+      .catch(() => {});
 
     Promise.all([
       rtcParamsPromise,
@@ -987,7 +984,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         ),
       ATTR: (name) => {
         if (!allowlist[name.toLowerCase()]) {
-          dev().warn('TAG', `Invalid attribute ${name}`);
         } else {
           return this.element.getAttribute(name);
         }
@@ -1579,7 +1575,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     this.initiateSraRequests().then(() => {
       checkStillCurrent();
       if (!this.sraDeferred) {
-        dev().warn(TAG, `SRA failed to include element ${this.ifi_}`);
         if (isExperimentOn(this.win, 'doubleclickSraReportExcludedBlock')) {
           this.getAmpDoc()
             .getBody()
@@ -1619,7 +1614,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     impressions.split(',').forEach((url) => {
       try {
         if (!Services.urlForDoc(this.element).isSecure(url)) {
-          dev().warn(TAG, `insecure impression url: ${url}`);
           return;
         }
         // Create amp-pixel and append to document to send impression.
@@ -1788,7 +1782,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
                     // consistency), and propagate error to A4A ad promise
                     // chain.
                     assignAdUrlToError(/** @type {!Error} */ (error), sraUrl);
-                    this.warnOnError('SRA request failure', error);
                     // Publisher explicitly wants SRA so do not attempt to
                     // recover as SRA guarantees cannot be enforced.
                     typeInstances.forEach((instance) => {
@@ -1813,15 +1806,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         return Promise.all(sraRequestPromises);
       });
     return sraRequests;
-  }
-
-  /**
-   * @param {string} message
-   * @param {*} error
-   * @visibleForTesting
-   */
-  warnOnError(message, error) {
-    dev().warn(TAG, message, error);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/safeframe-host.js
@@ -81,11 +81,9 @@ export function safeframeListener(event) {
   const sentinel = data[MESSAGE_FIELDS.SENTINEL] || payload['sentinel'];
   const safeframeHost = safeframeHosts[sentinel];
   if (!safeframeHost) {
-    dev().warn(TAG, `Safeframe Host for sentinel: ${sentinel} not found.`);
     return;
   }
   if (!safeframeHost.equalsSafeframeContentWindow(event.source)) {
-    dev().warn(TAG, `Safeframe source did not match event.source.`);
     return;
   }
   if (!safeframeHost.channel) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
@@ -15,16 +15,13 @@
  */
 
 import {RENDERING_TYPE_HEADER, XORIGIN_MODE} from '../../amp-a4a/0.1/amp-a4a';
-import {dev, devAssert} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {getEnclosingContainerTypes} from '../../../ads/google/a4a/utils';
 import {getPageLayoutBoxBlocking} from '../../../src/utils/page-layout-box';
 import {isInManualExperiment} from '../../../ads/google/a4a/traffic-experiments';
 import {isObject} from '../../../src/types';
 import {tryResolve} from '../../../src/utils/promise';
 import {utf8Encode} from '../../../src/utils/bytes';
-
-/** @type {string} */
-const TAG = 'amp-ad-network-doubleclick-impl';
 
 /**
  * @const {string}
@@ -457,16 +454,6 @@ export function sraBlockCallbackHandler(
   // This allows the block to start rendering while the SRA
   // response is streaming back to the client.
   devAssert(sraRequestAdUrlResolvers.shift())(fetchResponse);
-  // If done, expect array to be empty (ensures ad response
-  // included data for all slots).
-  if (done && sraRequestAdUrlResolvers.length) {
-    dev().warn(
-      TAG,
-      'Premature end of SRA response',
-      sraRequestAdUrlResolvers.length,
-      sraUrl
-    );
-  }
 }
 
 /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -604,7 +604,6 @@ describes.realWin('Doubleclick SRA', config, (env) => {
             doubleclickInstances.push(impl);
             env.sandbox.stub(impl, 'isValidElement').returns(!invalid);
             env.sandbox.stub(impl, 'promiseErrorHandler_');
-            env.sandbox.stub(impl, 'warnOnError');
             if (invalid) {
               impl.element.setAttribute('data-test-invalid', 'true');
             }

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -32,7 +32,7 @@ import {Services} from '../../../src/services';
 import {adConfig} from '../../../ads/_config';
 import {clamp} from '../../../src/utils/math';
 import {computedStyle, setStyle} from '../../../src/style';
-import {dev, devAssert, userAssert} from '../../../src/log';
+import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAdCid} from '../../../src/ad-cid';
 import {getAdContainer, isAdPositionAllowed} from '../../../src/ad-helper';
@@ -198,9 +198,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.type_ = this.element.getAttribute('type');
-    const upgradeDelayMs = Math.round(this.getResource().getUpgradeDelayMs());
-    dev().info(TAG_3P_IMPL, `upgradeDelay ${this.type_}: ${upgradeDelayMs}`);
-
     this.placeholder_ = this.getPlaceholder();
     this.fallback_ = this.getFallback();
 
@@ -232,10 +229,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     userAssert(
       !!this.config.fullWidthHeightRatio,
       'Ad network does not support full width ads.'
-    );
-    dev().info(
-      TAG_3P_IMPL,
-      '#${this.getResource().getId()} Full width requested'
     );
     return true;
   }
@@ -503,12 +496,8 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     // affect it.
 
     return this.attemptChangeSize(height, width).then(
-      () => {
-        dev().info(TAG_3P_IMPL, `Size change accepted: ${width}x${height}`);
-      },
-      () => {
-        dev().info(TAG_3P_IMPL, `Size change rejected: ${width}x${height}`);
-      }
+      () => {},
+      () => {}
     );
   }
 

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -618,11 +618,6 @@ export class AmpAnalytics extends AMP.BaseElement {
    * @private
    */
   handleRequestForEvent_(requestName, trigger, event) {
-    if (!this.element.ownerDocument.defaultView) {
-      const TAG = this.getName_();
-      dev().warn(TAG, 'request against destroyed embed: ', trigger['on']);
-    }
-
     const request = this.requests_[requestName];
     const hasPostMessage =
       this.allowParentPostMessage_() && trigger['parentPostMessage'];

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -282,8 +282,6 @@ export class AmpAnalytics extends AMP.BaseElement {
   registerTriggers_() {
     if (this.hasOptedOut_()) {
       // Nothing to do when the user has opted out.
-      const TAG = this.getName_();
-      user().fine(TAG, 'User has opted out. No hits will be sent.');
       return Promise.resolve();
     }
 

--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -19,11 +19,11 @@ import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
 import {calculateScriptBaseUrl} from '../../../src/service/extension-location';
 import {deepMerge, dict, hasOwn} from '../../../src/utils/object';
-import {dev, user, userAssert} from '../../../src/log';
 import {getChildJsonConfig} from '../../../src/json';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject, toWin} from '../../../src/types';
 import {isCanary} from '../../../src/experiments';
+import {user, userAssert} from '../../../src/log';
 import {variableServiceForDoc} from './variables';
 
 const TAG = 'amp-analytics/config';
@@ -111,7 +111,6 @@ export class AnalyticsConfig {
     const vendorUrl = this.getVendorUrl_(type);
 
     const TAG = this.getName_();
-    dev().fine(TAG, 'Fetching vendor config', vendorUrl);
 
     return Services.xhrFor(toWin(this.win_))
       .fetchJson(vendorUrl, {ampCors: false})
@@ -119,7 +118,6 @@ export class AnalyticsConfig {
       .then(
         (jsonValue) => {
           this.vendorConfig_ = jsonValue || dict();
-          dev().fine(TAG, 'Vendor config loaded for ' + type, jsonValue);
         },
         (err) => {
           user().error(TAG, 'Error loading vendor config: ', vendorUrl, err);
@@ -140,7 +138,6 @@ export class AnalyticsConfig {
     }
     assertHttpsUrl(remoteConfigUrl, this.element_);
     const TAG = this.getName_();
-    dev().fine(TAG, 'Fetching remote config', remoteConfigUrl);
     const fetchConfig = {};
     if (this.element_.hasAttribute('data-credentials')) {
       fetchConfig.credentials = this.element_.getAttribute('data-credentials');
@@ -161,7 +158,6 @@ export class AnalyticsConfig {
       .then(
         (jsonValue) => {
           this.remoteConfig_ = jsonValue;
-          dev().fine(TAG, 'Remote config loaded', remoteConfigUrl);
         },
         (err) => {
           user().error(
@@ -207,7 +203,6 @@ export class AnalyticsConfig {
   handleConfigRewriter_(config, configRewriterUrl) {
     assertHttpsUrl(configRewriterUrl, this.element_);
     const TAG = this.getName_();
-    dev().fine(TAG, 'Rewriting config', configRewriterUrl);
 
     return this.handleVarGroups_(config).then(() => {
       const fetchConfig = {
@@ -233,7 +228,6 @@ export class AnalyticsConfig {
           .then(
             (jsonValue) => {
               this.config_ = this.mergeConfigs_(jsonValue);
-              dev().fine(TAG, 'Configuration re-written', configRewriterUrl);
             },
             (err) => {
               user().error(

--- a/extensions/amp-analytics/0.1/iframe-transport-message-queue.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-message-queue.js
@@ -16,10 +16,7 @@
 
 import {MessageType} from '../../../src/3p-frame-messaging';
 import {SubscriptionApi} from '../../../src/iframe-helper';
-import {dev, devAssert} from '../../../src/log';
-
-/** @private @const {string} */
-const TAG_ = 'amp-analytics/iframe-transport-message-queue';
+import {devAssert} from '../../../src/log';
 
 /** @private @const {number} */
 const MAX_QUEUE_SIZE_ = 100;
@@ -99,10 +96,6 @@ export class IframeTransportMessageQueue {
     );
     this.pendingEvents_.push(event);
     if (this.queueSize() >= MAX_QUEUE_SIZE_) {
-      dev().warn(
-        TAG_,
-        'Exceeded maximum size of queue for: ' + event.creativeId
-      );
       this.pendingEvents_.shift();
     }
     this.flushQueue_();

--- a/extensions/amp-analytics/0.1/linker-manager.js
+++ b/extensions/amp-analytics/0.1/linker-manager.js
@@ -173,11 +173,6 @@ export class LinkerManager {
       const mergedConfig = {...defaultConfig, ...config[name]};
 
       if (mergedConfig['enabled'] !== true) {
-        user().info(
-          TAG,
-          'linker config for %s is not enabled and will be ignored.',
-          name
-        );
         return;
       }
 

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -245,19 +245,15 @@ export class Transport {
       return;
     }
     const image = createPixel(win, request.url, referrerPolicy);
-    loadPromise(image)
-      .then(() => {
-        dev().fine(TAG_, 'Sent image request', request.url);
-      })
-      .catch(() => {
-        if (!suppressWarnings) {
-          user().warn(
-            TAG_,
-            'Response unparseable or failed to send image request',
-            request.url
-          );
-        }
-      });
+    loadPromise(image).catch(() => {
+      if (!suppressWarnings) {
+        user().warn(
+          TAG_,
+          'Response unparseable or failed to send image request',
+          request.url
+        );
+      }
+    });
   }
 
   /**
@@ -270,11 +266,7 @@ export class Transport {
     if (!sendBeacon) {
       return false;
     }
-    const result = sendBeacon(request.url, request.payload || '');
-    if (result) {
-      dev().fine(TAG_, 'Sent beacon request', request);
-    }
-    return result;
+    return sendBeacon(request.url, request.payload || '');
   }
 
   /**
@@ -296,12 +288,6 @@ export class Transport {
 
     // Prevent pre-flight HEAD request.
     xhr.setRequestHeader('Content-Type', 'text/plain');
-
-    xhr.onreadystatechange = () => {
-      if (xhr.readyState == 4) {
-        dev().fine(TAG_, 'Sent XHR request', request.url);
-      }
-    };
 
     xhr.send(request.payload || '');
     return true;

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -85,7 +85,6 @@ export class Transport {
    */
   sendRequest(url, segments, inBatch) {
     if (!url || segments.length === 0) {
-      dev().info(TAG_, 'Empty request not sent: ', url);
       return;
     }
     const serializer = this.getSerializer_();

--- a/extensions/amp-animation/0.1/web-animations.js
+++ b/extensions/amp-animation/0.1/web-animations.js
@@ -201,9 +201,6 @@ export class Builder {
    */
   createRunner(spec, opt_args, opt_positionObserverData = null) {
     return this.resolveRequests([], spec, opt_args).then((requests) => {
-      if (getMode().localDev || getMode().development) {
-        user().fine(TAG, 'Animation: ', requests);
-      }
       return Promise.all(this.loaders_).then(() => {
         return this.isAnimationWorkletSupported_() && opt_positionObserverData
           ? new ScrollTimelineWorkletRunner(

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -122,7 +122,6 @@ class AmpApesterMedia extends AMP.BaseElement {
   viewportCallback_(inViewport) {
     if (inViewport && !this.seen_) {
       if (this.iframe_ && this.iframe_.contentWindow) {
-        dev().fine(TAG, 'media seen');
         this.seen_ = true;
         this.iframe_.contentWindow./*OK*/ postMessage('interaction seen', '*');
       }

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -280,7 +280,6 @@ class AmpApesterMedia extends AMP.BaseElement {
     return this.queryMedia_().then(
       (response) => {
         if (!response || response['status'] === 204) {
-          dev().warn(TAG, 'Display', 'No Content for provided tag');
           return this.unlayoutCallback();
         }
         const payload = response['payload'];

--- a/extensions/amp-app-banner/0.1/amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/amp-app-banner.js
@@ -196,7 +196,6 @@ export class AmpAppBanner extends AbstractAppBanner {
 
   /** @override */
   layoutCallback() {
-    user().info(TAG, 'Only iOS or Android platforms are currently supported.');
     return this.hide_();
   }
 }
@@ -241,10 +240,6 @@ export class AmpIosAppBanner extends AbstractAppBanner {
     this.canShowBuiltinBanner_ =
       !this.viewer_.isEmbedded() && platform.isSafari();
     if (this.canShowBuiltinBanner_) {
-      user().info(
-        TAG,
-        'Browser supports builtin banners. Not rendering amp-app-banner.'
-      );
       this.hide_();
       return;
     }
@@ -401,10 +396,6 @@ export class AmpAndroidAppBanner extends AbstractAppBanner {
       !isProxyOrigin && !viewer.isEmbedded() && isChromeAndroid;
 
     if (this.canShowBuiltinBanner_) {
-      user().info(
-        TAG,
-        'Browser supports builtin banners. Not rendering amp-app-banner.'
-      );
       this.hide_();
       return;
     }

--- a/extensions/amp-auto-ads/0.1/ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/ad-strategy.js
@@ -17,10 +17,6 @@
 import {PlacementState} from './placement';
 import {SizeInfoDef} from './ad-network-config';
 import {tryResolve} from '../../../src/utils/promise';
-import {user} from '../../../src/log';
-
-/** @const */
-const TAG = 'amp-auto-ads';
 
 /**
  * @typedef {{
@@ -101,7 +97,6 @@ export class AdStrategy {
   placeNextAd_() {
     const nextPlacement = this.availablePlacements_.shift();
     if (!nextPlacement) {
-      user().info(TAG, 'unable to fulfill ad strategy');
       return Promise.resolve(false);
     }
     return nextPlacement

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -343,7 +343,6 @@ export class Placement {
 export function getPlacementsFromConfigObj(ampdoc, configObj) {
   const placementObjs = /** @type {Array} */ (configObj['placements']);
   if (!placementObjs) {
-    user().info(TAG, 'No placements in config');
     return [];
   }
   const placements = [];

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -443,7 +443,6 @@ export function runCandidates(ampdoc, candidates) {
       if (!Criteria.meetsAll(candidate)) {
         return;
       }
-      dev().info(TAG, 'apply', candidate);
       return apply(ampdoc, candidate);
     }, NOOP)
   );
@@ -457,7 +456,6 @@ export function runCandidates(ampdoc, candidates) {
  */
 export function scan(ampdoc, opt_root) {
   if (!isEnabledForDoc(ampdoc)) {
-    dev().info(TAG, 'disabled');
     return;
   }
   const root = opt_root || ampdoc.win.document;

--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -33,7 +33,6 @@ import {backwardWrappingDistance, forwardWrappingDistance} from './array-util';
 import {clamp, mod} from '../../../src/utils/math';
 import {createCustomEvent, listen, listenOnce} from '../../../src/event-helper';
 import {debounce} from '../../../src/utils/rate-limit';
-import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {
   getStyle,
@@ -613,10 +612,6 @@ export class Carousel {
    * @param {!Array<!Element>} slides
    */
   updateSlides(slides) {
-    if (!slides.length) {
-      const TAG = this.element_.tagName.toUpperCase();
-      dev().warn(TAG, 'No slides were found.');
-    }
     this.slides_ = slides;
     this.carouselAccessibility_.updateSlides(slides);
     // TODO(sparhami) Should need to call `this.updateUi()` here.

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -1687,21 +1687,10 @@ export class Bind {
   debugPrintState_(opt_elementOrExpr) {
     if (opt_elementOrExpr) {
       if (typeof opt_elementOrExpr == 'string') {
-        const value = getValueForExpr(this.state_, opt_elementOrExpr);
-        user().info(TAG, value);
       } else if (opt_elementOrExpr.nodeType == Node.ELEMENT_NODE) {
         const element = user().assertElement(opt_elementOrExpr);
         this.debugPrintElement_(element);
-      } else {
-        user().info(
-          TAG,
-          'Invalid argument. Pass a JSON expression or an ' +
-            'element instead e.g. AMP.printState("foo.bar") or ' +
-            'AMP.printState($0) after selecting an element.'
-        );
       }
-    } else {
-      user().info(TAG, this.state_);
     }
   }
 
@@ -1715,7 +1704,6 @@ export class Bind {
       return boundElement.element == element;
     });
     if (index < 0) {
-      user().info(TAG, 'Element has no bindings:', element);
       return;
     }
     // Evaluate expressions in bindings in `element`.
@@ -1725,24 +1713,13 @@ export class Bind {
       const {expressionString} = boundProperty;
       promises.push(this.evaluateExpression_(expressionString, this.state_));
     });
-    // Print the map of attribute to expression value for `element`.
-    Promise.all(promises).then((results) => {
-      const output = map();
-      boundProperties.forEach((boundProperty, i) => {
-        const {property} = boundProperty;
-        output[property] = results[i];
-      });
-      user().info(TAG, output);
-    });
   }
 
   /**
    * @param {string} expression
    */
   debugEvaluate_(expression) {
-    this.evaluateExpression_(expression, this.state_).then((result) => {
-      user().info(TAG, result);
-    });
+    this.evaluateExpression_(expression, this.state_);
   }
 
   /**

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -229,7 +229,7 @@ class AmpBrightcove extends AMP.BaseElement {
     }
 
     if (eventType === 'ready') {
-      this.onReady_(data);
+      this.onReady_();
     }
 
     if (eventType === 'playing') {
@@ -274,11 +274,8 @@ class AmpBrightcove extends AMP.BaseElement {
     }
   }
 
-  /**
-   * @param {!JsonObject} data
-   * @private
-   */
-  onReady_(data) {
+  /** @private */
+  onReady_() {
     this.hasAmpSupport_ = true;
 
     Services.timerFor(this.win).cancel(this.readyTimeout_);
@@ -289,15 +286,6 @@ class AmpBrightcove extends AMP.BaseElement {
     Services.videoManagerForDoc(element).register(this);
 
     this.playerReadyResolver_(this.iframe_);
-
-    dev().info(
-      TAG,
-      'Player %s ready. ' +
-        'Brightcove Player version: %s AMP Support version: %s',
-      this.playerId_,
-      data['bcVersion'],
-      data['ampSupportVersion']
-    );
   }
 
   /**

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -19,7 +19,6 @@ import {Animation} from '../../../src/animation';
 import {BaseCarousel} from './base-carousel';
 import {Keys} from '../../../src/utils/key-codes';
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
 import {isLayoutSizeFixed} from '../../../src/layout';
 import {listen} from '../../../src/event-helper';
 import {numeric} from '../../../src/transition';
@@ -260,21 +259,9 @@ export class AmpScrollableCarousel extends BaseCarousel {
     ).delay(() => {
       // TODO(yuxichen): test out the threshold for identifying fast scrolling
       if (Math.abs(startingScrollLeft - this.pos_) < 30) {
-        dev().fine(
-          TAG,
-          'slow scrolling: %s - %s',
-          startingScrollLeft,
-          this.pos_
-        );
         this.scrollTimerId_ = null;
         this.commitSwitch_(this.pos_);
       } else {
-        dev().fine(
-          TAG,
-          'fast scrolling: %s - %s',
-          startingScrollLeft,
-          this.pos_
-        );
         this.waitForScroll_(this.pos_);
       }
     }, 100));

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -397,13 +397,6 @@ export class ConsentInstance {
           // TODO: Good to have a way to inform CMP service in this case
           return;
         }
-        user().info(
-          TAG,
-          'Current consent information length exceeds %s ' +
-            'and will not be stored when the page is served ' +
-            'from a viewer that supports the Local Storage API.',
-          CONSENT_STORAGE_MAX
-        );
       }
       this.savedConsentInfo_ = consentInfo;
       storage.setNonBoolean(this.storageKey_, value);

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -326,11 +326,6 @@ export class AmpGeo extends AMP.BaseElement {
       return Promise.resolve(null);
     }
 
-    user().info(
-      TAG,
-      'API request is being used for country, this may result in FOUC'
-    );
-
     return Services.timerFor(this.win)
       .timeoutPromise(
         API_TIMEOUT * 1000,

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -21,7 +21,6 @@ import {
 } from '../../../src/dom';
 import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
-import {getMode} from '../../../src/mode';
 import {listen} from '../../../src/event-helper';
 import {removeFragment} from '../../../src/url';
 import {toggle} from '../../../src/style';
@@ -345,13 +344,6 @@ function install(win, src, element) {
   }
   return win.navigator.serviceWorker.register(src, options).then(
     function (registration) {
-      if (getMode().development) {
-        user().info(
-          TAG,
-          'ServiceWorker registration successful with scope: ',
-          registration.scope
-        );
-      }
       // Check if there is a new service worker installing.
       const installingSw = registration.installing;
       if (installingSw) {

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -405,9 +405,6 @@ class AmpJWPlayer extends AMP.BaseElement {
     const event = data['event'];
     const detail = data['detail'];
 
-    // Log any valid events
-    dev().info('JWPLAYER', 'EVENT:', event || 'anon event', detail || data);
-
     if (event === 'ready') {
       detail && this.onReadyOnce_(detail);
       return;
@@ -471,8 +468,6 @@ class AmpJWPlayer extends AMP.BaseElement {
       if (!this.iframe_ || !this.iframe_.contentWindow) {
         return;
       }
-
-      dev().info('JWPLAYER', 'COMMAND:', method, optParams);
 
       this.iframe_.contentWindow./*OK*/ postMessage(
         JSON.stringify(

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -776,21 +776,9 @@ class AmpLightbox extends AMP.BaseElement {
       this.win
     ).delay(() => {
       if (Math.abs(startingScrollTop - this.pos_) < 30) {
-        dev().fine(
-          TAG,
-          'slow scrolling: %s - %s',
-          startingScrollTop,
-          this.pos_
-        );
         this.scrollTimerId_ = null;
         this.update_(this.pos_);
       } else {
-        dev().fine(
-          TAG,
-          'fast scrolling: %s - %s',
-          startingScrollTop,
-          this.pos_
-        );
         this.waitForScroll_(this.pos_);
       }
     }, 100));
@@ -802,7 +790,6 @@ class AmpLightbox extends AMP.BaseElement {
    * @private
    */
   update_(pos) {
-    dev().fine(TAG, 'update_');
     this.updateChildrenInViewport_(pos);
     this.pos_ = pos;
   }

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -932,10 +932,8 @@ export class AmpList extends AMP.BaseElement {
    */
   doRenderPass_() {
     const current = this.renderItems_;
-
-    user().fine(TAG, 'Rendering list', this.element, 'with data', current.data);
-
     devAssert(current && current.data, 'Nothing to render.');
+
     const scheduleNextPass = () => {
       // If there's a new `renderItems_`, schedule it for render.
       if (this.renderItems_ !== current) {

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -512,7 +512,6 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   mutatedAttributesCallback(mutations) {
-    dev().info(TAG, 'mutate:', this.element, mutations);
     let promise;
 
     /**

--- a/extensions/amp-mraid/0.1/amp-mraid.js
+++ b/extensions/amp-mraid/0.1/amp-mraid.js
@@ -82,7 +82,6 @@ export class MraidInitializer {
     }
 
     if (getMode().runtime !== 'inabox') {
-      dev().fine(TAG, 'Only supported with Inabox');
       this.handleMismatch_();
       return;
     }

--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -464,7 +464,6 @@ export class NextPageService {
    */
   setTitlePage(page = this.hostPage_) {
     if (!page) {
-      dev().warn(TAG, 'setTitlePage called before next-page-service is built');
       return;
     }
     const {title, url} = page;

--- a/extensions/amp-onetap-google/0.1/amp-onetap-google.js
+++ b/extensions/amp-onetap-google/0.1/amp-onetap-google.js
@@ -31,7 +31,7 @@ import {CSS} from '../../../build/amp-onetap-google-0.1.css';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {assertHttpsUrl} from '../../../src/url';
-import {dev, devAssert, user} from '../../../src/log';
+import {devAssert, user} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getData, listen} from '../../../src/event-helper';
 import {isObject} from '../../../src/types';
@@ -148,8 +148,6 @@ export class AmpOnetapGoogle extends AMP.BaseElement {
       case ACTIONS.SET_TAP_OUTSIDE_MODE:
         this.shouldCancelOnTapOutside_ = !!data['cancel'];
         break;
-      default:
-        dev().warn(TAG, `Unknown action type: ${data['command']}`);
     }
   }
 

--- a/extensions/amp-powr-player/0.1/amp-powr-player.js
+++ b/extensions/amp-powr-player/0.1/amp-powr-player.js
@@ -172,7 +172,7 @@ class AmpPowrPlayer extends AMP.BaseElement {
     }
 
     if (eventType === 'ready') {
-      this.onReady_(data);
+      this.onReady_();
     }
 
     if (eventType === 'playing') {
@@ -197,11 +197,8 @@ class AmpPowrPlayer extends AMP.BaseElement {
     }
   }
 
-  /**
-   * @param {!JsonObject} data
-   * @private
-   */
-  onReady_(data) {
+  /** @private */
+  onReady_() {
     this.frameHasAmpSupport_ = true;
 
     const {element} = this;
@@ -210,15 +207,6 @@ class AmpPowrPlayer extends AMP.BaseElement {
     Services.videoManagerForDoc(element).register(this);
 
     this.playerReadyResolver_(this.iframe_);
-
-    dev().info(
-      TAG,
-      'Player %s ready. ' +
-        'Powr Player version: %s IFrame Support version: %s',
-      this.playerId_,
-      data['powrVersion'],
-      data['iframeVersion']
-    );
   }
 
   /**

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -279,16 +279,6 @@ export class AmpScript extends AMP.BaseElement {
         // TODO(dvoytenko): consider additional "progress" UI.
       },
       sanitizer: new SanitizerImpl(this, sandboxTokens),
-      // Callbacks.
-      onCreateWorker: (data) => {
-        dev().info(TAG, 'Create worker:', data);
-      },
-      onSendMessage: (data) => {
-        dev().info(TAG, 'To worker:', data);
-      },
-      onReceiveMessage: (data) => {
-        dev().info(TAG, 'From worker:', data);
-      },
     };
 
     // Create worker and hydrate.

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -559,13 +559,6 @@ export class AmpStoryEmbeddedComponent {
         this.setState_(EmbeddedComponentState.HIDDEN, null /** component */);
         break;
       case EmbeddedComponentState.FOCUSED:
-        if (this.state_ !== EmbeddedComponentState.HIDDEN) {
-          dev().warn(
-            TAG,
-            `Invalid component update. Not possible to go from ${this.state_}
-              to ${component.state}`
-          );
-        }
         this.setState_(EmbeddedComponentState.FOCUSED, component);
         break;
       case EmbeddedComponentState.EXPANDED:
@@ -573,12 +566,6 @@ export class AmpStoryEmbeddedComponent {
           this.setState_(EmbeddedComponentState.EXPANDED, component);
         } else if (this.state_ === EmbeddedComponentState.EXPANDED) {
           this.maybeCloseExpandedView_(component.element);
-        } else {
-          dev().warn(
-            TAG,
-            `Invalid component update. Not possible to go from ${this.state_}
-               to ${component.state}`
-          );
         }
         break;
     }
@@ -616,7 +603,6 @@ export class AmpStoryEmbeddedComponent {
           });
         break;
       default:
-        dev().warn(TAG, `EmbeddedComponentState ${this.state_} does not exist`);
         break;
     }
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -501,7 +501,6 @@ export class AmpStoryPage extends AMP.BaseElement {
         this.state_ = state;
         break;
       default:
-        dev().warn(TAG, `PageState ${state} does not exist`);
         break;
     }
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -944,9 +944,7 @@ export class AmpStory extends AMP.BaseElement {
 
     try {
       lockOrientation('portrait');
-    } catch (e) {
-      dev().warn(TAG, 'Failed to lock screen orientation:', e.message);
-    }
+    } catch (e) {}
   }
 
   /** @override */

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -46,7 +46,6 @@ import {toggle} from '../../../../src/style';
 
 // TODO(#14591): Clean when bookend API v0.1 is deprecated.
 const BOOKEND_VERSION_1 = 'v1.0';
-const BOOKEND_VERSION_0 = 'v0.1';
 
 /**
  * Key for components in bookend config.
@@ -483,12 +482,6 @@ export class AmpStoryBookend extends DraggableDrawer {
               response[SHARE_PROVIDERS_KEY] ||
               response[DEPRECATED_SHARE_PROVIDERS_KEY],
           });
-        } else {
-          dev().warn(
-            TAG,
-            `Version ${BOOKEND_VERSION_0} of the amp-story` +
-              `-bookend is deprecated. Use ${BOOKEND_VERSION_1} instead.`
-          );
         }
         return this.config_;
       })

--- a/extensions/amp-subscriptions/0.1/actions.js
+++ b/extensions/amp-subscriptions/0.1/actions.js
@@ -16,11 +16,10 @@
 
 import {ActionStatus} from './analytics';
 import {assertHttpsUrl, parseQueryString} from '../../../src/url';
-import {dev, userAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {openLoginDialog} from '../../amp-access/0.1/login-dialog';
+import {userAssert} from '../../../src/log';
 
-const TAG = 'amp-subscriptions';
 const LOCAL = 'local';
 
 /**
@@ -115,13 +114,10 @@ export class Actions {
       return this.actionPromise_;
     }
 
-    dev().fine(TAG, 'Start action: ', url, action);
-
     this.analytics_.actionEvent(LOCAL, action, ActionStatus.STARTED);
     const dialogPromise = this.openPopup_(url);
     const actionPromise = dialogPromise
       .then((result) => {
-        dev().fine(TAG, 'Action completed: ', action, result);
         this.actionPromise_ = null;
         const query = parseQueryString(result);
         const s = query['success'];
@@ -134,7 +130,6 @@ export class Actions {
         return success || !s;
       })
       .catch((reason) => {
-        dev().fine(TAG, 'Action failed: ', action, reason);
         this.analytics_.actionEvent(LOCAL, action, ActionStatus.FAILED);
         if (this.actionPromise_ == actionPromise) {
           this.actionPromise_ = null;

--- a/extensions/amp-subscriptions/0.1/analytics.js
+++ b/extensions/amp-subscriptions/0.1/analytics.js
@@ -16,9 +16,6 @@
 
 import {dict} from '../../../src/utils/object';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
-import {user} from '../../../src/log';
-
-const TAG = 'amp-subscriptions';
 
 /**
  * subscriptions-platform-* event names are deprecated in favor
@@ -125,8 +122,6 @@ export class SubscriptionAnalytics {
       eventType !== SubscriptionAnalyticsEvents.SUBSCRIPTIONS_ACTION
         ? eventType
         : eventType + `-${internalVars['action']}-${internalVars['status']}`;
-
-    user().info(TAG, loggedString, opt_vars || '');
 
     opt_vars = opt_vars || dict({});
     triggerAnalyticsEvent(

--- a/extensions/amp-subscriptions/0.1/viewer-tracker.js
+++ b/extensions/amp-subscriptions/0.1/viewer-tracker.js
@@ -16,10 +16,7 @@
 
 import {Services} from '../../../src/services';
 import {cancellation} from '../../../src/error';
-import {dev} from '../../../src/log';
 import {listenOnce} from '../../../src/event-helper';
-
-const TAG = 'local-viewer';
 
 export class ViewerTracker {
   /**
@@ -68,10 +65,8 @@ export class ViewerTracker {
     if (this.reportViewPromise_) {
       return this.reportViewPromise_;
     }
-    dev().fine(TAG, 'start view monitoring');
     this.reportViewPromise_ = this.whenViewed_(timeToView).catch((reason) => {
       // Ignore - view has been canceled.
-      dev().fine(TAG, 'view cancelled:', reason);
       this.reportViewPromise_ = null;
       throw reason;
     });

--- a/extensions/amp-video/0.1/flexible-bitrate.js
+++ b/extensions/amp-video/0.1/flexible-bitrate.js
@@ -16,11 +16,9 @@
 
 import {DomBasedWeakRef} from '../../../src/utils/dom-based-weakref';
 import {childElement, childElementsByTag} from '../../../src/dom';
-import {dev, devAssert} from '../../../src/log';
+import {devAssert} from '../../../src/log';
 import {listen, listenOnce} from '../../../src/event-helper';
 import {toArray} from '../../../src/types';
-
-const TAG = 'amp-video';
 
 /** @const {!Object<string, number>} */
 const BITRATE_BY_EFFECTIVE_TYPE = {
@@ -205,7 +203,6 @@ export class BitrateManager {
    */
   switchToLowerBitrate_(video, currentBitrate) {
     if (!this.hasLowerBitrate_(video, currentBitrate)) {
-      dev().fine(TAG, 'No lower bitrate available');
       return;
     }
     const {currentTime} = video;
@@ -216,7 +213,6 @@ export class BitrateManager {
       // Restore currentTime after loading new source.
       video.currentTime = currentTime;
       video.play();
-      dev().fine(TAG, 'Playing at lower bitrate %s', video.currentSrc);
     });
   }
 

--- a/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
+++ b/extensions/amp-viewer-integration/0.1/amp-viewer-integration.js
@@ -29,7 +29,6 @@ import {
 } from './messaging/messaging';
 import {Services} from '../../../src/services';
 import {TouchHandler} from './touch-handler';
-import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getAmpdoc} from '../../../src/service';
 import {getData, listen, listenOnce} from '../../../src/event-helper';
@@ -78,7 +77,6 @@ export class AmpViewerIntegration {
    * @return {!Promise<undefined>}
    */
   init() {
-    dev().fine(TAG, 'handshake init()');
     const ampdoc = getAmpdoc(this.win.document);
     const viewer = Services.viewerForDoc(ampdoc);
     this.isWebView_ = viewer.getParam('webview') == '1';
@@ -139,12 +137,6 @@ export class AmpViewerIntegration {
   webviewPreHandshakePromise_(source, origin) {
     return new Promise((resolve) => {
       const unlisten = listen(this.win, 'message', (e) => {
-        dev().fine(
-          TAG,
-          'AMPDOC got a pre-handshake message:',
-          e.type,
-          getData(e)
-        );
         const data = parseMessage(getData(e));
         if (!data) {
           return;
@@ -181,7 +173,6 @@ export class AmpViewerIntegration {
    * @private
    */
   openChannelAndStart_(viewer, ampdoc, origin, messaging) {
-    dev().fine(TAG, 'Send a handshake request');
     const ampdocUrl = ampdoc.getUrl();
     const srcUrl = getSourceUrl(ampdocUrl);
     return messaging
@@ -194,7 +185,6 @@ export class AmpViewerIntegration {
         true /* awaitResponse */
       )
       .then(() => {
-        dev().fine(TAG, 'Channel has been opened!');
         this.setup_(messaging, viewer, origin);
       });
   }

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -26,13 +26,13 @@ import {
 import {Services} from '../../../src/services';
 import {WebPushWidgetVisibilities} from './amp-web-push-widget';
 import {WindowMessenger} from './window-messenger';
-import {dev, user} from '../../../src/log';
 import {escapeCssSelectorIdent} from '../../../src/css';
 import {getMode} from '../../../src/mode';
 import {getServicePromiseForDoc} from '../../../src/service';
 import {installStylesForDoc} from '../../../src/style-installer';
 import {openWindowDialog} from '../../../src/dom';
 import {parseQueryString, parseUrlDeprecated} from '../../../src/url';
+import {user} from '../../../src/log';
 
 /** @typedef {{
  *    isControllingFrame: boolean,
@@ -162,8 +162,6 @@ export class WebPushService {
    * @return {!Promise}
    */
   start(configJson) {
-    dev().fine(TAG, 'amp-web-push extension starting up.');
-
     // Exit early if web push isn't supported
     if (!this.environmentSupportsWebPush()) {
       user().warn(TAG, 'Web push is not supported.');
@@ -177,11 +175,6 @@ export class WebPushService {
 
     iframeLoadPromise
       .then(() => {
-        dev().fine(
-          TAG,
-          `Helper frame ${this.config_['helper-iframe-url']} ` +
-            'DOM loaded. Connecting to the frame via postMessage()...'
-        );
         return this.frameMessenger_.connect(
           this.iframe_.getDomElement().contentWindow,
           parseUrlDeprecated(this.config_['helper-iframe-url']).origin

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -15,7 +15,7 @@
  */
 
 import {assertHttpsUrl, parseUrlDeprecated} from './url';
-import {dev, devAssert, user, userAssert} from './log';
+import {devAssert, user, userAssert} from './log';
 import {dict} from './utils/object';
 import {getContextMetadata} from '../src/iframe-attributes';
 import {getMode} from './mode';
@@ -29,9 +29,6 @@ let count = {};
 
 /** @type {string} */
 let overrideBootstrapBaseUrl;
-
-/** @const {string} */
-const TAG = '3p-frame';
 
 /**
  * Produces the attributes for the ad template.
@@ -425,7 +422,6 @@ export function applySandbox(iframe) {
   for (let i = 0; i < requiredFlags.length; i++) {
     const flag = requiredFlags[i];
     if (!iframe.sandbox.supports(flag)) {
-      dev().info(TAG, "Iframe doesn't support %s", flag);
       return;
     }
   }

--- a/src/ad-cid.js
+++ b/src/ad-cid.js
@@ -74,9 +74,8 @@ export function getOrCreateAdCid(
   // 1 second, assume it will never arrive.
   return Services.timerFor(ampDoc.win)
     .timeoutPromise(timeout, cidPromise, 'cid timeout')
-    .catch((error) => {
+    .catch(() => {
       // Timeout is not fatal.
-      dev().warn('AD-CID', error);
       return undefined;
     });
 }

--- a/src/animation.js
+++ b/src/animation.js
@@ -201,7 +201,6 @@ class AnimationPlayer {
     if (this.vsync_.canAnimate(this.contextNode_)) {
       this.task_(this.state_);
     } else {
-      dev().warn(TAG_, 'cannot animate');
       this.complete_(/* success */ false, /* dir */ 0);
     }
   }
@@ -323,7 +322,6 @@ class AnimationPlayer {
       if (this.vsync_.canAnimate(this.contextNode_)) {
         this.task_(this.state_);
       } else {
-        dev().warn(TAG_, 'cancel animation');
         this.complete_(/* success */ false, /* dir */ 0);
       }
     }

--- a/src/chunk.js
+++ b/src/chunk.js
@@ -15,16 +15,10 @@
  */
 
 import {Services} from './services';
-import {dev} from './log';
 import {getData} from './event-helper';
 import {getServiceForDoc, registerServiceBuilderForDoc} from './service';
 import {makeBodyVisibleRecovery} from './style-installer';
 import PriorityQueue from './utils/priority-queue';
-
-/**
- * @const {string}
- */
-const TAG = 'CHUNK';
 
 /**
  * @type {boolean}
@@ -434,14 +428,6 @@ class Chunks {
         .then(() => {
           this.scheduledImmediateInvocation_ = false;
           this.durationOfLastExecution_ += Date.now() - before;
-          dev().fine(
-            TAG,
-            t.getName_(),
-            'Chunk duration',
-            Date.now() - before,
-            this.durationOfLastExecution_
-          );
-
           this.schedule_();
         });
     }
@@ -543,19 +529,11 @@ export function onIdle(win, minimumTimeRemaining, timeout, fn) {
     if (info.timeRemaining() < minimumTimeRemaining) {
       const remainingTimeout = timeout - (Date.now() - startTime);
       if (remainingTimeout <= 0 || info.didTimeout) {
-        dev().fine(TAG, 'Timed out', timeout, info.didTimeout);
         fn(info);
       } else {
-        dev().fine(
-          TAG,
-          'Rescheduling with',
-          remainingTimeout,
-          info.timeRemaining()
-        );
         win.requestIdleCallback(rIC, {timeout: remainingTimeout});
       }
     } else {
-      dev().fine(TAG, 'Running idle callback with ', minimumTimeRemaining);
       fn(info);
     }
   }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -205,9 +205,7 @@ function getExperimentToggles(win) {
     if ('localStorage' in win) {
       experimentsString = win.localStorage.getItem(LOCAL_STORAGE_KEY);
     }
-  } catch (e) {
-    dev().warn(TAG, 'Failed to retrieve experiments from localStorage.');
-  }
+  } catch (err) {}
   const tokens = experimentsString ? experimentsString.split(/\s*,\s*/g) : [];
 
   const toggles = Object.create(null);

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -148,12 +148,7 @@ export function installFriendlyIframeEmbed(
     iframe.readyState = 'complete';
   };
   const registerViolationListener = () => {
-    iframe.contentWindow.addEventListener(
-      'securitypolicyviolation',
-      (violationEvent) => {
-        dev().warn('FIE', 'security policy violation', violationEvent);
-      }
-    );
+    iframe.contentWindow.addEventListener('securitypolicyviolation', () => {});
   };
   let loadedPromise;
   if (isSrcdocSupported()) {

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -16,7 +16,7 @@
 
 import {addAttributesToElement, closestAncestorElementBySelector} from './dom';
 import {deserializeMessage, isAmpMessage} from './3p-frame-messaging';
-import {dev, devAssert} from './log';
+import {devAssert} from './log';
 import {dict} from './utils/object';
 import {getData} from './event-helper';
 import {parseUrlDeprecated} from './url';
@@ -423,15 +423,7 @@ function getSentinel_(iframe, opt_is3P) {
 export function parseIfNeeded(data) {
   if (typeof data == 'string') {
     if (data.charAt(0) == '{') {
-      data =
-        tryParseJson(data, (e) => {
-          dev().warn(
-            'IFRAME-HELPER',
-            'Postmessage could not be parsed. ' +
-              'Is it in a valid JSON format?',
-            e
-          );
-        }) || null;
+      data = tryParseJson(data, () => {}) || null;
     } else if (isAmpMessage(data)) {
       data = deserializeMessage(data);
     } else {

--- a/src/impression.js
+++ b/src/impression.js
@@ -77,9 +77,7 @@ export function maybeTrackImpression(win) {
 
   trackImpressionPromise = Services.timerFor(win)
     .timeoutPromise(TIMEOUT_VALUE, promise, 'TrackImpressionPromise timeout')
-    .catch((error) => {
-      dev().warn('IMPRESSION', error);
-    });
+    .catch(() => {});
 
   const viewer = Services.viewerForDoc(win.document.documentElement);
   const isTrustedViewerPromise = viewer.isTrustedViewer();
@@ -156,14 +154,11 @@ function handleReplaceUrl(win) {
     .then(
       (response) => {
         if (!response || typeof response != 'object') {
-          dev().warn('IMPRESSION', 'get invalid replaceUrl response');
           return;
         }
         viewer.replaceUrl(response['replaceUrl'] || null);
       },
-      (err) => {
-        dev().warn('IMPRESSION', 'Error request replaceUrl from viewer', err);
-      }
+      () => {}
     );
 }
 

--- a/src/inabox/inabox-resources.js
+++ b/src/inabox/inabox-resources.js
@@ -21,12 +21,10 @@ import {READY_SCAN_SIGNAL} from '../service/resources-interface';
 import {Resource, ResourceState} from '../service/resource';
 import {Services} from '../services';
 import {VisibilityState} from '../visibility-state';
-import {dev} from '../log';
 import {getMode} from '../mode';
 import {hasNextNodeInDocumentOrder} from '../dom';
 import {registerServiceBuilderForDoc} from '../service';
 
-const TAG = 'inabox-resources';
 const FOUR_FRAME_DELAY = 70;
 
 /**
@@ -133,7 +131,6 @@ export class InaboxResources {
   add(element) {
     const resource = new Resource(++this.resourceIdCounter_, element, this);
     this.resources_.push(resource);
-    dev().fine(TAG, 'resource added:', resource.debugid);
   }
 
   /** @override */
@@ -156,7 +153,6 @@ export class InaboxResources {
     if (index !== -1) {
       this.resources_.splice(index, 1);
     }
-    dev().fine(TAG, 'element removed:', resource.debugid);
   }
 
   /** @override */
@@ -211,7 +207,6 @@ export class InaboxResources {
    */
   doPass_() {
     const now = Date.now();
-    dev().fine(TAG, 'doPass');
     // measure in a batch
     this.resources_.forEach((resource) => {
       if (!resource.isLayoutPending()) {
@@ -249,7 +244,6 @@ export class InaboxResources {
       ) {
         this.pendingBuildResources_.splice(i, 1);
         resource.build().then(() => this./*OK*/ schedulePass());
-        dev().fine(TAG, 'resource upgraded:', resource.debugid);
       }
     }
   }

--- a/src/inabox/inabox-viewport.js
+++ b/src/inabox/inabox-viewport.js
@@ -34,9 +34,6 @@ import {px, resetStyles, setImportantStyles} from '../style';
 import {registerServiceBuilderForDoc} from '../service';
 import {throttle} from '../utils/rate-limit';
 
-/** @const {string} */
-const TAG = 'inabox-viewport';
-
 /** @const {number} */
 const MIN_EVENT_INTERVAL = 100;
 
@@ -496,8 +493,6 @@ export class ViewportBindingInabox {
 
     /** @private {?UnlistenDef} */
     this.unobserveFunction_ = null;
-
-    dev().fine(TAG, 'initialized inabox viewport');
   }
 
   /** @override */
@@ -515,7 +510,6 @@ export class ViewportBindingInabox {
       MessageType.SEND_POSITIONS,
       MessageType.POSITION,
       (data) => {
-        dev().fine(TAG, 'Position changed: ', data);
         this.updateLayoutRects_(data['viewportRect'], data['targetRect']);
       }
     );
@@ -634,8 +628,6 @@ export class ViewportBindingInabox {
     );
 
     if (isChanged(boxRect, this.boxRect_)) {
-      dev().fine(TAG, 'Updating viewport box rect: ', boxRect);
-
       this.boxRect_ = boxRect;
       // Remeasure all AMP elements once iframe position or size are changed.
       // Because all layout boxes are calculated relatively to the

--- a/src/input.js
+++ b/src/input.js
@@ -16,11 +16,8 @@
 
 import {Observable} from './observable';
 import {Services} from './services';
-import {dev} from './log';
 import {listenOnce, listenOncePromise} from './event-helper';
 import {registerServiceBuilder} from './service';
-
-const TAG_ = 'Input';
 
 const MAX_MOUSE_CONFIRM_ATTEMPS_ = 3;
 const CLICK_TIMEOUT_ = 300;
@@ -58,7 +55,6 @@ export class Input {
       (win.navigator['maxTouchPoints'] !== undefined &&
         win.navigator['maxTouchPoints'] > 0) ||
       win['DocumentTouch'] !== undefined;
-    dev().fine(TAG_, 'touch detected:', this.hasTouch_);
 
     /** @private {boolean} */
     this.keyboardActive_ = false;
@@ -213,7 +209,6 @@ export class Input {
 
     this.keyboardActive_ = true;
     this.keyboardStateObservable_.fire(true);
-    dev().fine(TAG_, 'keyboard activated');
   }
 
   /** @private */
@@ -223,7 +218,6 @@ export class Input {
     }
     this.keyboardActive_ = false;
     this.keyboardStateObservable_.fire(false);
-    dev().fine(TAG_, 'keyboard deactivated');
   }
 
   /**
@@ -267,7 +261,6 @@ export class Input {
   mouseConfirmed_() {
     this.hasMouse_ = true;
     this.mouseDetectedObservable_.fire(true);
-    dev().fine(TAG_, 'mouse detected');
   }
 
   /** @private */
@@ -280,8 +273,6 @@ export class Input {
         'mousemove',
         /** @type {function(!Event)} */ (this.boundOnMouseMove_)
       );
-    } else {
-      dev().fine(TAG_, 'mouse detection failed');
     }
   }
 }

--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -518,9 +518,7 @@ export class MultidocManager {
         }),
         'Timeout reached waiting for visibility state change callback'
       )
-      .catch((error) => {
-        user().info(TAG, error);
-      });
+      .catch(() => {});
   }
 
   /**

--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -94,7 +94,6 @@ export class MultidocManager {
     });
     /** @const {!./service/ampdoc-impl.AmpDocShadow} */
     amp.ampdoc = ampdoc;
-    dev().fine(TAG, 'Attach to shadow root:', shadowRoot, ampdoc);
 
     // Install runtime CSS.
     installStylesForDoc(
@@ -214,7 +213,6 @@ export class MultidocManager {
       this.shadowRoots_.push(shadowRoot);
     }
 
-    dev().fine(TAG, 'Shadow root initialization is done:', shadowRoot, ampdoc);
     return amp;
   }
 
@@ -229,7 +227,6 @@ export class MultidocManager {
    */
   attachShadowDoc(hostElement, doc, url, opt_initParams) {
     user().assertString(url);
-    dev().fine(TAG, 'Attach shadow doc:', doc);
     // TODO(dvoytenko, #9490): once stable, port full document case to emulated
     // stream.
     return this.attachShadowDoc_(
@@ -272,7 +269,6 @@ export class MultidocManager {
    */
   attachShadowDocAsStream(hostElement, url, opt_initParams) {
     user().assertString(url);
-    dev().fine(TAG, 'Attach shadow doc as stream');
     return this.attachShadowDoc_(
       hostElement,
       url,
@@ -352,7 +348,6 @@ export class MultidocManager {
         switch (tagName) {
           case 'TITLE':
             shadowRoot.AMP.title = n.textContent;
-            dev().fine(TAG, '- set title: ', shadowRoot.AMP.title);
             break;
           case 'META':
             if (n.hasAttribute('charset')) {
@@ -372,11 +367,9 @@ export class MultidocManager {
             const href = n.getAttribute('href');
             if (rel == 'canonical') {
               shadowRoot.AMP.canonicalUrl = href;
-              dev().fine(TAG, '- set canonical: ', shadowRoot.AMP.canonicalUrl);
             } else if (rel == 'stylesheet') {
               // Must be a font definition: no other stylesheets are allowed.
               if (parentLinks[href]) {
-                dev().fine(TAG, '- stylesheet already included: ', href);
                 // To accomodate icon fonts whose stylesheets include
                 // the class definitions in addition to the font definition,
                 // we re-import the stylesheet into the shadow document.
@@ -395,16 +388,12 @@ export class MultidocManager {
                 el.setAttribute('type', 'text/css');
                 el.setAttribute('href', href);
                 this.win.document.head.appendChild(el);
-                dev().fine(TAG, '- import font to parent: ', href, el);
               }
-            } else {
-              dev().fine(TAG, '- ignore link rel=', rel);
             }
             break;
           case 'STYLE':
             if (n.hasAttribute('amp-boilerplate')) {
               // Ignore.
-              dev().fine(TAG, '- ignore boilerplate style: ', n);
             } else if (n.hasAttribute('amp-custom')) {
               installStylesForDoc(
                 ampdoc,
@@ -413,7 +402,6 @@ export class MultidocManager {
                 /* isRuntimeCss */ false,
                 'amp-custom'
               );
-              dev().fine(TAG, '- import style: ', n);
             } else if (n.hasAttribute('amp-keyframes')) {
               installStylesForDoc(
                 ampdoc,
@@ -422,33 +410,21 @@ export class MultidocManager {
                 /* isRuntimeCss */ false,
                 'amp-keyframes'
               );
-              dev().fine(TAG, '- import style: ', n);
             }
             break;
           case 'SCRIPT':
             if (n.hasAttribute('src')) {
-              dev().fine(TAG, '- src script: ', n);
               const src = n.getAttribute('src');
               const urlParts = parseExtensionUrl(src);
-              const isRuntime = !urlParts.extensionId;
               // Note: Some extensions don't have [custom-element] or
               // [custom-template] e.g. amp-viewer-integration.
               const customElement = n.getAttribute('custom-element');
               const customTemplate = n.getAttribute('custom-template');
-              if (isRuntime) {
-                dev().fine(TAG, '- ignore runtime script: ', src);
-              } else if (customElement || customTemplate) {
+              if (customElement || customTemplate) {
                 // This is an extension.
                 this.extensions_.installExtensionForDoc(
                   ampdoc,
                   customElement || customTemplate,
-                  urlParts.extensionVersion
-                );
-                dev().fine(
-                  TAG,
-                  '- load extension: ',
-                  customElement || customTemplate,
-                  ' ',
                   urlParts.extensionVersion
                 );
                 if (customElement) {
@@ -462,7 +438,6 @@ export class MultidocManager {
               const type = n.getAttribute('type') || 'application/javascript';
               if (type.indexOf('javascript') == -1) {
                 shadowRoot.appendChild(this.win.document.importNode(n, true));
-                dev().fine(TAG, '- non-src script: ', n);
               } else if (!n.hasAttribute('amp-onerror')) {
                 // Don't error on amp-onerror script (https://github.com/ampproject/amphtml/issues/31966)
                 user().error(TAG, '- unallowed inline javascript: ', n);

--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -359,7 +359,6 @@ export class MultidocManager {
               ampdoc.setMetaByName(name, n.getAttribute('content') || '');
             } else {
               // TODO(dvoytenko): copy other meta tags.
-              dev().warn(TAG, 'meta ignored: ', n);
             }
             break;
           case 'LINK':

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -1086,7 +1086,6 @@ class TransferLayerBody {
       return;
     }
 
-    dev().fine(TAG, 'transfer to fixed:', fe.id, fe.element);
     user().warn(
       TAG,
       'In order to improve scrolling performance in Safari,' +
@@ -1142,7 +1141,6 @@ class TransferLayerBody {
       return;
     }
     const {element, placeholder} = fe;
-    dev().fine(TAG, 'return from fixed:', fe.id, element);
 
     if (fe.lightboxed) {
       element.classList.remove(LIGHTBOX_ELEMENT_CLASS);

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -476,16 +476,7 @@ export class HistoryBindingNatural_ {
     history.pushState = this.historyPushState_.bind(this);
     history.replaceState = this.historyReplaceState_.bind(this);
 
-    this.popstateHandler_ = (e) => {
-      const event = /** @type {!PopStateEvent} */ (e);
-      const state = /** @type {!JsonObject} */ (event.state);
-      dev().fine(
-        TAG_,
-        'popstate event: ' +
-          this.win.history.length +
-          ', ' +
-          JSON.stringify(state)
-      );
+    this.popstateHandler_ = () => {
       this.onHistoryEvent_();
     };
     this.win.addEventListener('popstate', this.popstateHandler_);
@@ -594,10 +585,6 @@ export class HistoryBindingNatural_ {
   /** @private */
   onHistoryEvent_() {
     let state = this.getState_();
-    dev().fine(
-      TAG_,
-      'history event: ' + this.win.history.length + ', ' + JSON.stringify(state)
-    );
     const stackIndex = state ? state[HISTORY_PROP_] : undefined;
     let newStackIndex = this.stackIndex_;
     const waitingState = this.waitingState_;
@@ -797,13 +784,6 @@ export class HistoryBindingNatural_ {
       this.win.history.length - 1
     );
     if (this.stackIndex_ != historyState.stackIndex) {
-      dev().fine(
-        TAG_,
-        'stack index changed: ' +
-          this.stackIndex_ +
-          ' -> ' +
-          historyState.stackIndex
-      );
       this.stackIndex_ = historyState.stackIndex;
       if (this.onStateUpdated_) {
         this.onStateUpdated_(historyState);
@@ -1056,7 +1036,6 @@ export class HistoryBindingVirtual_ {
   updateHistoryState_(state) {
     const {stackIndex} = state;
     if (this.stackIndex_ != stackIndex) {
-      dev().fine(TAG_, `stackIndex: ${this.stackIndex_} -> ${stackIndex}`);
       this.stackIndex_ = stackIndex;
       if (this.onStateUpdated_) {
         this.onStateUpdated_(state);

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -878,20 +878,12 @@ export class HistoryBindingVirtual_ {
    * otherwise.
    * @param {*} maybeHistoryState
    * @param {!HistoryStateDef} fallbackState
-   * @param {string} debugId
    * @return {!HistoryStateDef}
    * @private
    */
-  toHistoryState_(maybeHistoryState, fallbackState, debugId) {
+  toHistoryState_(maybeHistoryState, fallbackState) {
     if (this.isHistoryState_(maybeHistoryState)) {
       return /** @type {!HistoryStateDef} */ (maybeHistoryState);
-    } else {
-      dev().warn(
-        TAG_,
-        'Ignored unexpected "%s" data:',
-        debugId,
-        maybeHistoryState
-      );
     }
     return fallbackState;
   }
@@ -1024,8 +1016,6 @@ export class HistoryBindingVirtual_ {
     }
     if (this.isHistoryState_(data)) {
       this.updateHistoryState_(/** @type {!HistoryStateDef} */ (data));
-    } else {
-      dev().warn(TAG_, 'Ignored unexpected "historyPopped" data:', data);
     }
   }
 

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -18,7 +18,6 @@ import {Services} from '../services';
 import {TickLabel} from '../enums';
 import {htmlFor} from '../static-template';
 import {isExperimentOn} from '../experiments';
-import {user} from '../log';
 
 /** @const {number} */
 const NTH_FRAME = 200;
@@ -166,10 +165,6 @@ export class JankMeter {
           const span = this.win_.Math.floor(entries[i].duration / 50);
           if (entries[i].name == 'cross-origin-descendant') {
             this.longTaskChild_ += span;
-            user().info(
-              'LONGTASK',
-              `from child frame ${entries[i].duration}ms`
-            );
           } else {
             this.longTaskSelf_ += span;
           }

--- a/src/service/jank-meter.js
+++ b/src/service/jank-meter.js
@@ -16,9 +16,9 @@
 
 import {Services} from '../services';
 import {TickLabel} from '../enums';
-import {dev, user} from '../log';
 import {htmlFor} from '../static-template';
 import {isExperimentOn} from '../experiments';
+import {user} from '../log';
 
 /** @const {number} */
 const NTH_FRAME = 200;
@@ -79,7 +79,6 @@ export class JankMeter {
     this.totalFrameCnt_++;
     if (paintLatency > 16) {
       this.badFrameCnt_++;
-      dev().info('JANK', 'Paint latency: ' + paintLatency + 'ms');
     }
 
     // Report metrics on Nth frame, so we have sort of normalized numbers.
@@ -173,7 +172,6 @@ export class JankMeter {
             );
           } else {
             this.longTaskSelf_ += span;
-            dev().info('LONGTASK', `from self frame ${entries[i].duration}ms`);
           }
         }
       }

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -572,11 +572,6 @@ export class Navigation {
    * @private
    */
   removeViewerQueryBeforeNavigation_(win, fromLocation, target) {
-    dev().info(
-      TAG,
-      'Removing iframe query string before navigation:',
-      fromLocation.search
-    );
     const original = fromLocation.href;
     const noQuery = `${fromLocation.origin}${fromLocation.pathname}${fromLocation.hash}`;
     win.history.replaceState(null, '', noQuery);
@@ -584,7 +579,6 @@ export class Navigation {
     const restoreQuery = () => {
       const currentHref = win.location.href;
       if (currentHref == noQuery) {
-        dev().info(TAG, 'Restored iframe URL with query string:', original);
         win.history.replaceState(null, '', original);
       } else {
         dev().error(TAG, 'Unexpected iframe URL change:', currentHref, noQuery);

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -658,11 +658,11 @@ export class Navigation {
     // we do `replace` to avoid messing with the container's history.
     if (toLocation.hash != fromLocation.hash) {
       this.history_.replaceStateForTarget(toLocation.hash).then(() => {
-        this.scrollToElement_(el, hash);
+        this.scrollToElement_(el);
       });
     } else {
       // If the hash did not update just scroll to the element.
-      this.scrollToElement_(el, hash);
+      this.scrollToElement_(el);
     }
   }
 
@@ -685,10 +685,9 @@ export class Navigation {
   /**
    * Scrolls the page to the given element.
    * @param {?Element} elem
-   * @param {string} hash
    * @private
    */
-  scrollToElement_(elem, hash) {
+  scrollToElement_(elem) {
     // Scroll to the element if found.
     if (elem) {
       // The first call to scrollIntoView overrides browsers' default scrolling
@@ -703,11 +702,6 @@ export class Navigation {
       Services.timerFor(this.ampdoc.win).delay(
         () => this.viewport_./*OK*/ scrollIntoView(dev().assertElement(elem)),
         1
-      );
-    } else {
-      dev().warn(
-        TAG,
-        `failed to find element with id=${hash} or a[name=${hash}]`
       );
     }
   }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -39,8 +39,6 @@ const QUEUE_LIMIT = 50;
 /** @const {string} */
 const VISIBILITY_CHANGE_EVENT = 'visibilitychange';
 
-const TAG = 'Performance';
-
 /**
  * Fields:
  * {{
@@ -445,9 +443,7 @@ export class Performance {
         this.flush();
       });
       obs.observe(init);
-    } catch (err) {
-      dev().warn(TAG, err);
-    }
+    } catch (err) {}
   }
 
   /**

--- a/src/service/real-time-config/real-time-config-impl.js
+++ b/src/service/real-time-config/real-time-config-impl.js
@@ -16,12 +16,12 @@
 import {CONSENT_POLICY_STATE} from '../../consent-state';
 import {RTC_VENDORS} from './callout-vendors';
 import {Services} from '../../services';
-import {dev, user, userAssert} from '../../log';
 import {getMode} from '../../mode';
 import {isArray, isObject} from '../../types';
 import {isCancellation} from '../../error';
 import {registerServiceBuilderForDoc} from '../../service';
 import {tryParseJson} from '../../json';
+import {user, userAssert} from '../../log';
 
 /** @type {string} */
 const TAG = 'real-time-config';
@@ -117,7 +117,6 @@ export class RealTimeConfigManager {
    * @private
    */
   buildErrorResponse_(error, callout, errorReportingUrl, opt_rtcTime) {
-    dev().warn(TAG, `RTC callout to ${callout} caused ${error}`);
     if (errorReportingUrl) {
       this.sendErrorMessage(error, errorReportingUrl);
     }
@@ -223,12 +222,6 @@ export class RealTimeConfigManager {
           CONSENT_POLICY_STATE[sendRegardlessOfConsentState[i]]
         ) {
           return true;
-        } else if (!CONSENT_POLICY_STATE[sendRegardlessOfConsentState[i]]) {
-          dev().warn(
-            TAG,
-            'Invalid RTC consent state given: ' +
-              `${sendRegardlessOfConsentState[i]}`
-          );
         }
       }
       return false;
@@ -317,8 +310,6 @@ export class RealTimeConfigManager {
         errorReportingUrl = urlObj.errorReportingUrl;
       } else if (typeof urlObj == 'string') {
         url = urlObj;
-      } else {
-        dev().warn(TAG, `Invalid url: ${urlObj}`);
       }
       this.inflateAndSendRtc_(
         url,
@@ -622,7 +613,6 @@ export class RealTimeConfigManager {
       const validateErrorReportingUrl = (urlObj) => {
         const errorUrl = urlObj['errorReportingUrl'];
         if (errorUrl && !Services.urlForDoc(this.ampDoc_).isSecure(errorUrl)) {
-          dev().warn(TAG, `Insecure RTC errorReportingUrl: ${errorUrl}`);
           urlObj['errorReportingUrl'] = undefined;
         }
       };

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -932,17 +932,10 @@ export class Resource {
 
     // Unwanted re-layouts are ignored.
     if (this.layoutCount_ > 0 && !this.element.isRelayoutNeeded()) {
-      dev().fine(
-        TAG,
-        "layout canceled since it wasn't requested:",
-        this.debugid,
-        this.state_
-      );
       this.state_ = ResourceState.LAYOUT_COMPLETE;
       return Promise.resolve();
     }
 
-    dev().fine(TAG, 'start layout:', this.debugid, 'count:', this.layoutCount_);
     this.layoutCount_++;
     this.state_ = ResourceState.LAYOUT_SCHEDULED;
     this.abortController_ = new AbortController();
@@ -993,10 +986,7 @@ export class Resource {
       ? ResourceState.LAYOUT_COMPLETE
       : ResourceState.LAYOUT_FAILED;
     this.lastLayoutError_ = opt_reason;
-    if (success) {
-      dev().fine(TAG, 'layout complete:', this.debugid);
-    } else {
-      dev().fine(TAG, 'loading failed:', this.debugid, opt_reason);
+    if (!success) {
       return Promise.reject(opt_reason);
     }
   }

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -249,9 +249,7 @@ export class ResourcesImpl {
         // Wait for intersection callback instead of measuring all elements
         // during the first pass.
         this.relayoutAll_ = false;
-      } catch (e) {
-        dev().warn(TAG_, 'Falling back to classic Resources:', e);
-      }
+      } catch (e) {}
     }
 
     // When user scrolling stops, run pass to check newly in-viewport elements.

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -45,7 +45,6 @@ import {remove} from '../utils/array';
 import {startupChunk} from '../chunk';
 import {throttle} from '../utils/rate-limit';
 
-const TAG_ = 'Resources';
 const LAYOUT_TASK_ID_ = 'L';
 const LAYOUT_TASK_OFFSET_ = 0;
 const PRELOAD_TASK_ID_ = 'P';
@@ -1600,13 +1599,6 @@ export class ResourcesImpl {
     this.exec_.dequeue(task);
     this.schedulePass(POST_TASK_PASS_DELAY_);
     if (!success) {
-      dev().info(
-        TAG_,
-        'task failed:',
-        task.id,
-        task.resource.debugid,
-        opt_reason
-      );
       return Promise.reject(opt_reason);
     }
   }

--- a/src/service/storage-impl.js
+++ b/src/service/storage-impl.js
@@ -170,7 +170,6 @@ export class Storage {
         message['type'] == 'amp-storage-reset' &&
         message['origin'] == this.origin_
       ) {
-        dev().fine(TAG, 'Received reset message');
         this.storePromise_ = null;
       }
     });
@@ -178,7 +177,6 @@ export class Storage {
 
   /** @private */
   broadcastReset_() {
-    dev().fine(TAG, 'Broadcasted reset message');
     this.viewer_.broadcast(
       /** @type {!JsonObject} */ ({
         'type': 'amp-storage-reset',

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -151,14 +151,9 @@ export class ViewerImpl {
     }
 
     this.isRuntimeOn_ = !parseInt(ampdoc.getParam('off'), 10);
-    dev().fine(TAG_, '- runtimeOn:', this.isRuntimeOn_);
-
     this.overtakeHistory_ = !!(
       parseInt(ampdoc.getParam('history'), 10) || this.overtakeHistory_
     );
-    dev().fine(TAG_, '- history:', this.overtakeHistory_);
-
-    dev().fine(TAG_, '- visibilityState:', this.ampdoc.getVisibilityState());
 
     /**
      * Whether the AMP document is embedded in a Chrome Custom Tab.
@@ -265,7 +260,6 @@ export class ViewerImpl {
         }
         this.win.history.replaceState({}, '', newUrl);
         delete this.hashParams_['click'];
-        dev().fine(TAG_, 'replace fragment:' + this.win.location.href);
       }
     }
 
@@ -429,7 +423,6 @@ export class ViewerImpl {
   /** @override */
   toggleRuntime() {
     this.isRuntimeOn_ = !this.isRuntimeOn_;
-    dev().fine(TAG_, 'Runtime state:', this.isRuntimeOn_);
     this.runtimeOnObservable_.fire(this.isRuntimeOn_);
   }
 
@@ -546,11 +539,6 @@ export class ViewerImpl {
     }
 
     this.ampdoc.overrideVisibilityState(state);
-    dev().fine(
-      TAG_,
-      'visibilitychange event:',
-      this.ampdoc.getVisibilityState()
-    );
   }
 
   /** @override */
@@ -750,7 +738,6 @@ export class ViewerImpl {
     if (origin == null) {
       throw new Error('message channel must have an origin');
     }
-    dev().fine(TAG_, 'message channel established with origin: ', origin);
     this.messageDeliverer_ = deliverer;
     this.messagingOrigin_ = origin;
     this.messagingReadyResolver_(origin);
@@ -891,7 +878,6 @@ export class ViewerImpl {
       ) {
         this.win.history.replaceState({}, '', replaceUrl.href);
         this.win.location.originalHref = url.href;
-        dev().fine(TAG_, 'replace url:' + replaceUrl.href);
       }
     } catch (e) {
       dev().error(TAG_, 'replaceUrl failed', e);

--- a/src/service/viewport/viewport-binding-ios-embed-wrapper.js
+++ b/src/service/viewport/viewport-binding-ios-embed-wrapper.js
@@ -27,8 +27,6 @@ import {layoutRectLtwh} from '../../layout-rect';
 import {waitForBodyOpen} from '../../dom';
 import {whenDocumentReady} from '../../document-ready';
 
-const TAG_ = 'Viewport';
-
 /**
  * Implementation of ViewportBindingDef based for iframed iOS case where iframes
  * are not scrollable. Scrolling accomplished here by inserting a scrollable
@@ -85,8 +83,6 @@ export class ViewportBindingIosEmbedWrapper_ {
     whenDocumentReady(doc).then(() => {
       documentElement.classList.add('i-amphtml-ios-overscroll');
     });
-
-    dev().fine(TAG_, 'initialized ios-embed-wrapper viewport');
   }
 
   /** @override */

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -21,10 +21,7 @@ import {
   marginBottomOfLastChild,
 } from './viewport-binding-def';
 import {computedStyle, px, setImportantStyles} from '../../style';
-import {dev} from '../../log';
 import {layoutRectLtwh} from '../../layout-rect';
-
-const TAG_ = 'Viewport';
 
 /**
  * Implementation of ViewportBindingDef based on the native window. It assumes
@@ -61,8 +58,6 @@ export class ViewportBindingNatural_ {
 
     /** @const {function()} */
     this.boundResizeEventListener_ = () => this.resizeObservable_.fire();
-
-    dev().fine(TAG_, 'initialized natural viewport');
   }
 
   /** @private */

--- a/src/service/viewport/viewport-impl.js
+++ b/src/service/viewport/viewport-impl.js
@@ -850,7 +850,6 @@ export class ViewportImpl {
   setViewportMetaString_(viewportMetaString) {
     const viewportMeta = this.getViewportMeta_();
     if (viewportMeta && viewportMeta.content != viewportMetaString) {
-      dev().fine(TAG_, 'changed viewport meta to:', viewportMetaString);
       viewportMeta.content = viewportMetaString;
       return true;
     }
@@ -943,20 +942,6 @@ export class ViewportImpl {
     const size = this.getSize();
     const scrollTop = this.getScrollTop();
     const scrollLeft = this.getScrollLeft();
-    dev().fine(
-      TAG_,
-      'changed event:',
-      'relayoutAll=',
-      relayoutAll,
-      'top=',
-      scrollTop,
-      'left=',
-      scrollLeft,
-      'bottom=',
-      scrollTop + size.height,
-      'velocity=',
-      velocity
-    );
     this.changeObservable_.fire({
       relayoutAll,
       top: scrollTop,
@@ -1010,10 +995,6 @@ export class ViewportImpl {
     if (now != referenceTime) {
       velocity = (newScrollTop - referenceTop) / (now - referenceTime);
     }
-    dev().fine(
-      TAG_,
-      'scroll: scrollTop=' + newScrollTop + '; velocity=' + velocity
-    );
     if (Math.abs(velocity) < 0.03) {
       this.changed_(/* relayoutAll */ false, velocity);
       this.scrollTracking_ = false;

--- a/src/service/vsync-impl.js
+++ b/src/service/vsync-impl.js
@@ -313,10 +313,6 @@ export class Vsync {
   runAnim(contextNode, task, opt_state) {
     // Do not request animation frames when the document is not visible.
     if (!this.canAnimate_(contextNode)) {
-      dev().warn(
-        'VSYNC',
-        'Did not schedule a vsync request, because document was invisible'
-      );
       return false;
     }
     this.run(task, opt_state);

--- a/src/utils/dom-ancestor-visitor.js
+++ b/src/utils/dom-ancestor-visitor.js
@@ -120,12 +120,7 @@ class Visitor {
     let result;
     try {
       result = this.callback_(element, style);
-    } catch (e) {
-      dev().warn(
-        'DOM-ANCESTOR-VISITOR',
-        `Visitor encountered error during callback execution: "${e}".`
-      );
-    }
+    } catch (e) {}
     if (!--this.maxAncestorsToVisit_ || result != undefined) {
       this.complete = true;
     }

--- a/src/utils/lru-cache.js
+++ b/src/utils/lru-cache.js
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-import {dev} from '../log';
-
-/** @const {string} */
-const TAG = 'lru-cache';
-
 /**
  * @template T
  */
@@ -86,7 +81,6 @@ export class LruCache {
       return;
     }
 
-    dev().warn(TAG, 'Trimming LRU cache');
     const cache = this.cache_;
     let oldest = this.access_ + 1;
     let oldestKey;

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -90,7 +90,6 @@ class AmpWorker {
       useLocal,
       useRtvVersion
     );
-    dev().fine(TAG, 'Fetching web worker from', url);
 
     /** @private {Worker} */
     this.worker_ = null;

--- a/src/web-worker/web-worker.js
+++ b/src/web-worker/web-worker.js
@@ -77,9 +77,6 @@ self.addEventListener('message', function (event) {
 
   switch (method) {
     case 'bind.init':
-      if (evaluator) {
-        dev().warn(TAG, 'Overwriting existing evaluator for scope:', scope);
-      }
       const allowUrlProperties = args[0];
       evaluators_[scope] = new BindEvaluator(allowUrlProperties);
       returnValue = true;


### PR DESCRIPTION
**summary**
After a taking a poll in a chat with a number of AMP Core Contributors, it seems the majority of folks do not use AMP's Log Levels.

In order to save the bytes + mental overhead, we're going to remove the concept from the codebase.
I plan to do this in two parts:

1. Remove all uses of fine, warn, and info.
2. Remove all traces of LogLevel API from src/log.js.