### PR TITLE
Bento Selector: Support hybrid selected/disabled state

### DIFF
--- a/extensions/amp-selector/1.0/amp-selector.css
+++ b/extensions/amp-selector/1.0/amp-selector.css
@@ -31,15 +31,15 @@ amp-selector[multiple] [option][selected] {
   outline: solid 1px rgba(0, 0, 0, 0.7);
 }
 
-amp-selector [option][selected] {
-  cursor: auto;
-  outline: solid 1px rgba(0, 0, 0, 0.7);
-}
-
 amp-selector [disabled][option],
 amp-selector[disabled] [option],
 amp-selector [selected][disabled],
 amp-selector[disabled] [selected] {
   cursor: auto;
   outline: none;
+}
+
+amp-selector [option][selected] {
+  cursor: auto;
+  outline: solid 1px rgba(0, 0, 0, 0.7);
 }

--- a/extensions/amp-selector/1.0/amp-selector.css
+++ b/extensions/amp-selector/1.0/amp-selector.css
@@ -37,6 +37,7 @@ amp-selector [selected][disabled],
 amp-selector[disabled] [selected] {
   cursor: auto;
   outline: none;
+  opacity: 0.4;
 }
 
 amp-selector [option][selected] {


### PR DESCRIPTION
This PR:
- Allows disabled, selected options to show an outline
- Allows selected options of disabled amp-selectors to show an outline
- Shows disabled options with 0.4 opacity so they are visually knowable as disabled (already non-clickable)

Partial for #28282

Prior to this change:
(Note: The second img looks selectable but is disabled, and "Option 3" is selected and disabled but does not look this way.)
![image](https://user-images.githubusercontent.com/10456171/108875306-0a817800-75cb-11eb-8dcb-21c9ce14967c.png)

After this change:
All disabled/selected/hybrid states are knowable visually
![image](https://user-images.githubusercontent.com/10456171/108875231-f178c700-75ca-11eb-813b-7fa2aa243bb0.png)
