### PR TITLE
✨  Shorten URL in error messages

### DIFF
--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -852,7 +852,7 @@ export class AmpList extends AMP.BaseElement {
           userAssert(
             response,
             'Failed fetching JSON data: XHR Failed fetching ' +
-              `(${request.xhrUrl}): received no response.`
+              `(${this.buildElidedUrl_(request)}): received no response.`
           );
           const init = response['init'];
           if (init) {
@@ -860,7 +860,8 @@ export class AmpList extends AMP.BaseElement {
             if (status >= 300) {
               /** HTTP status codes of 300+ mean redirects and errors. */
               throw user().createError(
-                `Failed fetching JSON data (${request.xhrUrl}): HTTP error`,
+                `Failed fetching JSON data (${this.buildElidedUrl_(request)})` +
+                  ': HTTP error',
                 status
               );
             }
@@ -868,8 +869,8 @@ export class AmpList extends AMP.BaseElement {
           userAssert(
             typeof response['html'] === 'string',
             'Failed fetching JSON data: XHR Failed fetching ' +
-              `(${request.xhrUrl}): Expected response with format ` +
-              'html: <string>}. Received: ',
+              `(${this.buildElidedUrl_(request)}): Expected response with ` +
+              'format {html: <string>}. Received: ',
             response
           );
           request.fetchOpt.responseType = 'application/json';
@@ -878,7 +879,7 @@ export class AmpList extends AMP.BaseElement {
         (error) => {
           throw user().createError(
             'Failed fetching JSON data: XHR Failed fetching ' +
-              `(${request.xhrUrl})`,
+              `(${this.buildElidedUrl_(request)})`,
             error
           );
         }
@@ -890,6 +891,17 @@ export class AmpList extends AMP.BaseElement {
         }
         return this.scheduleRender_(data, /* append */ false);
       });
+  }
+
+  /**
+   * Builds an elided, shortened URL suitable for display in error messages from
+   * the given request.
+   * @param {!FetchRequestDef} request
+   * @return {string}
+   */
+  buildElidedUrl_(request) {
+    const url = Services.urlForDoc(this.element).parse(request.xhrUrl);
+    return `${url.origin}/...`;
   }
 
   /**

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -829,7 +829,7 @@ describes.repeated(
               return expect(
                 list.layoutCallback()
               ).to.eventually.be.rejectedWith(
-                /XHR Failed fetching \(https:\/\/data.com.+?\): error/
+                /XHR Failed fetching \(https:\/\/data.com\/\.\.\.\): error/
               );
             });
 
@@ -853,7 +853,7 @@ describes.repeated(
               return expect(
                 list.layoutCallback()
               ).to.eventually.be.rejectedWith(
-                /fetching JSON data \(https:\/\/data.com.+?\): HTTP error 400/
+                /fetching JSON data \(https:\/\/data.com\/\.\.\.\): HTTP error 400/
               );
             });
 


### PR DESCRIPTION
Currently the full URL is too long for Gmail since the URL includes
`__amp_source_origin`, which is the full data URL for the AMP document
itself. The long URL spams the JS console with unreadable log messages.

This follows the eliding pattern for the non-SSR path in xhr-impl:

https://github.com/ampproject/amphtml/blob/a0f71dfb0381e236d6c6be287549748838731467/src/service/xhr-impl.js#L111

/to @caroqliu 