### PR TITLE
Don't use getRootNode().createElement()

### DIFF
--- a/extensions/amp-access-laterpay/0.1/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.1/laterpay-impl.js
@@ -272,7 +272,7 @@ export class LaterpayVendor {
    */
   getArticleTitle_() {
     const title = this.ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelector(this.laterpayConfig_['articleTitleSelector']);
     userAssert(
       title,

--- a/extensions/amp-access-laterpay/0.2/laterpay-impl.js
+++ b/extensions/amp-access-laterpay/0.2/laterpay-impl.js
@@ -331,7 +331,7 @@ export class LaterpayVendor {
    */
   getArticleTitle_() {
     const title = this.ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelector(this.laterpayConfig_['articleTitleSelector']);
     userAssert(
       title,

--- a/extensions/amp-access-poool/0.1/poool-impl.js
+++ b/extensions/amp-access-poool/0.1/poool-impl.js
@@ -228,7 +228,7 @@ export class PooolVendor {
    */
   onRelease_() {
     const articlePreview = this.ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelector('[poool-access-preview]');
 
     if (articlePreview) {
@@ -238,7 +238,7 @@ export class PooolVendor {
     }
 
     const articleContent = this.ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelector('[poool-access-content]');
 
     if (articleContent) {

--- a/extensions/amp-access-scroll/0.1/scroll-impl.js
+++ b/extensions/amp-access-scroll/0.1/scroll-impl.js
@@ -131,7 +131,7 @@ export class ScrollAccessVendor extends AccessClientAdapter {
     // TODO(dbow): Handle timeout?
     return super.authorize().then((response) => {
       const isStory = this.ampdoc
-        .getRootNode()
+        .getDocumentOrShadowRoot()
         .querySelector('amp-story[standalone]');
 
       if (response && response['scroll']) {

--- a/extensions/amp-access/0.1/amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/amp-access-server-jwt.js
@@ -357,7 +357,7 @@ export class AccessServerJwtAdapter {
         const section = sections[i];
         const sectionId = section.getAttribute('i-amphtml-access-id');
         const target = this.ampdoc
-          .getRootNode()
+          .getDocumentOrShadowRoot()
           .querySelector(
             `[i-amphtml-access-id="${escapeCssSelectorIdent(sectionId)}"]`
           );

--- a/extensions/amp-access/0.1/amp-access-server.js
+++ b/extensions/amp-access/0.1/amp-access-server.js
@@ -201,7 +201,7 @@ export class AccessServerAdapter {
         const section = sections[i];
         const sectionId = section.getAttribute('i-amphtml-access-id');
         const target = this.ampdoc
-          .getRootNode()
+          .getDocumentOrShadowRoot()
           .querySelector(
             `[i-amphtml-access-id="${escapeCssSelectorIdent(sectionId)}"]`
           );

--- a/extensions/amp-access/0.1/amp-access-source.js
+++ b/extensions/amp-access/0.1/amp-access-source.js
@@ -262,7 +262,7 @@ export class AccessSource {
    * @private
    */
   getRootElement_() {
-    const root = this.ampdoc.getRootNode();
+    const root = this.ampdoc.getDocumentOrShadowRoot();
     return dev().assertElement(root.documentElement || root.body || root);
   }
 

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -144,7 +144,7 @@ export class AccessService {
 
     // Re-authorize newly added sections.
     ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .addEventListener(AmpEvents.DOM_UPDATE, this.onDomUpdate_.bind(this));
   }
 
@@ -288,7 +288,7 @@ export class AccessService {
    * @private
    */
   getRootElement_() {
-    const root = this.ampdoc.getRootNode();
+    const root = this.ampdoc.getDocumentOrShadowRoot();
     return dev().assertElement(root.documentElement || root.body || root);
   }
 
@@ -365,7 +365,7 @@ export class AccessService {
         // Guard against anything else in flight.
         this.lastAuthorizationPromises_.then(() => {
           this.ampdoc.whenReady().then(() => {
-            const root = this.ampdoc.getRootNode();
+            const root = this.ampdoc.getDocumentOrShadowRoot();
             const responses = this.combinedResponses();
             return this.applyAuthorizationToRoot_(root, responses);
           });
@@ -404,7 +404,7 @@ export class AccessService {
     const rendered = authorizations.then(() => {
       this.toggleTopClass_('amp-access-loading', false);
       return this.ampdoc.whenReady().then(() => {
-        const root = this.ampdoc.getRootNode();
+        const root = this.ampdoc.getDocumentOrShadowRoot();
         const responses = this.combinedResponses();
         return this.applyAuthorizationToRoot_(root, responses);
       });
@@ -659,7 +659,7 @@ export class AccessService {
       unlistenSet.push(this.viewport_.onScroll(resolve));
 
       // 4. Tap: register a view.
-      unlistenSet.push(listenOnce(this.ampdoc.getRootNode(), 'click', resolve));
+      unlistenSet.push(listenOnce(this.ampdoc.getDocumentOrShadowRoot(), 'click', resolve));
     }).then(
       () => {
         unlistenSet.forEach((unlisten) => unlisten());

--- a/extensions/amp-analytics/0.1/activity-impl.js
+++ b/extensions/amp-analytics/0.1/activity-impl.js
@@ -238,13 +238,13 @@ export class Activity {
   /** @private */
   setUpActivityListeners_() {
     this.setUpListenersFromArray_(
-      this.ampdoc.getRootNode(),
+      this.ampdoc.getDocumentOrShadowRoot(),
       ACTIVE_EVENT_TYPES,
       this.boundHandleActivity_
     );
 
     this.setUpListenersFromArray_(
-      this.ampdoc.getRootNode(),
+      this.ampdoc.getDocumentOrShadowRoot(),
       INACTIVE_EVENT_TYPES,
       this.boundHandleInactive_
     );

--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -493,7 +493,7 @@ export class AmpdocAnalyticsRoot extends AnalyticsRoot {
 
   /** @override */
   getRoot() {
-    return this.ampdoc.getRootNode();
+    return this.ampdoc.getDocumentOrShadowRoot();
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/instrumentation.js
+++ b/extensions/amp-analytics/0.1/instrumentation.js
@@ -51,7 +51,7 @@ export class InstrumentationService {
     this.ampdoc = ampdoc;
 
     /** @const */
-    this.root_ = this.findRoot_(ampdoc.getRootNode());
+    this.root_ = this.findRoot_(ampdoc.getDocumentOrShadowRoot());
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/visibility-manager.js
+++ b/extensions/amp-analytics/0.1/visibility-manager.js
@@ -623,7 +623,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
 
     if (getMode(this.ampdoc.win).runtime == 'inabox') {
       // In-a-box: visibility depends on the InOb.
-      const root = this.ampdoc.getRootNode();
+      const root = this.ampdoc.getDocumentOrShadowRoot();
       const rootElement = dev().assertElement(
         root.documentElement || root.body || root
       );
@@ -695,7 +695,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
 
   /** @override */
   getRootMinOpacity() {
-    const root = this.ampdoc.getRootNode();
+    const root = this.ampdoc.getDocumentOrShadowRoot();
     const rootElement = dev().assertElement(
       root.documentElement || root.body || root
     );
@@ -705,7 +705,7 @@ export class VisibilityManagerForDoc extends VisibilityManager {
   /** @override */
   getRootLayoutBox() {
     // This code is the same for "in-a-box" and standalone doc.
-    const root = this.ampdoc.getRootNode();
+    const root = this.ampdoc.getDocumentOrShadowRoot();
     const rootElement = dev().assertElement(
       root.documentElement || root.body || root
     );

--- a/extensions/amp-animation/0.1/amp-animation.js
+++ b/extensions/amp-animation/0.1/amp-animation.js
@@ -479,7 +479,7 @@ export class AmpAnimation extends AMP.BaseElement {
     return Promise.all([polyfillPromise, readyPromise]).then(() => {
       const builder = new Builder(
         hostWin,
-        this.getRootNode_(),
+        this.getDocumentOrShadowRoot_(),
         baseUrl,
         this.getVsync(),
         Services.ownersForDoc(this.element.getAmpDoc())
@@ -492,8 +492,8 @@ export class AmpAnimation extends AMP.BaseElement {
    * @return {!Document|!ShadowRoot}
    * @private
    */
-  getRootNode_() {
-    return this.getAmpDoc().getRootNode();
+  getDocumentOrShadowRoot_() {
+    return this.getAmpDoc().getDocumentOrShadowRoot();
   }
 
   /** @private */

--- a/extensions/amp-animation/0.1/web-animation-service.js
+++ b/extensions/amp-animation/0.1/web-animation-service.js
@@ -42,7 +42,7 @@ export class WebAnimationService {
       () =>
         new Builder(
           this.ampdoc_.win,
-          this.ampdoc_.getRootNode(),
+          this.ampdoc_.getDocumentOrShadowRoot(),
           this.ampdoc_.getUrl(),
           this.vsync_,
           this.owners_,

--- a/extensions/amp-apester-media/0.1/utils.js
+++ b/extensions/amp-apester-media/0.1/utils.js
@@ -139,7 +139,7 @@ export function extractTags(ampdoc, element) {
   const concatedTags = extractedTags.concat(
     articleMetaTags.length
       ? articleMetaTags
-      : extractTitle(ampdoc.getRootNode()) || []
+      : extractTitle(ampdoc.getDocumentOrShadowRoot()) || []
   );
   const loweredCase = concatedTags.map((tag) => tag.toLowerCase().trim());
   const noDuplication = loweredCase.filter(

--- a/extensions/amp-auto-ads/0.1/ad-tracker.js
+++ b/extensions/amp-auto-ads/0.1/ad-tracker.js
@@ -171,7 +171,7 @@ export class AdTracker {
  */
 export function getExistingAds(ampdoc) {
   return [].slice
-    .call(ampdoc.getRootNode().querySelectorAll('AMP-AD'))
+    .call(ampdoc.getDocumentOrShadowRoot().querySelectorAll('AMP-AD'))
     .filter((ad) => {
       // Filters out AMP-STICKY-AD.
       if (ad.parentElement && ad.parentElement.tagName == 'AMP-STICKY-AD') {

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -70,7 +70,7 @@ export class AnchorAdStrategy {
    * @private
    */
   hasExistingStickyAd_() {
-    return !!this.ampdoc.getRootNode().querySelector('AMP-STICKY-AD');
+    return !!this.ampdoc.getDocumentOrShadowRoot().querySelector('AMP-STICKY-AD');
   }
 
   /**

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -371,7 +371,7 @@ function getPlacementsFromObject(ampdoc, placementObj, placements) {
     user().warn(TAG, 'No anchor in placement');
     return;
   }
-  const anchorElements = getAnchorElements(ampdoc.getRootNode(), anchor);
+  const anchorElements = getAnchorElements(ampdoc.getDocumentOrShadowRoot(), anchor);
   if (!anchorElements.length) {
     user().warn(TAG, 'No anchor element found');
     return;

--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -118,7 +118,7 @@ const NOOP = () => {};
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @return {!Document|!ShadowRoot}
  */
-const getRootNode = (ampdoc) => ampdoc.getRootNode();
+const getDocumentOrShadowRoot = (ampdoc) => ampdoc.getDocumentOrShadowRoot();
 
 /** @visibleForTesting */
 export class Criteria {
@@ -315,7 +315,7 @@ export class DocMetaAnnotations {
    * @return {string|undefined}
    */
   static getOgType(ampdoc) {
-    const tag = getRootNode(ampdoc).querySelector(META_OG_TYPE);
+    const tag = getDocumentOrShadowRoot(ampdoc).querySelector(META_OG_TYPE);
     if (tag) {
       return tag.getAttribute('content');
     }
@@ -336,7 +336,7 @@ export class DocMetaAnnotations {
    * @return {!Array<string>}
    */
   static getAllLdJsonTypes(ampdoc) {
-    return toArray(getRootNode(ampdoc).querySelectorAll(SCRIPT_LD_JSON))
+    return toArray(getDocumentOrShadowRoot(ampdoc).querySelectorAll(SCRIPT_LD_JSON))
       .map((el) => {
         const {textContent} = el;
         return (tryParseJson(textContent) || {})['@type'];
@@ -369,7 +369,7 @@ function usesLightboxExplicitly(ampdoc) {
 
   const lightboxedElementsSelector = `[${LIGHTBOXABLE_ATTR}]:not([${VISITED_ATTR}])`;
 
-  const exists = (selector) => !!getRootNode(ampdoc).querySelector(selector);
+  const exists = (selector) => !!getDocumentOrShadowRoot(ampdoc).querySelector(selector);
 
   return (
     exists(requiredExtensionSelector) && exists(lightboxedElementsSelector)
@@ -467,7 +467,7 @@ export function scan(ampdoc, opt_root) {
 AMP.extension(TAG, '0.1', (AMP) => {
   const {ampdoc} = AMP;
   ampdoc.whenReady().then(() => {
-    getRootNode(ampdoc).addEventListener(AmpEvents.DOM_UPDATE, (e) => {
+    getDocumentOrShadowRoot(ampdoc).addEventListener(AmpEvents.DOM_UPDATE, (e) => {
       const {target} = e;
       scan(ampdoc, dev().assertElement(target));
     });

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -197,7 +197,7 @@ export class Bind {
     /** @const @private {!Promise<!Document>} */
     this.rootNodePromise_ = ampdoc.whenFirstVisible().then(() => {
       // Otherwise, scan the root node of the ampdoc.
-      return ampdoc.whenReady().then(() => ampdoc.getRootNode());
+      return ampdoc.whenReady().then(() => ampdoc.getDocumentOrShadowRoot());
     });
 
     /**

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -894,7 +894,7 @@ export class AmpDatePicker extends AMP.BaseElement {
   setupDateField_(type) {
     const fieldSelector = this.element.getAttribute(`${type}-selector`);
     const existingField = this.getAmpDoc()
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelector(fieldSelector);
     if (existingField) {
       if (
@@ -958,7 +958,7 @@ export class AmpDatePicker extends AMP.BaseElement {
    */
   setupListeners_() {
     const ampdoc = this.getAmpDoc();
-    const root = ampdoc.getRootNode().documentElement || ampdoc.getBody();
+    const root = ampdoc.getDocumentOrShadowRoot().documentElement || ampdoc.getBody();
     // Only add for overlay since click events just handle opening and closing
     if (this.mode_ == DatePickerMode.OVERLAY) {
       this.listen_(root, 'click', this.handleClick_.bind(this));
@@ -1306,7 +1306,7 @@ export class AmpDatePicker extends AMP.BaseElement {
       .map((t) => ({
         dates: new DatesList(t.dates),
         template: ampdoc
-          .getRootNode()
+          .getDocumentOrShadowRoot()
           .querySelector(`#${escapeCssSelectorIdent(t.id)}[date-template]`),
       }));
 

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -161,7 +161,7 @@ export class AmpFont extends AMP.BaseElement {
   onFontLoadFinish_(addClassName, removeClassName) {
     const ampdoc = this.getAmpDoc();
     // Add the class to <html> unless in ShadowRoot, where we append to <body>
-    const root = ampdoc.getRootNode().documentElement || ampdoc.getBody();
+    const root = ampdoc.getDocumentOrShadowRoot().documentElement || ampdoc.getBody();
     if (addClassName) {
       root.classList.add(addClassName);
     }

--- a/extensions/amp-form/0.1/amp-form-textarea.js
+++ b/extensions/amp-form/0.1/amp-form-textarea.js
@@ -47,7 +47,7 @@ export class AmpFormTextarea {
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   static install(ampdoc) {
-    const root = ampdoc.getRootNode();
+    const root = ampdoc.getDocumentOrShadowRoot();
 
     let ampFormTextarea = null;
     const maybeInstall = () => {
@@ -72,7 +72,7 @@ export class AmpFormTextarea {
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
-    const root = ampdoc.getRootNode();
+    const root = ampdoc.getDocumentOrShadowRoot();
 
     /** @private @const */
     this.doc_ = root.ownerDocument || root;

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -1624,7 +1624,7 @@ export class AmpFormService {
    */
   installHandlers_(ampdoc) {
     return ampdoc.whenReady().then(() => {
-      const root = ampdoc.getRootNode();
+      const root = ampdoc.getDocumentOrShadowRoot();
 
       this.installSubmissionHandlers_(root.querySelectorAll('form'));
       AmpFormTextarea.install(ampdoc);

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -89,7 +89,7 @@ export class FormValidator {
     this.mutator = Services.mutatorForDoc(form);
 
     /** @protected @const {!Document|!ShadowRoot} */
-    this.root = this.ampdoc.getRootNode();
+    this.root = this.ampdoc.getDocumentOrShadowRoot();
 
     /**
      * Tribool indicating last known validity of form.

--- a/extensions/amp-form/0.1/test/test-amp-form-textarea.js
+++ b/extensions/amp-form/0.1/test/test-amp-form-textarea.js
@@ -35,7 +35,7 @@ describes.realWin(
   (env) => {
     let doc;
     beforeEach(() => {
-      doc = env.ampdoc.getRootNode();
+      doc = env.ampdoc.getDocumentOrShadowRoot();
       installStylesForDoc(env.ampdoc, CSS, () => {}, false, 'amp-form');
     });
 

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -71,7 +71,7 @@ describes.repeated(
         let mutateElementStub;
 
         beforeEach(() => {
-          document = env.ampdoc.getRootNode();
+          document = env.ampdoc.getDocumentOrShadowRoot();
           timer = Services.timerFor(env.win);
           const ownerDoc = document.ownerDocument || document;
           createElement = (tagName, attrs) =>
@@ -780,7 +780,7 @@ describes.repeated(
             };
 
             const bubbleEl = env.ampdoc
-              .getRootNode()
+              .getDocumentOrShadowRoot()
               .querySelector('.i-amphtml-validation-bubble');
             const validationBubble = bubbleEl['__BUBBLE_OBJ'];
             env.sandbox.spy(validationBubble, 'show');
@@ -3373,7 +3373,7 @@ describes.repeated(
         let createElement;
 
         beforeEach(() => {
-          doc = env.ampdoc.getRootNode();
+          doc = env.ampdoc.getDocumentOrShadowRoot();
           const ownerDoc = doc.ownerDocument || doc;
           createElement = ownerDoc.createElement.bind(ownerDoc);
         });

--- a/extensions/amp-form/0.1/test/test-validation-bubble.js
+++ b/extensions/amp-form/0.1/test/test-validation-bubble.js
@@ -19,7 +19,7 @@ import {ValidationBubble} from '../validation-bubble';
 describes.realWin('validation-bubble', {amp: true}, (env) => {
   it('should append a dom element to the document', () => {
     const {ampdoc} = env;
-    const document = ampdoc.getRootNode();
+    const document = ampdoc.getDocumentOrShadowRoot();
 
     new ValidationBubble(ampdoc);
     expect(document.querySelector('.i-amphtml-validation-bubble')).to.not.be
@@ -28,7 +28,7 @@ describes.realWin('validation-bubble', {amp: true}, (env) => {
 
   it('should show and hide bubble', () => {
     const {ampdoc} = env;
-    const document = ampdoc.getRootNode();
+    const document = ampdoc.getDocumentOrShadowRoot();
 
     const targetEl = document.createElement('div');
     targetEl.textContent = 'I am the target!';

--- a/extensions/amp-fx-collection/0.1/amp-fx-collection.js
+++ b/extensions/amp-fx-collection/0.1/amp-fx-collection.js
@@ -48,7 +48,7 @@ export class AmpFxCollection {
     this.seen_ = [];
 
     Promise.all([ampdoc.whenReady(), ampdoc.whenFirstVisible()]).then(() => {
-      const root = this.ampdoc_.getRootNode();
+      const root = this.ampdoc_.getDocumentOrShadowRoot();
       // Scan when page becomes visible.
       this.scan_();
       // Rescan as DOM changes happen.
@@ -61,7 +61,7 @@ export class AmpFxCollection {
    * fx provider.
    */
   scan_() {
-    const elements = this.ampdoc_.getRootNode().querySelectorAll('[amp-fx]');
+    const elements = this.ampdoc_.getDocumentOrShadowRoot().querySelectorAll('[amp-fx]');
     iterateCursor(elements, (element) => {
       if (this.seen_.includes(element)) {
         return;

--- a/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/amp-gwd-animation.js
@@ -167,7 +167,7 @@ export class GwdAnimation extends AMP.BaseElement {
    * @private
    */
   getRoot_() {
-    return this.fie_ ? this.fie_.win.document : this.getAmpDoc().getRootNode();
+    return this.fie_ ? this.fie_.win.document : this.getAmpDoc().getDocumentOrShadowRoot();
   }
 
   /**

--- a/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
+++ b/extensions/amp-gwd-animation/0.1/test/test-amp-gwd-animation.js
@@ -90,7 +90,7 @@ describes.sandboxed('AMP GWD Animation', {}, () => {
           beforeEach(() => {
             ampdoc = env.ampdoc;
             win = ampdoc.win;
-            doc = ampdoc.getRootNode();
+            doc = ampdoc.getDocumentOrShadowRoot();
 
             // Create a test amp-carousel GWD page deck.
             doc.body.innerHTML = `<amp-carousel id="pagedeck"

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -837,7 +837,7 @@ export class AmpIframe extends AMP.BaseElement {
   isUserGesture_() {
     // Best effort polyfill until native support is available: check that
     // iframe has focus and audio playback isn't immediately paused.
-    if (this.getAmpDoc().getRootNode().activeElement !== this.iframe_) {
+    if (this.getAmpDoc().getDocumentOrShadowRoot().activeElement !== this.iframe_) {
       return false;
     }
     const audio = this.win.document.createElement('audio');

--- a/extensions/amp-inputmask/0.1/amp-inputmask.js
+++ b/extensions/amp-inputmask/0.1/amp-inputmask.js
@@ -34,7 +34,7 @@ export class AmpInputmaskService {
 
     /** @const */
     this.domUpdateUnlistener_ = listen(
-      this.ampdoc.getRootNode(),
+      this.ampdoc.getDocumentOrShadowRoot(),
       AmpEvents.DOM_UPDATE,
       () => this.install()
     );
@@ -45,7 +45,7 @@ export class AmpInputmaskService {
    */
   install() {
     const maskElements = this.ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelectorAll('input[mask]');
     iterateCursor(maskElements, (element) => {
       if (TextMask.isMasked(element)) {

--- a/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
+++ b/extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js
@@ -280,7 +280,7 @@ class UrlRewriter_ {
     /** @const @private {!Location} */
     this.shellLoc_ = this.urlService_.parse(shellUrl);
 
-    listen(ampdoc.getRootNode(), 'click', this.handle_.bind(this));
+    listen(ampdoc.getDocumentOrShadowRoot(), 'click', this.handle_.bind(this));
   }
 
   /**

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -1413,7 +1413,7 @@ export function installLightboxGallery(ampdoc) {
     .whenReady()
     .then(() => ampdoc.getBody())
     .then((body) => {
-      const existingGallery = elementByTag(ampdoc.getRootNode(), TAG);
+      const existingGallery = elementByTag(ampdoc.getDocumentOrShadowRoot(), TAG);
       if (!existingGallery) {
         const gallery = ampdoc.win.document.createElement(TAG);
         gallery.setAttribute('layout', 'nodisplay');

--- a/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
+++ b/extensions/amp-lightbox-gallery/0.1/service/lightbox-manager-impl.js
@@ -142,7 +142,7 @@ export class LightboxManager {
 
     this.scanPromise_ = this.scanLightboxables_();
 
-    const root = this.ampdoc_.getRootNode();
+    const root = this.ampdoc_.getDocumentOrShadowRoot();
 
     // Rescan whenever DOM changes happen.
     root.addEventListener(AmpEvents.DOM_UPDATE, () => {
@@ -166,7 +166,7 @@ export class LightboxManager {
    */
   scanLightboxables_() {
     return this.ampdoc_.whenReady().then(() => {
-      const matches = this.ampdoc_.getRootNode().querySelectorAll('[lightbox]');
+      const matches = this.ampdoc_.getDocumentOrShadowRoot().querySelectorAll('[lightbox]');
       const processLightboxElement = this.processLightboxElement_.bind(this);
       iterateCursor(matches, processLightboxElement);
     });
@@ -291,7 +291,7 @@ export class LightboxManager {
     if (isActionableByTap(element)) {
       return;
     }
-    const gallery = elementByTag(this.ampdoc_.getRootNode(), GALLERY_TAG);
+    const gallery = elementByTag(this.ampdoc_.getDocumentOrShadowRoot(), GALLERY_TAG);
     const actions = Services.actionServiceForDoc(element);
     actions.setActions(element, `tap:${gallery.id}.activate`);
   }

--- a/extensions/amp-link-rewriter/0.1/scope.js
+++ b/extensions/amp-link-rewriter/0.1/scope.js
@@ -23,7 +23,7 @@ import {iterateCursor} from '../../../src/dom';
  * @return {!Array<!Element>}
  */
 export function getScopeElements(ampDoc, configOpts) {
-  const doc = ampDoc.getRootNode();
+  const doc = ampDoc.getDocumentOrShadowRoot();
   let cssSelector = configOpts.section.join(' a, ');
   let selection = doc.querySelectorAll('a');
   const filteredSelection = [];

--- a/extensions/amp-link-rewriter/0.1/test/test-amp-link-rewriter.js
+++ b/extensions/amp-link-rewriter/0.1/test/test-amp-link-rewriter.js
@@ -66,7 +66,7 @@ describes.fakeWin(
 
     it('Should match the built url', () => {
       const linkRewriterElement = helpers.createLinkRewriterElement(config);
-      env.ampdoc.getRootNode().body.appendChild(linkRewriterElement);
+      env.ampdoc.getDocumentOrShadowRoot().body.appendChild(linkRewriterElement);
 
       const rewriter = new LinkRewriter('', linkRewriterElement, env.ampdoc);
 

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -74,7 +74,7 @@ export class LiveListManager {
     this.work_ = this.fetchDocument_.bind(this);
 
     /** @private @const {boolean} */
-    this.isTransformed_ = isDocTransformed(ampdoc.getRootNode());
+    this.isTransformed_ = isDocTransformed(ampdoc.getDocumentOrShadowRoot());
 
     // Only start polling when doc is ready and when the doc is visible.
     this.whenDocReady_().then(() => {

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -179,7 +179,7 @@ describes.realWin(
         const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
         yield shadowDoc.whenReady();
 
-        const shadowRoot = shadowDoc.getRootNode();
+        const shadowRoot = shadowDoc.getDocumentOrShadowRoot();
 
         expect(shadowRoot.querySelector('header')).to.have.class(
           'i-amphtml-next-page-hidden'
@@ -213,7 +213,7 @@ describes.realWin(
         yield macroTask();
         const shadowDoc = attachShadowDocSpy.firstCall.returnValue.ampdoc;
         yield shadowDoc.whenReady();
-        const shadowRoot = shadowDoc.getRootNode();
+        const shadowRoot = shadowDoc.getDocumentOrShadowRoot();
         expect(shadowRoot.getElementById('analytics1')).to.be.null;
         expect(shadowRoot.getElementById('analytics2')).to.be.null;
       });

--- a/extensions/amp-next-page/1.0/page.js
+++ b/extensions/amp-next-page/1.0/page.js
@@ -108,7 +108,7 @@ export class Page {
     if (!this.shadowDoc_) {
       return;
     }
-    return this.shadowDoc_.ampdoc.getRootNode();
+    return this.shadowDoc_.ampdoc.getDocumentOrShadowRoot();
   }
 
   /** @return {?Element} */

--- a/extensions/amp-onetap-google/0.1/amp-onetap-google.js
+++ b/extensions/amp-onetap-google/0.1/amp-onetap-google.js
@@ -189,7 +189,7 @@ export class AmpOnetapGoogle extends AMP.BaseElement {
     if (this.iframe_) {
       return;
     }
-    this.iframe_ = this.getAmpDoc().getRootNode().createElement('iframe');
+    this.iframe_ = this.getAmpDoc().win.document.createElement('iframe');
 
     // Don't insert <iframe> until URL has been expanded.
     // Likewise, don't display the UI until then.

--- a/extensions/amp-onetap-google/0.1/amp-onetap-google.js
+++ b/extensions/amp-onetap-google/0.1/amp-onetap-google.js
@@ -216,7 +216,7 @@ export class AmpOnetapGoogle extends AMP.BaseElement {
       listen(this.win, 'message', (event) => {
         this.handleIntermediateIframeMessage_(origin, event);
       }),
-      listen(this.getAmpDoc().getRootNode(), 'click', () => {
+      listen(this.getAmpDoc().getDocumentOrShadowRoot(), 'click', () => {
         if (
           this.shouldCancelOnTapOutside_ &&
           !this.element.hasAttribute('hidden')

--- a/extensions/amp-sidebar/0.1/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test/test-toolbar.js
@@ -124,7 +124,7 @@ describe('amp-sidebar - toolbar', () => {
           toolbar.onLayoutChange();
         });
         const toolbarElements = toArray(
-          obj.ampdoc.getRootNode().getElementsByClassName('i-amphtml-toolbar')
+          obj.ampdoc.getDocumentOrShadowRoot().getElementsByClassName('i-amphtml-toolbar')
         );
         resizeIframeToWidth(obj.iframe, '1px', () => {
           toolbars.forEach((toolbar) => {
@@ -146,7 +146,7 @@ describe('amp-sidebar - toolbar', () => {
           toolbar.onLayoutChange();
         });
         const toolbarElements = toArray(
-          obj.ampdoc.getRootNode().getElementsByClassName('i-amphtml-toolbar')
+          obj.ampdoc.getDocumentOrShadowRoot().getElementsByClassName('i-amphtml-toolbar')
         );
         expect(toolbarElements.length).to.be.above(0);
         expect(toolbarElements[0].parentElement).to.not.have.display('none');
@@ -169,7 +169,7 @@ describe('amp-sidebar - toolbar', () => {
         });
         const toolbarQuery = `#${targetId} > nav[toolbar]`;
         const toolbarTargetElements = toArray(
-          obj.ampdoc.getRootNode().querySelectorAll(toolbarQuery)
+          obj.ampdoc.getDocumentOrShadowRoot().querySelectorAll(toolbarQuery)
         );
         expect(toolbars.length).to.be.equal(1);
         expect(toolbarTargetElements.length).to.be.equal(1);
@@ -187,7 +187,7 @@ describe('amp-sidebar - toolbar', () => {
     ]).then((obj) => {
       const {toolbars} = obj;
       const toolbarTargets = toArray(
-        obj.ampdoc.getRootNode().querySelectorAll(`#${targetId}`)
+        obj.ampdoc.getDocumentOrShadowRoot().querySelectorAll(`#${targetId}`)
       );
       resizeIframeToWidth(obj.iframe, '4000px', () => {
         toolbars.forEach((toolbar) => {
@@ -210,7 +210,7 @@ describe('amp-sidebar - toolbar', () => {
     ]).then((obj) => {
       const {toolbars} = obj;
       const toolbarTargets = toArray(
-        obj.ampdoc.getRootNode().querySelectorAll(`#${targetId}`)
+        obj.ampdoc.getDocumentOrShadowRoot().querySelectorAll(`#${targetId}`)
       );
       resizeIframeToWidth(obj.iframe, '200px', () => {
         toolbars.forEach((toolbar) => {
@@ -237,7 +237,7 @@ describe('amp-sidebar - toolbar', () => {
         });
         const toolbarNavElementsWithState = toArray(
           obj.ampdoc
-            .getRootNode()
+            .getDocumentOrShadowRoot()
             .querySelectorAll('nav[toolbar].amp-sidebar-toolbar-target-shown')
         );
         expect(toolbarNavElementsWithState.length).to.be.equal(1);
@@ -260,7 +260,7 @@ describe('amp-sidebar - toolbar', () => {
         });
         const toolbarNavElementsWithState = toArray(
           obj.ampdoc
-            .getRootNode()
+            .getDocumentOrShadowRoot()
             .querySelectorAll('nav[toolbar].amp-sidebar-toolbar-target-hidden')
         );
         expect(toolbarNavElementsWithState.length).to.be.equal(1);

--- a/extensions/amp-sidebar/0.2/test/test-toolbar.js
+++ b/extensions/amp-sidebar/0.2/test/test-toolbar.js
@@ -121,7 +121,7 @@ describes.realWin('amp-sidebar - toolbar', {}, (env) => {
           toolbar.onLayoutChange();
         });
         const toolbarElements = toArray(
-          obj.ampdoc.getRootNode().getElementsByClassName('i-amphtml-toolbar')
+          obj.ampdoc.getDocumentOrShadowRoot().getElementsByClassName('i-amphtml-toolbar')
         );
         resizeIframeToWidth(obj.iframe, '1px', () => {
           toolbars.forEach((toolbar) => {
@@ -143,7 +143,7 @@ describes.realWin('amp-sidebar - toolbar', {}, (env) => {
           toolbar.onLayoutChange();
         });
         const toolbarElements = toArray(
-          obj.ampdoc.getRootNode().getElementsByClassName('i-amphtml-toolbar')
+          obj.ampdoc.getDocumentOrShadowRoot().getElementsByClassName('i-amphtml-toolbar')
         );
         expect(toolbarElements.length).to.be.above(0);
         expect(toolbarElements[0].parentElement).to.not.have.display('none');
@@ -166,7 +166,7 @@ describes.realWin('amp-sidebar - toolbar', {}, (env) => {
         });
         const toolbarQuery = `#${targetId} > nav[toolbar]`;
         const toolbarTargetElements = toArray(
-          obj.ampdoc.getRootNode().querySelectorAll(toolbarQuery)
+          obj.ampdoc.getDocumentOrShadowRoot().querySelectorAll(toolbarQuery)
         );
         expect(toolbars.length).to.be.equal(1);
         expect(toolbarTargetElements.length).to.be.equal(1);
@@ -184,7 +184,7 @@ describes.realWin('amp-sidebar - toolbar', {}, (env) => {
     ]).then((obj) => {
       const {toolbars} = obj;
       const toolbarTargets = toArray(
-        obj.ampdoc.getRootNode().querySelectorAll(`#${targetId}`)
+        obj.ampdoc.getDocumentOrShadowRoot().querySelectorAll(`#${targetId}`)
       );
       resizeIframeToWidth(obj.iframe, '4000px', () => {
         toolbars.forEach((toolbar) => {
@@ -207,7 +207,7 @@ describes.realWin('amp-sidebar - toolbar', {}, (env) => {
     ]).then((obj) => {
       const {toolbars} = obj;
       const toolbarTargets = toArray(
-        obj.ampdoc.getRootNode().querySelectorAll(`#${targetId}`)
+        obj.ampdoc.getDocumentOrShadowRoot().querySelectorAll(`#${targetId}`)
       );
       resizeIframeToWidth(obj.iframe, '200px', () => {
         toolbars.forEach((toolbar) => {
@@ -234,7 +234,7 @@ describes.realWin('amp-sidebar - toolbar', {}, (env) => {
         });
         const toolbarNavElementsWithState = toArray(
           obj.ampdoc
-            .getRootNode()
+            .getDocumentOrShadowRoot()
             .querySelectorAll('nav[toolbar].amp-sidebar-toolbar-target-shown')
         );
         expect(toolbarNavElementsWithState.length).to.be.equal(1);
@@ -257,7 +257,7 @@ describes.realWin('amp-sidebar - toolbar', {}, (env) => {
         });
         const toolbarNavElementsWithState = toArray(
           obj.ampdoc
-            .getRootNode()
+            .getDocumentOrShadowRoot()
             .querySelectorAll('nav[toolbar].amp-sidebar-toolbar-target-hidden')
         );
         expect(toolbarNavElementsWithState.length).to.be.equal(1);

--- a/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter-manager.js
+++ b/extensions/amp-skimlinks/0.1/link-rewriter/link-rewriter-manager.js
@@ -54,12 +54,12 @@ export class LinkRewriterManager {
    */
   constructor(ampdoc) {
     /**
-     * Use getRootNode() to support "shadow AMP" mode where the rootNode is not
+     * Use getDocumentOrShadowRoot() to support "shadow AMP" mode where the rootNode is not
      * necessarily the page document.
      * See https://www.ampproject.org/docs/integration/pwa-amp/amp-in-pwa
      * @private {!Document|!ShadowRoot}
      */
-    this.rootNode_ = ampdoc.getRootNode();
+    this.rootNode_ = ampdoc.getDocumentOrShadowRoot();
 
     /**
      * List of link rewriter Id in priority order as defined

--- a/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
+++ b/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
@@ -37,7 +37,7 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, (env) => {
 
   beforeEach(() => {
     win = env.win;
-    rootDocument = env.ampdoc.getRootNode();
+    rootDocument = env.ampdoc.getDocumentOrShadowRoot();
     env.sandbox.spy(rootDocument, 'addEventListener');
     env.sandbox.spy(rootDocument, 'querySelector');
 
@@ -443,7 +443,7 @@ describes.fakeWin('Link Rewriter', {amp: true}, (env) => {
     env.sandbox.stub(chunkModule, 'chunk').callsFake((node, task) => {
       task();
     });
-    rootDocument = env.ampdoc.getRootNode();
+    rootDocument = env.ampdoc.getDocumentOrShadowRoot();
 
     createResolveResponseHelper = (syncData, asyncData) => {
       const twoStepsResponse = new TwoStepsResponse(syncData, asyncData);
@@ -778,7 +778,7 @@ describes.fakeWin('LinkReplacementCache', {amp: true}, (env) => {
   let rootDocument, cache, anchor1, anchor2, anchor3;
 
   beforeEach(() => {
-    rootDocument = env.ampdoc.getRootNode();
+    rootDocument = env.ampdoc.getDocumentOrShadowRoot();
     anchor1 = rootDocument.createElement('a');
     anchor2 = rootDocument.createElement('a');
     anchor3 = rootDocument.createElement('a');

--- a/extensions/amp-standalone/0.1/amp-standalone.js
+++ b/extensions/amp-standalone/0.1/amp-standalone.js
@@ -46,7 +46,7 @@ export class StandaloneService {
    * Add an event listener to change the link navigation behavior.
    */
   initialize() {
-    listen(this.ampdoc_.getRootNode(), 'click', (event) =>
+    listen(this.ampdoc_.getDocumentOrShadowRoot(), 'click', (event) =>
       this.handleClick_(event)
     );
   }

--- a/extensions/amp-story/1.0/bookend/amp-story-bookend.js
+++ b/extensions/amp-story/1.0/bookend/amp-story-bookend.js
@@ -658,7 +658,7 @@ export class AmpStoryBookend extends DraggableDrawer {
    * @private
    */
   getStoryMetadata_() {
-    const jsonLd = getJsonLd(this.getAmpDoc().getRootNode());
+    const jsonLd = getJsonLd(this.getAmpDoc().getDocumentOrShadowRoot());
 
     const urlService = Services.urlForDoc(this.element);
     const {canonicalUrl} = Services.documentInfoForDoc(this.getAmpDoc());

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -139,7 +139,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, (env) => {
     env.sandbox
       .stub(serviceAdapter, 'getReaderId')
       .callsFake(() => Promise.resolve('ari1'));
-    const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
+    const analytics = new SubscriptionAnalytics(ampdoc.getDocumentOrShadowRoot());
     env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
     analyticsMock = env.sandbox.mock(analytics);
     getEncryptedDocumentKeyStub = env.sandbox

--- a/extensions/amp-subscriptions/0.1/crypto-handler.js
+++ b/extensions/amp-subscriptions/0.1/crypto-handler.js
@@ -38,7 +38,7 @@ export class CryptoHandler {
     this.decryptionPromise_ = null;
 
     const parsedEncryptedKeys = this.ampdoc_
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelector('script[cryptokeys]');
 
     /** @private {?string} */
@@ -123,7 +123,7 @@ export class CryptoHandler {
       const keybytes = base64Decode(decryptedDocumentKey);
       return safeAesGcmImportKey(keybytes.buffer).then((formattedkey) => {
         const encryptedSections = this.ampdoc_
-          .getRootNode()
+          .getDocumentOrShadowRoot()
           .querySelectorAll('script[ciphertext]');
         const promises = [];
         iterateCursor(encryptedSections, (encryptedSection) => {

--- a/extensions/amp-subscriptions/0.1/doc-impl.js
+++ b/extensions/amp-subscriptions/0.1/doc-impl.js
@@ -40,13 +40,13 @@ export class DocImpl {
   }
 
   /** @override */
-  getRootNode() {
-    return this.ampdoc_.getRootNode();
+  getDocumentOrShadowRoot() {
+    return this.ampdoc_.getDocumentOrShadowRoot();
   }
 
   /** @override */
   getRootElement() {
-    const root = this.ampdoc_.getRootNode();
+    const root = this.ampdoc_.getDocumentOrShadowRoot();
     return dev().assertElement(root.documentElement || root.body || root);
   }
 

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-base.js
@@ -43,7 +43,7 @@ export class LocalSubscriptionBasePlatform {
     this.ampdoc_ = ampdoc;
 
     /** @private @const */
-    this.rootNode_ = ampdoc.getRootNode();
+    this.rootNode_ = ampdoc.getDocumentOrShadowRoot();
 
     /** @protected {!JsonObject} */
     this.serviceConfig_ = platformConfig;

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
@@ -33,7 +33,7 @@ export class LocalSubscriptionPlatformRenderer {
     this.ampdoc_ = ampdoc;
 
     /** @private @const */
-    this.rootNode_ = ampdoc.getRootNode();
+    this.rootNode_ = ampdoc.getDocumentOrShadowRoot();
 
     /** @private @const {!./dialog.Dialog} */
     this.dialog_ = dialog;
@@ -86,7 +86,7 @@ export class LocalSubscriptionPlatformRenderer {
       .then(() => {
         // Find the first matching dialog.
         const candidates = this.ampdoc_
-          .getRootNode()
+          .getDocumentOrShadowRoot()
           .querySelectorAll('[subscriptions-dialog][subscriptions-display]');
         for (let i = 0; i < candidates.length; i++) {
           const candidate = candidates[i];

--- a/extensions/amp-subscriptions/0.1/test/test-actions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-actions.js
@@ -46,7 +46,7 @@ describes.realWin('Actions', {amp: true}, (env) => {
     urlBuilder.setAuthResponse({
       'a': 'A',
     });
-    analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
+    analytics = new SubscriptionAnalytics(ampdoc.getDocumentOrShadowRoot());
     analyticsMock = env.sandbox.mock(analytics);
     buildSpy = env.sandbox.spy(Actions.prototype, 'build');
     actions = new Actions(ampdoc, urlBuilder, analytics, {

--- a/extensions/amp-subscriptions/0.1/test/test-analytics.js
+++ b/extensions/amp-subscriptions/0.1/test/test-analytics.js
@@ -37,7 +37,7 @@ describes.realWin('SubscriptionAnalytics', {amp: true}, (env) => {
 
   beforeEach(() => {
     ampdoc = env.ampdoc;
-    analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
+    analytics = new SubscriptionAnalytics(ampdoc.getDocumentOrShadowRoot());
   });
 
   it('should not fail', () => {

--- a/extensions/amp-subscriptions/0.1/test/test-doc-impl.js
+++ b/extensions/amp-subscriptions/0.1/test/test-doc-impl.js
@@ -27,9 +27,9 @@ describes.realWin('DocImpl', {amp: true}, (env) => {
 
   it('should proxy inteface to ampdoc', () => {
     expect(configDoc.getWin()).to.equal(ampdoc.win);
-    expect(configDoc.getRootNode()).to.equal(ampdoc.getRootNode());
+    expect(configDoc.getDocumentOrShadowRoot()).to.equal(ampdoc.getDocumentOrShadowRoot());
     expect(configDoc.getRootElement()).to.equal(
-      ampdoc.getRootNode().documentElement
+      ampdoc.getDocumentOrShadowRoot().documentElement
     );
     expect(configDoc.getHead()).to.equal(ampdoc.getHeadNode());
   });

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
@@ -42,7 +42,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, (env) => {
   beforeEach(() => {
     ampdoc = env.ampdoc;
     serviceAdapter = new ServiceAdapter(null);
-    const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
+    const analytics = new SubscriptionAnalytics(ampdoc.getDocumentOrShadowRoot());
     env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
     env.sandbox
       .stub(serviceAdapter, 'getPageConfig')

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -70,7 +70,7 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
   beforeEach(() => {
     ampdoc = env.ampdoc;
     serviceAdapter = new ServiceAdapter(null);
-    const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
+    const analytics = new SubscriptionAnalytics(ampdoc.getDocumentOrShadowRoot());
     env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
     env.sandbox
       .stub(serviceAdapter, 'getScoreFactorStates')

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-platform.js
@@ -70,7 +70,7 @@ describes.fakeWin('ViewerSubscriptionPlatform', {amp: true}, (env) => {
     win = env.win;
     clock = window.sandbox.useFakeTimers();
     serviceAdapter = new ServiceAdapter(null);
-    const analytics = new SubscriptionAnalytics(ampdoc.getRootNode());
+    const analytics = new SubscriptionAnalytics(ampdoc.getDocumentOrShadowRoot());
     env.sandbox.stub(serviceAdapter, 'getAnalytics').callsFake(() => analytics);
     env.sandbox
       .stub(serviceAdapter, 'getPageConfig')

--- a/extensions/amp-subscriptions/0.1/test/test-viewer-tracker.js
+++ b/extensions/amp-subscriptions/0.1/test/test-viewer-tracker.js
@@ -101,7 +101,7 @@ describes.realWin('ViewerTracker', {amp: true}, (env) => {
         clickEvent = document.createEventObject();
         clickEvent.type = 'click';
       }
-      const node = ampdoc.getRootNode();
+      const node = ampdoc.getDocumentOrShadowRoot();
       node.body.dispatchEvent(clickEvent);
       await viewPromise;
     });

--- a/extensions/amp-subscriptions/0.1/viewer-tracker.js
+++ b/extensions/amp-subscriptions/0.1/viewer-tracker.js
@@ -115,7 +115,7 @@ export class ViewerTracker {
 
       // 4. Tap: register a view.
       unlistenSet.push(
-        listenOnce(this.ampdoc_.getRootNode(), 'click', resolve)
+        listenOnce(this.ampdoc_.getDocumentOrShadowRoot(), 'click', resolve)
       );
     }).then(
       () => {

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -360,7 +360,7 @@ export class VideoDocking {
     )}]`;
 
     const dockableElements = ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelectorAll(dockableSelector);
 
     for (let i = 0; i < dockableElements.length; i++) {
@@ -398,7 +398,7 @@ export class VideoDocking {
    * @private
    */
   findSlot_() {
-    const root = this.ampdoc_.getRootNode();
+    const root = this.ampdoc_.getDocumentOrShadowRoot();
 
     // For consistency always honor the dock attribute on the first el in page.
     const video = root.querySelector('[dock]');
@@ -504,7 +504,7 @@ export class VideoDocking {
    * @private
    */
   getDoc_() {
-    const root = this.ampdoc_.getRootNode();
+    const root = this.ampdoc_.getDocumentOrShadowRoot();
     return /** @type {!Document} */ (root.ownerDocument || root);
   }
 
@@ -1252,7 +1252,7 @@ export class VideoDocking {
 
     const onDragEnd = () => this.onDragEnd_(unlisteners);
 
-    const root = this.ampdoc_.getRootNode();
+    const root = this.ampdoc_.getDocumentOrShadowRoot();
     const unlisteners = [
       this.disableScroll_(),
       this.disableUserSelect_(),

--- a/extensions/amp-video-docking/0.1/controls.js
+++ b/extensions/amp-video-docking/0.1/controls.js
@@ -473,7 +473,7 @@ export class Controls {
 
   /** @private */
   hideOnTapOutside_() {
-    listen(this.ampdoc_.getRootNode(), 'mousedown', (e) => {
+    listen(this.ampdoc_.getDocumentOrShadowRoot(), 'mousedown', (e) => {
       if (this.isControlsTarget_(dev().assertElement(e.target))) {
         return;
       }

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -168,7 +168,7 @@ describes.realWin('video docking', {amp: true}, (env) => {
   beforeEach(() => {
     ampdoc = env.ampdoc;
     any = env.sandbox.match.any;
-    querySelectorStub = env.sandbox.stub(ampdoc.getRootNode(), 'querySelector');
+    querySelectorStub = env.sandbox.stub(ampdoc.getDocumentOrShadowRoot(), 'querySelector');
 
     manager = {
       getPlayingState() {

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -182,7 +182,7 @@ class AmpVideoIframe extends AMP.BaseElement {
    */
   getMetadata_() {
     const {sourceUrl, canonicalUrl} = Services.documentInfoForDoc(this.element);
-    const {title, documentElement} = this.getAmpDoc().getRootNode();
+    const {title, documentElement} = this.getAmpDoc().getDocumentOrShadowRoot();
 
     return dict({
       'sourceUrl': sourceUrl,

--- a/extensions/amp-web-push/0.1/amp-web-push-config.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-config.js
@@ -186,7 +186,7 @@ export class WebPushConfig extends AMP.BaseElement {
    */
   ensureUniqueElement_() {
     const webPushConfigElements = this.getAmpDoc()
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelectorAll(`#${escapeCssSelectorIdent(CONFIG_TAG)}`);
     if (webPushConfigElements.length > 1) {
       throw user().createError(

--- a/extensions/amp-web-push/0.1/web-push-service.js
+++ b/extensions/amp-web-push/0.1/web-push-service.js
@@ -456,7 +456,7 @@ export class WebPushService {
    */
   setWidgetVisibilities(widgetCategoryName, isVisible) {
     const widgetDomElements = this.ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelectorAll(
         `${escapeCssSelectorIdent(
           WIDGET_TAG
@@ -484,7 +484,7 @@ export class WebPushService {
    */
   doesWidgetCategoryMarkupExist_(widgetCategoryName) {
     const widgetDomElements = this.ampdoc
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelectorAll(
         `${escapeCssSelectorIdent(
           WIDGET_TAG

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -36,7 +36,7 @@ export function installGlobalSubmitListenerForDoc(ampdoc) {
     (ampFormInstalled) => {
       if (ampFormInstalled) {
         ampdoc
-          .getRootNode()
+          .getDocumentOrShadowRoot()
           .addEventListener('submit', onDocumentFormSubmit_, true);
       }
     }

--- a/src/dom.js
+++ b/src/dom.js
@@ -234,9 +234,9 @@ export function isConnectedNode(node) {
  * @return {!Node}
  */
 export function rootNodeFor(node) {
-  if (Node.prototype.getRootNode) {
-    // Type checker says `getRootNode` may return null.
-    return node.getRootNode() || node;
+  if (Node.prototype.getDocumentOrShadowRoot) {
+    // Type checker says `getDocumentOrShadowRoot` may return null.
+    return node.getDocumentOrShadowRoot() || node;
   }
   let n;
   // Check isShadowRoot() is only needed for the polyfill case.

--- a/src/error.js
+++ b/src/error.js
@@ -411,7 +411,7 @@ export function maybeReportErrorToViewer(win, data) {
     return Promise.resolve(false);
   }
   const ampdocSingle = ampdocService.getSingleDoc();
-  const htmlElement = ampdocSingle.getRootNode().documentElement;
+  const htmlElement = ampdocSingle.getDocumentOrShadowRoot().documentElement;
   const docOptedIn = htmlElement.hasAttribute('report-errors-to-viewer');
   if (!docOptedIn) {
     return Promise.resolve(false);
@@ -755,6 +755,6 @@ export function reportErrorToAnalytics(error, win) {
  * @private
  */
 function getRootElement_(win) {
-  const root = Services.ampdocServiceFor(win).getSingleDoc().getRootNode();
+  const root = Services.ampdocServiceFor(win).getSingleDoc().getDocumentOrShadowRoot();
   return dev().assertElement(root.documentElement || root.body || root);
 }

--- a/src/inabox/inabox-resources.js
+++ b/src/inabox/inabox-resources.js
@@ -245,7 +245,7 @@ export class InaboxResources {
       const resource = this.pendingBuildResources_[i];
       if (
         this.documentReady_ ||
-        hasNextNodeInDocumentOrder(resource.element, this.ampdoc_.getRootNode())
+        hasNextNodeInDocumentOrder(resource.element, this.ampdoc_.getDocumentOrShadowRoot())
       ) {
         this.pendingBuildResources_.splice(i, 1);
         resource.build().then(() => this./*OK*/ schedulePass());

--- a/src/inabox/utils.js
+++ b/src/inabox/utils.js
@@ -26,7 +26,7 @@ import {whenContentIniLoad} from '../ini-load';
  */
 export function registerIniLoadListener(ampdoc) {
   const {win} = ampdoc;
-  const root = ampdoc.getRootNode();
+  const root = ampdoc.getDocumentOrShadowRoot();
   whenContentIniLoad(
     ampdoc,
     win,

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -250,7 +250,7 @@ export class ActionService {
     this.ampdoc = ampdoc;
 
     /** @const {!Document|!ShadowRoot} */
-    this.root_ = opt_root || ampdoc.getRootNode();
+    this.root_ = opt_root || ampdoc.getDocumentOrShadowRoot();
 
     /** @const {boolean} */
     this.isEmail_ =

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -445,7 +445,7 @@ export class AmpDoc {
    * @return {!Document|!ShadowRoot}
    * @abstract
    */
-  getRootNode() {}
+  getDocumentOrShadowRoot() {}
 
   /**
    * Returns the head node. It's either an element or a shadow root.
@@ -514,7 +514,7 @@ export class AmpDoc {
    * @return {?Element}
    */
   getElementById(id) {
-    return this.getRootNode().getElementById(id);
+    return this.getDocumentOrShadowRoot().getElementById(id);
   }
 
   /**
@@ -523,7 +523,7 @@ export class AmpDoc {
    * @return {boolean}
    */
   contains(node) {
-    return this.getRootNode().contains(node);
+    return this.getDocumentOrShadowRoot().contains(node);
   }
 
   /**
@@ -728,7 +728,7 @@ export class AmpDocSingle extends AmpDoc {
   }
 
   /** @override */
-  getRootNode() {
+  getDocumentOrShadowRoot() {
     return this.win.document;
   }
 
@@ -816,7 +816,7 @@ export class AmpDocShadow extends AmpDoc {
   }
 
   /** @override */
-  getRootNode() {
+  getDocumentOrShadowRoot() {
     return this.shadowRoot_;
   }
 
@@ -931,7 +931,7 @@ export class AmpDocFie extends AmpDoc {
   }
 
   /** @override */
-  getRootNode() {
+  getDocumentOrShadowRoot() {
     return this.win.document;
   }
 

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -323,11 +323,9 @@ export class AmpDoc {
    * Whether the runtime in the single-doc mode. Alternative is the shadow-doc
    * mode that supports multiple documents per a single window.
    * @return {boolean}
+   * @abstract
    */
-  isSingleDoc() {
-    // TODO(#22733): remove when ampdoc-fie is launched.
-    return /** @type {?} */ (devAssert(null, 'not implemented'));
-  }
+  isSingleDoc() {}
 
   /**
    * @return {?AmpDoc}
@@ -408,16 +406,16 @@ export class AmpDoc {
   /**
    * Stores the value of an ampdoc's meta tag content for a given name. To be
    * implemented by subclasses.
-   * @param {string} unusedName
-   * @param {string} unusedContent
    *
    * Avoid using this method in components. It is only meant to be used by the
    * runtime for AmpDoc subclasses where <meta> elements do not exist and name/
    * content pairs must be stored in this.meta_.
+   *
+   * @param {string} unusedName
+   * @param {string} unusedContent
+   * @abstract
    */
-  setMetaByName(unusedName, unusedContent) {
-    devAssert(null, 'not implemented');
-  }
+  setMetaByName(unusedName, unusedContent) {}
 
   /**
    * Returns whether the specified extension has been declared on this ampdoc.
@@ -445,10 +443,9 @@ export class AmpDoc {
    * node can be used, among other things, to add ampdoc-wide event listeners.
    *
    * @return {!Document|!ShadowRoot}
+   * @abstract
    */
-  getRootNode() {
-    return /** @type {?} */ (devAssert(null, 'not implemented'));
-  }
+  getRootNode() {}
 
   /**
    * Returns the head node. It's either an element or a shadow root.
@@ -461,10 +458,9 @@ export class AmpDoc {
    * Returns `true` if the ampdoc's body is available.
    *
    * @return {boolean}
+   * @abstract
    */
-  isBodyAvailable() {
-    return /** @type {?} */ (devAssert(false, 'not implemented'));
-  }
+  isBodyAvailable() {}
 
   /**
    * Returns the ampdoc's body. Requires the body to already be available.
@@ -472,19 +468,17 @@ export class AmpDoc {
    * See `isBodyAvailable` and `waitForBodyOpen`.
    *
    * @return {!Element}
+   * @abstract
    */
-  getBody() {
-    return /** @type {?} */ (devAssert(null, 'not implemented'));
-  }
+  getBody() {}
 
   /**
    * Returns a promise that will be resolved when the ampdoc's body is
    * available.
    * @return {!Promise<!Element>}
+   * @abstract
    */
-  waitForBodyOpen() {
-    return /** @type {?} */ (devAssert(null, 'not implemented'));
-  }
+  waitForBodyOpen() {}
 
   /**
    * Returns `true` if document is ready.
@@ -492,27 +486,24 @@ export class AmpDoc {
    * See `whenReady`.
    *
    * @return {boolean}
+   * @abstract
    */
-  isReady() {
-    return /** @type {?} */ (devAssert(null, 'not implemented'));
-  }
+  isReady() {}
 
   /**
    * Returns a promise that will be resolved when the ampdoc's DOM is fully
    * ready.
    * @return {!Promise}
+   * @abstract
    */
-  whenReady() {
-    return /** @type {?} */ (devAssert(null, 'not implemented'));
-  }
+  whenReady() {}
 
   /**
    * Returns the URL from which the document was loaded.
    * @return {string}
+   * @abstract
    */
-  getUrl() {
-    return /** @type {?} */ (devAssert(null, 'not implemented'));
-  }
+  getUrl() {}
 
   /**
    * Locates an element with the specified ID within the ampdoc. In the

--- a/src/service/document-info-impl.js
+++ b/src/service/document-info-impl.js
@@ -84,7 +84,7 @@ export class DocInfo {
     const ampdoc = this.ampdoc_;
     const url = ampdoc.getUrl();
     const sourceUrl = getSourceUrl(url);
-    const rootNode = ampdoc.getRootNode();
+    const rootNode = ampdoc.getDocumentOrShadowRoot();
     let canonicalUrl = rootNode && rootNode.AMP && rootNode.AMP.canonicalUrl;
     if (!canonicalUrl) {
       const canonicalTag = rootNode.querySelector('link[rel=canonical]');

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -222,7 +222,7 @@ export class Extensions {
    * @return {!Promise<!ExtensionDef>}
    */
   installExtensionForDoc(ampdoc, extensionId, opt_extensionVersion) {
-    const rootNode = ampdoc.getRootNode();
+    const rootNode = ampdoc.getDocumentOrShadowRoot();
     let extLoaders = rootNode[LOADER_PROP];
     if (!extLoaders) {
       extLoaders = rootNode[LOADER_PROP] = map();

--- a/src/service/fixed-layer.js
+++ b/src/service/fixed-layer.js
@@ -166,7 +166,7 @@ export class FixedLayer {
       return false;
     }
 
-    const root = this.ampdoc.getRootNode();
+    const root = this.ampdoc.getDocumentOrShadowRoot();
     const stylesheets = root.styleSheets;
     if (!stylesheets) {
       return true;
@@ -260,7 +260,7 @@ export class FixedLayer {
       return;
     }
 
-    const root = this.ampdoc.getRootNode();
+    const root = this.ampdoc.getDocumentOrShadowRoot();
     const element = root.documentElement || root;
     const hiddenObserver = Services.hiddenObserverForDoc(element);
     this.hiddenObserverUnlistener_ = hiddenObserver.add(() => {
@@ -903,7 +903,7 @@ export class FixedLayer {
       return lastPaddingTop - paddingTop + (paddingTop - lastPaddingTop) * time;
     };
     return Animation.animate(
-      this.ampdoc.getRootNode(),
+      this.ampdoc.getDocumentOrShadowRoot(),
       (time) => {
         const p = tr(time);
         this.transformMutate(`translateY(${p}px)`);

--- a/src/service/hidden-observer-impl.js
+++ b/src/service/hidden-observer-impl.js
@@ -40,7 +40,7 @@ export class HiddenObserver {
    */
   constructor(ampdoc) {
     /** @const {!Document|!ShadowRoot} */
-    this.root_ = ampdoc.getRootNode();
+    this.root_ = ampdoc.getDocumentOrShadowRoot();
     const doc = this.root_.ownerDocument || this.root_;
 
     /** @const {!Window} */

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -99,7 +99,7 @@ export class Navigation {
     this.ampdoc = ampdoc;
 
     /** @private @const {!Document|!ShadowRoot} */
-    this.rootNode_ = ampdoc.getRootNode();
+    this.rootNode_ = ampdoc.getDocumentOrShadowRoot();
 
     /** @private @const {!./viewport/viewport-interface.ViewportInterface} */
     this.viewport_ = Services.viewportForDoc(this.ampdoc);
@@ -122,7 +122,7 @@ export class Navigation {
 
     /** @private @const {boolean} */
     this.isEmbed_ =
-      this.rootNode_ != this.ampdoc.getRootNode() || !!this.ampdoc.getParent();
+      this.rootNode_ != this.ampdoc.getDocumentOrShadowRoot() || !!this.ampdoc.getParent();
 
     /** @private @const {boolean} */
     this.isInABox_ = getMode(this.ampdoc.win).runtime == 'inabox';
@@ -755,7 +755,7 @@ export class Navigation {
     const docOptedIn =
       this.ampdoc.isSingleDoc() &&
       this.ampdoc
-        .getRootNode()
+        .getDocumentOrShadowRoot()
         .documentElement.hasAttribute('allow-navigation-interception');
 
     if (

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -556,7 +556,7 @@ export class ResourcesImpl {
       const resource = this.pendingBuildResources_[i];
       if (
         this.documentReady_ ||
-        hasNextNodeInDocumentOrder(resource.element, this.ampdoc.getRootNode())
+        hasNextNodeInDocumentOrder(resource.element, this.ampdoc.getDocumentOrShadowRoot())
       ) {
         // Remove resource before build to remove it from the pending list
         // in either case the build succeed or throws an error.

--- a/src/service/url-impl.js
+++ b/src/service/url-impl.js
@@ -38,7 +38,7 @@ export class Url {
    * @param {!./ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
-    const root = ampdoc.getRootNode();
+    const root = ampdoc.getDocumentOrShadowRoot();
     const doc = root.ownerDocument || root;
 
     /** @private @const {!HTMLAnchorElement} */

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -589,7 +589,7 @@ export class GlobalVariableSource extends VariableSource {
 
     this.setAsync('AMP_STATE', (key) => {
       // This is safe since AMP_STATE is not an A4A allowlisted variable.
-      const root = this.ampdoc.getRootNode();
+      const root = this.ampdoc.getDocumentOrShadowRoot();
       const element = /** @type {!Element|!ShadowRoot} */ (root.documentElement ||
         root);
       return Services.bindForDocOrNull(element).then((bind) => {

--- a/src/service/variable-source.js
+++ b/src/service/variable-source.js
@@ -342,7 +342,7 @@ export class VariableSource {
 
     // Disallow all URL macros for AMP4Email format documents.
     if (this.ampdoc.isSingleDoc()) {
-      const doc = /** @type {!Document} */ (this.ampdoc.getRootNode());
+      const doc = /** @type {!Document} */ (this.ampdoc.getDocumentOrShadowRoot());
       if (isAmp4Email(doc)) {
         /**
          * The allowlist of variables allowed for variable substitution.

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -331,7 +331,7 @@ export class VideoManager {
    * @return {!Promise<string>}
    */
   getVideoStateProperty(id, property) {
-    const root = this.ampdoc.getRootNode();
+    const root = this.ampdoc.getDocumentOrShadowRoot();
     const videoElement = user().assertElement(
       root.getElementById(/** @type {string} */ (id)),
       `Could not find an element with id="${id}" for VIDEO_STATE`
@@ -1117,7 +1117,7 @@ export class AutoFullscreenManager {
 
   /** @private */
   installFullscreenListener_() {
-    const root = this.ampdoc_.getRootNode();
+    const root = this.ampdoc_.getDocumentOrShadowRoot();
     const exitHandler = () => this.onFullscreenExit_();
     this.unlisteners_.push(
       listen(root, 'webkitfullscreenchange', exitHandler),

--- a/src/service/viewport/viewport-binding-natural.js
+++ b/src/service/viewport/viewport-binding-natural.js
@@ -180,7 +180,7 @@ export class ViewportBindingNatural_ {
     const pageScrollTop =
       this.getScrollingElement()./*OK*/ scrollTop ||
       this.win./*OK*/ pageYOffset;
-    const {host} = this.ampdoc.getRootNode();
+    const {host} = this.ampdoc.getDocumentOrShadowRoot();
     return host ? pageScrollTop - host./*OK*/ offsetTop : pageScrollTop;
   }
 

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -56,7 +56,7 @@ export class SsrTemplateHelper {
   isEnabled() {
     const ampdoc = this.viewer_.getAmpDoc();
     if (ampdoc.isSingleDoc()) {
-      const htmlElement = ampdoc.getRootNode().documentElement;
+      const htmlElement = ampdoc.getDocumentOrShadowRoot().documentElement;
       if (htmlElement.hasAttribute('allow-viewer-render-template')) {
         return this.viewer_.hasCapability('viewerRenderTemplate');
       }

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -61,7 +61,7 @@ export function installStylesForDoc(
   );
 
   if (cb) {
-    const rootNode = ampdoc.getRootNode();
+    const rootNode = ampdoc.getDocumentOrShadowRoot();
     // Styles aren't always available synchronously. E.g. if there is a
     // pending style download, it will have to finish before the new
     // style is visible.

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -210,7 +210,7 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
     return whenUnblocked;
   }
 
-  const htmlElement = ampdocSingle.getRootNode().documentElement;
+  const htmlElement = ampdocSingle.getDocumentOrShadowRoot().documentElement;
   const docOptedIn = htmlElement.hasAttribute('allow-xhr-interception');
   if (!docOptedIn) {
     return whenUnblocked;

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -832,7 +832,7 @@ describes.realWin('AmpDocSingle', {}, (env) => {
   });
 
   it('should return document as root', () => {
-    expect(ampdoc.getRootNode()).to.equal(win.document);
+    expect(ampdoc.getDocumentOrShadowRoot()).to.equal(win.document);
     expect(ampdoc.getHeadNode()).to.equal(win.document.head);
     expect(ampdoc.isSingleDoc()).to.be.true;
   });
@@ -963,7 +963,7 @@ describes.realWin('AmpDocShadow', {}, (env) => {
     if (!ampdoc) {
       return;
     }
-    expect(ampdoc.getRootNode()).to.equal(shadowRoot);
+    expect(ampdoc.getDocumentOrShadowRoot()).to.equal(shadowRoot);
     expect(ampdoc.getHeadNode()).to.equal(shadowRoot);
   });
 
@@ -1086,7 +1086,7 @@ describes.realWin('AmpDocFie', {}, (env) => {
   });
 
   it('should return document as root', () => {
-    expect(ampdoc.getRootNode()).to.equal(childWin.document);
+    expect(ampdoc.getDocumentOrShadowRoot()).to.equal(childWin.document);
     expect(ampdoc.getHeadNode()).to.equal(childWin.document.head);
   });
 

--- a/test/unit/test-document-info.js
+++ b/test/unit/test-document-info.js
@@ -86,7 +86,7 @@ describe
           querySelector() {
             return 'http://www.origin.com/foo/?f=0';
           },
-          getRootNode() {
+          getDocumentOrShadowRoot() {
             return win.document;
           },
         },
@@ -123,7 +123,7 @@ describe
           querySelector() {
             return 'http://www.origin.com/foo/?f=0';
           },
-          getRootNode() {
+          getDocumentOrShadowRoot() {
             return win.document;
           },
         },
@@ -322,7 +322,7 @@ describe
           querySelector() {
             return 'http://www.origin.com/foo/?f=0';
           },
-          getRootNode() {
+          getDocumentOrShadowRoot() {
             return win.document;
           },
         },
@@ -360,7 +360,7 @@ describe
           querySelector() {
             return 'http://www.origin.com/foo/?f=0';
           },
-          getRootNode() {
+          getDocumentOrShadowRoot() {
             return win.document;
           },
         },
@@ -397,7 +397,7 @@ describe
           querySelector() {
             return 'http://www.origin.com/foo/?f=0';
           },
-          getRootNode() {
+          getDocumentOrShadowRoot() {
             return win.document;
           },
         },

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -417,7 +417,7 @@ describes.sandboxed('FixedLayer', {}, () => {
         this.firstElementChild = createElement('i-amphtml-fpa');
         toggle(this.firstElementChild, false);
       },
-      getRootNode() {
+      getDocumentOrShadowRoot() {
         return documentApi;
       },
       dispatchEvent() {},

--- a/test/unit/test-navigation.js
+++ b/test/unit/test-navigation.js
@@ -656,7 +656,7 @@ describes.sandboxed('Navigation', {}, () => {
           const meta = doc.createElement('meta');
           meta.setAttribute('name', 'amp-to-amp-navigation');
           meta.setAttribute('content', 'feature-foo, action-bar');
-          ampdoc.getRootNode().head.appendChild(meta);
+          ampdoc.getDocumentOrShadowRoot().head.appendChild(meta);
 
           const send = env.sandbox.stub(handler.viewer_, 'sendMessage');
           const hasCapability = env.sandbox.stub(
@@ -723,7 +723,7 @@ describes.sandboxed('Navigation', {}, () => {
           hasCapabilityStub.returns(true);
 
           ampdoc
-            .getRootNode()
+            .getDocumentOrShadowRoot()
             .documentElement.setAttribute('allow-navigation-interception', '');
         });
 
@@ -755,7 +755,7 @@ describes.sandboxed('Navigation', {}, () => {
 
           expect(
             ampdoc
-              .getRootNode()
+              .getDocumentOrShadowRoot()
               .documentElement.hasAttribute('allow-navigation-interception')
           ).to.be.true;
 
@@ -827,7 +827,7 @@ describes.sandboxed('Navigation', {}, () => {
 
         it('should require opted in ampdoc', () => {
           ampdoc
-            .getRootNode()
+            .getDocumentOrShadowRoot()
             .documentElement.removeAttribute('allow-navigation-interception');
           handler.handle_(event);
 

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -152,7 +152,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
             cookie: '',
             documentElement: {
               nodeType: /* element */ 1,
-              getRootNode() {
+              getDocumentOrShadowRoot() {
                 return win.document;
               },
               hasAttribute: () => {},
@@ -186,7 +186,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
           // Fake query selectors needed to bypass <meta> tag checks.
           querySelector: () => null,
           querySelectorAll: () => [],
-          getRootNode() {
+          getDocumentOrShadowRoot() {
             return win.document;
           },
         };

--- a/test/unit/test-viewer.js
+++ b/test/unit/test-viewer.js
@@ -101,7 +101,7 @@ describes.sandboxed('Viewer', {}, (env) => {
       body: {style: {}},
       documentElement: {style: {}},
       title: 'Awesome doc',
-      getRootNode() {
+      getDocumentOrShadowRoot() {
         return windowApi.document;
       },
       querySelector() {

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -93,7 +93,7 @@ describes.sandboxed('utils/xhr-utils', {}, (env) => {
 
     beforeEach(() => {
       ampDocSingle = {
-        getRootNode() {
+        getDocumentOrShadowRoot() {
           return {documentElement: doc};
         },
         whenFirstVisible: env.sandbox.stub().returns(Promise.resolve()),

--- a/third_party/resize-observer-polyfill/ResizeObserver.install.js
+++ b/third_party/resize-observer-polyfill/ResizeObserver.install.js
@@ -451,17 +451,17 @@ export function installResizeObserver(global) {
     }());
 
     /**
-     * A shim for the `Node.getRootNode()` API.
+     * A shim for the `Node.getDocumentOrShadowRoot()` API.
      *
-     * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode for
+     * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getDocumentOrShadowRoot for
      * more info.
      *
      * @param {Node} node
      * @returns {Node}
      */
-    function getRootNode(node) {
-        if (typeof node.getRootNode === 'function') {
-            return node.getRootNode();
+    function getDocumentOrShadowRoot(node) {
+        if (typeof node.getDocumentOrShadowRoot === 'function') {
+            return node.getDocumentOrShadowRoot();
         }
         var n;
         // eslint-disable-next-line no-empty
@@ -709,7 +709,7 @@ export function installResizeObserver(global) {
      * @returns {Node}
      */
     function getControlledRootNode(target, def) {
-        var rootNode = getRootNode(target);
+        var rootNode = getDocumentOrShadowRoot(target);
         // DOCUMENT_NODE = 9
         // DOCUMENT_FRAGMENT_NODE = 11 (shadow root)
         if (rootNode.nodeType === 9 ||
@@ -1041,7 +1041,7 @@ export function installResizeObserver(global) {
             /**
              * A mapping from a DOM root node and a respective controller. A root node
              * could be the main document, a same-origin iframe, or a shadow root.
-             * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode
+             * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getDocumentOrShadowRoot
              * for more info.
              *
              * @private {Map<Node, ResizeObserverController>}

--- a/third_party/resize-observer-polyfill/ResizeObserver.js
+++ b/third_party/resize-observer-polyfill/ResizeObserver.js
@@ -452,17 +452,17 @@
     }());
 
     /**
-     * A shim for the `Node.getRootNode()` API.
+     * A shim for the `Node.getDocumentOrShadowRoot()` API.
      *
-     * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode for
+     * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getDocumentOrShadowRoot for
      * more info.
      *
      * @param {Node} node
      * @returns {Node}
      */
-    function getRootNode(node) {
-        if (typeof node.getRootNode === 'function') {
-            return node.getRootNode();
+    function getDocumentOrShadowRoot(node) {
+        if (typeof node.getDocumentOrShadowRoot === 'function') {
+            return node.getDocumentOrShadowRoot();
         }
         var n;
         // eslint-disable-next-line no-empty
@@ -710,7 +710,7 @@
      * @returns {Node}
      */
     function getControlledRootNode(target, def) {
-        var rootNode = getRootNode(target);
+        var rootNode = getDocumentOrShadowRoot(target);
         // DOCUMENT_NODE = 9
         // DOCUMENT_FRAGMENT_NODE = 11 (shadow root)
         if (rootNode.nodeType === 9 ||
@@ -1042,7 +1042,7 @@
             /**
              * A mapping from a DOM root node and a respective controller. A root node
              * could be the main document, a same-origin iframe, or a shadow root.
-             * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode
+             * See https://developer.mozilla.org/en-US/docs/Web/API/Node/getDocumentOrShadowRoot
              * for more info.
              *
              * @private {Map<Node, ResizeObserverController>}

--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -122,7 +122,7 @@ class Doc {
    * The `Document` node or analog.
    * @return {!Node}
    */
-  getRootNode() {}
+  getDocumentOrShadowRoot() {}
 
   /**
    * The `Document.documentElement` element or analog.
@@ -189,7 +189,7 @@ class GlobalDoc {
   }
 
   /** @override */
-  getRootNode() {
+  getDocumentOrShadowRoot() {
     return this.doc_;
   }
 
@@ -873,7 +873,7 @@ class MetaParser {
 
     // Try to find product id.
     const productId = getMetaTag(
-      this.doc_.getRootNode(),
+      this.doc_.getDocumentOrShadowRoot(),
       'subscriptions-product-id'
     );
     if (!productId) {
@@ -882,7 +882,7 @@ class MetaParser {
 
     // Is locked?
     const accessibleForFree = getMetaTag(
-      this.doc_.getRootNode(),
+      this.doc_.getDocumentOrShadowRoot(),
       'subscriptions-accessible-for-free'
     );
     const locked =
@@ -917,7 +917,7 @@ class JsonLdParser {
 
     // type: 'application/ld+json'
     const elements = this.doc_
-      .getRootNode()
+      .getDocumentOrShadowRoot()
       .querySelectorAll('script[type="application/ld+json"]');
     for (let i = 0; i < elements.length; i++) {
       const element = elements[i];
@@ -1179,7 +1179,7 @@ class MicrodataParser {
 
     // Grab all the nodes with an itemtype and filter for our allowed types
     const nodeList = Array.prototype.slice
-      .call(this.doc_.getRootNode().querySelectorAll('[itemscope][itemtype]'))
+      .call(this.doc_.getDocumentOrShadowRoot().querySelectorAll('[itemscope][itemtype]'))
       .filter((node) =>
         this.checkType_.checkString(
           node.getAttribute('itemtype'),

--- a/third_party/subscriptions-project/swg.js
+++ b/third_party/subscriptions-project/swg.js
@@ -6109,7 +6109,7 @@ function serializeProtoMessageForUrl(message) {
  * @return {string}
  */
 function getCanonicalUrl(doc) {
-  const node = doc.getRootNode().querySelector("link[rel='canonical']");
+  const node = doc.getDocumentOrShadowRoot().querySelector("link[rel='canonical']");
   return (node && node.href) || '';
 }
 
@@ -8772,7 +8772,7 @@ class ButtonApi {
   ) {
     attributeValues.forEach((attributeValue) => {
       const elements = this.doc_
-        .getRootNode()
+        .getDocumentOrShadowRoot()
         .querySelectorAll(`button[${attribute}="${attributeValue}"]`);
       for (let i = 0; i < elements.length; i++) {
         this.attach(
@@ -9925,7 +9925,7 @@ class GlobalDoc {
   }
 
   /** @override */
-  getRootNode() {
+  getDocumentOrShadowRoot() {
     return this.doc_;
   }
 


### PR DESCRIPTION
Closure fails to detect this, but `getRootNode()` returns `{!Document|!ShadowRoot}`. `ShadowRoot`s do not have a `createElement` method.

Fixes https://github.com/ampproject/error-reporting/issues/57.