### PR TITLE
watch src dir for v0.js

### DIFF
--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -21,7 +21,7 @@ const {
   maybeInitializeExtensions,
   getExtensionsToBuild,
 } = require('../tasks/extension-helpers');
-const {doBuildJs} = require('../tasks/helpers');
+const {doBuildJs, compileCoreRuntime} = require('../tasks/helpers');
 const {jsBundles} = require('../compile/bundles.config');
 
 const extensionBundles = {};
@@ -131,7 +131,9 @@ async function lazyBuildJs(req, _res, next) {
  * Pre-builds the core runtime and the JS files that it loads.
  */
 async function preBuildRuntimeFiles() {
-  await build(jsBundles, 'amp.js', doBuildJs);
+  await build(jsBundles, 'amp.js', () =>
+    compileCoreRuntime({watch: true, minify: argv.compiled})
+  );
   await build(jsBundles, 'ww.max.js', doBuildJs);
 }
 

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -131,8 +131,8 @@ async function lazyBuildJs(req, _res, next) {
  * Pre-builds the core runtime and the JS files that it loads.
  */
 async function preBuildRuntimeFiles() {
-  await build(jsBundles, 'amp.js', () =>
-    compileCoreRuntime({watch: true, minify: argv.compiled})
+  await build(jsBundles, 'amp.js', (bundles, name, options) =>
+    compileCoreRuntime(options)
   );
   await build(jsBundles, 'ww.max.js', doBuildJs);
 }

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -131,7 +131,7 @@ async function lazyBuildJs(req, _res, next) {
  * Pre-builds the core runtime and the JS files that it loads.
  */
 async function preBuildRuntimeFiles() {
-  await build(jsBundles, 'amp.js', (bundles, name, options) =>
+  await build(jsBundles, 'amp.js', (_bundles, _name, options) =>
     compileCoreRuntime(options)
   );
   await build(jsBundles, 'ww.max.js', doBuildJs);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -150,6 +150,17 @@ async function bootstrapThirdPartyFrames(options) {
  * @param {!Object} options
  */
 async function compileCoreRuntime(options) {
+  async function watchFunc() {
+    const bundleComplete = await doBuildJs(jsBundles, 'amp.js', options);
+    if (options.onWatchBuild) {
+      options.onWatchBuild(bundleComplete);
+    } 
+  }
+
+  if (options.watch) {
+    fileWatch('src/**/*.js').on('change', debounce(watchFunc, watchDebounceDelay)); 
+  }
+
   await doBuildJs(jsBundles, 'amp.js', options);
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -151,7 +151,10 @@ async function bootstrapThirdPartyFrames(options) {
  */
 async function compileCoreRuntime(options) {
   async function watchFunc() {
-    const bundleComplete = await doBuildJs(jsBundles, 'amp.js', options);
+    const bundleComplete = await doBuildJs(jsBundles, 'amp.js', {
+      ...options,
+      watch: false,
+    });
     if (options.onWatchBuild) {
       options.onWatchBuild(bundleComplete);
     }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -154,11 +154,14 @@ async function compileCoreRuntime(options) {
     const bundleComplete = await doBuildJs(jsBundles, 'amp.js', options);
     if (options.onWatchBuild) {
       options.onWatchBuild(bundleComplete);
-    } 
+    }
   }
 
   if (options.watch) {
-    fileWatch('src/**/*.js').on('change', debounce(watchFunc, watchDebounceDelay)); 
+    fileWatch('src/**/*.js').on(
+      'change',
+      debounce(watchFunc, watchDebounceDelay)
+    );
   }
 
   await doBuildJs(jsBundles, 'amp.js', options);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -158,13 +158,11 @@ async function compileCoreRuntime(options) {
   }
 
   if (options.watch) {
-    fileWatch('src/**/*.js').on(
-      'change',
-      debounce(watchFunc, watchDebounceDelay)
-    );
+    const debouncedRebuild = debounce(watchFunc, watchDebounceDelay);
+    fileWatch('src/**/*.js').on('change', debouncedRebuild);
   }
 
-  await doBuildJs(jsBundles, 'amp.js', options);
+  await doBuildJs(jsBundles, 'amp.js', {...options, watch: false});
 }
 
 /**


### PR DESCRIPTION
**summary**
In watch mode, we should rebuild `v0.js` each time any of its dependents change. Similarly to extensions, the science here is inexact, and I'm watching the `src` folder as a heuristic for a dependency change.

In a followup PR, I plan on using the machinery in the bundlers to tell us exactly which files need to be watched.