### PR TITLE
Revert display observer for amp-iframe until lightbox/offscreen is supported

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -34,10 +34,6 @@ import {
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isExperimentOn} from '../../../src/experiments';
 import {moveLayoutRect} from '../../../src/layout-rect';
-import {
-  observeDisplay,
-  unobserveDisplay,
-} from '../../../src/utils/display-observer';
 import {parseJson} from '../../../src/json';
 import {removeElement} from '../../../src/dom';
 import {removeFragment} from '../../../src/url';
@@ -96,9 +92,6 @@ export class AmpIframe extends AMP.BaseElement {
     /** @private  {?HTMLIFrameElement} */
     this.iframe_ = null;
 
-    /** @private  {boolean} */
-    this.isDisplayed_ = false;
-
     /** @private {boolean} */
     this.isResizable_ = false;
 
@@ -135,8 +128,6 @@ export class AmpIframe extends AMP.BaseElement {
      * @private {boolean}
      */
     this.hasErroredEmbedSize_ = false;
-
-    this.onDisplay_ = this.onDisplay_.bind(this);
   }
 
   /** @override */
@@ -489,9 +480,6 @@ export class AmpIframe extends AMP.BaseElement {
 
     this.container_.appendChild(iframe);
 
-    this.isDisplayed_ = false;
-    observeDisplay(this.element, this.onDisplay_);
-
     return this.loadPromise(iframe).then(() => {
       // On iOS the iframe at times fails to render inside the `overflow:auto`
       // container. To avoid this problem, we set the `overflow:auto` property
@@ -580,7 +568,6 @@ export class AmpIframe extends AMP.BaseElement {
    * @override
    **/
   unlayoutCallback() {
-    unobserveDisplay(this.element, this.onDisplay_);
     if (this.unlistenPym_) {
       this.unlistenPym_();
       this.unlistenPym_ = null;
@@ -634,21 +621,6 @@ export class AmpIframe extends AMP.BaseElement {
   /** @override */
   unlayoutOnPause() {
     return true;
-  }
-
-  /**
-   * @param {boolean} isDisplayed
-   * @private
-   */
-  onDisplay_(isDisplayed) {
-    if (isDisplayed === this.isDisplayed_) {
-      return;
-    }
-    this.isDisplayed_ = isDisplayed;
-    const hasOwner = !!this.element.getOwner();
-    if (!isDisplayed && !hasOwner && this.iframe_) {
-      this.getVsync().mutate(() => this.unload());
-    }
   }
 
   /**


### PR DESCRIPTION
A partial revert of #31976.

Will be rolled forward by #32541 when other fixes are complete.