### PR TITLE
🏗 Lazy building 3p integrations

### DIFF
--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -23,11 +23,15 @@ const {
   maybeInitializeExtensions,
   getExtensionsToBuild,
 } = require('../tasks/extension-helpers');
+const {buildVendorLazily} = require('../tasks/3p-vendor-helpers');
 const {doBuildJs, compileCoreRuntime} = require('../tasks/helpers');
 const {jsBundles} = require('../compile/bundles.config');
+const {VERSION} = require('../compile/internal-version');
 
 const extensionBundles = {};
 maybeInitializeExtensions(extensionBundles, /* includeLatest */ true);
+
+const vendorBundles = generateBundles();
 
 /**
  * Gets the unminified name of the bundle if it can be lazily built.
@@ -133,14 +137,14 @@ async function lazyBuildJs(req, _res, next) {
  * Lazy builds a 3p iframe vendor file when requested.
  *
  * @param {!Object} req
- * @param {!Object} res
- * @param {function()} next
+ * @param {!Object} _res
+ * @param {function(): void} next
  */
-async function lazyBuild3pVendor(req, res, next) {
+async function lazyBuild3pVendor(req, _res, next) {
   const matcher = argv.compiled
-    ? /\/dist\.3p\/\d+\/vendor\/([^\/]*)\.js/ // '/dist.3p/current/vendor/*.js'
+    ? new RegExp(`\\/dist\\.3p\\/${VERSION}\\/vendor\\/([^\/]*)\\.js`) // '/dist.3p/21900000/vendor/*.js'
     : /\/dist\.3p\/current\/vendor\/([^\/]*)\.max\.js/; // '/dist.3p/current/vendor/*.max.js'
-  await lazyBuild(req.url, matcher, generateBundles(), doBuildJs, next);
+  await lazyBuild(req.url, matcher, vendorBundles, buildVendorLazily, next);
 }
 
 /**

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -15,15 +15,16 @@
  */
 'use strict';
 
-const {generateBundles} = require('../tasks/3p-vendor-helpers');
-
 const argv = require('minimist')(process.argv.slice(2));
+const {
+  doBuild3pVendor,
+  generateBundles,
+} = require('../tasks/3p-vendor-helpers');
 const {
   doBuildExtension,
   maybeInitializeExtensions,
   getExtensionsToBuild,
 } = require('../tasks/extension-helpers');
-const {buildVendorLazily} = require('../tasks/3p-vendor-helpers');
 const {doBuildJs, compileCoreRuntime} = require('../tasks/helpers');
 const {jsBundles} = require('../compile/bundles.config');
 const {VERSION} = require('../compile/internal-version');
@@ -144,7 +145,7 @@ async function lazyBuild3pVendor(req, _res, next) {
   const matcher = argv.compiled
     ? new RegExp(`\\/dist\\.3p\\/${VERSION}\\/vendor\\/([^\/]*)\\.js`) // '/dist.3p/21900000/vendor/*.js'
     : /\/dist\.3p\/current\/vendor\/([^\/]*)\.max\.js/; // '/dist.3p/current/vendor/*.max.js'
-  await lazyBuild(req.url, matcher, vendorBundles, buildVendorLazily, next);
+  await lazyBuild(req.url, matcher, vendorBundles, doBuild3pVendor, next);
 }
 
 /**

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+const {generateBundles} = require('../tasks/3p-vendor-helpers');
+
 const argv = require('minimist')(process.argv.slice(2));
 const {
   doBuildExtension,
@@ -128,6 +130,20 @@ async function lazyBuildJs(req, _res, next) {
 }
 
 /**
+ * Lazy builds a 3p iframe vendor file when requested.
+ *
+ * @param {!Object} req
+ * @param {!Object} res
+ * @param {function()} next
+ */
+async function lazyBuild3pVendor(req, res, next) {
+  const matcher = argv.compiled
+    ? /\/dist\.3p\/\d+\/vendor\/([^\/]*)\.js/ // '/dist.3p/current/vendor/*.js'
+    : /\/dist\.3p\/current\/vendor\/([^\/]*)\.max\.js/; // '/dist.3p/current/vendor/*.max.js'
+  await lazyBuild(req.url, matcher, generateBundles(), doBuildJs, next);
+}
+
+/**
  * Pre-builds the core runtime and the JS files that it loads.
  */
 async function preBuildRuntimeFiles() {
@@ -152,6 +168,7 @@ async function preBuildExtensions() {
 module.exports = {
   lazyBuildExtensions,
   lazyBuildJs,
+  lazyBuild3pVendor,
   preBuildExtensions,
   preBuildRuntimeFiles,
 };

--- a/build-system/tasks/3p-vendor-helpers.js
+++ b/build-system/tasks/3p-vendor-helpers.js
@@ -75,7 +75,7 @@ async function buildVendorConfigs(options) {
  * @param {?Object} options
  * @return {!Promise}
  */
-async function buildVendorLazily(jsBundles, name, options) {
+async function doBuild3pVendor(jsBundles, name, options) {
   const target = jsBundles[name];
   if (target) {
     return compileJsWithEsbuild(
@@ -92,7 +92,7 @@ async function buildVendorLazily(jsBundles, name, options) {
 }
 
 /**
- * Generate bundles for all JS to be built.
+ * Generate bundles for all 3p vendors to be built.
  * @return {Object}
  */
 function generateBundles() {
@@ -140,6 +140,6 @@ function listVendors() {
 
 module.exports = {
   buildVendorConfigs,
-  buildVendorLazily,
+  doBuild3pVendor,
   generateBundles,
 };

--- a/build-system/tasks/3p-vendor-helpers.js
+++ b/build-system/tasks/3p-vendor-helpers.js
@@ -16,11 +16,13 @@
 
 const debounce = require('debounce');
 const globby = require('globby');
-const {compileJsWithEsbuild} = require('./helpers');
+const {doBuildJs} = require('./helpers');
 const {endBuildStep} = require('./helpers');
 const {VERSION} = require('../compile/internal-version');
 const {watchDebounceDelay} = require('./helpers');
 const {watch} = require('chokidar');
+
+const SRCPATH = ['3p/vendors/*.js'];
 
 /**
  * Entry point for 'amp ad-vendor-configs'
@@ -31,13 +33,7 @@ const {watch} = require('chokidar');
 async function buildVendorConfigs(options) {
   options = options || {};
 
-  const srcPath = ['3p/vendors/*.js'];
   const destPath = 'dist.3p/';
-
-  // ignore test JS if not fortesting or build.
-  if (!options.fortesting) {
-    srcPath.push('!3p/vendors/_ping_.js');
-  }
 
   if (options.watch) {
     // Do not set watchers again when we get called by the watcher.
@@ -45,12 +41,55 @@ async function buildVendorConfigs(options) {
     const watchFunc = () => {
       buildVendorConfigs(copyOptions);
     };
-    watch(srcPath).on('change', debounce(watchFunc, watchDebounceDelay));
+    watch(SRCPATH).on('change', debounce(watchFunc, watchDebounceDelay));
   }
 
   const startTime = Date.now();
+  const bundles = generateBundles();
 
-  const filesToBuild = globby.sync(srcPath);
+  await Promise.all(
+    Object.keys(bundles).map((name) => doBuildJs(bundles, name, options))
+  );
+
+  endBuildStep(
+    (options.minify ? 'Minified' : 'Compiled') +
+      ' all 3p iframe vendor configs into',
+    destPath,
+    startTime
+  );
+}
+
+/**
+ * Generate bundles for all JS to be built.
+ * @return {Object}
+ */
+function generateBundles() {
+  const bundles = {};
+  listVendors().forEach((vendor) => {
+    bundles[`${vendor}`] = {
+      srcDir: './3p/vendors/',
+      srcFilename: `${vendor}.js`,
+      destDir: './dist.3p/current/vendor/',
+      minifiedDestDir: `./dist.3p/${VERSION}/vendor/`,
+      options: {
+        include3pDirectories: true,
+        includePolyfills: true,
+        externs: ['./ads/ads.extern.js'],
+        toName: `${vendor}.max.js`,
+        minifiedName: `${vendor}.js`,
+        esmPassCompilation: false,
+      },
+    };
+  });
+  return bundles;
+}
+
+/**
+ * Return all 3p iframe vendors' names.
+ * @return {!Array<string>}
+ */
+function listVendors() {
+  const filesToBuild = globby.sync(SRCPATH);
   const srcMatcher = /^3p\/vendors\/(.*)\.js/;
   const results = [];
 
@@ -63,46 +102,12 @@ async function buildVendorConfigs(options) {
 
     // Extract vendor file name
     const name = match[1];
-    results.push(buildVendor(name, options));
+    results.push(name);
   }
-  await Promise.all(results);
-
-  endBuildStep(
-    (options.minify ? 'Minified' : 'Compiled') +
-      ' all 3p iframe vendor configs into',
-    destPath,
-    startTime
-  );
-}
-
-/**
- * Build the JavaScript for the vendor specified
- *
- * @param {string} name Name of the extension. Must be the sub directory in
- *     the extensions directory and the name of the JS and optional CSS file.
- * @param {!Object} options
- * @return {!Promise}
- */
-async function buildVendor(name, options) {
-  await compileJsWithEsbuild(
-    './3p/vendors/',
-    name + '.js',
-    './dist.3p/',
-    Object.assign(options, {
-      include3pDirectories: true,
-      includePolyfills: true,
-      externs: ['./ads/ads.extern.js'],
-      toName: `current/vendor/${name}.max.js`,
-      minifiedName: `${VERSION}/vendor/${name}.js`,
-    })
-  );
-
-  // If an incremental watch build fails, simply return.
-  if (options.errored) {
-    return;
-  }
+  return results;
 }
 
 module.exports = {
   buildVendorConfigs,
+  generateBundles,
 };

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -31,6 +31,7 @@ const {
 const {
   lazyBuildExtensions,
   lazyBuildJs,
+  lazyBuild3pVendor,
   preBuildRuntimeFiles,
   preBuildExtensions,
 } = require('../server/lazy-build');
@@ -74,6 +75,7 @@ function getMiddleware() {
   if (lazyBuild) {
     middleware.push(lazyBuildExtensions);
     middleware.push(lazyBuildJs);
+    middleware.push(lazyBuild3pVendor);
   }
   return middleware;
 }


### PR DESCRIPTION
Currently, 3p integrations cannot be lazily built. This PR fixes the lazy building so that `gulp` can defer building 3p integration JS files till needed.