### PR TITLE
🏗 Rewrite `dep-check` with `esbuild` and `babel`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 .g4ignore
 build/
 .karma-cache*
-.amp-build
+.amp-dep-check
 c
 /dist
 dist.3p

--- a/build-system/babel-config/dep-check-config.js
+++ b/build-system/babel-config/dep-check-config.js
@@ -39,6 +39,9 @@ function getDepCheckConfig() {
     },
   ];
   const depCheckPlugins = [
+    './build-system/babel-plugins/babel-plugin-transform-json-import',
+    './build-system/babel-plugins/babel-plugin-transform-json-configuration',
+    './build-system/babel-plugins/babel-plugin-transform-jss',
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
     '@babel/plugin-transform-react-constant-elements',

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -28,7 +28,7 @@ const ROOT_DIR = path.resolve(__dirname, '../../');
  */
 async function clean() {
   const pathsToDelete = [
-    '.amp-build',
+    '.amp-dep-check',
     '.karma-cache*',
     'build',
     'build-system/server/new-server/transforms/dist',

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -254,7 +254,7 @@ function flattenGraph(entryPoints) {
   return flatten(entryPoints.deps).reduce((acc, cur) => {
     const {name} = cur;
     if (!acc[name]) {
-      acc[name] = Object.keys(cur.deps).map((x) => cur.deps[x]);
+      acc[name] = Object.values(cur.deps);
     }
     return acc;
   }, Object.create(null));

--- a/package-lock.json
+++ b/package-lock.json
@@ -31659,28 +31659,6 @@
         }
       }
     },
-    "vinyl-source-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-2.0.0.tgz",
-      "integrity": "sha1-84pa+53R6Ttl1VBGmsYYKsT1S44=",
-      "dev": true,
-      "requires": {
-        "through2": "^2.0.3",
-        "vinyl": "^2.1.0"
-      },
-      "dependencies": {
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
-      }
-    },
     "vinyl-sourcemap": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "@chiragrupani/karma-chromium-edge-launcher": "2.1.0",
     "@jest/core": "26.6.3",
     "@sinonjs/fake-timers": "7.0.2",
-    "@types/node": "14.14.28",
     "@types/fancy-log": "1.3.1",
     "@types/minimist": "1.2.1",
+    "@types/node": "14.14.28",
     "acorn-globals": "6.0.0",
     "amphtml-validator": "1.0.34",
     "ast-replace": "1.1.3",
@@ -190,7 +190,6 @@
     "tsickle": "0.39.1",
     "typescript": "4.1.3",
     "uglifyify": "5.0.2",
-    "vinyl-source-stream": "2.0.0",
     "vinyl-sourcemaps-apply": "0.2.1",
     "watchify": "4.0.0"
   }


### PR DESCRIPTION
This is another in a series of PRs that modernize our development tasks.

**PR highlights:**
- Rewrite `dep-check` with `esbuild` and `babel`
- Rewrite `getSrcs()`, which was only writing one file (and rename it to `getEntryPointModule()`)
- Rewrite `getGraph()` to use `esbuild` and `babel` (and rename it to `getModuleGraph()`)
- Clean up `flattenGraph()`
- Eliminate the use of `browserify`, `babelify`, `gulp.dest`, and `vinyl-source-stream`
- Delete `vinyl-source-stream` from `package.json` (others need more work)

**Screenshots:**

![image](https://user-images.githubusercontent.com/26553114/108928671-8c47c480-7610-11eb-8ffc-14bf759d09fc.png)


**Reference:** https://esbuild.github.io/api/#metafile

Partial fix for #32585


