### PR TITLE
🏗  Add support for multiple (comma-separated) --target files for `gulp prepend-global`

### DIFF
--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -32,14 +32,13 @@ const {runCiJob} = require('./ci-job');
 const jobName = 'module-tests.js';
 
 function prependConfig() {
-  // TODO(@ampproject/wg-infra): change prepend-global to take multiple target files instead of looping here.
-  for (const target of MINIFIED_TARGETS) {
-    for (const ext of ['js', 'mjs']) {
-      timedExecOrDie(
-        `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=dist/${target}.${ext}`
-      );
-    }
-  }
+  const targets = MINIFIED_TARGETS.flatMap((target) => [
+    `dist/${target}.js`,
+    `dist/${target}.mjs`,
+  ]).join(',');
+  timedExecOrDie(
+    `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=${targets}`
+  );
 }
 
 function pushBuildWorkflow() {

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -32,12 +32,12 @@ const {runCiJob} = require('./ci-job');
 const jobName = 'nomodule-tests.js';
 
 function prependConfig() {
-  // TODO(@ampproject/wg-infra): change prepend-global to take multiple target files instead of looping here.
-  for (const target of MINIFIED_TARGETS) {
-    timedExecOrDie(
-      `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=dist/${target}.js`
-    );
-  }
+  const targets = MINIFIED_TARGETS.flatMap((target) => [
+    `dist/${target}.js`,
+  ]).join(',');
+  timedExecOrDie(
+    `gulp prepend-global --${process.env.config} --local_dev --fortesting --derandomize --target=${targets}`
+  );
 }
 
 function pushBuildWorkflow() {

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -62,24 +62,14 @@ function sanityCheck(str) {
  * @param {string} filename File containing the config
  * @param {boolean=} opt_localBranch Whether to use the local branch version
  * @param {string=} opt_branch If not the local branch, which branch to use
- * @return {!Promise}
+ * @return {!Promise<string>}
  */
-async function checkoutBranchConfigs(filename, opt_localBranch, opt_branch) {
+async function fetchConfigFromBranch_(filename, opt_localBranch, opt_branch) {
   if (opt_localBranch) {
-    return;
+    return fs.promises.readFile(filename, 'utf8');
   }
   const branch = opt_branch || 'origin/master';
-
-  try {
-    return await exec(`git checkout ${branch} ${filename}`);
-  } catch (e) {
-    // This means the files don't exist in master. Assume that it exists
-    // in the current branch.
-    if (/did not match any file/.test(e.message)) {
-      return;
-    }
-    throw e;
-  }
+  return (await exec(`git show ${branch}:${filename}`)).stdout;
 }
 
 /**
@@ -98,9 +88,9 @@ function prependConfig(configString, fileString) {
  * @param {string} filename Destination filename
  * @param {string} fileString String to write
  * @param {boolean=} opt_dryrun If true, print the contents without writing them
- * @return {!Promise}
+ * @return {!Promise<void>}
  */
-async function writeTarget(filename, fileString, opt_dryrun) {
+async function writeTarget_(filename, fileString, opt_dryrun) {
   if (opt_dryrun) {
     log(cyan(`overwriting: ${filename}`));
     log(fileString);
@@ -130,7 +120,7 @@ function valueOrDefault(value, defaultValue) {
  * @param {string=} opt_branch If not the local branch, which branch to use
  * @param {boolean=} opt_fortesting Whether to force getMode().test to be true
  * @param {boolean=} opt_derandomize Whether to remove experiment randomization
- * @return {!Promise}
+ * @return {!Promise<void>}
  */
 async function applyConfig(
   config,
@@ -142,9 +132,11 @@ async function applyConfig(
   opt_fortesting,
   opt_derandomize
 ) {
-  await checkoutBranchConfigs(filename, opt_localBranch, opt_branch);
-
-  let configString = await fs.promises.readFile(filename, 'utf8');
+  const configString = await fetchConfigFromBranch_(
+    filename,
+    opt_localBranch,
+    opt_branch
+  );
   const [targetString, overlayString] = await Promise.all([
     fs.promises.readFile(target, 'utf8'),
     fs.promises.readFile(customConfigFile, 'utf8').catch(() => {}),
@@ -170,18 +162,20 @@ async function applyConfig(
     }
   }
   if (opt_localDev) {
-    configJson = enableLocalDev(target, configJson);
+    configJson = enableLocalDev_(target, configJson);
   }
   if (opt_fortesting) {
     configJson = {test: true, ...configJson};
   }
   if (opt_derandomize) {
-    configJson = derandomize(target, configJson);
+    configJson = derandomize_(target, configJson);
   }
-  configString = JSON.stringify(configJson);
-  const fileString = await prependConfig(configString, targetString);
+  const fileString = await prependConfig(
+    JSON.stringify(configJson),
+    targetString
+  );
   sanityCheck(fileString);
-  await writeTarget(target, fileString, argv.dryrun);
+  await writeTarget_(target, fileString, argv.dryrun);
   const details =
     '(' +
     cyan(config) +
@@ -197,7 +191,7 @@ async function applyConfig(
  * @param {!JSON} configJson The json object in which to enable local dev
  * @return {!JSON}
  */
-function enableLocalDev(target, configJson) {
+function enableLocalDev_(target, configJson) {
   let LOCAL_DEV_AMP_CONFIG = {localDev: true};
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
@@ -228,7 +222,7 @@ function enableLocalDev(target, configJson) {
  * @param {!JSON} configJson The json object in which to enable local dev
  * @return {!JSON}
  */
-function derandomize(target, configJson) {
+function derandomize_(target, configJson) {
   for (const [key, value] of Object.entries(configJson)) {
     if (typeof value == 'number') {
       configJson[key] = Math.round(value);
@@ -240,7 +234,7 @@ function derandomize(target, configJson) {
 
 /**
  * @param {string} target Target file from which to remove the AMP config
- * @return {!Promise}
+ * @return {!Promise<void>}
  */
 async function removeConfig(target) {
   const file = await fs.promises.readFile(target);
@@ -251,21 +245,19 @@ async function removeConfig(target) {
   sanityCheck(contents);
   const config = /self\.AMP_CONFIG\|\|\(self\.AMP_CONFIG=.*?\/\*AMP_CONFIG\*\//;
   contents = contents.replace(config, '');
-  await writeTarget(target, contents, argv.dryrun);
+  await writeTarget_(target, contents, argv.dryrun);
   log('Removed existing config from', cyan(target));
 }
 
 async function prependGlobal() {
-  const TESTING_HOST = process.env.AMP_TESTING_HOST;
-  const target = argv.target || TESTING_HOST;
-
-  if (!target) {
+  if (!argv.target) {
     log(red('Missing --target.'));
     return;
   }
+  const targets = argv.target.split(',');
 
-  if (!(argv.prod || argv.canary)) {
-    log(red('One of --prod or --canary should be provided.'));
+  if (Boolean(argv.prod) == Boolean(argv.canary)) {
+    log(red('Exactly one of --prod or --canary should be provided.'));
     return;
   }
 
@@ -284,34 +276,36 @@ async function prependGlobal() {
       'build-system/global-configs/prod-config.json'
     );
   }
-  await removeConfig(target);
-  return applyConfig(
-    config,
-    target,
-    filename,
-    argv.local_dev,
-    argv.local_branch,
-    argv.branch,
-    argv.fortesting,
-    argv.derandomize
-  );
+  await Promise.all([...targets.map(removeConfig)]);
+  return Promise.all([
+    ...targets.map((target) =>
+      applyConfig(
+        config,
+        target,
+        filename,
+        argv.local_dev,
+        argv.local_branch,
+        argv.branch,
+        argv.fortesting,
+        argv.derandomize
+      )
+    ),
+  ]);
 }
 
 module.exports = {
   applyConfig,
-  checkoutBranchConfigs,
   numConfigs,
   prependConfig,
   prependGlobal,
   removeConfig,
   sanityCheck,
   valueOrDefault,
-  writeTarget,
 };
 
 prependGlobal.description = 'Prepends a json config to a target file';
 prependGlobal.flags = {
-  'target': '  The file to prepend the json config to.',
+  'target': '  Comma separated list of files to prepend the json config to.',
   'canary':
     '  Prepend the default canary config. ' +
     'Takes in an optional value for a custom canary config source.',


### PR DESCRIPTION
Other changes:
* Remove unused legacy code that uses allows setting --target via an environment variable
* Get config file directly from the requested branch without checking it out into the filesystem
  * Remove unexpected behaviour where a missing config file in the requested branch defaults to using the local branch's copy of the file
* Do not export functions that aren't used anywhere else
* Ensure only one of `--prod` or` --canary` can be passed
* Fix Promise return types