### PR TITLE
Run LoadTask synchronously.

### DIFF
--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -317,6 +317,15 @@ export class LoadTask extends MediaTask {
     mediaEl.load();
     return Promise.resolve();
   }
+
+  /** @override */
+  requiresSynchronousExecution() {
+    // When recycling a media pool element, its sources are removed and the
+    // LoadTask runs to reset it (buffered data, readyState, etc). It needs to
+    // run synchronously so the media element can't be used in a new context
+    // but with old data.
+    return true;
+  }
 }
 
 /**


### PR DESCRIPTION
When recycling a media pool element, its sources are removed and the LoadTask runs to reset it (buffered data, readyState, etc). It needs to run synchronously so the media element can't be used in a new context but with old data.