### PR TITLE
🏗 Sync Chrome version used by Visual tests with Percy backend

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -68,7 +68,7 @@ const percyCss = [
 // 5. Go to "Tools" -> "Version information"
 // 6. Paste the full version in the "Version" field and click "Lookup"
 // 7. Copy the value next to "Branch Base Position" and update the line below
-const PUPPETEER_CHROMIUM_REVISION = '812852'; // 87.0.4280.0
+const PUPPETEER_CHROMIUM_REVISION = '827102'; // 88.0.4324.0
 
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {
   widths: [375],

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -57,11 +57,18 @@ const percyCss = [
   '.i-amphtml-new-loader * { animation: none !important; }',
 ].join('\n');
 
-// Pin the version of Chromium to 78.0.3904.0, same as the one running on Percy.
-// Use https://omahaproxy.appspot.com/ to convert version<->revision numbers.
-// REPEATING TODO(@ampproject/wg-infra): keep this pinned with Percy whenever we
-// update the version of Chrome in the project settings.
-const PUPPETEER_CHROMIUM_REVISION = '693954';
+// REPEATING TODO(@ampproject/wg-infra): Update this whenever the Percy backend
+// starts using a new version of Chrome to render DOM snapshots.
+//
+// Steps:
+// 1. Open a recent Percy build, and click the “ⓘ” icon
+// 2. Note the Chrome major version at the bottom
+// 3. Look up the full version at https://en.wikipedia.org/wiki/Google_Chrome_version_history
+// 4. Open https://omahaproxy.appspot.com in a browser
+// 5. Go to "Tools" -> "Version information"
+// 6. Paste the full version in the "Version" field and click "Lookup"
+// 7. Copy the value next to "Branch Base Position" and update the line below
+const PUPPETEER_CHROMIUM_REVISION = '812852'; // 87.0.4280.0
 
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {
   widths: [375],


### PR DESCRIPTION
Visual tests have been flaky of late because the Percy backend was using Chrome v78. We therefore pinned our CI to that version while running visual tests. Now, Percy has moved to v87.

This PR pins our CI to the current stable channel version v88. This will be the way to go until Percy agrees to regularly update to Chrome stable channel.