### PR TITLE
🏗  Remove `gulp` streaming from a few developer tasks

### DIFF
--- a/build-system/tasks/caches-json.js
+++ b/build-system/tasks/caches-json.js
@@ -15,35 +15,35 @@
  */
 'use strict';
 
-const fs = require('fs');
+const path = require('path');
 const {log, logLocalDev} = require('../common/logging');
 const {red, green, cyan} = require('kleur/colors');
 
 const expectedCaches = ['google', 'bing'];
-const cachesJsonPath = 'build-system/global-configs/caches.json';
+const cachesJsonPath = '../global-configs/caches.json';
 
 /**
- * Fail if build-system/global-configs/caches.json is missing any expected caches.
+ * Entry point for gulp caches-jason.
  */
 async function cachesJson() {
-  let obj;
+  const filename = path.basename(cachesJsonPath);
+  let jsonContent;
   try {
-    const contents = fs.readFileSync(cachesJsonPath).toString();
-    obj = JSON.parse(contents);
+    jsonContent = require(cachesJsonPath);
   } catch (e) {
-    log(red('ERROR:'), 'Could not parse', cyan(cachesJsonPath));
+    log(red('ERROR:'), 'Could not parse', cyan(filename));
     process.exitCode = 1;
     return;
   }
   const foundCaches = [];
-  for (const foundCache of obj.caches) {
+  for (const foundCache of jsonContent.caches) {
     foundCaches.push(foundCache.id);
   }
   for (const cache of expectedCaches) {
     if (foundCaches.includes(cache)) {
-      logLocalDev(green('✔'), 'Found', cyan(cache), 'in', cyan(cachesJsonPath));
+      logLocalDev(green('✔'), 'Found', cyan(cache), 'in', cyan(filename));
     } else {
-      log(red('✖'), 'Missing', cyan(cache), 'in', cyan(cachesJsonPath));
+      log(red('✖'), 'Missing', cyan(cache), 'in', cyan(filename));
       process.exitCode = 1;
     }
   }
@@ -53,5 +53,4 @@ module.exports = {
   cachesJson,
 };
 
-cachesJson.description =
-  'Check that some expected caches are included in caches.json.';
+cachesJson.description = 'Check that caches.json contains all expected caches.';

--- a/build-system/tasks/caches-json.js
+++ b/build-system/tasks/caches-json.js
@@ -31,7 +31,7 @@ async function cachesJson() {
     const contents = fs.readFileSync(cachesJsonPath).toString();
     obj = JSON.parse(contents);
   } catch (e) {
-    log(red(`Could not parse ${cachesJsonPath}.`));
+    log(red('ERROR:'), 'Could not parse', cyan(cachesJsonPath));
     process.exitCode = 1;
     return;
   }

--- a/build-system/tasks/get-zindex/get-zindex.test.js
+++ b/build-system/tasks/get-zindex/get-zindex.test.js
@@ -32,8 +32,7 @@ const result = {
 };
 
 test('collects selectors', async (t) => {
-  const testFiles = `${__dirname}/*.css`;
-  const data = await m.getZindexSelectors(testFiles);
+  const data = await m.getZindexSelectors('*.css', __dirname);
   t.deepEqual(data, result);
 });
 

--- a/build-system/tasks/get-zindex/get-zindex.test.js
+++ b/build-system/tasks/get-zindex/get-zindex.test.js
@@ -31,17 +31,10 @@ const result = {
   },
 };
 
-test.cb('collects selectors', (t) => {
-  const data = Object.create(null);
+test('collects selectors', async (t) => {
   const testFiles = `${__dirname}/*.css`;
-  m.getZindexStream(testFiles)
-    .on('data', (chunk) => {
-      data[chunk.name] = chunk.selectors;
-    })
-    .on('end', () => {
-      t.deepEqual(data, result);
-      t.end();
-    });
+  const data = await m.getZindexSelectors(testFiles);
+  t.deepEqual(data, result);
 });
 
 test('sync - create array of arrays with z index order', (t) => {

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -17,6 +17,7 @@
 
 const fs = require('fs');
 const globby = require('globby');
+const path = require('path');
 const postcss = require('postcss');
 const prettier = require('prettier');
 const table = require('text-table');
@@ -94,15 +95,17 @@ function createTable(filesData) {
 }
 
 /**
- * Extract z-index selectors from all files matching the given glob
+ * Extract z-index selectors from all files matching the given glob starting at
+ * the given working directory
  * @param {string} glob
+ * @param {string=} cwd
  * @return {Object}
  */
-async function getZindexSelectors(glob) {
+async function getZindexSelectors(glob, cwd = '.') {
   const filesData = Object.create(null);
-  const files = globby.sync(glob);
+  const files = globby.sync(glob, {cwd});
   for (const file of files) {
-    const contents = await fs.promises.readFile(file, 'utf-8');
+    const contents = await fs.promises.readFile(path.join(cwd, file), 'utf-8');
     const selectors = Object.create(null);
     const plugins = [zIndexCollector.bind(null, selectors)];
     await postcss(plugins).process(contents, {from: file});

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -16,12 +16,11 @@
 'use strict';
 
 const fs = require('fs');
-const gulp = require('gulp');
-const PluginError = require('plugin-error');
+const globby = require('globby');
+const path = require('path');
 const postcss = require('postcss');
 const prettier = require('prettier');
 const table = require('text-table');
-const through = require('through2');
 
 const tableHeaders = [
   ['selector', 'z-index', 'file'],
@@ -54,33 +53,6 @@ function zIndexCollector(acc, css) {
       }
     });
   });
-}
-
-/**
- * @param {!Vinyl} file vinyl fs object
- * @param {string} enc encoding value
- * @param {function(err: ?Object, data: !Vinyl|string)} cb chunk data through
- */
-function onFileThrough(file, enc, cb) {
-  if (file.isNull()) {
-    cb(null, file);
-    return;
-  }
-
-  if (file.isStream()) {
-    cb(new PluginError('size', 'Stream not supported'));
-    return;
-  }
-
-  const selectors = Object.create(null);
-
-  postcss([zIndexCollector.bind(null, selectors)])
-    .process(file.contents.toString(), {
-      from: file.relative,
-    })
-    .then(() => {
-      cb(null, {name: file.relative, selectors});
-    });
 }
 
 /**
@@ -123,31 +95,33 @@ function createTable(filesData) {
 }
 
 /**
+ * Extract z-index selectors from all files matching the given glob
  * @param {string} glob
- * @return {!Stream}
+ * @return {Object}
  */
-function getZindexStream(glob) {
-  return gulp.src(glob).pipe(through.obj(onFileThrough));
+async function getZindexSelectors(glob) {
+  const filesData = Object.create(null);
+  const files = globby.sync(glob);
+  for (const file of files) {
+    const contents = fs.readFileSync(file).toString();
+    const selectors = Object.create(null);
+    const plugins = [zIndexCollector.bind(null, selectors)];
+    await postcss(plugins).process(contents, {from: file});
+    filesData[path.basename(file)] = selectors;
+  }
+  return filesData;
 }
 
 /**
- * @param {function()} cb
+ * Entry point for gulp get-zindex
  */
-function getZindex(cb) {
-  const filesData = Object.create(null);
-  // Don't return the stream here since we do a `writeFileSync`
-  getZindexStream('{css,src,extensions}/**/*.css')
-    .on('data', (chunk) => {
-      filesData[chunk.name] = chunk.selectors;
-    })
-    .on('end', async () => {
-      const filename = 'css/Z_INDEX.md';
-      const rows = [...tableHeaders, ...createTable(filesData)];
-      const tbl = table(rows, tableOptions);
-      const output = `${preamble}\n\n${tbl}`;
-      fs.writeFileSync(filename, await prettierFormat(filename, output));
-      cb();
-    });
+async function getZindex() {
+  const filesData = await getZindexSelectors('{css,src,extensions}/**/*.css');
+  const filename = 'css/Z_INDEX.md';
+  const rows = [...tableHeaders, ...createTable(filesData)];
+  const tbl = table(rows, tableOptions);
+  const output = `${preamble}\n\n${tbl}`;
+  fs.writeFileSync(filename, await prettierFormat(filename, output));
 }
 
 async function prettierFormat(filename, output) {
@@ -160,7 +134,7 @@ async function prettierFormat(filename, output) {
 module.exports = {
   createTable,
   getZindex,
-  getZindexStream,
+  getZindexSelectors,
 };
 
 getZindex.description =

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -17,7 +17,6 @@
 
 const fs = require('fs');
 const globby = require('globby');
-const path = require('path');
 const postcss = require('postcss');
 const prettier = require('prettier');
 const table = require('text-table');
@@ -103,11 +102,11 @@ async function getZindexSelectors(glob) {
   const filesData = Object.create(null);
   const files = globby.sync(glob);
   for (const file of files) {
-    const contents = fs.readFileSync(file).toString();
+    const contents = await fs.promises.readFile(file, 'utf-8');
     const selectors = Object.create(null);
     const plugins = [zIndexCollector.bind(null, selectors)];
     await postcss(plugins).process(contents, {from: file});
-    filesData[path.basename(file)] = selectors;
+    filesData[file] = selectors;
   }
   return filesData;
 }

--- a/build-system/tasks/performance-urls.js
+++ b/build-system/tasks/performance-urls.js
@@ -15,60 +15,42 @@
  */
 
 const fs = require('fs');
-const gulp = require('gulp');
 const path = require('path');
-const through2 = require('through2');
-const {green, red, yellow} = require('kleur/colors');
+const {green, red, cyan} = require('kleur/colors');
 const {log} = require('../common/logging');
 
 const CONFIG_PATH = 'build-system/tasks/performance/config.json';
 const LOCAL_HOST_URL = 'http://localhost:8000/';
 
 /**
- * Throws an error with the given message. Duplicate function
- * located in check-sourcemaps.js
- *
- * @param {string} message
- */
-function throwError(message) {
-  const err = new Error(message);
-  err.showStack = false;
-  throw err;
-}
-
-/**
  * Entry point for 'gulp performance-urls'
  * Check if all localhost urls in performance/config.json exist
- * @return {!Promise}
  */
 async function performanceUrls() {
-  return gulp.src([CONFIG_PATH]).pipe(
-    through2.obj(function (file) {
-      let obj;
-      try {
-        obj = JSON.parse(file.contents.toString());
-      } catch (e) {
-        log(yellow(`Could not parse ${CONFIG_PATH}. `));
-        throwError(`Could not parse ${CONFIG_PATH}. `);
-        return;
-      }
-      const filepaths = obj.handlers.flatMap((handler) =>
-        handler.urls
-          .filter((url) => url.startsWith(LOCAL_HOST_URL))
-          .map((url) =>
-            path.join(__dirname, '../../', url.split(LOCAL_HOST_URL)[1])
-          )
-      );
-      for (const filepath of filepaths) {
-        if (!fs.existsSync(filepath)) {
-          log(red(filepath + ' does not exist.'));
-          throwError(`${filepath} does not exist.`);
-          return;
-        }
-      }
-      log(green('SUCCESS:'), 'All local performance task urls are valid.');
-    })
+  let obj;
+  try {
+    const contents = fs.readFileSync(CONFIG_PATH).toString();
+    obj = JSON.parse(contents);
+  } catch (e) {
+    log(red('ERROR:'), 'Could not parse', cyan(CONFIG_PATH));
+    process.exitCode = 1;
+    return;
+  }
+  const filepaths = obj.handlers.flatMap((handler) =>
+    handler.urls
+      .filter((url) => url.startsWith(LOCAL_HOST_URL))
+      .map((url) =>
+        path.join(__dirname, '../../', url.split(LOCAL_HOST_URL)[1])
+      )
   );
+  for (const filepath of filepaths) {
+    if (!fs.existsSync(filepath)) {
+      log(red('ERROR:'), cyan(filepath), 'does not exist');
+      process.exitCode = 1;
+      return;
+    }
+  }
+  log(green('SUCCESS:'), 'All local performance task urls are valid.');
 }
 
 module.exports = {

--- a/build-system/tasks/performance-urls.js
+++ b/build-system/tasks/performance-urls.js
@@ -19,7 +19,7 @@ const path = require('path');
 const {green, red, cyan} = require('kleur/colors');
 const {log} = require('../common/logging');
 
-const CONFIG_PATH = 'build-system/tasks/performance/config.json';
+const CONFIG_PATH = './performance/config.json';
 const LOCAL_HOST_URL = 'http://localhost:8000/';
 
 /**
@@ -27,16 +27,15 @@ const LOCAL_HOST_URL = 'http://localhost:8000/';
  * Check if all localhost urls in performance/config.json exist
  */
 async function performanceUrls() {
-  let obj;
+  let jsonContent;
   try {
-    const contents = fs.readFileSync(CONFIG_PATH).toString();
-    obj = JSON.parse(contents);
+    jsonContent = require(CONFIG_PATH);
   } catch (e) {
     log(red('ERROR:'), 'Could not parse', cyan(CONFIG_PATH));
     process.exitCode = 1;
     return;
   }
-  const filepaths = obj.handlers.flatMap((handler) =>
+  const filepaths = jsonContent.handlers.flatMap((handler) =>
     handler.urls
       .filter((url) => url.startsWith(LOCAL_HOST_URL))
       .map((url) =>

--- a/build-system/tasks/server-tests.js
+++ b/build-system/tasks/server-tests.js
@@ -17,10 +17,8 @@
 const assert = require('assert');
 const fs = require('fs');
 const globby = require('globby');
-const gulp = require('gulp');
 const path = require('path');
 const posthtml = require('posthtml');
-const through = require('through2');
 const {
   log,
   logWithoutTimestamp,
@@ -175,39 +173,36 @@ function reportResult() {
 /**
  * Runs the test in a single input file
  *
- * @return {!ReadableStream}
+ * @param {string} inputFile
  */
-function runTest() {
-  return through.obj(async (file, enc, cb) => {
-    const inputFile = file.path;
-    const input = await getInput(inputFile);
-    const testName = getTestName(inputFile);
-    const expectedOutput = await getExpectedOutput(inputFile);
-    const extraOptions = loadOptions(inputFile);
-    const transform = await getTransform(inputFile, extraOptions);
-    const output = await getOutput(transform, input);
-    try {
-      assert.strictEqual(output, expectedOutput);
-    } catch (err) {
-      ++failed;
-      logError(testName, err);
-      cb();
-      return;
-    }
-    ++passed;
-    logWithoutTimestampLocalDev(green('✔'), 'Passed', cyan(testName));
-    cb();
-  });
+async function runTest(inputFile) {
+  const input = await getInput(inputFile);
+  const testName = getTestName(inputFile);
+  const expectedOutput = await getExpectedOutput(inputFile);
+  const extraOptions = loadOptions(inputFile);
+  const transform = await getTransform(inputFile, extraOptions);
+  const output = await getOutput(transform, input);
+  try {
+    assert.strictEqual(output, expectedOutput);
+  } catch (err) {
+    ++failed;
+    logError(testName, err);
+    return;
+  }
+  ++passed;
+  logWithoutTimestampLocalDev(green('✔'), 'Passed', cyan(testName));
 }
 
 /**
  * Tests for AMP server custom transforms. Entry point for `gulp server-tests`.
- *
- * @return {!Vinyl}
  */
-function serverTests() {
+async function serverTests() {
   buildNewServer();
-  return gulp.src(inputPaths).pipe(runTest()).on('end', reportResult);
+  const inputFiles = globby.sync(inputPaths);
+  for (const inputFile of inputFiles) {
+    await runTest(inputFile);
+  }
+  reportResult();
 }
 
 module.exports = {

--- a/build-system/tasks/server-tests.js
+++ b/build-system/tasks/server-tests.js
@@ -176,11 +176,12 @@ function reportResult() {
  * @param {string} inputFile
  */
 async function runTest(inputFile) {
-  const input = await getInput(inputFile);
   const testName = getTestName(inputFile);
-  const expectedOutput = await getExpectedOutput(inputFile);
-  const extraOptions = loadOptions(inputFile);
-  const transform = await getTransform(inputFile, extraOptions);
+  const [input, expectedOutput, transform] = await Promise.all([
+    getInput(inputFile),
+    getExpectedOutput(inputFile),
+    getTransform(inputFile, loadOptions(inputFile)),
+  ]);
   const output = await getOutput(transform, input);
   try {
     assert.strictEqual(output, expectedOutput);


### PR DESCRIPTION
This is another in a series of PRs that modernize our development tasks.

**PR highlights:**
- Remove `gulp` file streaming from `server-tests`, `presubmit`, `caches-json`, `performance-urls`, and `get-zindex`
- Opportunistic bugfixes:
	- Make file I/O async where possible
    - Add `bing` to the list of expected caches in `caches.json`
    - Fail task on parsing errors in `caches-json` and `performance-urls`
    - Minor logging cleanup

For easy reviewing (without whitespace-only changes), use this link: https://github.com/ampproject/amphtml/pull/32623/files?w=1

Partial fix for #32585