### PR TITLE
♻️ Move RTC manager to a service

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -650,8 +650,6 @@ AMP.AmpAdUIHandler = class {
   constructor(baseInstance) {}
 };
 
-AMP.RealTimeConfigManager;
-
 /**
  * Actual filled values for this exists in
  * src/service/real-time-config/real-time-config-impl.js

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -315,6 +315,9 @@ exports.rules = [
         'src/service/variable-source.js',
       'extensions/amp-a4a/0.1/amp-a4a.js->' +
         'src/service/url-replacements-impl.js',
+      // Real time config.
+      'extensions/amp-a4a/0.1/amp-a4a.js->' +
+        'src/service/real-time-config/real-time-config-impl.js',
       // Parsing extension urls.
       'extensions/amp-a4a/0.1/head-validation.js->' +
         'src/service/extension-location.js',

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -63,6 +63,7 @@ import {
   installFriendlyIframeEmbed,
   isSrcdocSupported,
 } from '../../../src/friendly-iframe-embed';
+import {installRealTimeConfigServiceForDoc} from '../../../src/service/real-time-config/real-time-config-impl';
 import {installUrlReplacementsForEmbed} from '../../../src/service/url-replacements-impl';
 import {
   intersectionEntryToJson,
@@ -2376,31 +2377,23 @@ export class AmpA4A extends AMP.BaseElement {
    * @return {Promise<!Array<!rtcResponseDef>>|undefined}
    */
   tryExecuteRealTimeConfig_(consentState, consentString, consentMetadata) {
-    if (!!AMP.RealTimeConfigManager) {
-      return this.getBlockRtc_().then((shouldBlock) => {
-        if (shouldBlock) {
-          return;
-        }
-        try {
-          return new AMP.RealTimeConfigManager(
-            this.getAmpDoc()
-          ).maybeExecuteRealTimeConfig(
-            this.element,
-            this.getCustomRealTimeConfigMacros_(),
-            consentState,
-            consentString,
-            consentMetadata,
-            this.verifyStillCurrent()
-          );
-        } catch (err) {
-          user().error(TAG, 'Could not perform Real Time Config.', err);
-        }
-      });
-    } else if (this.element.getAttribute('rtc-config')) {
-      user().error(
-        TAG,
-        'RTC not supported for ad network ' +
-          `${this.element.getAttribute('type')}`
+    if (this.element.getAttribute('rtc-config')) {
+      installRealTimeConfigServiceForDoc(this.getAmpDoc());
+      return this.getBlockRtc_().then((shouldBlock) =>
+        shouldBlock
+          ? undefined
+          : Services.realTimeConfigForDoc(
+              this.getAmpDoc()
+            ).then((realTimeConfig) =>
+              realTimeConfig.maybeExecuteRealTimeConfig(
+                this.element,
+                this.getCustomRealTimeConfigMacros_(),
+                consentState,
+                consentString,
+                consentMetadata,
+                this.verifyStillCurrent()
+              )
+            )
       );
     }
   }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -45,7 +45,6 @@ import {FriendlyIframeEmbed} from '../../../../src/friendly-iframe-embed';
 import {GEO_IN_GROUP} from '../../../amp-geo/0.1/amp-geo-in-group';
 import {LayoutPriority} from '../../../../src/layout';
 import {MockA4AImpl, TEST_URL} from './utils';
-import {RealTimeConfigManager} from '../../../../src/service/real-time-config/real-time-config-impl';
 import {Services} from '../../../../src/services';
 import {Signals} from '../../../../src/utils/signals';
 import {cancellation} from '../../../../src/error';
@@ -56,6 +55,7 @@ import {
   incrementLoadingAds,
   is3pThrottled,
 } from '../../../amp-ad/0.1/concurrent-load';
+import {installRealTimeConfigServiceForDoc} from '../../../../src/service/real-time-config/real-time-config-impl';
 import {layoutRectLtwh, layoutSizeFromRect} from '../../../../src/layout-rect';
 import {resetScheduledElementForTesting} from '../../../../src/service/custom-element-registry';
 import {data as testFragments} from './testdata/test_fragments';
@@ -1303,6 +1303,7 @@ describe('amp-a4a', () => {
       a4a.resumeCallback();
       expect(onLayoutMeasureSpy).to.be.calledOnce;
     });
+
     it('resumeCallback does not call onLayoutMeasure for FIE', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1335,6 +1336,7 @@ describe('amp-a4a', () => {
       a4a.resumeCallback();
       expect(onLayoutMeasureSpy).to.not.be.called;
     });
+
     it('resumeCallback w/ measure required no onLayoutMeasure', async () => {
       // Force non-FIE
       adResponse.body = adResponse.body.replace('⚡4ads', '');
@@ -1371,6 +1373,7 @@ describe('amp-a4a', () => {
       a4a.resumeCallback();
       expect(onLayoutMeasureSpy).to.not.be.called;
     });
+
     it('should run end-to-end and render in friendly iframe', async () => {
       // TODO(ccordry): delete this test when no signing launches.
       // eslint-disable-next-line no-undef
@@ -1386,18 +1389,21 @@ describe('amp-a4a', () => {
       );
       const {doc} = fixture;
       const a4aElement = createA4aElement(doc);
+      a4aElement.setAttribute('rtc-config', true);
       const a4a = new MockA4AImpl(a4aElement);
       a4a.releaseType_ = '0';
       const getAdUrlSpy = window.sandbox.spy(a4a, 'getAdUrl');
       const rtcResponse = Promise.resolve([
         {response: 'a', rtcTime: 1, callout: 'https://a.com'},
       ]);
+
+      installRealTimeConfigServiceForDoc(doc);
       const maybeExecuteRealTimeConfigStub = window.sandbox
         .stub()
         .returns(rtcResponse);
-      AMP.RealTimeConfigManager = RealTimeConfigManager;
+      const rtc = await Services.realTimeConfigForDoc(doc);
       window.sandbox
-        .stub(AMP.RealTimeConfigManager.prototype, 'maybeExecuteRealTimeConfig')
+        .stub(rtc, 'maybeExecuteRealTimeConfig')
         .callsFake(maybeExecuteRealTimeConfigStub);
       const tryExecuteRealTimeConfigSpy = window.sandbox.spy(
         a4a,
@@ -1489,6 +1495,7 @@ describe('amp-a4a', () => {
         LayoutPriority.CONTENT
       );
     });
+
     it('should update priority for non AMP if in experiment', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1533,6 +1540,7 @@ describe('amp-a4a', () => {
       );
       expect(is3pThrottled(a4a.win)).to.be.false;
     });
+
     // TODO (keithwrightbos) - move into above e2e once signed creative with
     // image within creative can be regenerated.
     it('should prefetch amp images', async () => {
@@ -1579,6 +1587,7 @@ describe('amp-a4a', () => {
         )
       ).to.not.be.ok;
     });
+
     it('must not be position:fixed', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1597,6 +1606,7 @@ describe('amp-a4a', () => {
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.not.be.ok;
     });
+
     it('does not initialize promise chain 0 height/width', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1623,6 +1633,7 @@ describe('amp-a4a', () => {
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.be.ok;
     });
+
     it('does not initialize promise chain when hidden by media query', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1644,6 +1655,7 @@ describe('amp-a4a', () => {
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.be.ok;
     });
+
     it('does not initialize promise chain when has attribute "hidden"', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1741,15 +1753,19 @@ describe('amp-a4a', () => {
         }
       }
     }
+
     it('#layoutCallback valid AMP', () => {
       return executeLayoutCallbackTest(true);
     });
+
     it('#layoutCallback not valid AMP', () => {
       return executeLayoutCallbackTest(false);
     });
+
     it('#layoutCallback AMP render fail, recover non-AMP', () => {
       return executeLayoutCallbackTest(true, true);
     });
+
     it('should run end-to-end in the presence of an XHR error', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1777,6 +1793,7 @@ describe('amp-a4a', () => {
       expect(iframe).to.be.visible;
       expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
     });
+
     it('should use adUrl from onNetworkFailure', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1812,6 +1829,7 @@ describe('amp-a4a', () => {
       expect(iframe).to.be.visible;
       expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
     });
+
     it('should not execute frame GET if disabled via onNetworkFailure', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1842,6 +1860,7 @@ describe('amp-a4a', () => {
       const iframe = a4aElement.querySelector('iframe');
       expect(iframe).to.not.be.ok;
     });
+
     it('should handle XHR error when resolves before layoutCallback', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1864,6 +1883,7 @@ describe('amp-a4a', () => {
       expect(iframe).to.be.visible;
       expect(onCreativeRenderSpy.withArgs(null)).to.be.called;
     });
+
     it('should handle XHR error when resolves after layoutCallback', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -2082,6 +2102,7 @@ describe('amp-a4a', () => {
         return expect(getAdUrlSpy).to.be.calledOnce;
       });
     });
+
     it('should ignore invalid safeframe version header', async () => {
       adResponse.headers[SAFEFRAME_VERSION_HEADER] = 'some-bad-item';
       adResponse.headers[RENDERING_TYPE_HEADER] = 'safeframe';
@@ -2147,6 +2168,7 @@ describe('amp-a4a', () => {
       a4a = new MockA4AImpl(createA4aElement(fixture.doc));
       return fixture;
     });
+
     it('should parse metadata', () => {
       const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
       const expected = Object.assign(metaData, {
@@ -2154,6 +2176,7 @@ describe('amp-a4a', () => {
       });
       expect(actual).to.deep.equal(expected);
     });
+
     // TODO(levitzky) remove the following two tests after metadata bug is
     // fixed.
     it('should parse metadata with wrong opening tag', () => {
@@ -2168,6 +2191,7 @@ describe('amp-a4a', () => {
       };
       expect(actual).to.deep.equal(expected);
     });
+
     it('should return null if metadata opening tag is (truly) wrong', () => {
       const creative = buildCreativeString(metaData).replace(
         '<script type="application/json" amp-ad-metadata>',
@@ -2187,14 +2211,17 @@ describe('amp-a4a', () => {
         )
       ).to.be.null;
     });
+
     it('should return null if invalid extensions', () => {
       metaData.customElementExtensions = 'amp-vine';
       expect(a4a.getAmpAdMetadata(buildCreativeString(metaData))).to.be.null;
     });
+
     it('should return null if non-array stylesheets', () => {
       metaData.customStylesheets = 'https://fonts.googleapis.com/css?foobar';
       expect(a4a.getAmpAdMetadata(buildCreativeString(metaData))).to.be.null;
     });
+
     it('should return null if invalid stylesheet object', () => {
       metaData.customStylesheets = [
         {href: 'https://fonts.googleapis.com/css?foobar'},
@@ -2202,6 +2229,7 @@ describe('amp-a4a', () => {
       ];
       expect(a4a.getAmpAdMetadata(buildCreativeString(metaData))).to.be.null;
     });
+
     it('should not include amp images if not an array', () => {
       metaData.images = 'https://foo.com';
       const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
@@ -2212,6 +2240,7 @@ describe('amp-a4a', () => {
       delete expected.images;
       expect(actual).to.deep.equal(expected);
     });
+
     it('should tolerate missing images', () => {
       delete metaData.images;
       const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
@@ -2222,6 +2251,7 @@ describe('amp-a4a', () => {
       delete expected.images;
       expect(actual).to.deep.equal(expected);
     });
+
     it('should limit to 5 images', () => {
       while (metaData.images.length < 10) {
         metaData.images.push('https://another.image.com?abc=def');
@@ -2306,6 +2336,7 @@ describe('amp-a4a', () => {
     let a4aElement;
     let a4a;
     let fixture;
+
     beforeEach(async () => {
       fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -2314,15 +2345,18 @@ describe('amp-a4a', () => {
       a4a.buildCallback();
       return fixture;
     });
+
     it('should return false if throttled', () => {
       incrementLoadingAds(fixture.win);
       expect(a4a.renderOutsideViewport()).to.be.false;
     });
+
     it('should return true if throttled, but AMP creative', () => {
       incrementLoadingAds(fixture.win);
       a4a.isVerifiedAmpCreative_ = true;
       expect(a4a.renderOutsideViewport()).to.equal(3);
     });
+
     it('should return 1.25 if prefer-viewability-over-views', () => {
       a4aElement.setAttribute(
         'data-loading-strategy',
@@ -2338,6 +2372,7 @@ describe('amp-a4a', () => {
     const metaData = AmpA4A.prototype.getAmpAdMetadata(buildCreativeString());
     let a4aElement;
     let a4a;
+
     beforeEach(async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -2808,7 +2843,6 @@ describe('amp-a4a', () => {
       let geoService, a4a, element, fixture;
 
       beforeEach(async () => {
-        AMP.RealTimeConfigManager = RealTimeConfigManager;
         fixture = await createIframePromise();
         element = createA4aElement(fixture.doc);
         a4a = new MockA4AImpl(element);
@@ -2877,16 +2911,13 @@ describe('amp-a4a', () => {
           .stub(Services, 'geoForDocOrNull')
           .returns(Promise.resolve(geoService));
 
-        const maybeExecuteRealTimeConfigStub = window.sandbox.stub();
-        window.sandbox
-          .stub(
-            AMP.RealTimeConfigManager.prototype,
-            'maybeExecuteRealTimeConfig'
-          )
-          .callsFake(maybeExecuteRealTimeConfigStub);
+        const realTimeConfigStub = window.sandbox.stub(
+          Services,
+          'realTimeConfigForDoc'
+        );
         element.setAttribute('block-rtc', 'usca');
         await a4a.tryExecuteRealTimeConfig_();
-        expect(maybeExecuteRealTimeConfigStub).to.not.be.called;
+        expect(realTimeConfigStub).to.not.be.called;
       });
     });
   });
@@ -3203,7 +3234,6 @@ describe('amp-a4a', () => {
 describes.realWin('AmpA4a-RTC', {amp: true}, (env) => {
   let element;
   let a4a;
-  let errorSpy;
 
   beforeEach(() => {
     // ensures window location == AMP cache passes
@@ -3217,31 +3247,11 @@ describes.realWin('AmpA4a-RTC', {amp: true}, (env) => {
     });
     doc.body.appendChild(element);
     a4a = new AmpA4A(element);
-    errorSpy = env.sandbox.spy(user(), 'error');
   });
 
   describe('#tryExecuteRealTimeConfig', () => {
-    beforeEach(() => {
-      AMP.RealTimeConfigManager = undefined;
-    });
-
     it('should not execute if RTC never imported', () => {
       expect(a4a.tryExecuteRealTimeConfig_()).to.be.undefined;
-    });
-    it('should log user error if RTC Config set but RTC not supported', () => {
-      element.setAttribute(
-        'rtc-config',
-        JSON.stringify({'urls': ['https://a.com']})
-      );
-      expect(allowConsoleError(() => a4a.tryExecuteRealTimeConfig_())).to.be
-        .undefined;
-      expect(errorSpy.calledOnce).to.be.true;
-      expect(
-        errorSpy.calledWith(
-          'amp-a4a',
-          'RTC not supported for ad network doubleclick'
-        )
-      ).to.be.true;
     });
   });
 

--- a/src/services.js
+++ b/src/services.js
@@ -622,6 +622,17 @@ export class Services {
   }
 
   /**
+   * @param {!Element|!../service/ampdoc-impl.AmpDoc} elementOrAmpDoc
+   * @return {!Promise<RealTimeConfigManager>}
+   */
+  static realTimeConfigForDoc(elementOrAmpDoc) {
+    return /** @type {!Promise<RealTimeConfigManager>} */ (getServicePromiseForDoc(
+      elementOrAmpDoc,
+      'real-time-config'
+    ));
+  }
+
+  /**
    * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
    * @return {!Promise<!./service/storage-impl.Storage>}
    */

--- a/test/unit/test-real-time-config.js
+++ b/test/unit/test-real-time-config.js
@@ -33,7 +33,7 @@ import {isFiniteNumber} from '../../src/types';
 describes.realWin('real-time-config service', {amp: true}, (env) => {
   let element;
   let fetchJsonStub;
-  let getCalloutParam_, maybeExecuteRealTimeConfig_, validateRtcConfig_;
+  let getCalloutParam_, execute_, validateRtcConfig_;
   let truncUrl_, inflateAndSendRtc_, sendErrorMessage;
   let rtc;
 
@@ -61,7 +61,7 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
       .returns(urlReplacements);
 
     rtc = new RealTimeConfigManager(doc);
-    maybeExecuteRealTimeConfig_ = rtc.maybeExecuteRealTimeConfig.bind(rtc);
+    execute_ = rtc.execute.bind(rtc);
     getCalloutParam_ = rtc.getCalloutParam_.bind(rtc);
     validateRtcConfig_ = rtc.validateRtcConfig_.bind(rtc);
     truncUrl_ = rtc.truncUrl_.bind(rtc);
@@ -122,7 +122,7 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
     });
   });
 
-  describe('#maybeExecuteRealTimeConfig_', () => {
+  describe('#execute_', () => {
     function executeTest(args) {
       const {
         urls,
@@ -145,7 +145,7 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
         );
       });
       const customMacros = args['customMacros'] || {};
-      const rtcResponsePromiseArray = maybeExecuteRealTimeConfig_(
+      const rtcResponsePromiseArray = execute_(
         element,
         customMacros,
         /* consentState */ undefined,
@@ -608,7 +608,7 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
     for (const consentState in CONSENT_POLICY_STATE) {
       it(`should handle consentState ${consentState}`, () => {
         setRtcConfig({urls: ['https://foo.com']});
-        const rtcResult = maybeExecuteRealTimeConfig_(
+        const rtcResult = execute_(
           element,
           {},
           CONSENT_POLICY_STATE[consentState],


### PR DESCRIPTION
Redo https://github.com/ampproject/amphtml/pull/32386

https://github.com/ampproject/amphtml/issues/32713 Ran into this issue, and this PR has it fixed. The root cause is that different amp-ad elements are incorrectly sharing the same service instance.