### PR TITLE
❄️ Skip flaky ads test

### DIFF
--- a/test/integration/test-amphtml-ads.js
+++ b/test/integration/test-amphtml-ads.js
@@ -277,7 +277,8 @@ t.run('AMPHTML ad on non-AMP page (inabox)', () => {
   );
 });
 
-t.run('A more real AMPHTML image ad', () => {
+// TODO(wg-monetization, #24421): Make this test less flaky.
+t.skip('A more real AMPHTML image ad', () => {
   const {testServerPort} = window.ampTestRuntimeConfig;
 
   // The image ad as seen in examples/inabox.gpt.html,


### PR DESCRIPTION
The ads tests in `test/integration/test-amphtml-ads.js` have been particularly flaky in the recent past. There is a long-standing issue to track this at #24421.

**Example failure logs:** https://app.circleci.com/pipelines/github/ampproject/amphtml/1726/workflows/1fb8f966-0e94-4f36-94b0-85a64339adc2/jobs/16647

This PR skips another of its tests because the flakiness is hampering development.

@ampproject/wg-monetization Could we prioritize fixing these tests during the upcoming fix-it week?

