### PR TITLE
gulp build: support esm

### DIFF
--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -35,13 +35,16 @@ function getUnminifiedConfig() {
       useSpread: true,
     },
   ];
+
+  const targets =
+    argv.esm || argv.sxg ? {esmodules: true} : {browsers: ['Last 2 versions']};
   const presetEnv = [
     '@babel/preset-env',
     {
       bugfixes: true,
       modules: false,
       loose: true,
-      targets: {'browsers': ['Last 2 versions']},
+      targets,
     },
   ];
   const replacePlugin = getReplacePlugin();

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -100,6 +100,7 @@ build.flags = {
   coverage: '  Adds code coverage instrumentation to JS files using istanbul.',
   version_override: '  Overrides the version written to AMP_CONFIG',
   watch: '  Watches for changes in files, re-builds when detected',
+  esm: '  Do not transpile down to ES5',
   define_experiment_constant:
     '  Builds runtime with the EXPERIMENT constant set to true',
 };


### PR DESCRIPTION
**summary**

Allow `gulp build` to process `--esm` mode. This aligns it with dist build's definition of esm mode (less transpilation, and fewer polyfills).


Note: esbuild still outputs an IIFE and not `esm`. this is intentional and controlled via the [format](https://esbuild.github.io/api/#format) option.