### PR TITLE
🏗 Split experiment builds and tests into separate jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,9 +225,36 @@ jobs:
           name: 'Performance Tests'
           command: node build-system/pr-check/performance-tests.js
       - fail_fast
-  'Experiment A Tests':
+  'Experiment A Build':
     executor:
       name: amphtml-xlarge-executor
+    steps:
+      - setup_vm
+      - run:
+          name: 'Experiment A Build'
+          command: node build-system/pr-check/experiment-build.js --experiment=experimentA
+      - fail_fast
+  'Experiment B Build':
+    executor:
+      name: amphtml-xlarge-executor
+    steps:
+      - setup_vm
+      - run:
+          name: 'Experiment B Build'
+          command: node build-system/pr-check/experiment-build.js --experiment=experimentB
+      - fail_fast
+  'Experiment C Build':
+    executor:
+      name: amphtml-xlarge-executor
+    steps:
+      - setup_vm
+      - run:
+          name: 'Experiment C Build'
+          command: node build-system/pr-check/experiment-build.js --experiment=experimentC
+      - fail_fast
+  'Experiment A Tests':
+    executor:
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - install_chrome
@@ -241,7 +268,7 @@ jobs:
       - fail_fast
   'Experiment B Tests':
     executor:
-      name: amphtml-xlarge-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - install_chrome
@@ -255,7 +282,7 @@ jobs:
       - fail_fast
   'Experiment C Tests':
     executor:
-      name: amphtml-xlarge-executor
+      name: amphtml-large-executor
     steps:
       - setup_vm
       - install_chrome
@@ -309,12 +336,24 @@ workflows:
           <<: *push_and_pr_builds
           requires:
             - 'Nomodule Build'
+      - 'Experiment A Build':
+          <<: *push_and_pr_builds
+      - 'Experiment B Build':
+          <<: *push_and_pr_builds
+      - 'Experiment C Build':
+          <<: *push_and_pr_builds
       - 'Experiment A Tests':
           <<: *push_and_pr_builds
+          requires:
+            - 'Experiment A Build'
       - 'Experiment B Tests':
           <<: *push_and_pr_builds
+          requires:
+            - 'Experiment B Build'
       - 'Experiment C Tests':
           <<: *push_and_pr_builds
+          requires:
+            - 'Experiment C Build'
       # TODO(wg-performance, #12128): This takes 30 mins and fails regularly.
       # - 'Performance Tests':
       #     <<: *push_builds_only

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ addons:
 stages:
   - name: build
   - name: test
-  - name: experiment
-    if: type = push
 jobs:
   include:
     - stage: build
@@ -99,22 +97,4 @@ jobs:
       name: 'End to End Tests'
       script:
         - unbuffer node build-system/pr-check/e2e-tests.js
-    - stage: experiment
-      name: 'Experiment A Tests'
-      script:
-        - unbuffer node build-system/pr-check/experiment-tests.js --experiment=experimentA
-    - stage: experiment
-      name: 'Experiment B Tests'
-      script:
-        - unbuffer node build-system/pr-check/experiment-tests.js --experiment=experimentB
-    - stage: experiment
-      name: 'Experiment C Tests'
-      script:
-        - unbuffer node build-system/pr-check/experiment-tests.js --experiment=experimentC
-    - stage: experiment
-      name: 'Performance Tests'
-      script:
-        - unbuffer node build-system/pr-check/performance-tests.js
-  allow_failures:
-    - script: unbuffer node build-system/pr-check/performance-tests.js # See #28148
   fast_finish: true

--- a/build-system/pr-check/experiment-build.js
+++ b/build-system/pr-check/experiment-build.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,28 @@
 'use strict';
 
 /**
- * @fileoverview Script that runs the experiment A/B/C tests during CI.
+ * @fileoverview Script that builds the experiment A/B/C runtime during CI.
  */
 
 const {
   getExperimentConfig,
-  downloadExperimentOutput,
   printSkipMessage,
   timedExecOrDie,
+  uploadExperimentOutput,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
 const {experiment} = require('minimist')(process.argv.slice(2));
 const {runCiJob} = require('./ci-job');
 
-const jobName = `${experiment}-tests.js`;
+const jobName = `${experiment}-build.js`;
 
 function pushBuildWorkflow() {
   const config = getExperimentConfig(experiment);
   if (config) {
     const defineFlag = `--define_experiment_constant ${config.define_experiment_constant}`;
-    const experimentFlag = `--experiment ${experiment}`;
-    downloadExperimentOutput(experiment);
-    timedExecOrDie(
-      `gulp integration --nobuild --compiled --headless ${experimentFlag} ${defineFlag}`
-    );
-    timedExecOrDie(
-      `gulp e2e --nobuild --compiled --headless ${experimentFlag} ${defineFlag}`
-    );
+    timedExecOrDie('gulp update-packages');
+    timedExecOrDie(`gulp dist --fortesting ${defineFlag}`);
+    uploadExperimentOutput(experiment);
   } else {
     printSkipMessage(
       jobName,


### PR DESCRIPTION
In #32574, we added experiment tests to the PR build workflow so that AMP code could be more solidly tested before merge.

This PR splits the building and testing of experiments into two separate jobs. There are a few advantages:
- Tests (which run serially anyway) now use a lower power VM (5x cheaper), so saves $$
- Rerunning tests will not need a full rebuild, saving time and $$
- We can now deploy experiment code via PR deploy if we want to

It also removes the now inaccurate and no longer used `experiment` stage from Travis (we're shutting it down soon)

**Results:** [link](https://app.circleci.com/pipelines/github/ampproject/amphtml/1804/workflows/832075ee-60cf-49c8-8173-4173157b4b3c)

![image](https://user-images.githubusercontent.com/26553114/107669296-95738180-6c5f-11eb-8eb5-ce2d6c57f450.png)

**Future work:** Speed up E2E tests #32616

Follow up to #32574