### PR TITLE
build-system: invalidate babel cache via watcher

### DIFF
--- a/build-system/tasks/3p-vendor-helpers.js
+++ b/build-system/tasks/3p-vendor-helpers.js
@@ -16,7 +16,7 @@
 
 const debounce = require('debounce');
 const globby = require('globby');
-const {compileJs} = require('./helpers');
+const {compileJs, invalidateBabelCache} = require('./helpers');
 const {endBuildStep} = require('./helpers');
 const {VERSION} = require('../compile/internal-version');
 const {watchDebounceDelay} = require('./helpers');
@@ -42,7 +42,8 @@ async function buildVendorConfigs(options) {
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.
     const copyOptions = {...options, watch: false, calledByWatcher: true};
-    const watchFunc = () => {
+    const watchFunc = (modifiedFile) => {
+      invalidateBabelCache(modifiedFile);
       buildVendorConfigs(copyOptions);
     };
     watch(srcPath).on('change', debounce(watchFunc, watchDebounceDelay));

--- a/build-system/tasks/3p-vendor-helpers.js
+++ b/build-system/tasks/3p-vendor-helpers.js
@@ -16,7 +16,7 @@
 
 const debounce = require('debounce');
 const globby = require('globby');
-const {compileJs, invalidateBabelCache} = require('./helpers');
+const {compileJs, invalidateUnminifiedBabelCache} = require('./helpers');
 const {endBuildStep} = require('./helpers');
 const {VERSION} = require('../compile/internal-version');
 const {watchDebounceDelay} = require('./helpers');
@@ -43,7 +43,7 @@ async function buildVendorConfigs(options) {
     // Do not set watchers again when we get called by the watcher.
     const copyOptions = {...options, watch: false, calledByWatcher: true};
     const watchFunc = (modifiedFile) => {
-      invalidateBabelCache(modifiedFile);
+      invalidateUnminifiedBabelCache(modifiedFile);
       buildVendorConfigs(copyOptions);
     };
     watch(srcPath).on('change', debounce(watchFunc, watchDebounceDelay));

--- a/build-system/tasks/analytics-vendor-configs.js
+++ b/build-system/tasks/analytics-vendor-configs.js
@@ -20,7 +20,7 @@ const debounce = require('debounce');
 const fs = require('fs-extra');
 const globby = require('globby');
 const jsonminify = require('jsonminify');
-const {endBuildStep} = require('./helpers');
+const {endBuildStep, invalidateBabelCache} = require('./helpers');
 const {join, basename, dirname, extname} = require('path');
 const {watchDebounceDelay} = require('./helpers');
 const {watch} = require('chokidar');
@@ -45,7 +45,8 @@ async function analyticsVendorConfigs(opt_options) {
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.
     const copyOptions = {...options, watch: false, calledByWatcher: true};
-    const watchFunc = () => {
+    const watchFunc = (modifiedFile) => {
+      invalidateBabelCache(modifiedFile);
       analyticsVendorConfigs(copyOptions);
     };
     watch(srcPath).on('change', debounce(watchFunc, watchDebounceDelay));

--- a/build-system/tasks/analytics-vendor-configs.js
+++ b/build-system/tasks/analytics-vendor-configs.js
@@ -20,7 +20,7 @@ const debounce = require('debounce');
 const fs = require('fs-extra');
 const globby = require('globby');
 const jsonminify = require('jsonminify');
-const {endBuildStep, invalidateBabelCache} = require('./helpers');
+const {endBuildStep, invalidateUnminifiedBabelCache} = require('./helpers');
 const {join, basename, dirname, extname} = require('path');
 const {watchDebounceDelay} = require('./helpers');
 const {watch} = require('chokidar');
@@ -46,7 +46,7 @@ async function analyticsVendorConfigs(opt_options) {
     // Do not set watchers again when we get called by the watcher.
     const copyOptions = {...options, watch: false, calledByWatcher: true};
     const watchFunc = (modifiedFile) => {
-      invalidateBabelCache(modifiedFile);
+      invalidateUnminifiedBabelCache(modifiedFile);
       analyticsVendorConfigs(copyOptions);
     };
     watch(srcPath).on('change', debounce(watchFunc, watchDebounceDelay));

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -19,12 +19,16 @@ const debounce = require('debounce');
 const fs = require('fs-extra');
 const wrappers = require('../compile/compile-wrappers');
 const {
+  endBuildStep,
+  watchDebounceDelay,
+  invalidateBabelCache,
+} = require('./helpers');
+const {
   extensionAliasBundles,
   extensionBundles,
   verifyExtensionBundles,
 } = require('../compile/bundles.config');
 const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
-const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {isCiBuild} = require('../common/ci');
 const {jsifyCssAsync} = require('./css/jsify-css');
 const {log} = require('../common/logging');
@@ -382,7 +386,8 @@ async function doBuildExtension(extensions, extension, options) {
  * @param {?Object} options
  */
 function watchExtension(path, name, version, latestVersion, hasCss, options) {
-  const watchFunc = function () {
+  const watchFunc = function (modifiedFile) {
+    invalidateBabelCache(modifiedFile);
     const bundleComplete = buildExtension(
       name,
       version,

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -21,7 +21,7 @@ const wrappers = require('../compile/compile-wrappers');
 const {
   endBuildStep,
   watchDebounceDelay,
-  invalidateBabelCache,
+  invalidateUnminifiedBabelCache,
 } = require('./helpers');
 const {
   extensionAliasBundles,
@@ -387,7 +387,7 @@ async function doBuildExtension(extensions, extension, options) {
  */
 function watchExtension(path, name, version, latestVersion, hasCss, options) {
   const watchFunc = function (modifiedFile) {
-    invalidateBabelCache(modifiedFile);
+    invalidateUnminifiedBabelCache(modifiedFile);
     const bundleComplete = buildExtension(
       name,
       version,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -110,7 +110,7 @@ const watchedTargets = new Map();
  * @param {string} filepath relative to the project root.
  */
 function invalidateUnminifiedBabelCache(filepath) {
-  cache.delete(filepath);
+  cache.delete(path.resolve(filepath)); // Must be absolute path.
 }
 
 /**
@@ -173,9 +173,11 @@ async function bootstrapThirdPartyFrames(options) {
  */
 async function compileCoreRuntime(options) {
   /**
+   * @param {string} modifiedFile
    * @return {Promise<void>}
    */
-  async function watchFunc() {
+  async function watchFunc(modifiedFile) {
+    invalidateUnminifiedBabelCache(modifiedFile);
     const bundleComplete = await doBuildJs(jsBundles, 'amp.js', {
       ...options,
       watch: false,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -109,7 +109,7 @@ const watchedTargets = new Map();
  * Used to remove a file from the babel cache after it is modified.
  * @param {string} filepath relative to the project root.
  */
-function invalidateBabelCache(filepath) {
+function invalidateUnminifiedBabelCache(filepath) {
   cache.delete(filepath);
 }
 
@@ -800,5 +800,5 @@ module.exports = {
   printConfigHelp,
   printNobuildHelp,
   watchDebounceDelay,
-  invalidateBabelCache,
+  invalidateUnminifiedBabelCache,
 };

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -105,6 +105,14 @@ const cache = new Map();
  */
 const watchedTargets = new Map();
 
+/*
+ * Used to remove a file from the babel cache after it is modified.
+ * @param {string} filepath relative to the project root.
+ */
+function invalidateBabelCache(filepath) {
+  cache.delete(filepath);
+}
+
 /**
  * @param {!Object} jsBundles
  * @param {string} name
@@ -792,4 +800,5 @@ module.exports = {
   printConfigHelp,
   printNobuildHelp,
   watchDebounceDelay,
+  invalidateBabelCache,
 };


### PR DESCRIPTION
**summary**
Followup to https://github.com/ampproject/amphtml/pull/32663#issuecomment-781736550

> The watcher knows each file that is modified. The babel cache is on a file by file basis. When the watcher detects that a file has been modified, we can remove it from the cache.

While technically faster, its a bit more fragile. Not tied to it.

---

While working on this, I noticed there is nothing set to retrigger builds of core runtime `src/` folder is modified.