### PR TITLE
🐛 [No signing] fix broken analytics

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -937,16 +937,17 @@ export class AmpA4A extends AMP.BaseElement {
       return Promise.reject(NO_CONTENT_RESPONSE);
     }
 
+    // Extract size will also parse x-ampanalytics header for some subclasses.
+    const size = this.extractSize(httpResponse.headers);
+    this.creativeSize_ = size || this.creativeSize_;
+
     if (this.skipClientSideValidation(httpResponse.headers)) {
       return this.handleFallback_(httpResponse, checkStillCurrent);
     }
 
-    // Duplicating httpResponse stream as safeframe/nameframe rending will need the
+    // Duplicating httpResponse stream as safeframe/nameframe rendering will need the
     // unaltered httpResponse content.
     const fallbackHttpResponse = httpResponse.clone();
-
-    const size = this.extractSize(httpResponse.headers);
-    this.creativeSize_ = size || this.creativeSize_;
 
     // This transformation consumes the detached DOM chunks and
     // exposes our waitForHead and transferBody methods.


### PR DESCRIPTION
Activeview is reported by an amp-analytics element created from the `x-ampanalytics` header. In #32446 I introduced a new feature that would optionally early exit for non-amp creatives, but if this happens before `a4a.extractSize` is called the analytics config never gets parsed, or created later.