### PR TITLE
Fix doubleclick rtc example page, allowlist json in RTC macro

### DIFF
--- a/examples/doubleclick-rtc.amp.html
+++ b/examples/doubleclick-rtc.amp.html
@@ -27,7 +27,7 @@
     <amp-ad width="320" height="50"
             type="doubleclick"
             data-slot="/4119129/mobile_ad_banner"
-            rtc-config='{"urls": ["https://www.example.biz/?pvi=PAGEVIEWID&href=HREF&ds=ATTR(data-slot)&h=ATTR(height)&w=ATTR(width)&ovw=ATTR(data-override-width)&json=ATTR(data-json)&ovh=ATTR(data-override-height)"], "timeoutMillis": 500}'
+            rtc-config='{"urls": ["https://www.example.biz/?pvi=PAGEVIEWID&href=HREF&ds=ATTR(data-slot)&h=ATTR(height)&w=ATTR(width)&ovw=ATTR(data-override-width)&json=ATTR(json)&ovh=ATTR(data-override-height)"], "timeoutMillis": 500}'
             json='{"targeting":{"food":["burgers","chicken"]},"categoryExclusions":["health"],"tagForChildDirectedTreatment":0}'>
     </amp-ad>
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -970,6 +970,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const allowlist = {
       'height': true,
       'width': true,
+      'json': true,
       'data-slot': true,
       'data-multi-size': true,
       'data-multi-size-validation': true,

--- a/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
+++ b/extensions/amp-ad-network-doubleclick-impl/doubleclick-rtc.md
@@ -29,13 +29,13 @@ Google Ad Manager's RTC implementation has made many macros available for RTC ur
 -   **ATTR(data-multi-size-validation)** - data-multi-size-validation attribute of the amp-ad element
 -   **ATTR(data-override-width)** - data-override-width attribute of the amp-ad element
 -   **ATTR(data-override-height)** - data-override-height attribute of the amp-ad element
--   **ATTR(data-json)** - data-json attribute of the amp-ad element
+-   **ATTR(json)** - json attribute of the amp-ad element
 -   **ELEMENT_POS** - Offset of the element from document's top
 -   **SCROLL_TOP** - Number of pixels that the user scrolled from the document's top
 -   **PAGE_HEIGHT** - Height of the amp-doc
 -   **BKG_STATE** - Current visibility state of the amp-doc
 -   **ADCID** - adClientId
--   **TGT** - Just the targeting piece of data-json
+-   **TGT** - Just the targeting piece of json
 -   **CANONICAL_URL** - The canonical URL of the page
 
 -   **TIMEOUT** - The publisher-specified timeout for the RTC callout.


### PR DESCRIPTION
data-json attribute does not exist, so it will simply error out. There are publishers misled by this template. `TGT` macro which uses the `json` attribute appears to be the correct one.