### PR TITLE
Ignore V1 elements in the inabox resource manager

### DIFF
--- a/src/inabox/inabox-resources.js
+++ b/src/inabox/inabox-resources.js
@@ -214,7 +214,7 @@ export class InaboxResources {
     dev().fine(TAG, 'doPass');
     // measure in a batch
     this.resources_.forEach((resource) => {
-      if (!resource.isLayoutPending()) {
+      if (!resource.isLayoutPending() || resource.element.V1()) {
         return;
       }
       resource.measure();
@@ -222,6 +222,7 @@ export class InaboxResources {
     // mutation in a batch
     this.resources_.forEach((resource) => {
       if (
+        !resource.element.V1() &&
         resource.getState() === ResourceState.READY_FOR_LAYOUT &&
         resource.isDisplayed()
       ) {

--- a/test/unit/inabox/test-inabox-resources.js
+++ b/test/unit/inabox/test-inabox-resources.js
@@ -15,6 +15,7 @@
  */
 import {Deferred} from '../../../src/utils/promise';
 import {InaboxResources} from '../../../src/inabox/inabox-resources';
+import {ResourceState} from '../../../src/service/resource';
 import {macroTask} from '../../../testing/yield';
 import {toggleExperiment} from '../../../src/experiments';
 
@@ -146,5 +147,45 @@ describes.realWin('inabox-resources', {amp: true}, (env) => {
     resources.dispose();
     expect(resource1.unload).to.be.calledOnce;
     expect(resource2.unload).to.be.calledOnce;
+  });
+
+  it('should ignore V1 resources for layout pass', async () => {
+    const element1 = env.createAmpElement('amp-foo');
+    const element2 = env.createAmpElement('amp-bar');
+    env.sandbox.stub(element2, 'V1').returns(true);
+
+    win.document.body.appendChild(element1);
+    win.document.body.appendChild(element2);
+    resources.add(element1);
+    resources.add(element2);
+
+    const resource1 = resources.get()[0];
+    const resource2 = resources.get()[1];
+    env.sandbox.stub(resource1, 'measure');
+    env.sandbox.stub(resource2, 'measure');
+    env.sandbox.stub(resource1, 'startLayout');
+    env.sandbox.stub(resource2, 'startLayout');
+
+    env.sandbox.stub(resource1, 'build').resolves();
+    env.sandbox.stub(resource2, 'build').resolves();
+    env.sandbox
+      .stub(resource1, 'getState')
+      .returns(ResourceState.READY_FOR_LAYOUT);
+    env.sandbox
+      .stub(resource2, 'getState')
+      .returns(ResourceState.READY_FOR_LAYOUT);
+    env.sandbox.stub(resource1, 'isDisplayed').returns(true);
+    env.sandbox.stub(resource2, 'isDisplayed').returns(true);
+    resources.upgraded(element1);
+
+    resources.schedulePass(0);
+    await new Promise(setTimeout);
+    await new Promise(setTimeout);
+
+    expect(resource1.measure).to.be.called;
+    expect(resource2.measure).to.not.be.called;
+
+    expect(resource1.startLayout).to.be.called;
+    expect(resource2.startLayout).to.not.be.called;
   });
 });


### PR DESCRIPTION
Partial for #31915.

This is a complete symmetry with the main `Resources` manager. See #32568 for more details.