### PR TITLE
The overflow element must not distort size-defined layouts

### DIFF
--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -434,6 +434,13 @@ i-amphtml-scroll-container.amp-active, i-amp-scroll-container.amp-active {
   line-height: normal;
 }
 
+/**
+ * "overflow" element must not contribute space to a size-defined element.
+ */
+.i-amphtml-layout-size-defined > [overflow] {
+  position: absolute;
+}
+
 .i-amphtml-element > [overflow].amp-visible {
   visibility: visible;
 }

--- a/test/integration/test-css.js
+++ b/test/integration/test-css.js
@@ -40,9 +40,7 @@ describe.configure().run('CSS', () => {
     expect(overflowRect.height).to.be.greaterThan(0);
     // The amp-iframe has a 1:1 aspect ratio, and its height should be
     // incremented by the overflow's height.
-    expect(
-      Math.abs(iframeRect.width + overflowRect.height) - iframeRect.height
-    ).to.lessThan(2);
+    expect(Math.abs(iframeRect.width - iframeRect.height)).to.lessThan(2);
   });
 
   it('should include height of [placeholder] child in size before build', async () => {

--- a/test/unit/test-layout.js
+++ b/test/unit/test-layout.js
@@ -616,6 +616,54 @@ describe('Layout', () => {
   });
 });
 
+describes.realWin('ampshared.css', {amp: true}, function (env) {
+  let win, doc;
+  let element;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+
+    element = doc.createElement('amp-element');
+    element.classList.add('i-amphtml-element');
+    doc.body.appendChild(element);
+  });
+
+  describe
+    .configure()
+    .enableIe()
+    .run('overflow', function () {
+      let overflow;
+
+      beforeEach(() => {
+        overflow = doc.createElement('div');
+        overflow.setAttribute('overflow', '');
+        overflow.style.height = '20px';
+        element.appendChild(overflow);
+      });
+
+      it('should not allow overflow element to distort a size-defined layout', () => {
+        element.setAttribute('layout', 'responsive');
+        element.setAttribute('width', 100);
+        element.setAttribute('height', 100);
+        expect(applyStaticLayout(element)).to.equal(Layout.RESPONSIVE);
+
+        expect(element.offsetWidth).to.equal(element.offsetHeight);
+        expect(overflow.offsetHeight).to.equal(20);
+        expect(win.getComputedStyle(overflow).position).to.equal('absolute');
+      });
+
+      it('should allow overflow element to distort container layout', () => {
+        element.setAttribute('layout', 'container');
+        overflow.text = 'test';
+        expect(applyStaticLayout(element)).to.equal(Layout.CONTAINER);
+
+        expect(element.offsetHeight).to.equal(overflow.offsetHeight);
+        expect(win.getComputedStyle(overflow).position).to.equal('relative');
+      });
+    });
+});
+
 describes.realWin('Layout: aspect-ratio CSS', {amp: true}, function (env) {
   let win, doc;
   let element;


### PR DESCRIPTION
This is remedies a situation allowed by the #27736. The overflow element should not distort size-defined elements, such as `layout=responsive`. It's a semi-breaking change, but realistically this shouldn't be an issue because the overflow is always recommended to be styled with `position:absolute` for these cases.