### PR TITLE
🏗 Clean up log coloring, enable on GH Actions

### DIFF
--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -29,6 +29,9 @@ if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "darwin"* ]]; then
   echo "$HOME/.npm/bin" >> $GITHUB_PATH # For later
 fi
 
+echo $(GREEN "Enabling log coloring...")
+echo "FORCE_COLOR=1" >> $GITHUB_ENV
+
 echo $(GREEN "Installing gulp-cli...")
 npm install --global gulp-cli
 

--- a/build-system/compile/log-messages.js
+++ b/build-system/compile/log-messages.js
@@ -15,7 +15,7 @@
  */
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
-const {cyan} = require('colors');
+const {cyan} = require('kleur/colors');
 const {log} = require('../common/logging');
 
 const pathPrefix = 'dist/log-messages';


### PR DESCRIPTION
In #32539, we replaced `ansi-colors` with `kleur/colors`. 2 changes here:
- Clean up one stray use of `colors`
- Enable log coloring on GH actions (supported even though it's not TTY)

Follow up to #32539.

**Reference:** https://github.com/lukeed/kleur#conditional-support