### PR TITLE
♿ TetraLogical: AMP Stories accessibility review / documentation

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.md
+++ b/extensions/amp-story-360/0.1/amp-story-360.md
@@ -64,6 +64,10 @@ The `amp-story-360` component provides a way to embed 360 images and videos in [
 
 Use the `amp-story-360` component to render 360 images and video. The component can animate between two points or be explorable via the device's gyroscope sensor. For best results, only use one element per [`amp-story-page`](https://amp.dev/documentation/components/amp-story-page/?format=stories).
 
+### Accessibility considerations
+
+Currently, the `amp-story-360` component does not provide any controls for mouse or keyboard users.
+
 ### Media Requirements
 
 The `amp-story-360` component renders videos and images in [equirectangular projection](https://en.wikipedia.org/wiki/Equirectangular_projection).

--- a/extensions/amp-story-interactive/amp-story-interactive.md
+++ b/extensions/amp-story-interactive/amp-story-interactive.md
@@ -50,7 +50,7 @@ The `amp-story-interactive-binary-poll` element provides a two option voting use
 
 Does not support pairing with `amp-story-interactive-results`, and can optionally have a prompt.
 
-<amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/binary-poll-raw.png" layout="intrinsic" width="400" height="230">
+<amp-img alt="An example of a binary poll: 'Like pizza?' with a button for 'Yes' and 'No'" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/binary-poll-raw.png" layout="intrinsic" width="400" height="230">
 
 ```html
 <amp-story-interactive-binary-poll
@@ -71,7 +71,7 @@ The `amp-story-interactive-poll` element provides a voting experience with 2-4 o
 
 Display different categories based on user poll answers by pairing `amp-story-interactive-poll` with `amp-story-interactive-results`. Add a prompt for extra context.
 
-<amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/poll-raw.png" layout="intrinsic" width="400" height="450">
+<amp-img alt="An example of an interactive poll: 'Pick a season' with options for each season, and their respective percentage votes" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/poll-raw.png" layout="intrinsic" width="400" height="450">
 
 [sourcecode:html]
 <amp-story-interactive-poll
@@ -92,7 +92,7 @@ The `amp-story-interactive-quiz` element provides a guessing experience with 2-4
 
 Display different categories based on percentage of correct user answers by pairing `amp-story-interactive-quiz` with `amp-story-interactive-results`. Add a prompt for extra context.
 
-<amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/quiz-raw.png" layout="intrinsic" width="400" height="450">
+<amp-img alt="Example of an interactive quiz: 'Who was the artist that created the famous painting The Last Supper?', with various options; the correct answer, 'Leonardo da Vinci', has a green tick next to it, compared to the wrong answers which have a red cross; all answers show a percentage of how many people picked that particular answer" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/quiz-raw.png" layout="intrinsic" width="400" height="450">
 
 [sourcecode:html]
 <amp-story-interactive-quiz
@@ -114,7 +114,7 @@ Each category specifies its content `option-{1/2/3/4}-{text/image/results-catego
 
 Results can feed its state from quizzes if all categories also specify `option-{1/2/3/4}-results-threshold`. If no categories have thresholds, the state will count the `option-{1/2/3/4}-results-category` from options selected in polls.
 
-<amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/results-raw.png" layout="intrinsic" width="400" height="500">
+<amp-img alt="Example of a result sheet: 'You are a Dog. You always have energery...'" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story-interactive/img/results-raw.png" layout="intrinsic" width="400" height="500">
 
 [sourcecode:html]
 <amp-story-interactive-results

--- a/extensions/amp-story-interactive/amp-story-interactive.md
+++ b/extensions/amp-story-interactive/amp-story-interactive.md
@@ -342,6 +342,10 @@ The `amp-story-interactive` component elements support [`amp-analytics`](https:/
 </amp-analytics>
 ```
 
+## Accessibility considerations
+
+Currently, this component lacks keyboard and screen reader accessibility.
+
 ## Validation
 
 See validation rules in [amp-story-interactive validator](https://github.com/ampproject/amphtml/blob/master/extensions/amp-story-interactive/validator-amp-story-interactive.protoascii).

--- a/extensions/amp-story/amp-story-grid-layer.md
+++ b/extensions/amp-story/amp-story-grid-layer.md
@@ -29,17 +29,17 @@ limitations under the License.
 The `<amp-story-grid-layer>` component lays its children out into a grid. Its implementation is based off of the [CSS Grid Spec](https://www.w3.org/TR/css-grid-1/).
 
 <div class="flex-images">
-  <amp-img alt="Layer 1" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-1.gif" width="200" height="355">
-  <noscript><img width="200" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-1.gif" /></noscript></amp-img>
+  <amp-img alt="Layer 1 - background" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-1.gif" width="200" height="355">
+  <noscript><img width="200" alt="Layer 1 - background" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-1.gif" /></noscript></amp-img>
   <span class="special-char">+</span>
-  <amp-img alt="Layer 2" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-2.jpg" width="200" height="355">
-  <noscript><img width="200" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-2.jpg" /></noscript></amp-img>
+  <amp-img alt="Layer 2 - page content (with equal margin from the screen edge)" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-2.jpg" alt="Layer 2" width="200" height="355">
+  <noscript><img width="200" alt="Layer 2 - page content (with equal margin from the screen edge)" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-2.jpg" /></noscript></amp-img>
   <span class="special-char">+</span>
-  <amp-img alt="Layer 3" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-3.jpg" width="200" height="355">
-  <noscript><img width="200" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-3.jpg" /></noscript></amp-img>
+  <amp-img alt="Layer 3 - logo, positioned in the bottom-right of the screen" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-3.jpg" width="200" height="355">
+  <noscript><img width="200" alt="Layer 3 - logo, positioned in the bottom-right of the screen" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-3.jpg" /></noscript></amp-img>
   <span class="special-char">=</span>
-  <amp-img alt="All layers" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-4.gif" width="200" height="355">
-  <noscript><img width="200" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-4.gif" /></noscript></amp-img>
+  <amp-img alt="All layers shown together" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-4.gif" width="200" height="355">
+  <noscript><img width="200" alt="All layers shown together" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/layers-layer-4.gif" /></noscript></amp-img>
 </div>
 
 ## Valid children
@@ -291,15 +291,15 @@ Names Areas: (none)
 
 Example:
 
-<amp-img alt="Fill template example" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-fill.png" width="145" height="255">
+<amp-img alt="Fill template example: a cat.jpg image, sized to fill the entire screen" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-fill.png" width="145" height="255">
   <noscript>
-    <img alt="Horizontal template example" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-fill.png" />
+    <img  alt="Fill template example: a cat.jpg image, sized to fill the entire screen" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-fill.png" />
   </noscript>
 </amp-img>
 
 ```html
 <amp-story-grid-layer template="fill">
-  <amp-img src="cat.jpg"></amp-img>
+  <amp-img src="cat.jpg" alt="..."></amp-img>
 </amp-story-grid-layer>
 ```
 
@@ -309,9 +309,9 @@ The `vertical` template lays its elements out along the y-axis. By default, its 
 
 Names Areas: (none)
 
-<amp-img alt="Vertical template example" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-vertical.png" width="145" height="255">
+<amp-img alt="Illustration: element1, element2 and element3, stacked vertically" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-vertical.png" width="145" height="255">
   <noscript>
-    <img alt="Horizontal template example" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-vertical.png" />
+    <img alt="Illustration: element1, element2 and element3, stacked vertically" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-vertical.png" />
   </noscript>
 </amp-img>
 
@@ -329,9 +329,9 @@ The `horizontal` template lays its elements out along the x-axis. By default, it
 
 Names Areas: (none)
 
-<amp-img alt="Horizontal template example" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-horizontal.png" width="145" height="255">
+<amp-img alt="Illustration: element1, element2 and element3, stacked horizontally in columns" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-horizontal.png" width="145" height="255">
   <noscript>
-    <img alt="Horizontal template example" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-horizontal.png" />
+    <img alt="Illustration: element1, element2 and element3, stacked horizontally in columns" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-horizontal.png" />
   </noscript>
 </amp-img>
 
@@ -353,9 +353,9 @@ Named Areas:
 -   `middle-third`
 -   `lower-third`
 
-<amp-img alt="Horizontal template example" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-thirds.png" width="145" height="255">
+<amp-img alt="Illustration: the screen split into three horizontal stacked areas - upper-third, middle-third, lower-third; element 3 is in the upper-third; element 2 is in the lower-third; element 1 is in the middle third" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-thirds.png" width="145" height="255">
   <noscript>
-    <img alt="Thirds template example" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-thirds.png" />
+    <img alt="Illustration: the screen split into three horizontal stacked areas - upper-third, middle-third, lower-third; element 3 is in the upper-third; element 2 is in the lower-third; element 1 is in the middle third" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/template-thirds.png" />
   </noscript>
 </amp-img>
 
@@ -380,16 +380,16 @@ Note: your story needs to enable the `supports-landscape` mode to use this templ
 
 Example:
 
-<amp-img alt="Landscape half-half UI template" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story-img-video-object-fit-position.png" width="600" height="287">
+<amp-img alt="Landscape half-half UI template - in small screen/smartphone, the image is behind the content; on large screen/tablet, the image is on the left, while the content is on the right" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story-img-video-object-fit-position.png" width="600" height="287">
   <noscript>
-    <img alt="Landscape half-half UI template" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story-img-video-object-fit-position.png" />
+    <img alt="Landscape half-half UI template - in small screen/smartphone, the image is behind the content; on large screen/tablet, the image is on the left, while the content is on the right" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story-img-video-object-fit-position.png" />
   </noscript>
 </amp-img>
 
 ```html
 <amp-story-page id="foo">
   <amp-story-grid-layer template="fill" position="landscape-half-left">
-    <amp-img src="cat.jpg"></amp-img>
+    <amp-img src="cat.jpg" alt="..."></amp-img>
   </amp-story-grid-layer>
   <amp-story-grid-layer template="vertical" position="landscape-half-right">
     <h2>Cat ipsum dolor sit amet...</h2>
@@ -403,14 +403,14 @@ Responsive presets on grid-layers maximize usable screen space and scale assets 
 
 ```html
 <amp-story-grid-layer preset="2021-background" template="fill">
-    <amp-img src="cat.jpg">
+    <amp-img src="cat.jpg" alt="...">
 </amp-story-grid-layer>
 <amp-story-grid-layer preset="2021-foreground">
     <h1>This will stay consistent with the bg</h1>
 </amp-story-grid-layer>
 <amp-story-grid-layer preset="2021-foreground" anchor="bottom-left">
     <!-- Position the icon close to the corner on all screens -->
-    <amp-img src="icon.jpg" style="bottom: 1em; left: 1em">
+    <amp-img src="icon.jpg" alt="..." style="bottom: 1em; left: 1em">
 </amp-story-grid-layer>
 ```
 
@@ -429,9 +429,9 @@ While this technique provides the most consistent user experience, it may crop u
 
 <div layout="container" width="3" height="2">
   <div style="width:33%;display:inline-block">
-    <amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/preset_story_scaled.gif" layout="responsive" width="200" height="350"/>
+    <amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/preset_story_scaled.gif" layout="responsive" alt="Animation showing how a perfectly scaled with a 7.2% bleed-area adapts to different screen aspect ratios, always keeping content visible" width="200" height="350"/>
   </div>
   <div style="width:66%;display:inline-block">
-    <amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/preset_story_anchor.gif" layout="responsive" width="500" height="400"/>
+    <amp-img src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/preset_story_anchor.gif" layout="responsive" alt="Animation showing a background that remains anchored to the bottom of the viewport, regardless of screen aspect ratio/height" width="500" height="400"/>
   </div>
 </div>

--- a/extensions/amp-story/amp-story-grid-layer.md
+++ b/extensions/amp-story/amp-story-grid-layer.md
@@ -367,6 +367,10 @@ Named Areas:
 </amp-story-grid-layer>
 ```
 
+{% call callout('Note', type='note') %}
+While these templates allow you to visually arrange content on the screen, the content will still be announced by screen readers / assistive technologies in the order in which it appears in the underlying markup. Make sure that the content order in your document's markup is logical, regardless of how it will be presented visually.
+{% endcall %}
+
 ### Pre templated UI
 
 #### Landscape half-half UI

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -308,6 +308,8 @@ If the `supports-landscape` attribute is specified on the `<amp-story>` element,
 -   Allow the story to be seen when a mobile device is held in a landscape orientation.
 -   Change the desktop experience to an immersive full bleed mode, replacing the default three portrait panels experience.
 
+While this is currently opt-in and optional, we strongly recommend making sure that users on mobile devices are able to view stories in whatever orientation best suits their needs - otherwise, they will simply be presented with a "The page is best viewed in portrait mode" message.
+
 Usage: `<amp-story ... supports-landscape>...</amp-story>`
 
 <figure class="centered-fig">

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -24,7 +24,7 @@ limitations under the License.
 
 # amp-story
 
-[Web stories](https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/?format=stories) are an immersive, tappable and easily shareable storytelling format. Web stories are built using the AMP Framework. The `amp-story` component provides the AMP story subsect of AMP. It is the base technology for web stories.
+[Web stories](https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/?format=stories) are an immersive, tappable and easily shareable storytelling format. Web stories are built using the AMP Framework. The `amp-story` component provides the AMP story subset of AMP. It is the base technology for web stories.
 
 <figure class="centered-fig">
   <amp-anim width="300" height="533" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story.gif">

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -27,7 +27,7 @@ limitations under the License.
 [Web stories](https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/?format=stories) are an immersive, tappable and easily shareable storytelling format. Web stories are built using the AMP Framework. The `amp-story` component provides the AMP story subset of AMP. It is the base technology for web stories.
 
 <figure class="centered-fig">
-  <amp-anim width="300" height="533" layout="fixed" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story.gif">
+  <amp-anim width="300" height="533" layout="fixed" alt="AMP Story Example" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story.gif">
     <noscript>
     <img alt="AMP Story Example" src="https://github.com/ampproject/amphtml/raw/master/extensions/amp-story/img/amp-story.gif" />
   </noscript>
@@ -149,6 +149,7 @@ The following markup is a decent starting point or boilerplate. Copy this and sa
             src="https://example.ampproject.org/helloworld/bg1.jpg"
             width="900"
             height="1600"
+            alt=""
           >
           </amp-img>
         </amp-story-grid-layer>
@@ -162,6 +163,7 @@ The following markup is a decent starting point or boilerplate. Copy this and sa
             src="https://example.ampproject.org/helloworld/bg2.gif"
             width="900"
             height="1600"
+            alt=""
           >
           </amp-img>
         </amp-story-grid-layer>
@@ -311,11 +313,11 @@ Usage: `<amp-story ... supports-landscape>...</amp-story>`
 <figure class="centered-fig">
   <span class="special-char">Before:</span>
   <amp-anim alt="Desktop three panels experience" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-desktop-three-panels.gif" width="400" height="299">
-  <noscript><img width="400" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-desktop-three-panels.gif" /></noscript>
+  <noscript><img width="400" alt="Desktop three panels experience" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-desktop-three-panels.gif" /></noscript>
   </amp-anim>
   <span class="special-char">After:</span>
   <amp-anim alt="Desktop full bleed experience" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-desktop-full-bleed.gif" width="400" height="299">
-  <noscript><img width="400" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-desktop-full-bleed.gif" /></noscript>
+  <noscript><img width="400" alt="Desktop full bleed experience" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-desktop-full-bleed.gif" /></noscript>
   </amp-anim>
 </figure>
 
@@ -391,7 +393,7 @@ Example:
 This same image can be used for both mobile portrait and landscape desktop using the `object-position` this way:
 
 ```html
-<amp-img src="cat.jpg" object-position="75% 40%"></amp-img>
+<amp-img src="cat.jpg" alt="..." object-position="75% 40%"></amp-img>
 ```
 
 ##### `data-text-background-color`
@@ -443,7 +445,7 @@ Example:
 <figure class="centered-fig">
   <span class="special-char">Example:</span>
   <amp-anim alt="Embedded component example" layout="flex-item" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-tooltip.gif" width="300" height="553">
-  <noscript><img width="300" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-tooltip.gif" /></noscript>
+  <noscript><img width="300"  alt="Embedded component example" src="https://raw.githubusercontent.com/ampproject/amphtml/master/extensions/amp-story/img/amp-story-tooltip.gif" /></noscript>
   </amp-anim>
 </figure>
 
@@ -720,6 +722,7 @@ _Example_: An image zooming-in from 2x to 5x its size over 4 seconds.
   src="https://picsum.photos/720/320?image=1026"
   width="720"
   height="320"
+  alt="..."
 >
 </amp-img>
 ```
@@ -739,6 +742,7 @@ _Example_: An image panning 200px to the left over 10 seconds.
   src="https://picsum.photos/720/320?image=1026"
   width="720"
   height="320"
+  alt="..."
 >
 </amp-img>
 ```
@@ -758,6 +762,7 @@ _Example_: An image panning 50px down over 15 seconds.
   src="https://picsum.photos/720/320?image=1026"
   width="720"
   height="320"
+  alt="..."
 >
 </amp-img>
 ```

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -846,7 +846,7 @@ where `page-id` refers to the unique id of an `amp-story-page`. You can also use
 
 ## Localization
 
-To localize your story, include the language code in the `lang` attribute on the `<html>` tag of your story, such as `<html ⚡ lang="en">` for English. The supported language codes are:
+You should always include the language code in the `lang` attribute on the `<html>` tag of your story, such as `<html ⚡ lang="en">` for English content. The supported language codes are:
 
 -   ar (Arabic)
 -   de (German)

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -49,9 +49,9 @@ As of 2018-07-16, version 0.1 is considered deprecated, and will be deleted on 2
 
 An [AMP story](#story:-amp-story) is a complete AMP HTML document that is comprised of [pages](https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/amp-story-page.md), within the pages are [layers](https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/amp-story-grid-layer.md), within the layers are AMP & HTML elements, like media, analytics, text, and so on.
 
-<amp-img alt="AMP story tag hierarchy" layout="responsive" src="https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png" width="591" height="358">
+<amp-img alt="An illustration of the nested markup structure of an amp-story: an amp-story element, which contains two amp-story-page blocks, which in turn contain an amp-story-grid-layer, which then contains the actual content elements" layout="responsive" src="https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png" width="591" height="358">
   <noscript>
-    <img alt="AMP story tag hierarchy" src="https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png" />
+    <img alt="An illustration of the nested markup structure of an amp-story: an amp-story element, which contains two amp-story-page blocks, which in turn contain an amp-story-grid-layer, which then contains the actual content elements" src="https://github.com/ampproject/docs/raw/master/assets/img/docs/amp-story-tag-hierarchy.png" />
   </noscript>
 </amp-img>
 

--- a/extensions/amp-story/amp-story.md
+++ b/extensions/amp-story/amp-story.md
@@ -600,6 +600,10 @@ Every element inside an `<amp-story-page>` can have an entrance animation.
 
 You can configure animations by specifying a set of [animation attributes](#animation-attributes) on the element; no additional AMP extensions or configuration is needed.
 
+{% call callout('Note', type='note') %}
+Animations can help make your Web Story more visually exciting and engaging, but use them sparingly. Some users may find long, continuous animations distracting. Other users may have motion sensitivity and be adversely affected by excessive use of motion and parallax effects.
+{% endcall %}
+
 ### Animation effects
 
 The following animation effects are available as presets for AMP stories:

--- a/extensions/amp-video/0.1/amp-video.md
+++ b/extensions/amp-video/0.1/amp-video.md
@@ -35,7 +35,7 @@ The `amp-video` component loads the video resource specified by its `src` attrib
 The `amp-video` component accepts up to four unique types of HTML nodes as children:
 
 -   `source` tags: Just like in the HTML `<video>` tag, you can add `<source>` tag children to specify different source media files to play.
--   `track` tags to enable subtitles in the video. If the track is hosted on a different origin than the document, you must add the `crossorigin` attribute to the `<amp-video>` tag.
+-   `track` tags to enable subtitles in the video. If the track is hosted on a different origin than the document, you must add the `crossorigin` attribute to the `<amp-video>` tag. Whenever the video has narration or important audio information, make sure to include subtitles/captions for users who may not be able to hear it or have their sound turned off.
 -   a placeholder for before the video starts
 -   a fallback if the browser doesn’t support HTML5 video: One or zero immediate child nodes can have the `fallback` attribute. If present, this node and its children form the content that displays if HTML5 video is not supported on the user’s browser.
 

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -35,7 +35,7 @@ The `amp-video` component loads the video resource specified by its `src` attrib
 The `amp-video` component accepts up to four unique types of HTML nodes as children:
 
 -   `source` tags: Just like in the HTML `<video>` tag, you can add `<source>` tag children to specify different source media files to play.
--   `track` tags to enable subtitles in the video. If the track is hosted on a different origin than the document, you must add the `crossorigin` attribute to the `<amp-video>` tag.
+-   `track` tags to enable subtitles in the video. If the track is hosted on a different origin than the document, you must add the `crossorigin` attribute to the `<amp-video>` tag. Whenever the video has narration or important audio information, make sure to include subtitles/captions for users who may not be able to hear it or have their sound turned off.
 -   a placeholder for before the video starts
 -   a fallback if the browser doesn’t support HTML5 video: One or zero immediate child nodes can have the `fallback` attribute. If present, this node and its children form the content that displays if HTML5 video is not supported on the user’s browser.
 


### PR DESCRIPTION
Suggested changes and additions based on the TetraLogical accessibility review commissioned by @nainar / @caroqliu

Main changes:

* where appropriate, add extra prose about importance of providing captions
* accessibility consideration notes for 360 and interactive components (that lack keyboard accessibility, and the latter lacks screenreader support altogether)
* note about judicious use of animations
* typo "subsect" > "subset"
* expand alt text of documentation images to actually convey information
* where appropriate, add `alt="..."` placeholder attribute to reinforce the idea for developers that they should provide text alternatives
* note about content order still matching source order for AT users, even if using named areas in template to provide a different apparent content order

x-ref: https://github.com/ampproject/amp.dev/pull/5397