### PR TITLE
analytics: bail out for detached targets

### DIFF
--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -24,6 +24,7 @@ import {
 import {AmpdocAnalyticsRoot, EmbedAnalyticsRoot} from './analytics-root';
 import {AnalyticsGroup} from './analytics-group';
 import {Services} from '../../../src/services';
+import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
 import {
@@ -32,10 +33,9 @@ import {
   getServicePromiseForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service';
-import {dev} from '../../../src/log';
 
 const PROP = '__AMP_AN_ROOT';
-const TAG = 'ANALYTICS-INSTRUMENTATION',
+const TAG = 'ANALYTICS-INSTRUMENTATION';
 
 /**
  * @implements {../../../src/service.Disposable}

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -35,6 +35,7 @@ import {
 import {dev} from '../../../src/log';
 
 const PROP = '__AMP_AN_ROOT';
+const TAG = 'ANALYTICS-INSTRUMENTATION',
 
 /**
  * @implements {../../../src/service.Disposable}
@@ -105,7 +106,7 @@ export class InstrumentationService {
   ) {
     if (!target.isConnected) {
       dev().error(
-        'ANALYTICS-INSTRUMENTATION',
+        TAG,
         'Attempting to trigger event for detached target: %s',
         target
       );

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -32,6 +32,7 @@ import {
   getServicePromiseForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service';
+import {dev} from '../../../src/log';
 
 const PROP = '__AMP_AN_ROOT';
 
@@ -102,6 +103,14 @@ export class InstrumentationService {
     vars = dict(),
     enableDataVars = true
   ) {
+    if (!target.isConnected) {
+      dev().error(
+        'Attempting to trigger analytics event for detached target: %s',
+        target
+      );
+      return;
+    }
+
     const event = new AnalyticsEvent(target, eventType, vars, enableDataVars);
     const root = this.findRoot_(target);
     const trackerName = getTrackerKeyName(eventType);

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -105,7 +105,8 @@ export class InstrumentationService {
   ) {
     if (!target.isConnected) {
       dev().error(
-        'Attempting to trigger analytics event for detached target: %s',
+        'ANALYTICS-INSTRUMENTATION',
+        'Attempting to trigger event for detached target: %s',
         target
       );
       return;

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -63,6 +63,19 @@ describes.realWin('InstrumentationService', {amp: 1}, (env) => {
     expect(event.type).to.equal('test-event');
     expect(event.vars).to.deep.equal({foo: 'bar'});
   });
+
+  it('should bail and emit error if element is detached', () => {
+    expectAsyncConsoleError(/detached/);
+    const detached = ampdoc.win.document.createElement('div');
+    const tracker = root.getTracker(
+      AnalyticsEventType.CUSTOM,
+      CustomEventTracker
+    );
+    const triggerStub = env.sandbox.stub(tracker, 'trigger');
+    service.triggerEventForTarget(detached, 'test-event');
+
+    expect(triggerStub).not.called;
+  });
 });
 
 describes.realWin(


### PR DESCRIPTION
**summary**
Followup to https://github.com/ampproject/amphtml/pull/32578.

When a node is detached, we can't perform our standard analytics flow for it (which includes finding its window + ampdoc).
While I'm sure each individual instance where this could occur needs its own handling, we can at least throw a more specific error so that we can identify the issue correctly (as well as not spiral into other unrelated errors due to unexpected throws - like missing AMP_TOP etc.).


Example error:
![Screen Shot 2021-02-10 at 11 04 33 AM](https://user-images.githubusercontent.com/4656974/107536444-c71d1780-6b8f-11eb-9f59-5a8fb2abc5d1.png)
