### PR TITLE
[ampproject/amphtml] ♿ [Story a11y] Empty img alt tags

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1855,13 +1855,11 @@ export class AmpStoryPage extends AMP.BaseElement {
   initializeImgAltTags_() {
     toArray(this.element.querySelectorAll('amp-img')).forEach((ampImgNode) => {
       if (!ampImgNode.getAttribute('alt')) {
-        ampImgNode.setAttribute('alt', ' ');
-        // If the child img element is in the dom, propogate the attribute to it.
+        ampImgNode.setAttribute('alt', '');
+        // If the child img element is in the dom, put empty alt on it.
         const childImgNode = ampImgNode.querySelector('img');
         childImgNode &&
-          ampImgNode
-            .getImpl()
-            .then((ampImg) => ampImg.propagateAttributes('alt', childImgNode));
+          ampImgNode.getImpl().then(() => childImgNode.setAttribute('alt', ''));
       }
     });
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1856,10 +1856,12 @@ export class AmpStoryPage extends AMP.BaseElement {
     toArray(this.element.querySelectorAll('amp-img')).forEach((ampImgNode) => {
       if (!ampImgNode.getAttribute('alt')) {
         ampImgNode.setAttribute('alt', '');
-        // If the child img element is in the dom, put empty alt on it.
+        // If the child img element is in the dom, propogate the attribute to it.
         const childImgNode = ampImgNode.querySelector('img');
         childImgNode &&
-          ampImgNode.getImpl().then(() => childImgNode.setAttribute('alt', ''));
+          ampImgNode.then((ampImg) =>
+            ampImg.propagateAttributes('alt', childImgNode)
+          );
       }
     });
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1859,9 +1859,9 @@ export class AmpStoryPage extends AMP.BaseElement {
         // If the child img element is in the dom, propogate the attribute to it.
         const childImgNode = ampImgNode.querySelector('img');
         childImgNode &&
-          ampImgNode.then((ampImg) =>
-            ampImg.propagateAttributes('alt', childImgNode)
-          );
+          ampImgNode
+            .getImpl()
+            .then((ampImg) => ampImg.propagateAttributes('alt', childImgNode));
       }
     });
   }


### PR DESCRIPTION
Contributes to #32493

Sets completely empty `alt` tag on images by default.