### PR TITLE
🏗 Fix incorrect Chrome version pinning for visual diff tests

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -146,16 +146,15 @@ function usesFilesOrLocalChanges(taskName) {
  * Runs 'npm install' to install packages in a given directory.
  *
  * @param {string} dir
- * @param {?NodeJS.ProcessEnv} options
  */
-function installPackages(dir, options = {}) {
+function installPackages(dir) {
   log(
     'Running',
     cyan('npm install'),
     'to install packages in',
     cyan(path.relative(ROOT_DIR, dir)) + '...'
   );
-  execOrDie(`npm install --prefix ${dir}`, {'stdio': 'ignore', ...options});
+  execOrDie(`npm install --prefix ${dir}`, {'stdio': 'ignore'});
 }
 
 module.exports = {

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -61,7 +61,7 @@ const percyCss = [
 // Use https://omahaproxy.appspot.com/ to convert version<->revision numbers.
 // REPEATING TODO(@ampproject/wg-infra): keep this pinned with Percy whenever we
 // update the version of Chrome in the project settings.
-const INSTALL_PACKAGE_OPTIONS = {'PUPPETEER_CHROMIUM_REVISION': '693954'};
+const PUPPETEER_CHROMIUM_REVISION = '693954';
 
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {
   widths: [375],
@@ -794,8 +794,9 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
 }
 
 function installPercy_() {
+  process.env['PUPPETEER_CHROMIUM_REVISION'] = PUPPETEER_CHROMIUM_REVISION;
   if (!argv.noinstall) {
-    installPackages(__dirname, INSTALL_PACKAGE_OPTIONS);
+    installPackages(__dirname);
   }
 
   puppeteer = require('puppeteer');


### PR DESCRIPTION
+ revert no-longer useful change to `installPackages` that was introduced in #32554

Proof that this works now: https://percy.io/ampproject/amphtml/builds/8835566/changed/501352751 ^_^