### PR TITLE
❄️ Deflake visual diff test `amp-story: bot rendering`

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-bot-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-bot-rendering.html
@@ -90,7 +90,7 @@
 
       <amp-story-page id="page2" title="This is a page title">
         <amp-story-grid-layer template="fill">
-          <amp-video
+          <amp-video autoplay
             controls="false"
             id="stamp-vid"
             width="400"

--- a/examples/visual-tests/amp-story/amp-story-bot-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-bot-rendering.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-social-share" src="https://cdn.ampproject.org/v0/amp-social-share-0.1.js"></script>
+    <script async custom-element="amp-video" src="https://cdn.ampproject.org/v0/amp-video-1.0.js"></script>
     <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed" rel="stylesheet">
     <title>Landscape story</title>
@@ -91,6 +91,7 @@
       <amp-story-page id="page2" title="This is a page title">
         <amp-story-grid-layer template="fill">
           <amp-video
+            controls="false"
             id="stamp-vid"
             width="400"
             height="750"

--- a/examples/visual-tests/amp-story/amp-story-bot-rendering.html
+++ b/examples/visual-tests/amp-story/amp-story-bot-rendering.html
@@ -90,7 +90,7 @@
 
       <amp-story-page id="page2" title="This is a page title">
         <amp-story-grid-layer template="fill">
-          <amp-video autoplay
+          <amp-video
             id="stamp-vid"
             width="400"
             height="750"


### PR DESCRIPTION
Removing `autoplay` attribute from `<amp-video>` which controls the mute/unmute button, which causes flakiness