### PR TITLE
Do not use getRootNode to create element

### DIFF
--- a/extensions/amp-onetap-google/0.1/amp-onetap-google.js
+++ b/extensions/amp-onetap-google/0.1/amp-onetap-google.js
@@ -189,7 +189,7 @@ export class AmpOnetapGoogle extends AMP.BaseElement {
     if (this.iframe_) {
       return;
     }
-    this.iframe_ = this.getAmpDoc().getRootNode().createElement('iframe');
+    this.iframe_ = this.getAmpDoc().win.document.createElement('iframe');
 
     // Don't insert <iframe> until URL has been expanded.
     // Likewise, don't display the UI until then.


### PR DESCRIPTION
Closure fails to detect this, but `getRootNode()` returns `{!Document|!ShadowRoot}`. `ShadowRoot`s do not have a `createElement` method.

Fixes https://github.com/ampproject/error-reporting/issues/57.