### PR TITLE
🏗 Rewrite `gulp prettify` using the `nodejs` API of `prettier`

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -217,7 +217,12 @@ const targetMatchers = {
   },
   [Targets.PRETTIFY]: (file) => {
     // OWNERS files can be prettified.
-    return prettifyFiles.includes(file);
+    return (
+      prettifyFiles.includes(file) ||
+      file == '.prettierrc' ||
+      file == '.prettierignore' ||
+      file == 'build-system/tasks/prettify.js'
+    );
   },
   [Targets.RENOVATE_CONFIG]: (file) => {
     return (

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -114,7 +114,7 @@ function printFixMessages() {
 }
 
 /**
- * Runs prettier on the given list of files with gulp-prettier.
+ * Prettifies on the given list of files.
  * @param {!Array<string>} filesToCheck
  */
 async function runPrettify(filesToCheck) {

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -24,9 +24,8 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
-const gulp = require('gulp');
 const path = require('path');
-const prettier = require('gulp-prettier');
+const prettier = require('prettier');
 const tempy = require('tempy');
 const {
   log,
@@ -43,25 +42,27 @@ const {prettifyGlobs} = require('../test-configs/config');
 
 const rootDir = path.dirname(path.dirname(__dirname));
 const tempDir = tempy.directory();
-const prettierCmd = 'node_modules/.bin/prettier';
-
-// Message header printed by gulp-prettier before the list of files with errors.
-// See https://github.com/bhargavrpatel/gulp-prettier/blob/master/index.js#L90
-const header =
-  'Code style issues found in the following file(s). Forgot to run Prettier?';
 
 /**
  * Checks files for formatting (and optionally fixes them) with Prettier.
- *
- * @return {!Promise}
  */
-function prettify() {
+async function prettify() {
   maybeUpdatePackages();
   const filesToCheck = getFilesToCheck(prettifyGlobs, {dot: true});
   if (filesToCheck.length == 0) {
-    return Promise.resolve();
+    return;
   }
-  return runPrettify(filesToCheck);
+  await runPrettify(filesToCheck);
+}
+
+/**
+ * Resolves the prettier config for the given file
+ * @param {string} file
+ * @return {Object}
+ */
+async function getOptions(file) {
+  const config = await prettier.resolveConfig(file);
+  return {filepath: file, ...config};
 }
 
 /**
@@ -70,110 +71,85 @@ function prettify() {
  *
  * @param {string} file
  */
-function printErrorWithSuggestedFixes(file) {
+async function printErrorWithSuggestedFixes(file) {
   logWithoutTimestamp('\n');
   log(`Suggested fixes for ${cyan(file)}:`);
+  const options = await getOptions(file);
+  const original = fs.readFileSync(file).toString();
+  const fixed = prettier.format(original, options);
   const fixedFile = `${tempDir}/${file}`;
   fs.ensureDirSync(path.dirname(fixedFile));
-  exec(`${prettierCmd} ${file} > ${fixedFile}`);
+  fs.writeFileSync(fixedFile, fixed);
   const diffCmd = `git -c color.ui=always diff -U0 ${file} ${fixedFile} | tail -n +5`;
   exec(diffCmd);
 }
 
 /**
- * Runs prettier on the given list of files with gulp-prettier.
- *
- * @param {!Array<string>} filesToCheck
- * @return {!Promise}
+ * Prints instructions for how to auto-fix errors.
  */
-function runPrettify(filesToCheck) {
+function printFixMessages() {
+  log(
+    yellow('NOTE 1:'),
+    "If you are using GitHub's web-UI to edit files,",
+    'copy the suggested fixes printed above into your PR.'
+  );
+  log(
+    yellow('NOTE 2:'),
+    'If you are using the git command-line workflow, run',
+    cyan('gulp prettify --local_changes --fix'),
+    'from your local branch.'
+  );
+  log(
+    yellow('NOTE 3:'),
+    'Since this is a destructive operation (that edits your files',
+    'in-place), make sure you commit before running the command.'
+  );
+  log(
+    yellow('NOTE 4:'),
+    'For more information, read',
+    cyan(
+      'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#code-quality-and-style\n'
+    )
+  );
+}
+
+/**
+ * Runs prettier on the given list of files with gulp-prettier.
+ * @param {!Array<string>} filesToCheck
+ */
+async function runPrettify(filesToCheck) {
   logLocalDev(green('Starting checks...'));
-  return new Promise((resolve, reject) => {
-    const onData = (data) => {
-      logOnSameLineLocalDev(
-        green('Checked: ') + path.relative(rootDir, data.path)
-      );
-    };
-
-    const rejectWithReason = (reasonText) => {
-      const reason = new Error(reasonText);
-      reason.showStack = false;
-      reject(reason);
-    };
-
-    const printFixMessages = () => {
-      log(
-        yellow('NOTE 1:'),
-        "If you are using GitHub's web-UI to edit files,",
-        'copy the suggested fixes printed above into your PR.'
-      );
-      log(
-        yellow('NOTE 2:'),
-        'If you are using the git command-line workflow, run',
-        cyan('gulp prettify --local_changes --fix'),
-        'from your local branch.'
-      );
-      log(
-        yellow('NOTE 3:'),
-        'Since this is a destructive operation (that edits your files',
-        'in-place), make sure you commit before running the command.'
-      );
-      log(
-        yellow('NOTE 4:'),
-        'For more information, read',
-        cyan(
-          'https://github.com/ampproject/amphtml/blob/master/contributing/getting-started-e2e.md#code-quality-and-style\n'
-        )
-      );
-    };
-
-    const onError = (error) => {
-      if (error.message.startsWith(header)) {
-        const filesWithErrors = error.message
-          .replace(header, '')
-          .trim()
-          .split('\n');
-        const reason = 'Found formatting errors in one or more files';
-        logOnSameLine(red('ERROR: ') + reason);
-        filesWithErrors.forEach((file) => {
-          printErrorWithSuggestedFixes(file);
-        });
-        printFixMessages();
-        rejectWithReason(reason);
-      } else {
-        const reason =
-          'Found an unrecoverable error in ' +
-          cyan(path.relative(rootDir, error.fileName));
-        logOnSameLine(red('ERROR: ') + reason + ':');
-        log(error.message);
-        rejectWithReason(reason);
-      }
-    };
-
-    const onFinish = () => {
-      logOnSameLineLocalDev(
-        'Checked ' + cyan(filesToCheck.length) + ' file(s)'
-      );
-      resolve();
-    };
-
+  const filesWithErrors = [];
+  for (const file of filesToCheck) {
+    const options = await getOptions(file);
+    const original = fs.readFileSync(file).toString();
     if (argv.fix) {
-      return gulp
-        .src(filesToCheck)
-        .pipe(prettier())
-        .on('data', onData)
-        .on('error', onError)
-        .pipe(gulp.dest((file) => file.base))
-        .on('finish', onFinish);
+      const fixed = prettier.format(original, options);
+      if (fixed != original) {
+        fs.writeFileSync(file, fixed);
+      }
+      if (!prettier.check(fixed, options)) {
+        filesWithErrors.push(file);
+      }
     } else {
-      return gulp
-        .src(filesToCheck)
-        .pipe(prettier.check())
-        .on('data', onData)
-        .on('error', onError)
-        .on('finish', onFinish);
+      if (!prettier.check(original, options)) {
+        filesWithErrors.push(file);
+      }
     }
-  });
+    logOnSameLineLocalDev(green('Checked: ') + path.relative(rootDir, file));
+  }
+  if (filesWithErrors.length) {
+    logOnSameLine(
+      red('ERROR:'),
+      'Found formatting errors in one or more files'
+    );
+    for (const file of filesWithErrors) {
+      await printErrorWithSuggestedFixes(file);
+    }
+    printFixMessages();
+    process.exitCode = 1;
+  }
+  logOnSameLineLocalDev('Checked ' + cyan(filesToCheck.length) + ' file(s)');
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15371,29 +15371,6 @@
         "through": "~2.3.4"
       }
     },
-    "gulp-prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-prettier/-/gulp-prettier-3.0.0.tgz",
-      "integrity": "sha512-vZFyC1F+7EjuI2WDUOcbPt9o3ZjdqjFMjr8a9Yk2K8EmNhP1w6X01QAkv5Ym3dsHCBsBA4AEFcYds2vOTSgx0A==",
-      "dev": true,
-      "requires": {
-        "plugin-error": "^1.0.1",
-        "prettier": "^2.0.0",
-        "through2": "^3.0.0"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-          "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "2 || 3"
-          }
-        }
-      }
-    },
     "gulp-regexp-sourcemaps": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gulp-regexp-sourcemaps/-/gulp-regexp-sourcemaps-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "gulp-jsonlint": "1.3.2",
     "gulp-jsonminify": "1.1.0",
     "gulp-nop": "0.0.3",
-    "gulp-prettier": "3.0.0",
     "gulp-regexp-sourcemaps": "1.0.1",
     "gulp-rename": "2.0.0",
     "gulp-sourcemaps": "3.0.0",


### PR DESCRIPTION
This is another in a series of PRs that modernize our development tasks.

**PR Highlights:**
- Directly use the `prettier` [nodejs API](https://prettier.io/docs/en/api.html)
- Eliminate file streaming via `gulp.src`
- Remove the dependency `gulp-prettier`
- Update the `PRETTIFY` build target to include the check itself

Partial fix for #32585 