### PR TITLE
♿  [Story a11y] Make CTAs not tabbable when not on active page

### DIFF
--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -50,7 +50,11 @@
                 layout="responsive"
                 height="1600"
                 width="900">
-                <h1 style="position: absolute;top: 0;z-index: 1">Hello!</h1>
+                <h1 style="position: absolute;top: 0;z-index: 1">
+                  This is a
+                  <a href="https://example.com" tabindex="2">Link</a>
+                </h1>
+                
             </amp-img>
           </amp-story-grid-layer>
           <amp-story-grid-layer template="center">

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -110,6 +110,7 @@ export const Selectors = {
   ALL_PLAYBACK_MEDIA:
     '> audio, amp-story-grid-layer audio, amp-story-grid-layer video',
   ALL_VIDEO: 'amp-story-grid-layer video',
+  ALL_TABBABLE: 'a',
 };
 
 /** @private @const {string} */
@@ -363,6 +364,7 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.setPageDescription_();
     this.element.setAttribute('role', 'region');
     this.initializeImgAltTags_();
+    this.initializeTabbableElements_();
   }
 
   /** @private */
@@ -1270,6 +1272,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.findAndPrepareEmbeddedComponents_();
       registerAllPromise.then(() => this.preloadAllMedia_());
     }
+    this.toggleTabbableElements_(distance == 0);
   }
 
   /**
@@ -1869,5 +1872,31 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   isAutoAdvance() {
     return this.advancement_.isAutoAdvance();
+  }
+
+  /**
+   * Set the data-orig-tabindex to the default tabindex of tabbable elements
+   */
+  initializeTabbableElements_() {
+    scopedQuerySelectorAll(this.element, Selectors.ALL_TABBABLE).forEach(
+      (el) => {
+        el.setAttribute('data-orig-tabindex', el.getAttribute('tabindex') || 0);
+      }
+    );
+  }
+
+  /**
+   * Toggles the tabbable elements (buttons, links, etc) to only reach them when page is active.
+   * @param {boolean} toggle
+   */
+  toggleTabbableElements_(toggle) {
+    scopedQuerySelectorAll(this.element, Selectors.ALL_TABBABLE).forEach(
+      (el) => {
+        el.setAttribute(
+          'tabindex',
+          toggle ? el.getAttribute('data-orig-tabindex') : -1
+        );
+      }
+    );
   }
 }


### PR DESCRIPTION
Disable in-page CTAs from tabbing when they are not on an active page. When they are on an active page, they should have their original tabindex. We can store the original tabindex on `data-orig-tabindex` when a page is initialized, and update `tabindex` when it becomes active or inactive.

Adding `tabindex="-1"` to the pages directly does not prevent the children from being tabbed, so the direct `a` tags need to be affected