### PR TITLE
🏗 Ensure that z-index table is up to date

### DIFF
--- a/build-system/common/diff.js
+++ b/build-system/common/diff.js
@@ -24,11 +24,19 @@ const {writeFile} = require('fs-extra');
  * Diffs a file against content that might replace it.
  * @param {string} filepath
  * @param {string} content
+ * @param {Array<string>=} gitDiffFlags
  * @return {!Promise<string>}
  */
-const diffTentative = (filepath, content) =>
+const diffTentative = (filepath, content, gitDiffFlags = ['-U1']) =>
   tempy.write.task(content, (temporary) =>
-    getStdout(`git -c color.ui=always diff -U1 ${filepath} ${temporary}`)
+    getStdout(
+      [
+        'git -c color.ui=always diff',
+        ...gitDiffFlags,
+        filepath,
+        temporary,
+      ].join(' ')
+    )
       .trim()
       .replace(new RegExp(temporary, 'g'), `/${filepath}`)
   );
@@ -40,9 +48,15 @@ const diffTentative = (filepath, content) =>
  * @param {string} callerTask
  * @param {string} filepath
  * @param {string} tentative
+ * @param {Array<string>=} opt_gitDiffFlags
  */
-async function writeDiffOrFail(callerTask, filepath, tentative) {
-  const diff = await diffTentative(filepath, tentative);
+async function writeDiffOrFail(
+  callerTask,
+  filepath,
+  tentative,
+  opt_gitDiffFlags
+) {
+  const diff = await diffTentative(filepath, tentative, opt_gitDiffFlags);
 
   if (!diff.length) {
     return;

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -43,6 +43,7 @@ function pushBuildWorkflow() {
   timedExecOrDie('gulp check-sourcemaps');
   timedExecOrDie('gulp performance-urls');
   timedExecOrDie('gulp check-video-interface-list');
+  timedExecOrDie('gulp get-zindex');
 }
 
 async function prBuildWorkflow() {
@@ -105,6 +106,7 @@ async function prBuildWorkflow() {
     timedExecOrDie('gulp check-sourcemaps');
     timedExecOrDie('gulp performance-urls');
     timedExecOrDie('gulp check-video-interface-list');
+    timedExecOrDie('gulp get-zindex');
   }
 }
 

--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,129 +1,141 @@
-Run `gulp get-zindex` to generate this file.
+**Run `gulp get-zindex --fix` to generate this file.**
 
-| selector                                                                                                | z-index    | file                                                                 |
-| ------------------------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------------------------- |
-| .i-amphtml-expanded-mode amp-story-grid-layer                                                           | auto       | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-expanded-mode amp-story-grid-layer \*                                                        | auto       | extensions/amp-story/1.0/amp-story.css                               |
-| amp-story amp-consent                                                                                   | initial    | extensions/amp-story/1.0/amp-story.css                               |
-| .amp-access-scroll-bar                                                                                  | 2147483647 | extensions/amp-access-scroll/0.1/amp-access-scroll.css               |
-| .amp-access-scroll-sheet                                                                                | 2147483647 | extensions/amp-access-scroll/0.1/amp-access-scroll.css               |
-| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/0.1/amp-sidebar.css                           |
-| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/0.2/amp-sidebar.css                           |
-| .amp-apester-fullscreen                                                                                 | 2147483646 | extensions/amp-apester-media/0.1/amp-apester-media.css               |
-| .i-amphtml-sidebar-mask                                                                                 | 2147483646 | extensions/amp-sidebar/0.1/amp-sidebar.css                           |
-| .i-amphtml-sidebar-mask                                                                                 | 2147483646 | extensions/amp-sidebar/0.2/amp-sidebar.css                           |
-| .amp-video-docked-controls                                                                              | 2147483646 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
-| amp-consent                                                                                             | 2147483645 | extensions/amp-consent/0.1/amp-consent.css                           |
-| .i-amphtml-video-docked-overlay                                                                         | 2147483645 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
-| .i-amphtml-consent-ui-mask                                                                              | 2147483644 | extensions/amp-consent/0.1/amp-consent.css                           |
-| .i-amphtml-video-docked                                                                                 | 2147483644 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
-| .amp-video-docked-shadow                                                                                | 2147483643 | extensions/amp-video-docking/0.1/amp-video-docking.css               |
-| .i-amphtml-lbg                                                                                          | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css         |
-| amp-lightbox-gallery[i-amphtml-lbg-fade]                                                                | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css         |
-| amp-subscriptions-dialog                                                                                | 2147483641 | extensions/amp-subscriptions/0.1/amp-subscriptions.css               |
-| .i-amphtml-story-unsupported-browser-overlay                                                            | 20000001   | extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css     |
-| .i-amphtml-story-no-rotation-overlay                                                                    | 20000000   | extensions/amp-story/1.0/amp-story-viewport-warning-layer.css        |
-| amp-story-education                                                                                     | 9999999    | extensions/amp-story-education/0.1/amp-story-education.css           |
-| [i-amphtml-vertical] .i-amphtml-story-page-description                                                  | 9999999    | extensions/amp-story/1.0/amp-story-vertical.css                      |
-| .i-amphtml-story-consent                                                                                | 100005     | extensions/amp-story/1.0/amp-story-consent.css                       |
-| amp-story-access[type=blocking]                                                                         | 100004     | extensions/amp-story/1.0/amp-story-access.css                        |
-| .i-amphtml-story-toast                                                                                  | 100004     | extensions/amp-story/1.0/amp-story.css                               |
-| amp-story-access                                                                                        | 100003     | extensions/amp-story/1.0/amp-story-access.css                        |
-| .i-amphtml-story-share-menu                                                                             | 100003     | extensions/amp-story/1.0/amp-story-share-menu.css                    |
-| .i-amphtml-story-opacity-mask                                                                           | 100003     | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-story-has-new-page-notification-container                                                    | 100002     | extensions/amp-story/1.0/amp-story-system-layer.css                  |
-| amp-story[standalone] .i-amphtml-story-developer-log                                                    | 100002     | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-story-button-container                                                                       | 100002     | extensions/amp-story/1.0/pagination-buttons.css                      |
-| .i-amphtml-ad-overlay-container                                                                         | 100001     | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css    |
-| .i-amphtml-story-bookend                                                                                | 100001     | extensions/amp-story/1.0/amp-story-bookend.css                       |
-| .i-amphtml-story-info-dialog                                                                            | 100001     | extensions/amp-story/1.0/amp-story-info-dialog.css                   |
-| .i-amphtml-story-progress-bar                                                                           | 100001     | extensions/amp-story/1.0/amp-story-system-layer.css                  |
-| .i-amphtml-story-focused-state-layer                                                                    | 100001     | extensions/amp-story/1.0/amp-story-tooltip.css                       |
-| .i-amphtml-story-page-attachment-expand                                                                 | 100000     | extensions/amp-story/1.0/amp-story-page-attachment.css               |
-| .i-amphtml-story-system-layer                                                                           | 100000     | extensions/amp-story/1.0/amp-story-system-layer.css                  |
-| .i-amphtml-story-360-activate-button                                                                    | 100000     | extensions/amp-story-360.css                                         |
-| .i-amphtml-story-360-discovery                                                                          | 100000     | extensions/amp-story-360.css                                         |
-| .i-amphtml-story-page-error                                                                             | 10000      | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-story-page-play-button                                                                       | 10000      | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-image-lightbox-trans                                                                         | 1001       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
-| .i-amphtml-jank-meter                                                                                   | 1000       | css/ampdoc.css                                                       |
-| amp-image-lightbox                                                                                      | 1000       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
-| amp-lightbox                                                                                            | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                         |
-| i-amphtml-ad-close-header                                                                               | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                         |
-| amp-live-list > [update]                                                                                | 1000       | extensions/amp-live-list/0.1/amp-live-list.css                       |
-| .i-amphtml-mega-menu-mask-parent                                                                        | 1000       | extensions/amp-mega-menu/0.1/amp-mega-menu.css                       |
-| amp-mega-menu                                                                                           | 1000       | extensions/amp-mega-menu/0.1/amp-mega-menu.css                       |
-| amp-user-notification                                                                                   | 1000       | extensions/amp-user-notification/0.1/amp-user-notification.css       |
-| i-amphtml-app-banner-top-padding                                                                        | 15         | extensions/amp-app-banner/0.1/amp-app-banner.css                     |
-| .amp-app-banner-dismiss-button                                                                          | 14         | extensions/amp-app-banner/0.1/amp-app-banner.css                     |
-| amp-app-banner                                                                                          | 13         | extensions/amp-app-banner/0.1/amp-app-banner.css                     |
-| amp-sticky-ad-top-padding                                                                               | 12         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                       |
-| amp-sticky-ad                                                                                           | 11         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                       |
-| .i-amphtml-autocomplete-results                                                                         | 10         | extensions/amp-autocomplete/0.1/amp-autocomplete.css                 |
-| .amp-carousel-button                                                                                    | 10         | extensions/amp-carousel/0.1/amp-carousel.css                         |
-| .amp-carousel-button                                                                                    | 10         | extensions/amp-carousel/0.2/amp-carousel.css                         |
-| amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                        | 10         | extensions/amp-date-picker/0.1/amp-date-picker.css                   |
-| .i-amphtml-story-spinner                                                                                | 10         | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before          | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
-| 100%                                                                                                    | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
-| .i-amphtml-story-ad-attribution                                                                         | 4          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css |
-| .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before | 4          | extensions/amp-story/1.0/amp-story-desktop-panels.css                |
-| .amp-story-draggable-drawer-root                                                                        | 4          | extensions/amp-story/1.0/amp-story-draggable-drawer.css              |
-| .i-amphtml-image-slider-bar                                                                             | 3          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
-| amp-story-page[active] .i-amphtml-story-page-open-attachment                                            | 3          | extensions/amp-story/1.0/amp-story-page-attachment.css               |
-| amp-story-cta-layer                                                                                     | 3          | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-element > [overflow]                                                                         | 2          | css/ampshared.css                                                    |
-| .i-amphtml-image-lightbox-caption                                                                       | 2          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
-| .i-amphtml-image-slider-hint                                                                            | 2          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
-| .i-amphtml-story-access-header                                                                          | 2          | extensions/amp-story/1.0/amp-story-access.css                        |
-| .i-amphtml-story-consent-header                                                                         | 2          | extensions/amp-story/1.0/amp-story-consent.css                       |
-| .i-amphtml-story-hint-container                                                                         | 2          | extensions/amp-story/1.0/amp-story-hint.css                          |
-| .i-amphtml-story-bookend-active amp-story-page[active]::after                                           | 2          | extensions/amp-story/1.0/amp-story.css                               |
-| amp-story-grid-layer                                                                                    | 2          | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-layout-size-defined > [fallback]                                                             | 1          | css/ampshared.css                                                    |
-| .i-amphtml-layout-size-defined > [placeholder]                                                          | 1          | css/ampshared.css                                                    |
-| .i-amphtml-loading-container                                                                            | 1          | css/ampshared.css                                                    |
-| .amp-video-eq                                                                                           | 1          | css/video-autoplay.css                                               |
-| i-amphtml-video-mask                                                                                    | 1          | css/video-autoplay.css                                               |
-| amp-addthis .i-amphtml-addthis-close                                                                    | 1          | extensions/amp-addthis/0.1/amp-addthis.css                           |
-| .i-amphtml-base-carousel-arrow-icon                                                                     | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
-| .i-amphtml-base-carousel-arrow-next-slot                                                                | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
-| .i-amphtml-base-carousel-arrow-prev-slot                                                                | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
-| .i-amphtml-base-carousel-arrows                                                                         | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css               |
-| .i-amphtml-carousel-arrows                                                                              | 1          | extensions/amp-carousel/0.2/amp-carousel.css                         |
-| .i-amphtml-image-lightbox-viewer                                                                        | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
-| .i-amphtml-image-lightbox-viewer-image                                                                  | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
-| .i-amphtml-image-slider-label-wrapper                                                                   | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
-| .i-amphtml-image-slider-right-mask                                                                      | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css                 |
-| .i-amphtml-inline-gallery-pagination-count                                                              | 1          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
-| .i-amphtml-inline-gallery-pagination-dot-container                                                      | 1          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
-| .i-amphtml-lbg-caption-scroll                                                                           | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css             |
-| [i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask                                      | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css             |
-| .i-amphtml-lbg-top-bar                                                                                  | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-controls.css            |
-| .i-amphtml-glass-pane                                                                                   | 1          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css             |
-| .i-amphtml-story-consent-actions                                                                        | 1          | extensions/amp-story/1.0/amp-story-consent.css                       |
-| .i-amphtml-story-draggable-drawer-header                                                                | 1          | extensions/amp-story/1.0/amp-story-draggable-drawer-header.css       |
-| .i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                   | 1          | extensions/amp-story/1.0/amp-story-hint.css                          |
-| .i-amphtml-story-interactive-option-text                                                                | 1          | extensions/amp-story/1.0/amp-story-interactive-poll.css              |
-| .i-amphtml-story-bookend-active.i-amphtml-story-system-layer                                            | 1          | extensions/amp-story/1.0/amp-story-system-layer.css                  |
-| .i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component                     | 1          | extensions/amp-story/1.0/amp-story.css                               |
-| amp-story-page[active]                                                                                  | 1          | extensions/amp-story/1.0/amp-story.css                               |
-| .i-amphtml-stream-gallery-next                                                                          | 1          | extensions/amp-stream-gallery/0.1/arrows.css                         |
-| .i-amphtml-stream-gallery-prev                                                                          | 1          | extensions/amp-stream-gallery/0.1/arrows.css                         |
-| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after           | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
-| 0%                                                                                                      | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css             |
-| .i-amphtml-image-lightbox-container                                                                     | 0          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css             |
-| .i-amphtml-inline-gallery-pagination-dots                                                               | 0          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
-| .i-amphtml-inline-gallery-pagination-numbers                                                            | 0          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css  |
-| [i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask                                    | 0          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css             |
-| .i-amphtml-story-access-content                                                                         | 0          | extensions/amp-story/1.0/amp-story-access.css                        |
-| .i-amphtml-story-consent-content                                                                        | 0          | extensions/amp-story/1.0/amp-story-consent.css                       |
-| .i-amphtml-story-interactive-quiz-option                                                                | 0          | extensions/amp-story/1.0/amp-story-interactive-quiz.css              |
-| amp-story-page                                                                                          | 0          | extensions/amp-story/1.0/amp-story.css                               |
-| .amp-video-docked-placeholder-background                                                                | 0          | extensions/amp-video-docking/0.1/amp-video-docking.css               |
-| .i-amphtml-carousel-spacer                                                                              | -1         | extensions/amp-base-carousel/0.1/carousel.css                        |
-| .i-amphtml-mega-menu-mask                                                                               | -1         | extensions/amp-mega-menu/0.1/amp-mega-menu.css                       |
-| .i-amphtml-story-access-logo::before                                                                    | -1         | extensions/amp-story/1.0/amp-story-access.css                        |
-| .i-amphtml-story-consent-logo::before                                                                   | -1         | extensions/amp-story/1.0/amp-story-consent.css                       |
-| amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                        | -1         | extensions/amp-story/1.0/amp-story-page-attachment.css               |
-| .i-amphtml-story-media-query-matcher                                                                    | -1         | extensions/amp-story/1.0/amp-story.css                               |
+| selector                                                                                                | z-index    | file                                                                   |
+| ------------------------------------------------------------------------------------------------------- | ---------- | ---------------------------------------------------------------------- |
+| amp-img.i-amphtml-ssr:not(.i-amphtml-element) > [placeholder]                                           | auto       | css/ampshared.css                                                      |
+| .i-amphtml-expanded-mode amp-story-grid-layer                                                           | auto       | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-expanded-mode amp-story-grid-layer \*                                                        | auto       | extensions/amp-story/1.0/amp-story.css                                 |
+| amp-sidebar::part(c)                                                                                    | inherit    | extensions/amp-sidebar/1.0/amp-sidebar.css                             |
+| amp-sidebar::part(sidebar)                                                                              | inherit    | extensions/amp-sidebar/1.0/amp-sidebar.css                             |
+| amp-story amp-consent                                                                                   | initial    | extensions/amp-story/1.0/amp-story.css                                 |
+| .amp-access-scroll-bar                                                                                  | 2147483647 | extensions/amp-access-scroll/0.1/amp-access-scroll.css                 |
+| .amp-access-scroll-sheet                                                                                | 2147483647 | extensions/amp-access-scroll/0.1/amp-access-scroll.css                 |
+| .i-amphtml-onetap-google-iframe                                                                         | 2147483647 | extensions/amp-onetap-google/0.1/amp-onetap-google.css                 |
+| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/0.1/amp-sidebar.css                             |
+| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/0.2/amp-sidebar.css                             |
+| amp-sidebar                                                                                             | 2147483647 | extensions/amp-sidebar/1.0/amp-sidebar.css                             |
+| .amp-apester-fullscreen                                                                                 | 2147483646 | extensions/amp-apester-media/0.1/amp-apester-media.css                 |
+| .i-amphtml-sidebar-mask                                                                                 | 2147483646 | extensions/amp-sidebar/0.1/amp-sidebar.css                             |
+| .i-amphtml-sidebar-mask                                                                                 | 2147483646 | extensions/amp-sidebar/0.2/amp-sidebar.css                             |
+| .amp-video-docked-controls                                                                              | 2147483646 | extensions/amp-video-docking/0.1/amp-video-docking.css                 |
+| amp-consent                                                                                             | 2147483645 | extensions/amp-consent/0.1/amp-consent.css                             |
+| .i-amphtml-video-docked-overlay                                                                         | 2147483645 | extensions/amp-video-docking/0.1/amp-video-docking.css                 |
+| .i-amphtml-consent-ui-mask                                                                              | 2147483644 | extensions/amp-consent/0.1/amp-consent.css                             |
+| .i-amphtml-video-docked                                                                                 | 2147483644 | extensions/amp-video-docking/0.1/amp-video-docking.css                 |
+| .amp-video-docked-shadow                                                                                | 2147483643 | extensions/amp-video-docking/0.1/amp-video-docking.css                 |
+| .i-amphtml-lbg                                                                                          | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css           |
+| amp-lightbox-gallery[i-amphtml-lbg-fade]                                                                | 2147483642 | extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.css           |
+| amp-subscriptions-dialog                                                                                | 2147483641 | extensions/amp-subscriptions/0.1/amp-subscriptions.css                 |
+| .i-amphtml-story-unsupported-browser-overlay                                                            | 20000001   | extensions/amp-story/1.0/amp-story-unsupported-browser-layer.css       |
+| .i-amphtml-story-no-rotation-overlay                                                                    | 20000000   | extensions/amp-story/1.0/amp-story-viewport-warning-layer.css          |
+| amp-story-education                                                                                     | 9999999    | extensions/amp-story-education/0.1/amp-story-education.css             |
+| [i-amphtml-vertical] .i-amphtml-story-page-description                                                  | 9999999    | extensions/amp-story/1.0/amp-story-vertical.css                        |
+| .i-amphtml-story-consent                                                                                | 100005     | extensions/amp-story/1.0/amp-story-consent.css                         |
+| amp-story-access[type=blocking]                                                                         | 100004     | extensions/amp-story/1.0/amp-story-access.css                          |
+| .i-amphtml-story-toast                                                                                  | 100004     | extensions/amp-story/1.0/amp-story.css                                 |
+| amp-story-access                                                                                        | 100003     | extensions/amp-story/1.0/amp-story-access.css                          |
+| .i-amphtml-story-share-menu                                                                             | 100003     | extensions/amp-story/1.0/amp-story-share-menu.css                      |
+| .i-amphtml-story-opacity-mask                                                                           | 100003     | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-story-has-new-page-notification-container                                                    | 100002     | extensions/amp-story/1.0/amp-story-system-layer.css                    |
+| amp-story[standalone] .i-amphtml-story-developer-log                                                    | 100002     | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-story-button-container                                                                       | 100002     | extensions/amp-story/1.0/pagination-buttons.css                        |
+| .i-amphtml-ad-overlay-container                                                                         | 100001     | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css      |
+| .i-amphtml-story-bookend                                                                                | 100001     | extensions/amp-story/1.0/amp-story-bookend.css                         |
+| .i-amphtml-story-info-dialog                                                                            | 100001     | extensions/amp-story/1.0/amp-story-info-dialog.css                     |
+| .i-amphtml-story-progress-bar                                                                           | 100001     | extensions/amp-story/1.0/amp-story-system-layer.css                    |
+| .i-amphtml-story-focused-state-layer                                                                    | 100001     | extensions/amp-story/1.0/amp-story-tooltip.css                         |
+| .i-amphtml-story-360-activate-button                                                                    | 100000     | extensions/amp-story-360/0.1/amp-story-360.css                         |
+| .i-amphtml-story-360-discovery                                                                          | 100000     | extensions/amp-story-360/0.1/amp-story-360.css                         |
+| .i-amphtml-story-page-attachment-expand                                                                 | 100000     | extensions/amp-story/1.0/amp-story-page-attachment.css                 |
+| .i-amphtml-story-system-layer                                                                           | 100000     | extensions/amp-story/1.0/amp-story-system-layer.css                    |
+| .i-amphtml-story-page-error                                                                             | 10000      | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-story-page-play-button                                                                       | 10000      | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-image-lightbox-trans                                                                         | 1001       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css               |
+| .i-amphtml-jank-meter                                                                                   | 1000       | css/ampdoc.css                                                         |
+| amp-image-lightbox                                                                                      | 1000       | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css               |
+| amp-lightbox                                                                                            | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                           |
+| i-amphtml-ad-close-header                                                                               | 1000       | extensions/amp-lightbox/0.1/amp-lightbox.css                           |
+| amp-live-list > [update]                                                                                | 1000       | extensions/amp-live-list/0.1/amp-live-list.css                         |
+| .i-amphtml-mega-menu-mask-parent                                                                        | 1000       | extensions/amp-mega-menu/0.1/amp-mega-menu.css                         |
+| amp-mega-menu                                                                                           | 1000       | extensions/amp-mega-menu/0.1/amp-mega-menu.css                         |
+| amp-user-notification                                                                                   | 1000       | extensions/amp-user-notification/0.1/amp-user-notification.css         |
+| i-amphtml-app-banner-top-padding                                                                        | 15         | extensions/amp-app-banner/0.1/amp-app-banner.css                       |
+| .amp-app-banner-dismiss-button                                                                          | 14         | extensions/amp-app-banner/0.1/amp-app-banner.css                       |
+| amp-app-banner                                                                                          | 13         | extensions/amp-app-banner/0.1/amp-app-banner.css                       |
+| amp-ad-sticky-padding                                                                                   | 12         | extensions/amp-ad/0.1/amp-ad.css                                       |
+| amp-sticky-ad-top-padding                                                                               | 12         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                         |
+| amp-ad[sticky]                                                                                          | 11         | extensions/amp-ad/0.1/amp-ad.css                                       |
+| amp-sticky-ad                                                                                           | 11         | extensions/amp-sticky-ad/1.0/amp-sticky-ad.css                         |
+| .i-amphtml-autocomplete-results                                                                         | 10         | extensions/amp-autocomplete/0.1/amp-autocomplete.css                   |
+| .amp-carousel-button                                                                                    | 10         | extensions/amp-carousel/0.1/amp-carousel.css                           |
+| .amp-carousel-button                                                                                    | 10         | extensions/amp-carousel/0.2/amp-carousel.css                           |
+| amp-date-picker[mode="overlay"] .i-amphtml-date-picker-container                                        | 10         | extensions/amp-date-picker/0.1/amp-date-picker.css                     |
+| .i-amphtml-story-spinner                                                                                | 10         | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:before          | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css               |
+| 100%                                                                                                    | 9          | extensions/amp-byside-content/0.1/amp-byside-content.css               |
+| .i-amphtml-story-ad-attribution                                                                         | 4          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-attribution.css   |
+| .i-amphtml-story-desktop-panels amp-story-page[i-amphtml-desktop-position="1"][amp-access-hide]::before | 4          | extensions/amp-story/1.0/amp-story-desktop-panels.css                  |
+| .amp-story-draggable-drawer-root                                                                        | 4          | extensions/amp-story/1.0/amp-story-draggable-drawer.css                |
+| .i-amphtml-image-slider-bar                                                                             | 3          | extensions/amp-image-slider/0.1/amp-image-slider.css                   |
+| amp-story-cta-layer                                                                                     | 3          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-inabox.css        |
+| amp-story-page[active] .i-amphtml-story-page-open-attachment                                            | 3          | extensions/amp-story/1.0/amp-story-page-attachment.css                 |
+| amp-story-cta-layer                                                                                     | 3          | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-element > [overflow]                                                                         | 2          | css/ampshared.css                                                      |
+| .i-amphtml-image-lightbox-caption                                                                       | 2          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css               |
+| .i-amphtml-image-slider-hint                                                                            | 2          | extensions/amp-image-slider/0.1/amp-image-slider.css                   |
+| .i-amphtml-story-access-header                                                                          | 2          | extensions/amp-story/1.0/amp-story-access.css                          |
+| .i-amphtml-story-consent-header                                                                         | 2          | extensions/amp-story/1.0/amp-story-consent.css                         |
+| .i-amphtml-story-hint-container                                                                         | 2          | extensions/amp-story/1.0/amp-story-hint.css                            |
+| .i-amphtml-story-bookend-active amp-story-page[active]::after                                           | 2          | extensions/amp-story/1.0/amp-story.css                                 |
+| amp-story-grid-layer                                                                                    | 2          | extensions/amp-story/1.0/amp-story.css                                 |
+| .amp-story-player-exit-control-button                                                                   | 1          | css/amp-story-player-iframe.css                                        |
+| .i-amphtml-layout-size-defined > [fallback]                                                             | 1          | css/ampshared.css                                                      |
+| .i-amphtml-layout-size-defined > [placeholder]                                                          | 1          | css/ampshared.css                                                      |
+| .i-amphtml-loading-container                                                                            | 1          | css/ampshared.css                                                      |
+| .amp-video-eq                                                                                           | 1          | css/video-autoplay.css                                                 |
+| .i-amphtml-video-mask                                                                                   | 1          | css/video-autoplay.css                                                 |
+| amp-addthis .i-amphtml-addthis-close                                                                    | 1          | extensions/amp-addthis/0.1/amp-addthis.css                             |
+| .i-amphtml-base-carousel-arrow-icon                                                                     | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css                 |
+| .i-amphtml-base-carousel-arrow-next-slot                                                                | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css                 |
+| .i-amphtml-base-carousel-arrow-prev-slot                                                                | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css                 |
+| .i-amphtml-base-carousel-arrows                                                                         | 1          | extensions/amp-base-carousel/0.1/amp-base-carousel.css                 |
+| .i-amphtml-carousel-arrows                                                                              | 1          | extensions/amp-carousel/0.2/amp-carousel.css                           |
+| .i-amphtml-image-lightbox-viewer                                                                        | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css               |
+| .i-amphtml-image-lightbox-viewer-image                                                                  | 1          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css               |
+| .i-amphtml-image-slider-label-wrapper                                                                   | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css                   |
+| .i-amphtml-image-slider-right-mask                                                                      | 1          | extensions/amp-image-slider/0.1/amp-image-slider.css                   |
+| .i-amphtml-inline-gallery-pagination-count                                                              | 1          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css    |
+| .i-amphtml-inline-gallery-pagination-dot-container                                                      | 1          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css    |
+| .i-amphtml-lbg-caption-scroll                                                                           | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css               |
+| [i-amphtml-lbg-caption-state="clip"] + .i-amphtml-lbg-caption-mask                                      | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css               |
+| .i-amphtml-lbg-top-bar                                                                                  | 1          | extensions/amp-lightbox-gallery/0.1/lightbox-controls.css              |
+| .i-amphtml-glass-pane                                                                                   | 1          | extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css               |
+| .i-amphtml-story-dev-tools-device-dialog-bg                                                             | 1          | extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.css |
+| .i-amphtml-story-interactive-option-text                                                                | 1          | extensions/amp-story-interactive/0.1/amp-story-interactive-poll.css    |
+| .i-amphtml-story-interactive-confetti-wrapper                                                           | 1          | extensions/amp-story-interactive/0.1/amp-story-interactive.css         |
+| .i-amphtml-story-interactive-disclaimer                                                                 | 1          | extensions/amp-story-interactive/0.1/amp-story-interactive.css         |
+| .i-amphtml-story-consent-actions                                                                        | 1          | extensions/amp-story/1.0/amp-story-consent.css                         |
+| .i-amphtml-story-draggable-drawer-header                                                                | 1          | extensions/amp-story/1.0/amp-story-draggable-drawer-header.css         |
+| .i-amphtml-story-hint-container .i-amphtml-story-hint-tap-button-icon                                   | 1          | extensions/amp-story/1.0/amp-story-hint.css                            |
+| .i-amphtml-story-bookend-active.i-amphtml-story-system-layer                                            | 1          | extensions/amp-story/1.0/amp-story-system-layer.css                    |
+| .i-amphtml-expanded-mode .i-amphtml-embedded-component.i-amphtml-expanded-component                     | 1          | extensions/amp-story/1.0/amp-story.css                                 |
+| amp-story-page[active]                                                                                  | 1          | extensions/amp-story/1.0/amp-story.css                                 |
+| .i-amphtml-stream-gallery-next                                                                          | 1          | extensions/amp-stream-gallery/0.1/arrows.css                           |
+| .i-amphtml-stream-gallery-prev                                                                          | 1          | extensions/amp-stream-gallery/0.1/arrows.css                           |
+| .i-amphtml-byside-content-loading-container .i-amphtml-byside-content-loading-animation:after           | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css               |
+| 0%                                                                                                      | 0          | extensions/amp-byside-content/0.1/amp-byside-content.css               |
+| .i-amphtml-image-lightbox-container                                                                     | 0          | extensions/amp-image-lightbox/0.1/amp-image-lightbox.css               |
+| .i-amphtml-inline-gallery-pagination-dots                                                               | 0          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css    |
+| .i-amphtml-inline-gallery-pagination-numbers                                                            | 0          | extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.css    |
+| [i-amphtml-lbg-caption-state="expand"] + .i-amphtml-lbg-caption-mask                                    | 0          | extensions/amp-lightbox-gallery/0.1/lightbox-caption.css               |
+| .i-amphtml-story-interactive-quiz-option                                                                | 0          | extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css    |
+| .i-amphtml-story-access-content                                                                         | 0          | extensions/amp-story/1.0/amp-story-access.css                          |
+| .i-amphtml-story-consent-content                                                                        | 0          | extensions/amp-story/1.0/amp-story-consent.css                         |
+| amp-story-page                                                                                          | 0          | extensions/amp-story/1.0/amp-story.css                                 |
+| .amp-video-docked-placeholder-background                                                                | 0          | extensions/amp-video-docking/0.1/amp-video-docking.css                 |
+| .i-amphtml-carousel-spacer                                                                              | -1         | extensions/amp-base-carousel/0.1/carousel.css                          |
+| .i-amphtml-mega-menu-mask                                                                               | -1         | extensions/amp-mega-menu/0.1/amp-mega-menu.css                         |
+| .i-amphtml-story-access-logo::before                                                                    | -1         | extensions/amp-story/1.0/amp-story-access.css                          |
+| .i-amphtml-story-consent-logo::before                                                                   | -1         | extensions/amp-story/1.0/amp-story-consent.css                         |
+| amp-story-page .i-amphtml-story-page-open-attachment-icon::after                                        | -1         | extensions/amp-story/1.0/amp-story-page-attachment.css                 |
+| .i-amphtml-story-media-query-matcher                                                                    | -1         | extensions/amp-story/1.0/amp-story.css                                 |


### PR DESCRIPTION
Successful `--fix` run: (truncated)

```diff
gulp get-zindex --fix

[10:10:23] Using gulpfile ~/git/amphtml/gulpfile.js
[10:10:23] Starting 'get-zindex'...

diff --git a/css/Z_INDEX.md b/css/Z_INDEX.md
index 437b768da..a1c673789 100644
--- a/css/Z_INDEX.md
+++ b/css/Z_INDEX.md
@@ -1,7 +1,9 @@
-Run `gulp get-zindex` to generate this file.
+Run `gulp get-zindex --fix` to generate this file.
 
 | selector                                     | z-index    | file                                      |
-| -------------------------------------------- | ---------- | --------------------------------------- |
+| -------------------------------------------- | ---------- | ----------------------------------------- |
 | .i-amphtml-expanded-mode amp-story-grid-lay  | auto       | extensions/amp-story/1.0/amp-story.css    |
 | .i-amphtml-expanded-mode amp-story-grid-lay  | auto       | extensions/amp-story/1.0/amp-story.css    |
+| amp-sidebar::part(c)                         | inherit    | extensions/amp-sidebar/1.0/amp-sidebar.cs |
+| amp-sidebar::part(sidebar)                   | inherit    | extensions/amp-sidebar/1.0/amp-sidebar.cs |
 | amp-story amp-consent                        | initial    | extensions/amp-story/1.0/amp-story.css    |
@@ -9,4 +11,6 @@ Run `gulp get-zindex` to generate this file.
 | .amp-access-scroll-sheet                     | 2147483647 | extensions/amp-access-scroll/0.1/amp-acce |
+| .i-amphtml-onetap-google-iframe              | 2147483647 | extensions/amp-onetap-google/0.1/amp-onet |
 | amp-sidebar                                  | 2147483647 | extensions/amp-sidebar/0.1/amp-sidebar.cs |
 | amp-sidebar                                  | 2147483647 | extensions/amp-sidebar/0.2/amp-sidebar.cs |
+| amp-sidebar                                  | 2147483647 | extensions/amp-sidebar/1.0/amp-sidebar.cs |
 | .amp-apester-fullscreen                      | 2147483646 | extensions/amp-apester-media/0.1/amp-apes |
@@ -59,3 +63,5 @@ Run `gulp get-zindex` to generate this file.
 | amp-app-banner                               | 13         | extensions/amp-app-banner/0.1/amp-app-ban |
+| amp-ad-sticky-padding                        | 12         | extensions/amp-ad/0.1/amp-ad.css          |
 | amp-sticky-ad-top-padding                    | 12         | extensions/amp-sticky-ad/1.0/amp-sticky-a |
+| amp-ad[sticky]                               | 11         | extensions/amp-ad/0.1/amp-ad.css          |
 | amp-sticky-ad                                | 11         | extensions/amp-sticky-ad/1.0/amp-sticky-a |
@@ -72,2 +78,3 @@ Run `gulp get-zindex` to generate this file.
 | .i-amphtml-image-slider-bar                  | 3          | extensions/amp-image-slider/0.1/amp-image |
+| amp-story-cta-layer                          | 3          | extensions/amp-story-auto-ads/0.1/amp-sto |
 | amp-story-page[active] .i-amphtml-story-pag  | 3          | extensions/amp-story/1.0/amp-story-page-a |
@@ -82,2 +89,3 @@ Run `gulp get-zindex` to generate this file.
 | amp-story-grid-layer                         | 2          | extensions/amp-story/1.0/amp-story.css    |
+| .amp-story-player-exit-control-button        | 1          | css/amp-story-player-iframe.css           |
 | .i-amphtml-layout-size-defined > [fallback]  | 1          | css/ampshared.css                         |
@@ -86,3 +94,3 @@ Run `gulp get-zindex` to generate this file.
 | .amp-video-eq                                | 1          | css/video-autoplay.css                    |
-| i-amphtml-video-mask                         | 1          | css/video-autoplay.css                  |
+| .i-amphtml-video-mask                        | 1          | css/video-autoplay.css                    |
 | amp-addthis .i-amphtml-addthis-close         | 1          | extensions/amp-addthis/0.1/amp-addthis.cs |

[10:10:23] Wrote css/Z_INDEX.md
[10:10:23] Finished 'get-zindex' after 720 ms
```

A check failure run is the same, except it errors-out when the table is incomplete.