### PR TITLE
🚀 Ensure src is the last propagated attribute for amp-img

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -38,10 +38,10 @@ const ATTRIBUTES_TO_PROPAGATE = [
   'aria-labelledby',
   'crossorigin',
   'referrerpolicy',
-  'sizes',
-  'src',
-  'srcset',
   'title',
+  'sizes',
+  'srcset',
+  'src',
 ];
 
 export class AmpImg extends BaseElement {


### PR DESCRIPTION
This is the first step in fixing #32629.

In Safari setting a `src` before a `srcset` on an image (even in the same microtask) will cause the browser to start requesting the contents of the `src` attribute.

This PR ensures the last attribute propagated from `amp-img` to `img` is the `src`. 