### PR TITLE
🚀 Dont autogenerate sizes if the ssr image contains sizes already, or is ssr'd using a transformer

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -199,6 +199,10 @@ export class AmpImg extends BaseElement {
     if (!this.img_) {
       return;
     }
+    // If the image is server rendered, do not generate sizes.
+    if (this.element.hasAttribute('i-amphtml-ssr')) {
+      return;
+    }
     // No need to generate sizes if already present.
     const sizes =
       this.element.hasAttribute('sizes') || this.img_.hasAttribute('sizes');

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -200,7 +200,8 @@ export class AmpImg extends BaseElement {
       return;
     }
     // No need to generate sizes if already present.
-    const sizes = this.element.getAttribute('sizes');
+    const sizes =
+      this.element.hasAttribute('sizes') || this.img_.hasAttribute('sizes');
     if (sizes) {
       return;
     }

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -641,6 +641,28 @@ describes.sandboxed('amp-img', {}, (env) => {
     }
 
     it('should not generate sizes for amp-imgs that already have sizes', async () => {
+      const serverRenderedImg = document.createElement('img');
+      serverRenderedImg.setAttribute('src', '/examples/img/sample.jpg');
+      serverRenderedImg.setAttribute('srcset', SRCSET_STRING);
+      serverRenderedImg.setAttribute('sizes', '50vw');
+      const ampImg = await getImg(
+        {
+          src: '/examples/img/sample.jpg',
+          srcset: SRCSET_STRING,
+          sizes: '50vw',
+          width: 300,
+          height: 200,
+        },
+        [serverRenderedImg]
+      );
+      const impl = await ampImg.getImpl(false);
+      impl.buildCallback();
+      await impl.layoutCallback();
+      const img = impl.img_;
+      expect(img.getAttribute('sizes')).to.equal('50vw');
+    });
+
+    it('should not generate sizes for amp-imgs, rendered with sizes from the server', async () => {
       const ampImg = await getImg({
         src: '/examples/img/sample.jpg',
         srcset: SRCSET_STRING,

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -668,7 +668,7 @@ describes.sandboxed('amp-img', {}, (env) => {
         srcset: SRCSET_STRING,
         width: 300,
         height: 200,
-        'i-amphtml-ssr': true,
+        'i-amphtml-ssr': '',
       });
       const impl = await ampImg.getImpl(false);
       impl.buildCallback();

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -640,7 +640,7 @@ describes.sandboxed('amp-img', {}, (env) => {
       return impl;
     }
 
-    it('should not generate sizes for amp-imgs that already have sizes', async () => {
+    it('should not generate sizes for amp-imgs that already have sizes on their rendered image children', async () => {
       const serverRenderedImg = document.createElement('img');
       serverRenderedImg.setAttribute('src', '/examples/img/sample.jpg');
       serverRenderedImg.setAttribute('srcset', SRCSET_STRING);
@@ -660,6 +660,21 @@ describes.sandboxed('amp-img', {}, (env) => {
       await impl.layoutCallback();
       const img = impl.img_;
       expect(img.getAttribute('sizes')).to.equal('50vw');
+    });
+
+    it('should not generate sizes for amp-imgs when rendered from the server', async () => {
+      const ampImg = await getImg({
+        src: '/examples/img/sample.jpg',
+        srcset: SRCSET_STRING,
+        width: 300,
+        height: 200,
+        'i-amphtml-ssr': true,
+      });
+      const impl = await ampImg.getImpl(false);
+      impl.buildCallback();
+      await impl.layoutCallback();
+      const img = impl.img_;
+      expect(img.hasAttribute('sizes')).to.be.false;
     });
 
     it('should not generate sizes for amp-imgs, rendered with sizes from the server', async () => {


### PR DESCRIPTION
Fixes #32644.