### PR TITLE
🏗 Execute integration tests on both prod and canary config, with experiments derandomized

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
       - restore_karma_cache:
           cache_name: nomodule
       - run:
-          name: 'Nomodule Tests'
+          name: 'Nomodule Tests (using << parameters.config >>-config.json)'
           command: node build-system/pr-check/nomodule-tests.js
       - save_karma_cache:
           cache_name: nomodule
@@ -214,7 +214,7 @@ jobs:
       - restore_karma_cache:
           cache_name: module
       - run:
-          name: 'Module Tests'
+          name: 'Module Tests (using << parameters.config >>-config.json)'
           command: node build-system/pr-check/module-tests.js
       - save_karma_cache:
           cache_name: module
@@ -338,7 +338,7 @@ workflows:
           requires:
             - 'Unminified Build'
       - 'Nomodule Tests':
-          name: 'Nomodule Tests (using << matrix.config >>-config.json)'
+          name: 'Nomodule Tests (<< matrix.config >>)'
           matrix:
             parameters:
               config: ['prod', 'canary']
@@ -346,7 +346,7 @@ workflows:
           requires:
             - 'Nomodule Build'
       - 'Module Tests':
-          name: 'Module Tests (using << matrix.config >>-config.json)'
+          name: 'Module Tests (<< matrix.config >>)'
           matrix:
             parameters:
               config: ['prod', 'canary']

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,13 @@ jobs:
   'Nomodule Tests':
     executor:
       name: amphtml-large-executor
+    parameters:
+      config:
+        description: 'Which config file to use'
+        type: enum
+        enum: ['prod', 'canary']
+    environment:
+      config: << parameters.config >>
     steps:
       - setup_vm
       - install_chrome
@@ -194,6 +201,13 @@ jobs:
   'Module Tests':
     executor:
       name: amphtml-large-executor
+    parameters:
+      config:
+        description: 'Which config file to use'
+        type: enum
+        enum: ['prod', 'canary']
+    environment:
+      config: << parameters.config >>
     steps:
       - setup_vm
       - install_chrome
@@ -324,10 +338,18 @@ workflows:
           requires:
             - 'Unminified Build'
       - 'Nomodule Tests':
+          name: 'Nomodule Tests (using << matrix.config >>-config.json)'
+          matrix:
+            parameters:
+              config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
             - 'Nomodule Build'
       - 'Module Tests':
+          name: 'Module Tests (using << matrix.config >>-config.json)'
+          matrix:
+            parameters:
+              config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
             - 'Nomodule Build'

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -32,6 +32,7 @@ const {runCiJob} = require('./ci-job');
 const jobName = 'module-tests.js';
 
 function prependConfig() {
+  // TODO(@ampproject/wg-infra): change prepend-global to take multiple target files instead of looping here.
   for (const target of MINIFIED_TARGETS) {
     for (const ext of ['js', 'mjs']) {
       timedExecOrDie(

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -26,14 +26,26 @@ const {
   timedExecOrDie,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
+const {MINIFIED_TARGETS} = require('../tasks/helpers');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'module-tests.js';
+
+function prependConfig() {
+  for (const target of MINIFIED_TARGETS) {
+    for (const ext of ['js', 'mjs']) {
+      timedExecOrDie(
+        `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=dist/${target}.${ext}`
+      );
+    }
+  }
+}
 
 function pushBuildWorkflow() {
   downloadNomoduleOutput();
   downloadModuleOutput();
   timedExecOrDie('gulp update-packages');
+  prependConfig();
   timedExecOrDie('gulp integration --nobuild --compiled --headless --esm');
 }
 
@@ -42,6 +54,7 @@ function prBuildWorkflow() {
     downloadNomoduleOutput();
     downloadModuleOutput();
     timedExecOrDie('gulp update-packages');
+    prependConfig();
     timedExecOrDie('gulp integration --nobuild --compiled --headless --esm');
   } else {
     printSkipMessage(

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -32,6 +32,7 @@ const {runCiJob} = require('./ci-job');
 const jobName = 'nomodule-tests.js';
 
 function prependConfig() {
+  // TODO(@ampproject/wg-infra): change prepend-global to take multiple target files instead of looping here.
   for (const target of MINIFIED_TARGETS) {
     timedExecOrDie(
       `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=dist/${target}.js`

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -26,13 +26,23 @@ const {
   timedExecOrThrow,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
+const {MINIFIED_TARGETS} = require('../tasks/helpers');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'nomodule-tests.js';
 
+function prependConfig() {
+  for (const target of MINIFIED_TARGETS) {
+    timedExecOrDie(
+      `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=dist/${target}.js`
+    );
+  }
+}
+
 function pushBuildWorkflow() {
   downloadNomoduleOutput();
   timedExecOrDie('gulp update-packages');
+  prependConfig();
   try {
     timedExecOrThrow(
       'gulp integration --nobuild --headless --compiled --report',
@@ -51,6 +61,7 @@ function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');
+    prependConfig();
     timedExecOrDie('gulp integration --nobuild --compiled --headless');
   } else {
     printSkipMessage(

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -194,8 +194,8 @@ async function applyConfig(
 
 /**
  * @param {string} target File containing the AMP runtime (amp.js or v0.js)
- * @param {string} configJson The json object in which to enable local dev
- * @return {string}
+ * @param {!JSON} configJson The json object in which to enable local dev
+ * @return {!JSON}
  */
 function enableLocalDev(target, configJson) {
   let LOCAL_DEV_AMP_CONFIG = {localDev: true};

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -264,10 +264,6 @@ async function prependGlobal() {
     return;
   }
 
-  if (argv.remove) {
-    return removeConfig(target);
-  }
-
   if (!(argv.prod || argv.canary)) {
     log(red('One of --prod or --canary should be provided.'));
     return;
@@ -329,9 +325,6 @@ prependGlobal.flags = {
   'local_branch':
     "  Don't switch branches and use the config from the local branch.",
   'fortesting': '  Force the config to return true for getMode().test',
-  'remove':
-    '  Removes previously prepended json config from the target ' +
-    'file (if present).',
   'derandomize':
     '  Rounds all experiment percentages to 0 or 1, whichever is closest.',
 };

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -46,8 +46,10 @@ const TEST_TYPE_SUBTYPES = isGithubActionsBuild()
         'integration',
         [
           'unminified',
-          'nomodule',
-          'module',
+          'nomodule-prod',
+          'nomodule-canary',
+          'module-prod',
+          'module-canary',
           'experimentA',
           'experimentB',
           'experimentC',
@@ -99,7 +101,14 @@ function inferTestType() {
     ? 'nomodule'
     : 'unminified';
 
-  return `${type}/${subtype}`;
+  return `${type}/${subtype}${maybeAddConfigSubtype()}`;
+}
+
+function maybeAddConfigSubtype() {
+  if (isCircleciBuild() && process.env.config) {
+    return `-${process.env.config}`;
+  }
+  return '';
 }
 
 async function postReport(type, action) {


### PR DESCRIPTION
Fixes #25720:
* splits the `integration/module` and `integration/nomodule` tests on CircleCI to `integration/module-prod`, `integration/module-canary`, `integration/nomodule-prod`, `integration/nomodule-canary`
* Runs `Math.round()` on all experiment percentage ratios to remove any randomness from the tests

See the CircleCI build for this PR to see the results