### PR TITLE
✨ Allow <amp-img layout=intrinsic> for email spec

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3626,6 +3626,7 @@ tags: {  # <amp-img>
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }


### PR DESCRIPTION
The absence of this layout in the spec allowlist seems like an
oversight because the email spec already allows intrinsic layout for
amp-carousel. The SVGs used for sizing intrinsic layout elements are
hardcoded by the AMP runtime, so there's no privacy or security
concerns.

This is discussed with the AMP for Email WG with mail.ru, Yahoo!
Mail and Gmail and the consensus is to allow this.

/to @honeybadgerdontcare 
/cc @ampproject/wg-amp4email 

WG meeting notes: https://docs.google.com/document/d/1lsG9svgClzfknEwWD8mMc7kf91N8RJhGrssNPc0lO9E/edit#bookmark=id.amayc9wwynok

This addresses the concern at https://github.com/ampproject/amp.dev/issues/4027#issuecomment-727250406.