### PR TITLE
Revert "analytics: bail out for detached targets"

### DIFF
--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -24,7 +24,6 @@ import {
 import {AmpdocAnalyticsRoot, EmbedAnalyticsRoot} from './analytics-root';
 import {AnalyticsGroup} from './analytics-group';
 import {Services} from '../../../src/services';
-import {dev} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
 import {
@@ -35,7 +34,6 @@ import {
 } from '../../../src/service';
 
 const PROP = '__AMP_AN_ROOT';
-const TAG = 'ANALYTICS-INSTRUMENTATION';
 
 /**
  * @implements {../../../src/service.Disposable}
@@ -104,15 +102,6 @@ export class InstrumentationService {
     vars = dict(),
     enableDataVars = true
   ) {
-    if (!target.isConnected) {
-      dev().error(
-        TAG,
-        'Attempting to trigger event for detached target: %s',
-        target
-      );
-      return;
-    }
-
     const event = new AnalyticsEvent(target, eventType, vars, enableDataVars);
     const root = this.findRoot_(target);
     const trackerName = getTrackerKeyName(eventType);

--- a/extensions/amp-analytics/0.1/test/test-instrumentation.js
+++ b/extensions/amp-analytics/0.1/test/test-instrumentation.js
@@ -63,19 +63,6 @@ describes.realWin('InstrumentationService', {amp: 1}, (env) => {
     expect(event.type).to.equal('test-event');
     expect(event.vars).to.deep.equal({foo: 'bar'});
   });
-
-  it('should bail and emit error if element is detached', () => {
-    expectAsyncConsoleError(/detached/);
-    const detached = ampdoc.win.document.createElement('div');
-    const tracker = root.getTracker(
-      AnalyticsEventType.CUSTOM,
-      CustomEventTracker
-    );
-    const triggerStub = env.sandbox.stub(tracker, 'trigger');
-    service.triggerEventForTarget(detached, 'test-event');
-
-    expect(triggerStub).not.called;
-  });
 });
 
 describes.realWin(


### PR DESCRIPTION
Reverts ampproject/amphtml#32637

Potential "fix" to https://github.com/ampproject/error-reporting/issues/54.
Setting this up in case we want to eventually merge, we'll have the CI predone.