### PR TITLE
remove stray "That"

### DIFF
--- a/extensions/amp-base-carousel/amp-base-carousel.md
+++ b/extensions/amp-base-carousel/amp-base-carousel.md
@@ -327,7 +327,7 @@ carousel.
 ##### snap-by
 
 A number, defaults to `1`. This determines the granularity of snapping and is
-useful when using `visible-count`. This
+useful when using `visible-count`.
 
 #### Miscellaneous
 


### PR DESCRIPTION
typo in the docs, fixes ampproject/amp.dev#4270