### PR TITLE
📖  Fix documentation about amp-list overflow condition

### DIFF
--- a/extensions/amp-list/amp-list.md
+++ b/extensions/amp-list/amp-list.md
@@ -153,7 +153,7 @@ In `<amp-list>`, you can use the [`items`](#items) attribute to render a subset 
 
 ### Specifying an overflow
 
-Optionally, the `<amp-list>` component can contain an element with the `overflow` attribute. Add an element with the AMP `overflow` attribute to `amp-list` if the AMP framework is unable to size it as requested. If you include a child element of `amp-list` with the `overflow` attribute, it will appear if one of the following conditions are met:
+Optionally, the `<amp-list>` component can contain an element with the `overflow` attribute. Add an element with the AMP `overflow` attribute to `amp-list` if the AMP framework is unable to size it as requested. If you include a child element of `amp-list` with the `overflow` attribute, it will appear if **none** of the following conditions are met:
 
 -   The bottom of `amp-list` is below the viewport.
 


### PR DESCRIPTION
The current documentation seems confusion/misleading - it's saying that
the overflow element **will** display when one of the conditions is met,
meaning that the amp-list will fail to resize if either the bottom of
the amp-list is below the viewport or near the end of the page content.
That seems wrong and opposite of what the actual behavior is: amp-list
should be able to resize and overflow elements should not display if one
of the condition is met.

/to @samouri 