### PR TITLE
🏗 Follow up changes to `gulp build` rewrite

### DIFF
--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -45,7 +45,6 @@ function getUnminifiedConfig() {
   const unminifiedPlugins = [
     argv.coverage ? 'babel-plugin-istanbul' : null,
     replacePlugin,
-    './build-system/babel-plugins/babel-plugin-transform-remove-directives',
     './build-system/babel-plugins/babel-plugin-transform-json-import',
     './build-system/babel-plugins/babel-plugin-transform-json-configuration',
     './build-system/babel-plugins/babel-plugin-transform-jss',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -401,7 +401,7 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
    */
   const esbuildBabelPlugin = {
     name: 'babel',
-    async setup(build, {transform} = {}) {
+    async setup(build) {
       const updateVersion = (contents) => {
         return contents.replace(
           /\$internalRuntimeVersion\$/g,
@@ -418,10 +418,6 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
         const result = await babel.transformAsync(contents, babelOptions);
         return {contents: updateVersion(result.code)};
       };
-
-      if (transform) {
-        return await transformContents(transform);
-      }
 
       build.onLoad({filter: /.*/, namespace: ''}, async (file) => {
         const contents = await fs.promises.readFile(file.path, 'utf-8');


### PR DESCRIPTION
Two follow up changes to #32663:

- Remove the `if (transform)` code path from the custom `babel` plugin for `esbuild` (https://github.com/ampproject/amphtml/pull/32663#discussion_r577171120)
- Remove `babel-plugin-transform-remove-directives` for unminified builds (https://github.com/ampproject/amphtml/pull/32663#discussion_r577168201) 

