### PR TITLE
Shadow DOM polyfill for elements that need it

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -134,8 +134,7 @@
     "name": "amp-date-picker",
     "version": "0.1",
     "latestVersion": "0.1",
-    "options": {"hasCss": true},
-    "postPrepend": ["third_party/react-dates/bundle.js"]
+    "options": {"hasCss": true}
   },
   {
     "name": "amp-delight-player",
@@ -239,8 +238,7 @@
   {
     "name": "amp-inputmask",
     "version": "0.1",
-    "latestVersion": "0.1",
-    "postPrepend": ["third_party/inputmask/bundle.js"]
+    "latestVersion": "0.1"
   },
   {
     "name": "amp-instagram",
@@ -577,12 +575,7 @@
     "name": "amp-viz-vega",
     "version": "0.1",
     "latestVersion": "0.1",
-    "options": {"hasCss": true},
-    "postPrepend": [
-      "third_party/d3/d3.js",
-      "third_party/d3-geo-projection/d3-geo-projection.js",
-      "third_party/vega/vega.js"
-    ]
+    "options": {"hasCss": true}
   },
   {"name": "amp-vk", "version": "0.1", "latestVersion": "0.1"},
   {

--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -383,6 +383,12 @@
     "options": {"hasCss": true}
   },
   {
+    "name": "amp-shadow-dom-polyfill",
+    "version": "0.1",
+    "latestVersion": "0.1",
+    "options": {"noWrapper": true}
+  },
+  {
     "name": "amp-sidebar",
     "version": ["0.1", "0.2", "1.0"],
     "latestVersion": "0.1",

--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -62,8 +62,6 @@ const COMMON_GLOBS = [
   'node_modules/@ampproject/viewer-messaging/messaging.js',
   'node_modules/@ampproject/worker-dom/package.json',
   'node_modules/@ampproject/worker-dom/dist/amp-production/main.mjs',
-  'node_modules/@webcomponents/webcomponentsjs/package.json',
-  'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js',
   'node_modules/preact/package.json',
   'node_modules/preact/dist/*.js',
   'node_modules/preact/hooks/package.json',

--- a/build-system/compile/sources.js
+++ b/build-system/compile/sources.js
@@ -62,6 +62,8 @@ const COMMON_GLOBS = [
   'node_modules/@ampproject/viewer-messaging/messaging.js',
   'node_modules/@ampproject/worker-dom/package.json',
   'node_modules/@ampproject/worker-dom/dist/amp-production/main.mjs',
+  'node_modules/@webcomponents/webcomponentsjs/package.json',
+  'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js',
   'node_modules/preact/package.json',
   'node_modules/preact/dist/*.js',
   'node_modules/preact/hooks/package.json',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -63,7 +63,7 @@ const EXTENSION_BUNDLE_MAP = {
   'amp-inputmask.js': ['third_party/inputmask/bundle.js'],
   'amp-date-picker.js': ['third_party/react-dates/bundle.js'],
   'amp-shadow-dom-polyfill.js': [
-    'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.js',
+    'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js',
   ],
 };
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -62,6 +62,9 @@ const EXTENSION_BUNDLE_MAP = {
   ],
   'amp-inputmask.js': ['third_party/inputmask/bundle.js'],
   'amp-date-picker.js': ['third_party/react-dates/bundle.js'],
+  'amp-shadow-dom-polyfill.js': [
+    'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.js',
+  ],
 };
 
 /**

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -125,34 +125,6 @@ function patchResizeObserver() {
 }
 
 /**
- * Patches Shadow DOM polyfill by wrapping its body into `install`
- * function.
- * This gives us an option to control when and how the polyfill is installed.
- * The polyfill can only be installed on the root context.
- */
-function patchShadowDom() {
-  // Copies webcomponents-sd into a new file that has an export.
-  const patchedName =
-    'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js';
-  let file = fs
-    .readFileSync(
-      'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.js'
-    )
-    .toString();
-
-  // Wrap the contents inside the install function.
-  // Also need to remove `nocompile` directive, otherwise Closure skips
-  // the entire import.
-  file = file.replace('@nocompile', '');
-  file = file.replace(
-    '"undefined"!=typeof window&&window===this?this:"undefined"!=typeof global&&null!=global?global:this',
-    'window'
-  );
-  file = `export function install() {${file}}`;
-  writeIfUpdated(patchedName, file);
-}
-
-/**
  * Deletes the map file for rrule, which breaks closure compiler.
  * TODO(rsimha): Remove this workaround after a fix is merged for
  * https://github.com/google/closure-compiler/issues/3720.
@@ -213,7 +185,6 @@ async function updatePackages() {
   patchWebAnimations();
   patchIntersectionObserver();
   patchResizeObserver();
-  patchShadowDom();
   removeRruleSourcemap();
 }
 

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -125,6 +125,30 @@ function patchResizeObserver() {
 }
 
 /**
+ * Patches Shadow DOM polyfill by wrapping its body into `install`
+ * function.
+ * This gives us an option to control when and how the polyfill is installed.
+ * The polyfill can only be installed on the root context.
+ */
+function patchShadowDom() {
+  // Copies webcomponents-sd into a new file that has an export.
+  const patchedName =
+    'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js';
+  let file = fs
+    .readFileSync(
+      'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.js'
+    )
+    .toString();
+
+  // ESM binaries fail on this expression.
+  file = file.replace(
+    '"undefined"!=typeof window&&window===this?this:"undefined"!=typeof global&&null!=global?global:this',
+    'window'
+  );
+  writeIfUpdated(patchedName, file);
+}
+
+/**
  * Deletes the map file for rrule, which breaks closure compiler.
  * TODO(rsimha): Remove this workaround after a fix is merged for
  * https://github.com/google/closure-compiler/issues/3720.
@@ -185,6 +209,7 @@ async function updatePackages() {
   patchWebAnimations();
   patchIntersectionObserver();
   patchResizeObserver();
+  patchShadowDom();
   removeRruleSourcemap();
 }
 

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -125,6 +125,29 @@ function patchResizeObserver() {
 }
 
 /**
+ * Patches Shadow DOM polyfill by wrapping its body into `install`
+ * function.
+ * This gives us an option to control when and how the polyfill is installed.
+ * The polyfill can only be installed on the root context.
+ */
+function patchShadowDom() {
+  // Copies webcomponents-sd into a new file that has an export.
+  const patchedName =
+    'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js';
+  let file = fs
+    .readFileSync(
+      'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.js'
+    )
+    .toString();
+
+  // Wrap the contents inside the install function.
+  // Also need to remove `nocompile` directive, otherwise Closure skips
+  // the entire import.
+  file = `export function install() {${file.replace('@nocompile', '')}}`;
+  writeIfUpdated(patchedName, file);
+}
+
+/**
  * Deletes the map file for rrule, which breaks closure compiler.
  * TODO(rsimha): Remove this workaround after a fix is merged for
  * https://github.com/google/closure-compiler/issues/3720.
@@ -185,6 +208,7 @@ async function updatePackages() {
   patchWebAnimations();
   patchIntersectionObserver();
   patchResizeObserver();
+  patchShadowDom();
   removeRruleSourcemap();
 }
 

--- a/build-system/tasks/update-packages.js
+++ b/build-system/tasks/update-packages.js
@@ -143,7 +143,12 @@ function patchShadowDom() {
   // Wrap the contents inside the install function.
   // Also need to remove `nocompile` directive, otherwise Closure skips
   // the entire import.
-  file = `export function install() {${file.replace('@nocompile', '')}}`;
+  file = file.replace('@nocompile', '');
+  file = file.replace(
+    '"undefined"!=typeof window&&window===this?this:"undefined"!=typeof global&&null!=global?global:this',
+    'window'
+  );
+  file = `export function install() {${file}}`;
   writeIfUpdated(patchedName, file);
 }
 

--- a/extensions/amp-a4a/0.1/test/test-friendly-frame-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-friendly-frame-renderer.js
@@ -84,15 +84,17 @@ describes.realWin('FriendlyFrameRenderer', realWinConfig, (env) => {
   });
 
   it('should set the correct srcdoc on the iframe', () => {
-    const srcdoc =
-      '<base href="http://www.google.com">' +
-      '<meta http-equiv=Content-Security-Policy content="script-src ' +
-      "'none';object-src 'none';child-src 'none'\">" +
-      '<p>Hello, World!</p>';
     return renderPromise.then(() => {
       const iframe = containerElement.querySelector('iframe');
       expect(iframe).to.be.ok;
-      expect(iframe.getAttribute('srcdoc')).to.equal(srcdoc);
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).to.contain('<base href="http://www.google.com">');
+      expect(srcdoc).to.contain(
+        '<meta http-equiv=Content-Security-Policy content="script-src '
+      );
+      expect(srcdoc).to.contain(
+        ";object-src 'none';child-src 'none'\"><p>Hello, World!</p>"
+      );
     });
   });
 

--- a/extensions/amp-a4a/0.1/test/test-friendly-frame-util.js
+++ b/extensions/amp-a4a/0.1/test/test-friendly-frame-util.js
@@ -80,14 +80,16 @@ describes.realWin('FriendlyFrameUtil', realWinConfig, (env) => {
   });
 
   it('should set the correct srcdoc on the iframe', () => {
-    const srcdoc =
-      '<base href="http://www.google.com">' +
-      '<meta http-equiv=Content-Security-Policy content="script-src ' +
-      "'none';object-src 'none';child-src 'none'\">" +
-      '<p>Hello, World!</p>';
     return renderPromise.then((iframe) => {
       expect(iframe).to.be.ok;
-      expect(iframe.getAttribute('srcdoc')).to.equal(srcdoc);
+      const srcdoc = iframe.getAttribute('srcdoc');
+      expect(srcdoc).to.contain('<base href="http://www.google.com">');
+      expect(srcdoc).to.contain(
+        '<meta http-equiv=Content-Security-Policy content="script-src '
+      );
+      expect(srcdoc).to.contain(
+        ";object-src 'none';child-src 'none'\"><p>Hello, World!</p>"
+      );
     });
   });
 

--- a/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
+++ b/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import {install} from '@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install';
-
-// This is a self-installing polyfill.
-install();
+/**
+ * @fileoverview This is just a placeholder for the polyfill that will be
+ * injected here from the `node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.js`
+ * script.
+ */

--- a/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
+++ b/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {install} from '@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install';
+
+// This is a self-installing polyfill.
+install();

--- a/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
+++ b/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
@@ -16,6 +16,6 @@
 
 /**
  * @fileoverview This is just a placeholder for the polyfill that will be
- * injected here from the `node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.js`
+ * injected here from the `node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js`
  * script.
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -5057,6 +5057,11 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@webcomponents/webcomponentsjs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+      "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg=="
+    },
     "@yarnpkg/core": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/core/-/core-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@ampproject/toolbox-cache-url": "2.7.2",
     "@ampproject/viewer-messaging": "1.1.2",
     "@ampproject/worker-dom": "0.27.4",
+    "@webcomponents/webcomponentsjs": "2.5.0",
     "dompurify": "2.2.6",
     "intersection-observer": "0.12.0",
     "jss": "10.3.0",

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -206,7 +206,7 @@ export class BaseElement {
    * @return {boolean}
    * @nocollapse
    */
-  static reqiuresShadowDom() {
+  static requiresShadowDom() {
     return false;
   }
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -206,7 +206,7 @@ export class BaseElement {
    * @return {boolean}
    * @nocollapse
    */
-  static usesShadowDom() {
+  static reqiuresShadowDom() {
     return false;
   }
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -201,7 +201,7 @@ export class BaseElement {
   /**
    * Subclasses can override this method to indicate that instances need to
    * use Shadow DOM. The Runtime will ensure that the Shadow DOM polyfill is
-   * installed before uprading and building this class.
+   * installed before upgrading and building this class.
    *
    * @return {boolean}
    * @nocollapse

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -198,6 +198,18 @@ export class BaseElement {
     return null;
   }
 
+  /**
+   * Subclasses can override this method to indicate that instances need to
+   * use Shadow DOM. The Runtime will ensure that the Shadow DOM polyfill is
+   * installed before uprading and building this class.
+   *
+   * @return {boolean}
+   * @nocollapse
+   */
+  static usesShadowDom() {
+    return false;
+  }
+
   /** @param {!AmpElement} element */
   constructor(element) {
     /** @public @const {!Element} */

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -28,6 +28,7 @@ import {
   setParentWindow,
 } from './service';
 import {escapeHtml} from './dom';
+import {getMode} from './mode';
 import {install as installAbortController} from './polyfills/abort-controller';
 import {installAmpdocServicesForEmbed} from './service/core-services';
 import {install as installCustomElements} from './polyfills/custom-elements';
@@ -48,6 +49,7 @@ import {
   setStyles,
 } from './style';
 import {toWin} from './types';
+import {urls} from './config';
 import {whenContentIniLoad} from './ini-load';
 
 /**
@@ -298,10 +300,20 @@ function mergeHtml(spec) {
     });
   }
 
+  const cdnBase = getMode().localDev ? 'http://localhost:8000/dist' : urls.cdn;
+  const cspScriptSrc = [
+    `${cdnBase}/esm/`,
+    `${cdnBase}/lts/`,
+    `${cdnBase}/mp/`,
+    `${cdnBase}/rtv/`,
+    `${cdnBase}/sp/`,
+    `${cdnBase}/sw/`,
+  ].join(' ');
+
   // Load CSP
   result.push(
     '<meta http-equiv=Content-Security-Policy ' +
-      "content=\"script-src 'none';object-src 'none';child-src 'none'\">"
+      `content="script-src ${cspScriptSrc};object-src 'none';child-src 'none'">`
   );
 
   // Postambule.

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -302,11 +302,8 @@ function mergeHtml(spec) {
 
   const cdnBase = getMode().localDev ? 'http://localhost:8000/dist' : urls.cdn;
   const cspScriptSrc = [
-    `${cdnBase}/esm/`,
     `${cdnBase}/lts/`,
-    `${cdnBase}/mp/`,
     `${cdnBase}/rtv/`,
-    `${cdnBase}/sp/`,
     `${cdnBase}/sw/`,
   ].join(' ');
 

--- a/src/polyfills/custom-elements.js
+++ b/src/polyfills/custom-elements.js
@@ -797,6 +797,7 @@ function polyfill(win) {
   subClass(HTMLElement, HTMLElementPolyfill);
 
   // Expose the polyfilled HTMLElement constructor for everyone to extend from.
+  win.HTMLElementOrig = win.HTMLElement;
   win.HTMLElement = HTMLElementPolyfill;
 
   // When we transpile `super` in Custom Element subclasses, we change it to
@@ -838,6 +839,7 @@ function wrapHTMLElement(win) {
   subClass(HTMLElement, HTMLElementWrapper);
 
   // Expose the wrapped HTMLElement constructor for everyone to extend from.
+  win.HTMLElementOrig = win.HTMLElement;
   win.HTMLElement = HTMLElementWrapper;
 }
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -142,6 +142,15 @@ const childIdGenerator = sequentialIdGenerator();
  * @template API_TYPE
  */
 export class PreactBaseElement extends AMP.BaseElement {
+  /**
+   * @return {boolean}
+   * @nocollapse
+   */
+  static usesShadowDom() {
+    // eslint-disable-next-line local/no-static-this
+    return usesShadowDom(this);
+  }
+
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -146,7 +146,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    * @return {boolean}
    * @nocollapse
    */
-  static usesShadowDom() {
+  static reqiuresShadowDom() {
     // eslint-disable-next-line local/no-static-this
     return usesShadowDom(this);
   }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -146,7 +146,7 @@ export class PreactBaseElement extends AMP.BaseElement {
    * @return {boolean}
    * @nocollapse
    */
-  static reqiuresShadowDom() {
+  static requiresShadowDom() {
     // eslint-disable-next-line local/no-static-this
     return usesShadowDom(this);
   }

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -15,6 +15,7 @@
  */
 
 import {ElementStub} from '../element-stub';
+import {Services} from '../services';
 import {createCustomElementClass, stubbedElements} from '../custom-element';
 import {extensionScriptsInNode} from '../element-service';
 import {reportError} from '../error';
@@ -38,6 +39,21 @@ function getExtendedElements(win) {
  * @param {typeof ../base-element.BaseElement} toClass
  */
 export function upgradeOrRegisterElement(win, name, toClass) {
+  const waitPromise = waitReadyForUpgrade(win, toClass);
+  if (waitPromise) {
+    waitPromise.then(() => upgradeOrRegisterElementReady(win, name, toClass));
+  } else {
+    upgradeOrRegisterElementReady(win, name, toClass);
+  }
+}
+
+/**
+ * Registers an element. Upgrades it if has previously been stubbed.
+ * @param {!Window} win
+ * @param {string} name
+ * @param {typeof ../base-element.BaseElement} toClass
+ */
+function upgradeOrRegisterElementReady(win, name, toClass) {
   const knownElements = getExtendedElements(win);
   if (!knownElements[name]) {
     registerElement(win, name, toClass);
@@ -69,7 +85,7 @@ export function upgradeOrRegisterElement(win, name, toClass) {
       element.tagName.toLowerCase() == name &&
       element.ownerDocument.defaultView == win
     ) {
-      tryUpgradeElement_(element, toClass);
+      tryUpgradeElement(element, toClass);
       // Remove element from array.
       stubbedElements.splice(i--, 1);
     }
@@ -82,11 +98,29 @@ export function upgradeOrRegisterElement(win, name, toClass) {
  * @param {typeof ../base-element.BaseElement} toClass
  * @private
  */
-function tryUpgradeElement_(element, toClass) {
+function tryUpgradeElement(element, toClass) {
   try {
     element.upgrade(toClass);
   } catch (e) {
     reportError(e, element);
+  }
+}
+
+/**
+ * Ensures that the element is ready for upgrade. Either returns immediately
+ * with `undefined` indicating that no waiting is necessary, or returns a
+ * promise that will resolve when the upgrade can proceed.
+ *
+ * @param {!Window} win
+ * @param {typeof ../base-element.BaseElement} elementClass
+ * @return {!Promise|undefind}
+ */
+function waitReadyForUpgrade(win, elementClass) {
+  // Make sure the polyfill is installed for Shadow DOM if element needs it.
+  if (elementClass.usesShadowDom() && !win.Element.prototype.attachShadow) {
+    const extId = 'amp-shadow-dom-polyfill';
+    const extensions = Services.extensionsFor(win);
+    return extensions.importUnwrapped(win, extId);
   }
 }
 

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -118,9 +118,8 @@ function tryUpgradeElement(element, toClass) {
 function waitReadyForUpgrade(win, elementClass) {
   // Make sure the polyfill is installed for Shadow DOM if element needs it.
   if (elementClass.usesShadowDom() && !win.Element.prototype.attachShadow) {
-    const extId = 'amp-shadow-dom-polyfill';
     const extensions = Services.extensionsFor(win);
-    return extensions.importUnwrapped(win, extId);
+    return extensions.importUnwrapped(win, 'amp-shadow-dom-polyfill');
   }
 }
 

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -117,7 +117,7 @@ function tryUpgradeElement(element, toClass) {
  */
 function waitReadyForUpgrade(win, elementClass) {
   // Make sure the polyfill is installed for Shadow DOM if element needs it.
-  if (elementClass.usesShadowDom() && !win.Element.prototype.attachShadow) {
+  if (elementClass.reqiuresShadowDom() && !win.Element.prototype.attachShadow) {
     const extensions = Services.extensionsFor(win);
     return extensions.importUnwrapped(win, 'amp-shadow-dom-polyfill');
   }

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -117,7 +117,7 @@ function tryUpgradeElement(element, toClass) {
  */
 function waitReadyForUpgrade(win, elementClass) {
   // Make sure the polyfill is installed for Shadow DOM if element needs it.
-  if (elementClass.reqiuresShadowDom() && !win.Element.prototype.attachShadow) {
+  if (elementClass.requiresShadowDom() && !win.Element.prototype.attachShadow) {
     const extensions = Services.extensionsFor(win);
     return extensions.importUnwrapped(win, 'amp-shadow-dom-polyfill');
   }

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -276,20 +276,16 @@ export class Extensions {
   /**
    * @param {!Window} win
    * @param {string} extensionId
-   * @param {string=} opt_extensionVersion
    * @return {!Promise}
    */
-  importUnwrapped(win, extensionId, opt_extensionVersion) {
+  importUnwrapped(win, extensionId) {
     const scriptsInHead = getExtensionScripts(win, extensionId);
     let scriptElement = scriptsInHead[0];
     let promise;
     if (scriptElement) {
       promise = Promise.resolve(scriptElement[SCRIPT_LOADED_PROP]);
     } else {
-      scriptElement = this.createExtensionScript_(
-        extensionId,
-        opt_extensionVersion
-      );
+      scriptElement = this.createExtensionScript_(extensionId);
       promise = scriptElement[SCRIPT_LOADED_PROP] = new Promise(
         (resolve, reject) => {
           scriptElement.onload = resolve;

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -280,10 +280,10 @@ export class Extensions {
    */
   importUnwrapped(win, extensionId) {
     const scriptsInHead = getExtensionScripts(win, extensionId);
-    let scriptElement = scriptsInHead[0];
+    let scriptElement = scriptsInHead.length > 0 ? scriptsInHead[0] : null;
     let promise;
     if (scriptElement) {
-      promise = Promise.resolve(scriptElement[SCRIPT_LOADED_PROP]);
+      promise = scriptElement[SCRIPT_LOADED_PROP];
     } else {
       scriptElement = this.createExtensionScript_(extensionId);
       promise = scriptElement[SCRIPT_LOADED_PROP] = new Promise(

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -37,6 +37,7 @@ const TAG = 'extensions';
 const UNKNOWN_EXTENSION = '_UNKNOWN_';
 const CUSTOM_TEMPLATES = ['amp-mustache'];
 const LOADER_PROP = '__AMP_EXT_LDR';
+const SCRIPT_LOADED_PROP = '__AMP_SCR_LOADED';
 
 /**
  * Default milliseconds to wait for all extensions to load before erroring.
@@ -244,7 +245,8 @@ export class Extensions {
    */
   reloadExtension(extensionId) {
     // Ignore inserted script elements to prevent recursion.
-    const els = this.getExtensionScripts_(
+    const els = getExtensionScripts(
+      this.win,
       extensionId,
       /* includeInserted */ false
     );
@@ -272,33 +274,31 @@ export class Extensions {
   }
 
   /**
-   * Returns the extension <script> element and attribute for the given
-   * extension ID, if it exists. Otherwise, returns null.
+   * @param {!Window} win
    * @param {string} extensionId
-   * @param {boolean=} includeInserted If true, includes script elements that
-   *   are inserted by the runtime dynamically. Default is true.
-   * @return {!Array<!Element>}
-   * @private
+   * @param {string=} opt_extensionVersion
+   * @return {!Promise}
    */
-  getExtensionScripts_(extensionId, includeInserted = true) {
-    // Always ignore <script> elements that have a mismatched RTV.
-    const modifier =
-      ':not([i-amphtml-loaded-new-version])' +
-      (includeInserted ? '' : ':not([i-amphtml-inserted])');
-    // We have to match against "src" because a few extensions, such as
-    // "amp-viewer-integration", do not have "custom-element" attribute.
-    const matches = this.win.document.head./*OK*/ querySelectorAll(
-      `script[src*="/${extensionId}-"]` + modifier
-    );
-    const filtered = [];
-    for (let i = 0; i < matches.length; i++) {
-      const match = matches[i];
-      const urlParts = parseExtensionUrl(match.src);
-      if (urlParts.extensionId === extensionId) {
-        filtered.push(match);
-      }
+  importUnwrapped(win, extensionId, opt_extensionVersion) {
+    const scriptsInHead = getExtensionScripts(win, extensionId);
+    let scriptElement = scriptsInHead[0];
+    let promise;
+    if (scriptElement) {
+      promise = Promise.resolve(scriptElement[SCRIPT_LOADED_PROP]);
+    } else {
+      scriptElement = this.createExtensionScript_(
+        extensionId,
+        opt_extensionVersion
+      );
+      promise = scriptElement[SCRIPT_LOADED_PROP] = new Promise(
+        (resolve, reject) => {
+          scriptElement.onload = resolve;
+          scriptElement.onerror = reject;
+        }
+      );
+      win.document.head.appendChild(scriptElement);
     }
-    return filtered;
+    return promise;
   }
 
   /**
@@ -595,7 +595,7 @@ export class Extensions {
       return false;
     }
     if (holder.scriptPresent === undefined) {
-      const scriptsInHead = this.getExtensionScripts_(extensionId);
+      const scriptsInHead = getExtensionScripts(this.win, extensionId);
       holder.scriptPresent = scriptsInHead.length > 0;
     }
     return !holder.scriptPresent;
@@ -685,4 +685,34 @@ function copyBuiltinElementsToChildWindow(parentWin, childWin) {
 function emptyService() {
   // All services need to resolve to an object.
   return {};
+}
+
+/**
+ * Returns the extension <script> element and attribute for the given
+ * extension ID, if it exists. Otherwise, returns null.
+ * @param {!Window} win
+ * @param {string} extensionId
+ * @param {boolean=} includeInserted If true, includes script elements that
+ *   are inserted by the runtime dynamically. Default is true.
+ * @return {!Array<!Element>}
+ */
+function getExtensionScripts(win, extensionId, includeInserted = true) {
+  // Always ignore <script> elements that have a mismatched RTV.
+  const modifier =
+    ':not([i-amphtml-loaded-new-version])' +
+    (includeInserted ? '' : ':not([i-amphtml-inserted])');
+  // We have to match against "src" because a few extensions, such as
+  // "amp-viewer-integration", do not have "custom-element" attribute.
+  const matches = win.document.head./*OK*/ querySelectorAll(
+    `script[src*="/${extensionId}-"]` + modifier
+  );
+  const filtered = [];
+  for (let i = 0; i < matches.length; i++) {
+    const match = matches[i];
+    const urlParts = parseExtensionUrl(match.src);
+    if (urlParts.extensionId === extensionId) {
+      filtered.push(match);
+    }
+  }
+  return filtered;
 }

--- a/test/fixtures/shadow-dom-element-polyfill.html
+++ b/test/fixtures/shadow-dom-element-polyfill.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>We can render a shadow dom element</title>
+  <link rel="canonical" href="https://www.example.com/shadow-dom-element.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script>
+    if (Element.prototype.attachShadow) {
+      delete Element.prototype.attachShadow;
+    }
+  </script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
+</head>
+<body>
+  <amp-base-carousel id="carousel-1" width="400" height="300" layout="responsive">
+    <amp-img id="slide1" src="/examples/img/hero@1x.jpg" layout="fill"></amp-img>
+    <amp-img id="slide2" src="/examples/img/sea@1x.jpg" layout="fill"></amp-img>
+  </amp-base-carousel>
+</body>
+</html>

--- a/test/fixtures/shadow-dom-element.html
+++ b/test/fixtures/shadow-dom-element.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>We can render a shadow dom element</title>
+  <link rel="canonical" href="https://www.example.com/shadow-dom-element.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
+</head>
+<body>
+  <amp-base-carousel id="carousel-1" width="400" height="300" layout="responsive">
+    <amp-img id="slide1" src="/examples/img/hero@1x.jpg" layout="fill"></amp-img>
+    <amp-img id="slide2" src="/examples/img/sea@1x.jpg" layout="fill"></amp-img>
+  </amp-base-carousel>
+</body>
+</html>

--- a/test/integration/test-shadow-dom-element.js
+++ b/test/integration/test-shadow-dom-element.js
@@ -15,6 +15,7 @@
  */
 
 import {createFixtureIframe} from '../../testing/iframe';
+import {toggleExperiment} from '../../src/experiments';
 import {whenUpgradedToCustomElement} from '../../src/dom';
 
 describe
@@ -28,6 +29,7 @@ describe
         'test/fixtures/shadow-dom-element.html',
         3000
       );
+      toggleExperiment(fixture.win, 'bento', true, true);
     });
 
     it('should create shadow root', async () => {
@@ -64,6 +66,7 @@ describe
         'test/fixtures/shadow-dom-element-polyfill.html',
         3000
       );
+      toggleExperiment(fixture.win, 'bento', true, true);
     });
 
     it('should create shadow root', async () => {

--- a/test/integration/test-shadow-dom-element.js
+++ b/test/integration/test-shadow-dom-element.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {createFixtureIframe} from '../../testing/iframe';
+import {whenUpgradedToCustomElement} from '../../src/dom';
+
+describe
+  .configure()
+  .enableIe()
+  .run('Render a shadow-dom based element', () => {
+    let fixture;
+
+    beforeEach(async () => {
+      fixture = await createFixtureIframe(
+        'test/fixtures/shadow-dom-element.html',
+        3000
+      );
+    });
+
+    it('should create shadow root', async () => {
+      const carousel = fixture.doc.querySelector('amp-base-carousel');
+      await whenUpgradedToCustomElement(carousel);
+      await carousel.whenBuilt();
+      await new Promise(setTimeout);
+
+      expect(carousel.shadowRoot).to.exist;
+
+      const slides = carousel.querySelectorAll('amp-img');
+      expect(slides).to.have.length(2);
+
+      const slots = carousel.shadowRoot
+        .querySelector('c')
+        .querySelectorAll('slot');
+      expect(slots).to.have.length(2);
+
+      expect(slides[0].assignedSlot).to.equal(slots[0]);
+      expect(slides[1].assignedSlot).to.equal(slots[1]);
+      expect(slots[0].assignedNodes()[0]).to.equal(slides[0]);
+      expect(slots[1].assignedNodes()[0]).to.equal(slides[1]);
+      expect(slots[0].getRootNode()).to.equal(carousel.shadowRoot);
+    });
+  });
+
+describe
+  .configure()
+  .run('Render a shadow-dom based element, force polyfill', () => {
+    let fixture;
+
+    beforeEach(async () => {
+      fixture = await createFixtureIframe(
+        'test/fixtures/shadow-dom-element-polyfill.html',
+        3000
+      );
+    });
+
+    it('should create shadow root', async () => {
+      const carousel = fixture.doc.querySelector('amp-base-carousel');
+      await whenUpgradedToCustomElement(carousel);
+      await carousel.whenBuilt();
+      await new Promise(setTimeout);
+
+      expect(carousel.shadowRoot).to.exist;
+
+      const slides = carousel.querySelectorAll('amp-img');
+      expect(slides).to.have.length(2);
+
+      const slots = carousel.shadowRoot
+        .querySelector('c')
+        .querySelectorAll('slot');
+      expect(slots).to.have.length(2);
+
+      expect(slides[0].assignedSlot).to.equal(slots[0]);
+      expect(slides[1].assignedSlot).to.equal(slots[1]);
+      expect(slots[0].assignedNodes()[0]).to.equal(slides[0]);
+      expect(slots[1].assignedNodes()[0]).to.equal(slides[1]);
+      expect(slots[0].getRootNode()).to.equal(carousel.shadowRoot);
+    });
+  });

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -340,8 +340,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       `;
     });
 
-    it('should return usesShadowDom', () => {
-      expect(Impl.usesShadowDom()).to.be.true;
+    it('should return reqiuresShadowDom', () => {
+      expect(Impl.reqiuresShadowDom()).to.be.true;
     });
 
     it('should render from scratch', async () => {
@@ -454,8 +454,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       element.addEventListener('amp:dom-update', updateEventSpy);
     });
 
-    it('should return usesShadowDom', () => {
-      expect(Impl.usesShadowDom()).to.be.false;
+    it('should return reqiuresShadowDom', () => {
+      expect(Impl.reqiuresShadowDom()).to.be.false;
     });
 
     it('should render from scratch', async () => {
@@ -605,8 +605,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
 
-    it('should return usesShadowDom', () => {
-      expect(Impl.usesShadowDom()).to.be.true;
+    it('should return reqiuresShadowDom', () => {
+      expect(Impl.reqiuresShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {
@@ -845,8 +845,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
 
-    it('should return usesShadowDom', () => {
-      expect(Impl.usesShadowDom()).to.be.true;
+    it('should return reqiuresShadowDom', () => {
+      expect(Impl.reqiuresShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {
@@ -927,8 +927,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
 
-    it('should return usesShadowDom', () => {
-      expect(Impl.usesShadowDom()).to.be.true;
+    it('should return reqiuresShadowDom', () => {
+      expect(Impl.reqiuresShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -340,8 +340,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       `;
     });
 
-    it('should return reqiuresShadowDom', () => {
-      expect(Impl.reqiuresShadowDom()).to.be.true;
+    it('should return requiresShadowDom', () => {
+      expect(Impl.requiresShadowDom()).to.be.true;
     });
 
     it('should render from scratch', async () => {
@@ -454,8 +454,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       element.addEventListener('amp:dom-update', updateEventSpy);
     });
 
-    it('should return reqiuresShadowDom', () => {
-      expect(Impl.reqiuresShadowDom()).to.be.false;
+    it('should return requiresShadowDom', () => {
+      expect(Impl.requiresShadowDom()).to.be.false;
     });
 
     it('should render from scratch', async () => {
@@ -605,8 +605,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
 
-    it('should return reqiuresShadowDom', () => {
-      expect(Impl.reqiuresShadowDom()).to.be.true;
+    it('should return requiresShadowDom', () => {
+      expect(Impl.requiresShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {
@@ -845,8 +845,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
 
-    it('should return reqiuresShadowDom', () => {
-      expect(Impl.reqiuresShadowDom()).to.be.true;
+    it('should return requiresShadowDom', () => {
+      expect(Impl.requiresShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {
@@ -927,8 +927,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
 
-    it('should return reqiuresShadowDom', () => {
-      expect(Impl.reqiuresShadowDom()).to.be.true;
+    it('should return requiresShadowDom', () => {
+      expect(Impl.requiresShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -340,6 +340,10 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       `;
     });
 
+    it('should return usesShadowDom', () => {
+      expect(Impl.usesShadowDom()).to.be.true;
+    });
+
     it('should render from scratch', async () => {
       doc.body.appendChild(element);
       await element.buildInternal();
@@ -448,6 +452,10 @@ describes.realWin('PreactBaseElement', spec, (env) => {
 
       updateEventSpy = env.sandbox.stub();
       element.addEventListener('amp:dom-update', updateEventSpy);
+    });
+
+    it('should return usesShadowDom', () => {
+      expect(Impl.usesShadowDom()).to.be.false;
     });
 
     it('should render from scratch', async () => {
@@ -595,6 +603,10 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       doc.body.appendChild(element);
       await element.buildInternal();
       await waitFor(() => component.callCount > 0, 'component rendered');
+    });
+
+    it('should return usesShadowDom', () => {
+      expect(Impl.usesShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {
@@ -833,6 +845,10 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       await waitFor(() => component.callCount > 0, 'component rendered');
     });
 
+    it('should return usesShadowDom', () => {
+      expect(Impl.usesShadowDom()).to.be.true;
+    });
+
     it('should render into shadow DOM', () => {
       expect(component).to.be.calledOnce;
       expect(element.shadowRoot).to.be.ok;
@@ -909,6 +925,10 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       doc.body.appendChild(element);
       await element.buildInternal();
       await waitFor(() => component.callCount > 0, 'component rendered');
+    });
+
+    it('should return usesShadowDom', () => {
+      expect(Impl.usesShadowDom()).to.be.true;
     });
 
     it('should render into shadow DOM', () => {

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -34,7 +34,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
   class ConcreteElement extends BaseElement {}
 
   class ConcreteElementWithShadow extends BaseElement {
-    static usesShadowDom() {
+    static reqiuresShadowDom() {
       return true;
     }
   }
@@ -68,7 +68,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
     );
   });
 
-  it('should register a new class immediately for usesShadowDom if no polyfilling needed', () => {
+  it('should register a new class immediately for reqiuresShadowDom if no polyfilling needed', () => {
     if (!win.Element.prototype.attachShadow) {
       win.Element.prototype.attachShadow = () => {};
     }

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -17,6 +17,7 @@
 import {AmpDocSingle} from '../../src/service/ampdoc-impl';
 import {BaseElement} from '../../src/base-element';
 import {ElementStub} from '../../src/element-stub';
+import {Services} from '../../src/services';
 import {
   copyElementToChildWindow,
   getElementClassForTesting,
@@ -31,6 +32,12 @@ import {getImplSyncForTesting} from '../../src/custom-element';
 
 describes.realWin('CustomElement register', {amp: true}, (env) => {
   class ConcreteElement extends BaseElement {}
+
+  class ConcreteElementWithShadow extends BaseElement {
+    static usesShadowDom() {
+      return true;
+    }
+  }
 
   let win, doc, ampdoc, extensions;
 
@@ -53,6 +60,47 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
     });
     doc.body.appendChild(testElement);
   }
+
+  it('should register a new class immediately if no need to wait', () => {
+    upgradeOrRegisterElement(win, 'amp-element1', ConcreteElement);
+    expect(getElementClassForTesting(win, 'amp-element1')).to.equal(
+      ConcreteElement
+    );
+  });
+
+  it('should register a new class immediately for usesShadowDom if no polyfilling needed', () => {
+    if (!win.Element.prototype.attachShadow) {
+      win.Element.prototype.attachShadow = () => {};
+    }
+    upgradeOrRegisterElement(win, 'amp-element1', ConcreteElementWithShadow);
+    expect(getElementClassForTesting(win, 'amp-element1')).to.equal(
+      ConcreteElementWithShadow
+    );
+  });
+
+  it('should wait for the shadow DOM polyfill before registering a class', async () => {
+    if (win.Element.prototype.attachShadow) {
+      delete win.Element.prototype.attachShadow;
+    }
+    const extensions = Services.extensionsFor(win);
+    const extensionsMock = env.sandbox.mock(extensions);
+    const polyfillPromise = Promise.resolve();
+    extensionsMock
+      .expects('importUnwrapped')
+      .withExactArgs(win, 'amp-shadow-dom-polyfill')
+      .returns(polyfillPromise)
+      .once();
+
+    upgradeOrRegisterElement(win, 'amp-element1', ConcreteElementWithShadow);
+    expect(getElementClassForTesting(win, 'amp-element1')).to.not.exist;
+
+    // Resolve polyfill.
+    await polyfillPromise;
+    expect(getElementClassForTesting(win, 'amp-element1')).to.equal(
+      ConcreteElementWithShadow
+    );
+    extensionsMock.verify();
+  });
 
   it('should go through stub/upgrade cycle', () => {
     registerElement(win, 'amp-element1', ElementStub);

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -34,7 +34,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
   class ConcreteElement extends BaseElement {}
 
   class ConcreteElementWithShadow extends BaseElement {
-    static reqiuresShadowDom() {
+    static requiresShadowDom() {
       return true;
     }
   }
@@ -68,7 +68,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
     );
   });
 
-  it('should register a new class immediately for reqiuresShadowDom if no polyfilling needed', () => {
+  it('should register a new class immediately for requiresShadowDom if no polyfilling needed', () => {
     if (!win.Element.prototype.attachShadow) {
       win.Element.prototype.attachShadow = () => {};
     }

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -190,7 +190,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add element in registration', () => {
       const ctor = function () {};
-      ctor.reqiuresShadowDom = () => false;
+      ctor.requiresShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
         () => {
@@ -657,7 +657,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should load extension class via load extension', () => {
       const ctor = function () {};
-      ctor.reqiuresShadowDom = () => false;
+      ctor.requiresShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
         () => {

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -19,6 +19,7 @@ import {BaseElement} from '../../src/base-element';
 import {ElementStub} from '../../src/element-stub';
 import {Extensions} from '../../src/service/extensions-impl';
 import {Services} from '../../src/services';
+import {dispatchCustomEvent} from '../../src/dom';
 import {getServiceForDoc} from '../../src/service';
 import {
   getTemplateClassForTesting,
@@ -189,6 +190,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add element in registration', () => {
       const ctor = function () {};
+      ctor.usesShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
         () => {
@@ -655,6 +657,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should load extension class via load extension', () => {
       const ctor = function () {};
+      ctor.usesShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
         () => {
@@ -1162,6 +1165,69 @@ describes.sandboxed('Extensions', {}, () => {
           doc.head.querySelectorAll('[custom-element="amp-embed"]')
         ).to.have.length(0);
         expect(extensions.extensions_['amp-embed']).to.be.undefined;
+      });
+    }
+  );
+
+  describes.fakeWin(
+    'importUnwrapped',
+    {
+      amp: true,
+      fakeRegisterElement: true,
+    },
+    (env) => {
+      let win, doc, extensions;
+
+      beforeEach(() => {
+        win = env.win;
+        doc = win.document;
+        extensions = env.extensions;
+      });
+
+      it('should insert extension script correctly', () => {
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(0);
+        const promise = extensions.importUnwrapped(win, 'amp-test');
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(1);
+
+        const script = doc.head.querySelector('[custom-element="amp-test"]');
+        dispatchCustomEvent(script, 'load', null, {bubbles: false});
+        return promise;
+      });
+
+      it('should only insert script once', () => {
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(0);
+
+        const promise1 = extensions.importUnwrapped(win, 'amp-test');
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(1);
+
+        const promise2 = extensions.importUnwrapped(win, 'amp-test');
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(1);
+        expect(promise2).to.equal(promise1);
+      });
+
+      it('should give script correct attributes', () => {
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(0);
+        extensions.importUnwrapped(win, 'amp-test');
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(1);
+
+        const script = doc.head.querySelector('[custom-element="amp-test"]');
+        expect(script.getAttribute('data-script')).to.equal('amp-test');
+        expect(script.getAttribute('async')).to.equal('');
+        expect(script.getAttribute('crossorigin')).to.equal('anonymous');
       });
     }
   );

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -190,7 +190,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should add element in registration', () => {
       const ctor = function () {};
-      ctor.usesShadowDom = () => false;
+      ctor.reqiuresShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
         () => {
@@ -657,7 +657,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should load extension class via load extension', () => {
       const ctor = function () {};
-      ctor.usesShadowDom = () => false;
+      ctor.reqiuresShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
         () => {

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -673,6 +673,15 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       };
     });
 
+    function extractScriptSrc(html) {
+      const beg = html.indexOf('script-src');
+      const end = html.indexOf(';', beg + 1);
+      if (beg == -1 || end == -1) {
+        throw new Error('script-src not found');
+      }
+      return html.substring(beg + 'script-src'.length, end).trim();
+    }
+
     it('should install base', () => {
       const html = mergeHtmlForTesting(spec);
       expect(html.indexOf('<base href="https://acme.org/embed1">')).to.equal(0);
@@ -702,88 +711,125 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
 
     it('should pre-pend to html', () => {
       const html = mergeHtmlForTesting(spec);
-      expect(html).to.equal(
-        '<base href="https://acme.org/embed1">' +
-          '<meta http-equiv=Content-Security-Policy content=' +
-          "\"script-src 'none';object-src 'none';child-src 'none'\">" +
-          '<a></a>'
+      expect(html).to.contain('<base href="https://acme.org/embed1">');
+      expect(html).to.contain(
+        '<meta http-equiv=Content-Security-Policy content='
       );
+      expect(html).to.contain("object-src 'none';child-src 'none'");
+      expect(html).to.contain("child-src 'none'\"><a></a>");
     });
 
     it('should insert into head', () => {
       spec.html = '<html><head>head</head><body>body';
       const html = mergeHtmlForTesting(spec);
-      expect(html).to.equal(
+      expect(html).to.contain(
         '<html><head><base href="https://acme.org/embed1">' +
-          '<meta http-equiv=Content-Security-Policy content=' +
-          "\"script-src 'none';object-src 'none';" +
-          "child-src 'none'\">head</head><body>body"
+          '<meta http-equiv=Content-Security-Policy content='
       );
+      expect(html).to.contain("child-src 'none'\">head</head><body>body");
     });
 
     it('should insert into head w/o html', () => {
       spec.html = '<head>head</head><body>body';
       const html = mergeHtmlForTesting(spec);
-      expect(html).to.equal(
+      expect(html).to.contain(
         '<head><base href="https://acme.org/embed1">' +
-          '<meta http-equiv=Content-Security-Policy content="' +
-          "script-src 'none';object-src 'none';child-src 'none'\">head" +
-          '</head><body>body'
+          '<meta http-equiv=Content-Security-Policy content="script-src'
+      );
+      expect(html).to.contain(
+        ";object-src 'none';child-src 'none'\">head</head><body>body"
       );
     });
 
     it('should insert before body', () => {
       spec.html = '<html><body>body';
       const html = mergeHtmlForTesting(spec);
-      expect(html).to.equal(
+      expect(html).to.contain(
         '<html><base href="https://acme.org/embed1">' +
-          '<meta http-equiv=Content-Security-Policy content="script-src ' +
-          "'none';object-src 'none';child-src 'none'\"><body>body"
+          '<meta http-equiv=Content-Security-Policy content="script-src '
+      );
+      expect(html).to.contain(
+        ";object-src 'none';child-src 'none'\"><body>body"
       );
     });
 
     it('should insert before body w/o html', () => {
       spec.html = '<body>body';
       const html = mergeHtmlForTesting(spec);
-      expect(html).to.equal(
+      expect(html).to.contain(
         '<base href="https://acme.org/embed1">' +
-          '<meta http-equiv=Content-Security-Policy content="script-src ' +
-          "'none';object-src 'none';child-src 'none'\"><body>body"
+          '<meta http-equiv=Content-Security-Policy content="script-src '
+      );
+      expect(html).to.contain(
+        ";object-src 'none';child-src 'none'\"><body>body"
       );
     });
 
     it('should insert after html', () => {
       spec.html = '<html>content';
       const html = mergeHtmlForTesting(spec);
-      expect(html).to.equal(
+      expect(html).to.contain(
         '<html><base href="https://acme.org/embed1">' +
-          '<meta http-equiv=Content-Security-Policy content="script-src ' +
-          "'none';object-src 'none';child-src 'none'\">content"
+          '<meta http-equiv=Content-Security-Policy content="script-src '
       );
+      expect(html).to.contain(";object-src 'none';child-src 'none'\">content");
     });
 
     it('should insert CSP', () => {
       spec.html = '<html><head></head><body></body></html>';
-      expect(mergeHtmlForTesting(spec)).to.equal(
-        '<html><head><base href="https://acme.org/embed1">' +
-          '<meta http-equiv=Content-Security-Policy ' +
-          "content=\"script-src 'none';object-src 'none';" +
+      expect(mergeHtmlForTesting(spec)).to.contain(
+        '<meta http-equiv=Content-Security-Policy content="script-src '
+      );
+      expect(mergeHtmlForTesting(spec)).to.contain(
+        ";object-src 'none';" +
           "child-src 'none'\">" +
           '</head><body></body></html>'
       );
       spec.html = '<html>foo';
-      expect(mergeHtmlForTesting(spec)).to.equal(
+      expect(mergeHtmlForTesting(spec)).to.contain(
         '<html><base href="https://acme.org/embed1">' +
           '<meta http-equiv=Content-Security-Policy ' +
-          "content=\"script-src 'none';object-src 'none';" +
-          "child-src 'none'\">foo"
+          'content="script-src '
+      );
+      expect(mergeHtmlForTesting(spec)).to.contain(
+        ";object-src 'none';child-src 'none'\">foo"
       );
       spec.html = '<body>foo';
-      expect(mergeHtmlForTesting(spec)).to.equal(
+      expect(mergeHtmlForTesting(spec)).to.contain(
         '<base href="https://acme.org/embed1">' +
           '<meta http-equiv=Content-Security-Policy ' +
-          "content=\"script-src 'none';object-src 'none';" +
-          "child-src 'none'\"><body>foo"
+          'content="script-src '
+      );
+      expect(mergeHtmlForTesting(spec)).to.contain(
+        ";object-src 'none';child-src 'none'\"><body>foo"
+      );
+    });
+
+    it('should create the correct script-src CSP in dev mode', () => {
+      env.sandbox.stub(self, '__AMP_MODE').value({localDev: true});
+      spec.html = '<html><head></head><body></body></html>';
+      const src = extractScriptSrc(mergeHtmlForTesting(spec));
+      expect(src).to.equal(
+        'http://localhost:8000/dist/esm/' +
+          ' http://localhost:8000/dist/lts/' +
+          ' http://localhost:8000/dist/mp/' +
+          ' http://localhost:8000/dist/rtv/' +
+          ' http://localhost:8000/dist/sp/' +
+          ' http://localhost:8000/dist/sw/'
+      );
+    });
+
+    it('should create the correct script-src CSP in non-dev mode', () => {
+      env.sandbox.stub(self, '__AMP_MODE').value({localDev: false});
+      spec.html = '<html><head></head><body></body></html>';
+      const src = extractScriptSrc(mergeHtmlForTesting(spec));
+      expect(src).to.equal(
+        'https://cdn.ampproject.org/esm/' +
+          ' https://cdn.ampproject.org/lts/' +
+          ' https://cdn.ampproject.org/mp/' +
+          ' https://cdn.ampproject.org/rtv/' +
+          ' https://cdn.ampproject.org/sp/' +
+          ' https://cdn.ampproject.org/sw/'
       );
     });
   });

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -810,11 +810,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       spec.html = '<html><head></head><body></body></html>';
       const src = extractScriptSrc(mergeHtmlForTesting(spec));
       expect(src).to.equal(
-        'http://localhost:8000/dist/esm/' +
-          ' http://localhost:8000/dist/lts/' +
-          ' http://localhost:8000/dist/mp/' +
+        'http://localhost:8000/dist/lts/' +
           ' http://localhost:8000/dist/rtv/' +
-          ' http://localhost:8000/dist/sp/' +
           ' http://localhost:8000/dist/sw/'
       );
     });
@@ -824,11 +821,8 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       spec.html = '<html><head></head><body></body></html>';
       const src = extractScriptSrc(mergeHtmlForTesting(spec));
       expect(src).to.equal(
-        'https://cdn.ampproject.org/esm/' +
-          ' https://cdn.ampproject.org/lts/' +
-          ' https://cdn.ampproject.org/mp/' +
+        'https://cdn.ampproject.org/lts/' +
           ' https://cdn.ampproject.org/rtv/' +
-          ' https://cdn.ampproject.org/sp/' +
           ' https://cdn.ampproject.org/sw/'
       );
     });

--- a/test/unit/test-polyfill-custom-elements.js
+++ b/test/unit/test-polyfill-custom-elements.js
@@ -62,6 +62,11 @@ describes.realWin(
       expect(() => {
         win.customElements.define('x-test', Test);
       }).not.to.throw();
+
+      expect(win.HTMLElementOrig).to.exist;
+      expect(Object.getPrototypeOf(win.HTMLElement)).to.equal(
+        win.HTMLElementOrig
+      );
     });
 
     it('handles missing innerHTML descriptor (Yandex)', () => {
@@ -77,6 +82,11 @@ describes.realWin(
       expect(() => {
         win.customElements.define('x-test', Test);
       }).not.to.throw();
+
+      expect(win.HTMLElementOrig).to.exist;
+      expect(Object.getPrototypeOf(win.HTMLElement)).to.equal(
+        win.HTMLElementOrig
+      );
     });
 
     it('handles innerHTML descriptor on HTMLElement (IE11)', () => {
@@ -94,6 +104,11 @@ describes.realWin(
       expect(() => {
         win.customElements.define('x-test', Test);
       }).not.to.throw();
+
+      expect(win.HTMLElementOrig).to.exist;
+      expect(Object.getPrototypeOf(win.HTMLElement)).to.equal(
+        win.HTMLElementOrig
+      );
     });
   }
 );

--- a/third_party/resize-observer-polyfill/ResizeObserver.install.js
+++ b/third_party/resize-observer-polyfill/ResizeObserver.install.js
@@ -962,21 +962,36 @@ export function installResizeObserver(global) {
             }
             if (mutationObserverSupported) {
                 this.mutationsObserver_ = new MutationObserver(this.refresh);
-                this.mutationsObserver_.observe(rootNode, {
-                    attributes: true,
-                    childList: true,
-                    characterData: true,
-                    subtree: true
-                });
+                try {
+                    this.mutationsObserver_.observe(rootNode, {
+                        attributes: true,
+                        childList: true,
+                        characterData: true,
+                        subtree: true
+                    });
+                }
+                catch (e) {
+                    // A Shadow DOM polyfill might fail when oberving a "synthetic"
+                    // ShadowRoot object. Ignore the error. The additional data
+                    // will arrive from the host observer below.
+                }
+                if (rootNode.host) {
+                    this.mutationsObserver_.observe(rootNode.host, {
+                        attributes: true,
+                        childList: true,
+                        characterData: true,
+                        subtree: true
+                    });
+                }
             }
             else {
                 rootNode.addEventListener('DOMSubtreeModified', this.refresh, true);
                 this.mutationEventsAdded_ = true;
             }
             // It's a shadow root. Monitor the host.
-            if (this.rootNode_.host) {
+            if (rootNode.host) {
                 this.hostObserver_ = new ResizeObserverSPI(this.refresh, this.globalController_, this);
-                this.hostObserver_.observe(this.rootNode_.host);
+                this.hostObserver_.observe(rootNode.host);
             }
             this.connected_ = true;
         };

--- a/third_party/resize-observer-polyfill/ResizeObserver.js
+++ b/third_party/resize-observer-polyfill/ResizeObserver.js
@@ -963,21 +963,36 @@
             }
             if (mutationObserverSupported) {
                 this.mutationsObserver_ = new MutationObserver(this.refresh);
-                this.mutationsObserver_.observe(rootNode, {
-                    attributes: true,
-                    childList: true,
-                    characterData: true,
-                    subtree: true
-                });
+                try {
+                    this.mutationsObserver_.observe(rootNode, {
+                        attributes: true,
+                        childList: true,
+                        characterData: true,
+                        subtree: true
+                    });
+                }
+                catch (e) {
+                    // A Shadow DOM polyfill might fail when oberving a "synthetic"
+                    // ShadowRoot object. Ignore the error. The additional data
+                    // will arrive from the host observer below.
+                }
+                if (rootNode.host) {
+                    this.mutationsObserver_.observe(rootNode.host, {
+                        attributes: true,
+                        childList: true,
+                        characterData: true,
+                        subtree: true
+                    });
+                }
             }
             else {
                 rootNode.addEventListener('DOMSubtreeModified', this.refresh, true);
                 this.mutationEventsAdded_ = true;
             }
             // It's a shadow root. Monitor the host.
-            if (this.rootNode_.host) {
+            if (rootNode.host) {
                 this.hostObserver_ = new ResizeObserverSPI(this.refresh, this.globalController_, this);
-                this.hostObserver_.observe(this.rootNode_.host);
+                this.hostObserver_.observe(rootNode.host);
             }
             this.connected_ = true;
         };


### PR DESCRIPTION
Partial for #30952.

1. The SD polyfill is not quite an AMP extension - it has a side-effect and has to be imported into the using window directly. I didn't find any other way to use it.
2. To accommodate - I added `importUnwrapped` in extensions service to allow direct window import instead of a usual AMP service.
3. The polyfill is loaded and installed before the first element that needs it is upgraded.
4. In order to be able to import the polyfill into the FIE's window, I had to expand the FIE's CSP rules. /cc @calebcordry 
5. Some lints are complaining about `this` in the static method, but I believe this particular use is correct.

TODO:

- [x] Tests
