### PR TITLE
Remove remoteHTMLDisabled attributes from adConfig

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -24,7 +24,6 @@ import {jsonConfiguration} from '../src/json';
  *   clientIdScope: (string|undefined),
  *   clientIdCookieName: (string|undefined),
  *   consentHandlingOverride: (boolean|undefined),
- *   remoteHTMLDisabled: (boolean|undefined),
  *   fullWidthHeightRatio: (number|undefined),
  * }}
  */

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -249,12 +249,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
   preconnectCallback(opt_onLayout) {
     const preconnect = Services.preconnectFor(this.win);
     // We always need the bootstrap.
-    preloadBootstrap(
-      this.win,
-      this.getAmpDoc(),
-      preconnect,
-      this.config.remoteHTMLDisabled
-    );
+    preloadBootstrap(this.win, this.getAmpDoc(), preconnect);
     if (typeof this.config.prefetch == 'string') {
       preconnect.preload(this.getAmpDoc(), this.config.prefetch, 'script');
     } else if (this.config.prefetch) {
@@ -427,7 +422,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
             this.type_,
             opt_context,
             {
-              disallowCustom: this.config.remoteHTMLDisabled,
               initialIntersection: intersectionEntryToJson(intersection),
             }
           );

--- a/extensions/amp-ad/0.1/amp-ad.js
+++ b/extensions/amp-ad/0.1/amp-ad.js
@@ -74,9 +74,9 @@ export class AmpAd extends AMP.BaseElement {
         this.getVsync().mutate(() => {
           this.element.setAttribute('data-amp-slot-index', slotId);
 
-          const useRemoteHtml =
-            !(adConfig[type] || {})['remoteHTMLDisabled'] &&
-            this.element.getAmpDoc().getMetaByName('amp-3p-iframe-src');
+          const useRemoteHtml = this.element
+            .getAmpDoc()
+            .getMetaByName('amp-3p-iframe-src');
           // TODO(tdrl): Check amp-ad registry to see if they have this already.
           // TODO(a4a-cam): Shorten this predicate.
           if (

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -27,7 +27,6 @@ import {Services} from '../../../../src/services';
 import {adConfig} from '../../../../ads/_config';
 import {createElementWithAttributes} from '../../../../src/dom';
 import {macroTask} from '../../../../testing/yield';
-import {user} from '../../../../src/log';
 
 function createAmpAd(win, attachToAmpdoc = false, ampdoc) {
   const ampAdElement = createElementWithAttributes(win.document, 'amp-ad', {
@@ -260,24 +259,6 @@ describes.realWin(
           ).to.be.ok;
         });
       });
-
-      it('should use default path if custom disabled', () => {
-        const meta = win.document.createElement('meta');
-        meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://src.test/boot/remote.html');
-        win.document.head.appendChild(meta);
-        ad3p.config.remoteHTMLDisabled = true;
-        ad3p.onLayoutMeasure();
-        env.sandbox.stub(user(), 'error');
-        return ad3p.layoutCallback().then(() => {
-          expect(
-            win.document.querySelector(
-              'iframe[src="' +
-                'http://ads.localhost:9876/dist.3p/current/frame.max.html"]'
-            )
-          ).to.be.ok;
-        });
-      });
     });
 
     describe('pause/resume', () => {
@@ -363,27 +344,6 @@ describes.realWin(
           expect(
             Array.from(win.document.querySelectorAll('link[rel=preload]')).some(
               (link) => link.href == `${remoteUrl}?$internalRuntimeVersion$`
-            )
-          ).to.be.true;
-        });
-      });
-
-      it('should not use remote html path for preload if disabled', () => {
-        const meta = win.document.createElement('meta');
-        meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://src.test/boot/remote.html');
-        win.document.head.appendChild(meta);
-        ad3p.config.remoteHTMLDisabled = true;
-        ad3p.buildCallback();
-        allowConsoleError(() => {
-          ad3p.preconnectCallback();
-        });
-        return whenFirstVisible.then(() => {
-          expect(
-            Array.from(win.document.querySelectorAll('link[rel=preload]')).some(
-              (link) =>
-                link.href ==
-                'http://ads.localhost:9876/dist.3p/current/frame.max.html'
             )
           ).to.be.true;
         });

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -208,35 +208,6 @@ describes.realWin('Ad loader', {amp: true}, (env) => {
         });
       });
 
-      it('uses Fast Fetch if remote.html is used but disabled', () => {
-        const meta = doc.createElement('meta');
-        meta.setAttribute('name', 'amp-3p-iframe-src');
-        meta.setAttribute('content', 'https://example.test/remote.html');
-        doc.head.appendChild(meta);
-        adConfig['zort'] = {remoteHTMLDisabled: true};
-        a4aRegistry['zort'] = function () {
-          return true;
-        };
-        ampAdElement.setAttribute('type', 'zort');
-        const zortInstance = {};
-        const zortConstructor = function () {
-          return zortInstance;
-        };
-        const extensions = Services.extensionsFor(win);
-        const extensionsStub = env.sandbox
-          .stub(extensions, 'loadElementClass')
-          .withArgs('amp-ad-network-zort-impl')
-          .returns(Promise.resolve(zortConstructor));
-        ampAd = new AmpAd(ampAdElement);
-        return ampAd.upgradeCallback().then((baseElement) => {
-          expect(extensionsStub).to.be.called;
-          expect(ampAdElement.getAttribute('data-a4a-upgrade-type')).to.equal(
-            'amp-ad-network-zort-impl'
-          );
-          expect(baseElement).to.equal(zortInstance);
-        });
-      });
-
       it('upgrades to registered, A4A type network-specific element', () => {
         a4aRegistry['zort'] = function () {
           return true;

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -66,7 +66,6 @@ function getFrameAttributes(parentWindow, element, opt_type, opt_context) {
  * @param {string=} opt_type
  * @param {Object=} opt_context
  * @param {{
- *   disallowCustom: (boolean|undefined),
  *   allowFullscreen: (boolean|undefined),
  *   initialIntersection: (IntersectionObserverEntry|undefined),
  * }=} options Options for the created iframe.
@@ -79,11 +78,7 @@ export function getIframe(
   opt_context,
   options = {}
 ) {
-  const {
-    disallowCustom = false,
-    allowFullscreen = false,
-    initialIntersection,
-  } = options;
+  const {allowFullscreen = false, initialIntersection} = options;
   // Check that the parentElement is already in DOM. This code uses a new and
   // fast `isConnected` API and thus only used when it's available.
   devAssert(
@@ -111,12 +106,7 @@ export function getIframe(
   count[attributes['type']] += 1;
 
   const ampdoc = parentElement.getAmpDoc();
-  const baseUrl = getBootstrapBaseUrl(
-    parentWindow,
-    ampdoc,
-    undefined,
-    disallowCustom
-  );
+  const baseUrl = getBootstrapBaseUrl(parentWindow, ampdoc);
   const host = parseUrlDeprecated(baseUrl).hostname;
   // This name attribute may be overwritten if this frame is chosen to
   // be the master frame. That is ok, as we will read the name off
@@ -220,10 +210,9 @@ export function getBootstrapUrl() {
  * @param {!Window} win
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!./preconnect.PreconnectService} preconnect
- * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  */
-export function preloadBootstrap(win, ampdoc, preconnect, opt_disallowCustom) {
-  const url = getBootstrapBaseUrl(win, ampdoc, undefined, opt_disallowCustom);
+export function preloadBootstrap(win, ampdoc, preconnect) {
+  const url = getBootstrapBaseUrl(win, ampdoc);
   preconnect.preload(ampdoc, url, 'document');
 
   // While the URL may point to a custom domain, this URL will always be
@@ -236,20 +225,18 @@ export function preloadBootstrap(win, ampdoc, preconnect, opt_disallowCustom) {
  * @param {!Window} parentWindow
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
  * @param {boolean=} opt_strictForUnitTest
- * @param {boolean=} opt_disallowCustom whether 3p url should not use meta tag.
  * @return {string}
  * @visibleForTesting
  */
 export function getBootstrapBaseUrl(
   parentWindow,
   ampdoc,
-  opt_strictForUnitTest,
-  opt_disallowCustom
+  opt_strictForUnitTest
 ) {
-  const customBootstrapBaseUrl = opt_disallowCustom
-    ? null
-    : getCustomBootstrapBaseUrl(parentWindow, ampdoc, opt_strictForUnitTest);
-  return customBootstrapBaseUrl || getDefaultBootstrapBaseUrl(parentWindow);
+  return (
+    getCustomBootstrapBaseUrl(parentWindow, ampdoc, opt_strictForUnitTest) ||
+    getDefaultBootstrapBaseUrl(parentWindow)
+  );
 }
 
 /**

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -405,14 +405,6 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
         });
       });
 
-      it('should pick default url if custom disabled', () => {
-        addCustomBootstrap('http://localhost:9876/boot/remote.html');
-        const ampdoc = Services.ampdoc(window.document);
-        expect(getBootstrapBaseUrl(window, ampdoc, true, true)).to.equal(
-          'http://ads.localhost:9876/dist.3p/current/frame.max.html'
-        );
-      });
-
       it('should create frame with default url if custom disabled', () => {
         setupElementFunctions(container);
         const iframe = getIframe(window, container, '_ping_', {
@@ -438,22 +430,6 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
             'href',
             'https://3p.ampproject.net/$internalRuntimeVersion$/f.js'
           );
-        });
-      });
-
-      it('should prefetch default bootstrap frame if custom disabled', () => {
-        mockMode({localDev: true});
-        addCustomBootstrap('http://localhost:9876/boot/remote.html');
-        const ampdoc = Services.ampdoc(window.document);
-        preloadBootstrap(window, ampdoc, preconnect, true);
-        // Wait for visible promise.
-        return ampdoc.whenFirstVisible().then(() => {
-          expect(
-            document.querySelectorAll(
-              'link[rel=preload]' +
-                '[href="http://ads.localhost:9876/dist.3p/current/frame.max.html"]'
-            )
-          ).to.be.ok;
         });
       });
 


### PR DESCRIPTION
With RTC support, custom remote.html is not really useful any more. No ad vendors are currently setting this attribute. 