### PR TITLE
🏗 Use natively installed `chromedriver` and `geckodriver` on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,11 @@ commands:
     steps:
       - browser-tools/install-chrome:
           replace-existing: true
+      - browser-tools/install-chromedriver
+  install_firefox:
+    steps:
+      - browser-tools/install-firefox
+      - browser-tools/install-geckodriver
   fail_fast:
     steps:
       - run:
@@ -211,6 +216,7 @@ jobs:
     steps:
       - setup_vm
       - install_chrome
+      - install_firefox
       - run:
           name: 'End-to-End Tests'
           command: node build-system/pr-check/e2e-tests.js
@@ -231,6 +237,7 @@ jobs:
     steps:
       - setup_vm
       - install_chrome
+      - install_firefox
       - restore_karma_cache:
           cache_name: experimentA
       - run:
@@ -245,6 +252,7 @@ jobs:
     steps:
       - setup_vm
       - install_chrome
+      - install_firefox
       - restore_karma_cache:
           cache_name: experimentB
       - run:
@@ -259,6 +267,7 @@ jobs:
     steps:
       - setup_vm
       - install_chrome
+      - install_firefox
       - restore_karma_cache:
           cache_name: experimentC
       - run:

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// import to install chromedriver and geckodriver
-require('chromedriver');
-require('geckodriver');
 
 const argv = require('minimist')(process.argv.slice(2));
 const chrome = require('selenium-webdriver/chrome');
@@ -34,7 +31,7 @@ const {AmpDriver, AmpdocEnvironment} = require('./amp-driver');
 const {Builder, Capabilities, logging} = require('selenium-webdriver');
 const {HOST, PORT} = require('../serve');
 const {installRepl, uninstallRepl} = require('./repl');
-const {isCiBuild} = require('../../common/ci');
+const {isCiBuild, isCircleciBuild} = require('../../common/ci');
 const {PuppeteerController} = require('./puppeteer-controller');
 
 /** Should have something in the name, otherwise nothing is shown. */
@@ -52,6 +49,15 @@ const supportedBrowsers = new Set(['chrome', 'firefox', 'safari']);
 let istanbulMiddleware;
 if (argv.coverage) {
   istanbulMiddleware = require('istanbul-middleware/lib/core');
+}
+
+/**
+ * Importing will install chromedriver and geckodriver. On CircleCI, stable
+ * versions of both drivers are natively installed, so do not reinstall here.
+ */
+if (!isCircleciBuild()) {
+  require('chromedriver');
+  require('geckodriver');
 }
 
 /**


### PR DESCRIPTION
Speculative fix for https://github.com/ampproject/amphtml/issues/32442#issuecomment-776811779