### PR TITLE
bind-expression: remove fn.name check

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -15,7 +15,7 @@
  */
 
 import {AstNodeType} from './bind-expr-defines';
-import {devAssert, user} from '../../../src/log';
+import {user} from '../../../src/log';
 import {dict, hasOwn, map} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
 import {isArray, isObject} from '../../../src/types';

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -183,11 +183,6 @@ function generateFunctionAllowlist() {
     Object.keys(functionsForType).forEach((name) => {
       const func = functionsForType[name];
       if (func) {
-        devAssert(
-          !func.name || name === func.name,
-          'Listed function name ' +
-            `"${name}" doesn't match name property "${func.name}".`
-        );
         out[type][name] = func;
       } else {
         // This can happen if a browser doesn't support a built-in function.


### PR DESCRIPTION
**summary**
The check is completely skipped on ie11, is fragile, and tbh i can't figure out when it could be useful