### PR TITLE
🏗️  Allow esbuild to handle esm->output format conversion

### DIFF
--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -36,7 +36,7 @@ function getUnminifiedConfig() {
     '@babel/preset-env',
     {
       bugfixes: true,
-      modules: 'commonjs',
+      modules: false,
       loose: true,
       targets: {'browsers': ['Last 2 versions']},
     },

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -457,6 +457,7 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
         entryPoints: [entryPoint],
         bundle: true,
         sourcemap: true,
+        format: argv.esm ? 'esm' : 'cjs',
         define: experimentDefines,
         outfile: destFile,
         plugins: [esbuildBabelPlugin],

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -457,7 +457,6 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
         entryPoints: [entryPoint],
         bundle: true,
         sourcemap: true,
-        format: argv.esm ? 'esm' : 'cjs',
         define: experimentDefines,
         outfile: destFile,
         plugins: [esbuildBabelPlugin],


### PR DESCRIPTION
This moves the ESM->CJS conversion from Babel into esbuild, which should aid esbuild's tree-shaking (it can now analyze static import/export, instead of imperative require/exports.foo).