### PR TITLE
Isolate state in test-amp-a4a.js

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -739,7 +739,6 @@ const forbiddenTerms = {
       'ads/google/test/test-utils.js',
       'extensions/amp-a4a/0.1/test/test-a4a-integration.js',
       'extensions/amp-a4a/0.1/test/test-a4a-var-source.js',
-      'extensions/amp-a4a/0.1/test/test-amp-a4a.js',
       'extensions/amp-a4a/0.1/test/test-amp-ad-utils.js',
       'extensions/amp-a4a/0.1/test/test-refresh.js',
       'extensions/amp-access/0.1/test/test-access-expr.js',


### PR DESCRIPTION
- Moves all code inside a `describes` block.
- Removes any references to `window`.

Should help with weird flakes due to persistent state across runs. Closes #29517