### PR TITLE
🐛🏗 Fix building HTML fixtures during integration tests

### DIFF
--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -45,10 +45,11 @@ class Runner extends RuntimeTestRunner {
 
   /** @override */
   async maybeBuild() {
-    if (argv.nobuild) {
-      return;
+    if (!argv.nobuild) {
+      await buildRuntime();
     }
-    await buildRuntime();
+    // buildRuntime will clean the directory! We have to do this afterwards.
+    await buildTransformedHtml();
   }
 }
 
@@ -85,7 +86,6 @@ async function integration() {
   buildNewServer();
   htmlTransform = require('../server/new-server/transforms/dist/transform')
     .transform;
-  await buildTransformedHtml();
 
   maybePrintArgvMessages();
 


### PR DESCRIPTION
`buildRuntime` (which is run unless you specify `--nobuild` flag) does a full build system cleaning, which also wipes out the built `test-bin` directory. We need to compile the HTML fixtures _after_ it, so they're not immediately cleaned.

Fixes #32091