### PR TITLE
♻️ [bento] Update imports of useValueRef

### DIFF
--- a/extensions/amp-lightbox/1.0/lightbox.js
+++ b/extensions/amp-lightbox/1.0/lightbox.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../src/preact';
-import {ContainWrapper} from '../../../src/preact/component';
+import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {forwardRef} from '../../../src/preact/compat';
 import {setStyle} from '../../../src/style';
 import {
@@ -43,17 +43,6 @@ const ANIMATION_PRESETS = {
 };
 
 const DEFAULT_CLOSE_LABEL = 'Close the modal';
-
-/**
- * @param {T} current
- * @return {{current: T}}
- * @template T
- */
-function useValueRef(current) {
-  const valueRef = useRef(null);
-  valueRef.current = current;
-  return valueRef;
-}
 
 /**
  * @param {!LightboxDef.Props} props


### PR DESCRIPTION
useValueRef hook moved into shared utils at

`src/preact/component` (from: https://github.com/ampproject/amphtml/pull/32584)

Updating instance of `useValueRef` in lightbox