### PR TITLE
🏗🚀 Rewrite and speed up `gulp build` using `esbuild` and `@babel/core`

### DIFF
--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -45,6 +45,7 @@ function getUnminifiedConfig() {
   const unminifiedPlugins = [
     argv.coverage ? 'babel-plugin-istanbul' : null,
     replacePlugin,
+    './build-system/babel-plugins/babel-plugin-transform-remove-directives',
     './build-system/babel-plugins/babel-plugin-transform-json-import',
     './build-system/babel-plugins/babel-plugin-transform-json-configuration',
     './build-system/babel-plugins/babel-plugin-transform-jss',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -40,7 +40,7 @@ const {jsBundles} = require('../compile/bundles.config');
 const {log, logLocalDev} = require('../common/logging');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {transpileTs} = require('../compile/typescript');
-const {watch} = require('chokidar');
+const {watch: fileWatch} = require('chokidar');
 
 /**
  * Tasks that should print the `--nobuild` help text.
@@ -130,7 +130,7 @@ async function bootstrapThirdPartyFrames(options) {
       const watchFunc = () => {
         thirdPartyBootstrap(frameObject.max, frameObject.min, options);
       };
-      watch(frameObject.max).on(
+      fileWatch(frameObject.max).on(
         'change',
         debounce(watchFunc, watchDebounceDelay)
       );
@@ -281,7 +281,7 @@ async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
         options.onWatchBuild(compileDone);
       }
     };
-    watch(entryPoint).on('change', debounce(watchFunc, watchDebounceDelay));
+    fileWatch(entryPoint).on('change', debounce(watchFunc, watchDebounceDelay));
   }
 
   async function doCompileMinifiedJs(continueOnError) {
@@ -393,7 +393,7 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
         options.onWatchBuild(bundleDone);
       }
     };
-    watch(entryPoint).on('change', debounce(watchFunc, watchDebounceDelay));
+    fileWatch(entryPoint).on('change', debounce(watchFunc, watchDebounceDelay));
   }
 
   /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -438,7 +438,7 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
    * Splits up the wrapper to compute the banner and footer
    * @return {Object}
    */
-  function processWrapper() {
+  function splitWrapper() {
     const wrapper = options.wrapper || wrappers.none;
     const sentinel = '<%= contents %>';
     const start = wrapper.indexOf(sentinel);
@@ -453,7 +453,7 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
    * @param {boolean} continueOnError
    */
   async function performBundle(continueOnError) {
-    const {banner, footer} = processWrapper();
+    const {banner, footer} = splitWrapper();
     await esbuild
       .build({
         entryPoints: [entryPoint],

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -184,7 +184,8 @@ function generateFunctionAllowlist() {
       const func = functionsForType[name];
       if (func) {
         devAssert(
-          !func.name || name === func.name,
+          // Partial match to account for bundlers adding a suffix to the name.
+          !func.name || func.name.startsWith(name),
           'Listed function name ' +
             `"${name}" doesn't match name property "${func.name}".`
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -5766,7 +5766,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "amphtml-validator": {
       "version": "1.0.34",
@@ -11884,6 +11885,12 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "esbuild": {
+      "version": "0.8.46",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.46.tgz",
+      "integrity": "sha512-xck9sXNCNmjDHCCfxTCyhKTiFuEBweh+IDAhMLOJI990v1Fzii6MyIkT1LbkvjgoVgPX2SK1kpi5eZVGNrl8yg==",
+      "dev": true
+    },
     "escalade": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
@@ -15152,71 +15159,6 @@
       "requires": {
         "gulp-util": "~2.2.14",
         "through": "~2.3.4"
-      }
-    },
-    "gulp-regexp-sourcemaps": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gulp-regexp-sourcemaps/-/gulp-regexp-sourcemaps-1.0.1.tgz",
-      "integrity": "sha1-qIEiRIUsEJUGg6lI4cDa0LEkmXk=",
-      "dev": true,
-      "requires": {
-        "regexp-sourcemaps": "^1.0.0",
-        "through2": "^0.6.3",
-        "vinyl-sourcemaps-apply": "^0.1.4"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
-          "integrity": "sha1-xfy9Q+LyOEI8LcmL3db3m3K8NFs=",
-          "dev": true,
-          "requires": {
-            "source-map": "^0.1.39"
-          }
-        }
       }
     },
     "gulp-rename": {
@@ -27868,26 +27810,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "regexp-sourcemaps": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/regexp-sourcemaps/-/regexp-sourcemaps-1.0.1.tgz",
-      "integrity": "sha1-SaWec2UB4XAZoNH1Nd+LW5GXomI=",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.4.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
     "regexp.prototype.flags": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
@@ -31947,38 +31869,6 @@
         "cloneable-readable": "^1.0.0",
         "remove-trailing-separator": "^1.0.1",
         "replace-ext": "^1.0.0"
-      }
-    },
-    "vinyl-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vinyl-buffer/-/vinyl-buffer-1.0.1.tgz",
-      "integrity": "sha1-lsGjR5uMU5JULGEgKQE7Wyf4i78=",
-      "dev": true,
-      "requires": {
-        "bl": "^1.2.1",
-        "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "bl": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
       }
     },
     "vinyl-file": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "envify": "4.1.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-preact-pure": "3.0.0",
+    "esbuild": "0.8.46",
     "escodegen": "2.0.0",
     "eslint": "7.19.0",
     "eslint-config-prettier": "7.2.0",
@@ -115,7 +116,6 @@
     "gulp-file": "0.4.0",
     "gulp-if": "3.0.0",
     "gulp-nop": "0.0.3",
-    "gulp-regexp-sourcemaps": "1.0.1",
     "gulp-rename": "2.0.0",
     "gulp-sourcemaps": "3.0.0",
     "gulp-watch": "5.0.1",
@@ -188,7 +188,6 @@
     "tsickle": "0.39.1",
     "typescript": "4.1.3",
     "uglifyify": "5.0.2",
-    "vinyl-buffer": "1.0.1",
     "vinyl-source-stream": "2.0.0",
     "vinyl-sourcemaps-apply": "0.2.1",
     "watchify": "4.0.0"


### PR DESCRIPTION
This is another in a series of PRs that modernize our development tasks.

**PR highlights:**
- Rewrite `gulp build` without file streaming
- Replace `browserify ` with `esbuild` and `@babel/core` for a considerable increase in speed
- Remove `gulp-regexp-sourcemaps`, `gulp-rename`, `gulp-sourcemaps`, `vinyl-source-stream`, and `watchify` 

**Results:** This brings down the time taken for a [full unminified build](https://app.circleci.com/pipelines/github/ampproject/amphtml/2058/workflows/cf6015b6-a8cf-48f3-8277-4ee497ef5567/jobs/21181/parallel-runs/0/steps/0-107) of AMP from ~5m to ~1m.

<img width="973" alt="" src="https://user-images.githubusercontent.com/26553114/108110553-6a26d300-7061-11eb-9d3d-5ca8ca8fe8f6.png">
<img width="985" alt="" src="https://user-images.githubusercontent.com/26553114/108110547-685d0f80-7061-11eb-9040-5f6863fccab3.png">



**References:**
- https://esbuild.github.io/api/
- https://babeljs.io/docs/en/babel-core

Partial fix for #32585