### PR TITLE
[ampproject/amphtml] ♿ [Story a11y] Pagination buttons mobile pointer-events patch

### DIFF
--- a/extensions/amp-story/1.0/pagination-buttons.css
+++ b/extensions/amp-story/1.0/pagination-buttons.css
@@ -67,6 +67,7 @@ amp-story:not([desktop]) .i-amphtml-story-button-move,
   border: none !important;
   background: none !important;
   padding: 0 !important;
+  pointer-events: none !important;
 }
 
 [desktop] .i-amphtml-story-button-move {


### PR DESCRIPTION
Bring back `pointer-events: none` on mobile pagination buttons.
A patch to #32861