### PR TITLE
[ampproject/amphtml] ♿ [Story a11y] Accessible close button in share menu and Twitter overlay

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-tooltip.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip.js
@@ -103,7 +103,7 @@ module.exports = {
     await page.tap('a.i-amphtml-story-tooltip');
     await page.waitForSelector('amp-story-page.i-amphtml-expanded-mode');
     await page.waitForTimeout(1000); // For animations to finish.
-    await page.tap('span.i-amphtml-expanded-view-close-button');
+    await page.tap('button.i-amphtml-expanded-view-close-button');
     await page.waitForTimeout(300); // For animations to finish.
     await verifySelectorsInvisible(page, name, [
       'amp-story-page.i-amphtml-expanded-mode',

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -218,7 +218,7 @@ export const EMBED_ID_ATTRIBUTE_NAME = 'i-amphtml-embed-id';
  */
 const buildExpandedViewOverlay = (element) => htmlFor(element)`
     <div class="i-amphtml-story-expanded-view-overflow i-amphtml-story-system-reset">
-      <button class="i-amphtml-expanded-view-close-button" aria-label=""></button>
+      <button class="i-amphtml-expanded-view-close-button" aria-label="close"></button>
     </div>`;
 
 /**
@@ -681,11 +681,15 @@ export class AmpStoryEmbeddedComponent {
         '.i-amphtml-expanded-view-close-button'
       )
     );
-    const localizedCloseString =
-      getLocalizationService(devAssert(this.storyEl_)).getLocalizedString(
+    const localizationService = getLocalizationService(
+      devAssert(this.storyEl_)
+    );
+    if (localizationService) {
+      const localizedCloseString = localizationService.getLocalizedString(
         LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
-      ) || 'Close';
-    closeButton.setAttribute('aria-label', localizedCloseString);
+      );
+      closeButton.setAttribute('aria-label', localizedCloseString);
+    }
     this.mutator_.mutateElement(dev().assertElement(this.componentPage_), () =>
       this.componentPage_.appendChild(this.expandedViewOverlay_)
     );

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -217,10 +217,8 @@ export const EMBED_ID_ATTRIBUTE_NAME = 'i-amphtml-embed-id';
  * @return {!Element}
  */
 const buildExpandedViewOverlay = (element) => htmlFor(element)`
-    <div class="i-amphtml-story-expanded-view-overflow
-        i-amphtml-story-system-reset">
-      <span class="i-amphtml-expanded-view-close-button" role="button">
-      </span>
+    <div class="i-amphtml-story-expanded-view-overflow i-amphtml-story-system-reset">
+      <button class="i-amphtml-expanded-view-close-button" aria-label=""></button>
     </div>`;
 
 /**
@@ -678,6 +676,16 @@ export class AmpStoryEmbeddedComponent {
    */
   buildAndAppendExpandedViewOverlay_() {
     this.expandedViewOverlay_ = buildExpandedViewOverlay(this.storyEl_);
+    const closeButton = dev().assertElement(
+      this.expandedViewOverlay_.querySelector(
+        '.i-amphtml-expanded-view-close-button'
+      )
+    );
+    const localizedCloseString =
+      getLocalizationService(devAssert(this.storyEl_)).getLocalizedString(
+        LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
+      ) || 'Close';
+    closeButton.setAttribute('aria-label', localizedCloseString);
     this.mutator_.mutateElement(dev().assertElement(this.componentPage_), () =>
       this.componentPage_.appendChild(this.expandedViewOverlay_)
     );

--- a/extensions/amp-story/1.0/amp-story-share-menu.css
+++ b/extensions/amp-story/1.0/amp-story-share-menu.css
@@ -112,6 +112,9 @@
   font-size: 24px !important;
   line-height: 30px !important;
   text-align: center !important;
+  border: 0 !important;
+  padding: 0 !important;
+  background: none !important;
 }
 
 [desktop].i-amphtml-story-share-menu .i-amphtml-story-share-item {

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -50,7 +50,7 @@ const getTemplate = (element) => {
   return htmlFor(element)`
     <div class="i-amphtml-story-share-menu i-amphtml-story-system-reset" aria-hidden="true" role="alert">
       <div class="i-amphtml-story-share-menu-container">
-        <button class="i-amphtml-story-share-menu-close-button" role="button" aria-label="">
+        <button class="i-amphtml-story-share-menu-close-button" aria-label="">
           &times;
         </button>
       </div>

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -173,13 +173,10 @@ export class ShareMenu {
     this.closeButton_ = dev().assertElement(
       this.element_.querySelector('.i-amphtml-story-share-menu-close-button')
     );
-    const localizationService = getLocalizationService(
-      devAssert(this.parentEl_)
-    );
-    devAssert(localizationService, 'Could not retrieve LocalizationService.');
-    const localizedCloseString = localizationService.getLocalizedString(
-      LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
-    );
+    const localizedCloseString =
+      getLocalizationService(devAssert(this.parentEl_)).getLocalizedString(
+        LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
+      ) || 'Close';
     this.closeButton_.setAttribute('aria-label', localizedCloseString);
 
     this.initializeListeners_();

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -27,12 +27,14 @@ import {
 } from './amp-story-store-service';
 import {CSS} from '../../../build/amp-story-share-menu-1.0.css';
 import {Keys} from '../../../src/utils/key-codes';
+import {LocalizedStringId} from '../../../src/localized-strings';
 import {Services} from '../../../src/services';
 import {ShareWidget} from './amp-story-share';
 import {closest} from '../../../src/dom';
 import {createShadowRootWithStyle} from './utils';
-import {dev} from '../../../src/log';
+import {dev, devAssert} from '../../../src/log';
 import {getAmpdoc} from '../../../src/service';
+import {getLocalizationService} from './amp-story-localization-service';
 import {htmlFor} from '../../../src/static-template';
 import {setStyles} from '../../../src/style';
 
@@ -48,9 +50,9 @@ const getTemplate = (element) => {
   return htmlFor(element)`
     <div class="i-amphtml-story-share-menu i-amphtml-story-system-reset" aria-hidden="true" role="alert">
       <div class="i-amphtml-story-share-menu-container">
-        <span class="i-amphtml-story-share-menu-close-button" role="button">
+        <button class="i-amphtml-story-share-menu-close-button" role="button" aria-label="">
           &times;
-        </span>
+        </button>
       </div>
     </div>`;
 };
@@ -78,6 +80,9 @@ export class ShareMenu {
 
     /** @private {?Element} */
     this.element_ = null;
+
+    /** @private {?Element} */
+    this.closeButton_ = null;
 
     /** @private {?Element} */
     this.innerContainerEl_ = null;
@@ -164,6 +169,18 @@ export class ShareMenu {
 
     this.element_ = getTemplate(this.parentEl_);
     createShadowRootWithStyle(root, this.element_, CSS);
+
+    this.closeButton_ = dev().assertElement(
+      this.element_.querySelector('.i-amphtml-story-share-menu-close-button')
+    );
+    const localizationService = getLocalizationService(
+      devAssert(this.parentEl_)
+    );
+    devAssert(localizationService, 'Could not retrieve LocalizationService.');
+    const localizedCloseString = localizationService.getLocalizedString(
+      LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
+    );
+    this.closeButton_.setAttribute('aria-label', localizedCloseString);
 
     this.initializeListeners_();
 
@@ -252,7 +269,7 @@ export class ShareMenu {
   onShareMenuClick_(event) {
     const el = dev().assertElement(event.target);
 
-    if (el.classList.contains('i-amphtml-story-share-menu-close-button')) {
+    if (el === this.closeButton_) {
       this.close_();
     }
 

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -50,7 +50,7 @@ const getTemplate = (element) => {
   return htmlFor(element)`
     <div class="i-amphtml-story-share-menu i-amphtml-story-system-reset" aria-hidden="true" role="alert">
       <div class="i-amphtml-story-share-menu-container">
-        <button class="i-amphtml-story-share-menu-close-button" aria-label="">
+        <button class="i-amphtml-story-share-menu-close-button" aria-label="close">
           &times;
         </button>
       </div>
@@ -173,11 +173,15 @@ export class ShareMenu {
     this.closeButton_ = dev().assertElement(
       this.element_.querySelector('.i-amphtml-story-share-menu-close-button')
     );
-    const localizedCloseString =
-      getLocalizationService(devAssert(this.parentEl_)).getLocalizedString(
+    const localizationService = getLocalizationService(
+      devAssert(this.parentEl_)
+    );
+    if (localizationService) {
+      const localizedCloseString = localizationService.getLocalizedString(
         LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
-      ) || 'Close';
-    this.closeButton_.setAttribute('aria-label', localizedCloseString);
+      );
+      this.closeButton_.setAttribute('aria-label', localizedCloseString);
+    }
 
     this.initializeListeners_();
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -847,6 +847,7 @@ amp-story .amp-video-eq,
   background-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 36 36" fill="rgba(255, 255, 255, 0.8)"><path d="M28.5 9.62L26.38 7.5 18 15.88 9.62 7.5 7.5 9.62 15.88 18 7.5 26.38l2.12 2.12L18 20.12l8.38 8.38 2.12-2.12L20.12 18z"/><path d="M0 0h36v36H0z" fill="none"/></svg>') !important;
   cursor: pointer !important;
   text-align: center !important;
+  background-color: transparent !important; /* Resets default button background-color. */
 }
 
 @keyframes play-button-fly-in {


### PR DESCRIPTION
Contributes to #32493
Applies same pattern for close button in share menu and Twitter overlay.

- Uses `button` element
- Uses localized "close" string for `aria-label`
- Uses close button element reference in click event delegation