### PR TITLE
🏗 Pass CircleCI matrix parameters to (module|nomodule)-tests.js as a command line flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
       - restore_karma_cache:
           cache_name: nomodule
       - run:
-          name: 'Nomodule Tests (using << parameters.config >>-config.json)'
+          name: 'Nomodule Tests (<< parameters.config >>)'
           command: node build-system/pr-check/nomodule-tests.js --config=<< parameters.config >>
       - save_karma_cache:
           cache_name: nomodule
@@ -210,7 +210,7 @@ jobs:
       - restore_karma_cache:
           cache_name: module
       - run:
-          name: 'Module Tests (using << parameters.config >>-config.json)'
+          name: 'Module Tests (<< parameters.config >>)'
           command: node build-system/pr-check/module-tests.js --config=<< parameters.config >>
       - save_karma_cache:
           cache_name: module

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,8 +185,6 @@ jobs:
         description: 'Which config file to use'
         type: enum
         enum: ['prod', 'canary']
-    environment:
-      config: << parameters.config >>
     steps:
       - setup_vm
       - install_chrome
@@ -194,7 +192,7 @@ jobs:
           cache_name: nomodule
       - run:
           name: 'Nomodule Tests (using << parameters.config >>-config.json)'
-          command: node build-system/pr-check/nomodule-tests.js
+          command: node build-system/pr-check/nomodule-tests.js --config=<< parameters.config >>
       - save_karma_cache:
           cache_name: nomodule
       - fail_fast
@@ -206,8 +204,6 @@ jobs:
         description: 'Which config file to use'
         type: enum
         enum: ['prod', 'canary']
-    environment:
-      config: << parameters.config >>
     steps:
       - setup_vm
       - install_chrome
@@ -215,7 +211,7 @@ jobs:
           cache_name: module
       - run:
           name: 'Module Tests (using << parameters.config >>-config.json)'
-          command: node build-system/pr-check/module-tests.js
+          command: node build-system/pr-check/module-tests.js --config=<< parameters.config >>
       - save_karma_cache:
           cache_name: module
       - fail_fast

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -19,6 +19,7 @@
  * @fileoverview Script that tests the module AMP runtime during CI.
  */
 
+const argv = require('minimist')(process.argv.slice(2));
 const {
   downloadModuleOutput,
   downloadNomoduleOutput,
@@ -37,7 +38,7 @@ function prependConfig() {
     `dist/${target}.mjs`,
   ]).join(',');
   timedExecOrDie(
-    `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=${targets}`
+    `gulp prepend-global --${argv.config} --local_dev --fortesting --derandomize --target=${targets}`
   );
 }
 

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -56,7 +56,9 @@ function prBuildWorkflow() {
     downloadModuleOutput();
     timedExecOrDie('gulp update-packages');
     prependConfig();
-    timedExecOrDie('gulp integration --nobuild --compiled --headless --esm');
+    timedExecOrDie(
+      `gulp integration --nobuild --compiled --headless --esm --config=${argv.config}`
+    );
   } else {
     printSkipMessage(
       jobName,

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -47,7 +47,7 @@ function pushBuildWorkflow() {
   prependConfig();
   try {
     timedExecOrThrow(
-      'gulp integration --nobuild --headless --compiled --report',
+      `gulp integration --nobuild --headless --compiled --report --config=${argv.config}`,
       'Integration tests failed!'
     );
   } catch (e) {
@@ -64,7 +64,9 @@ function prBuildWorkflow() {
     downloadNomoduleOutput();
     timedExecOrDie('gulp update-packages');
     prependConfig();
-    timedExecOrDie('gulp integration --nobuild --compiled --headless');
+    timedExecOrDie(
+      `gulp integration --nobuild --compiled --headless --config=${argv.config}`
+    );
   } else {
     printSkipMessage(
       jobName,

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -19,6 +19,7 @@
  * @fileoverview Script that tests the nomodule AMP runtime during CI.
  */
 
+const argv = require('minimist')(process.argv.slice(2));
 const {
   downloadNomoduleOutput,
   printSkipMessage,
@@ -36,7 +37,7 @@ function prependConfig() {
     `dist/${target}.js`,
   ]).join(',');
   timedExecOrDie(
-    `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=${targets}`
+    `gulp prepend-global --${argv.config} --local_dev --fortesting --derandomize --target=${targets}`
   );
 }
 

--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -105,8 +105,8 @@ function inferTestType() {
 }
 
 function maybeAddConfigSubtype() {
-  if (isCircleciBuild() && process.env.config) {
-    return `-${process.env.config}`;
+  if (isCircleciBuild() && argv.config) {
+    return `-${argv.config}`;
   }
   return '';
 }


### PR DESCRIPTION
As discussed in https://github.com/ampproject/amphtml/pull/32865#discussion_r583063328