### PR TITLE
❄️ Fix amphtml fie static visual diff

### DIFF
--- a/examples/visual-tests/amphtml-ads/amp-fie-static.html
+++ b/examples/visual-tests/amphtml-ads/amp-fie-static.html
@@ -21,17 +21,6 @@
   <div fallback>Could not display the fake ad :(</div>
 </amp-ad>
 
-<h1>AMPHTML ad - FIE - /amphtml-ads/resource/amp-creative.html</h1>
-<amp-ad width="300" height="250"
-        type="fake"
-        id="i-amphtml-demo-id-2"
-        a4a-conversion="true"
-        disable3pfallback="true"
-        src="/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html">
-  <div placeholder>Loading...</div>
-  <div fallback>Could not display the fake ad :(</div>
-</amp-ad>
-
 <h1>AMPHTML ad - FIE - amphtml-ads/carousel-ad.a4a.html</h1>
 <amp-ad width="300" height="250"
         type="fake"

--- a/test/visual-diff/visual-tests
+++ b/test/visual-diff/visual-tests
@@ -761,7 +761,6 @@
     },
     {
       // TODO(#28975, @ampproject/wg-monetization): see https://percy.io/ampproject/amphtml/builds-next/8494289/changed/482844300
-      "flaky": true,
       "url": "examples/visual-tests/amphtml-ads/amp-fie-static.html",
       "name": "amphtml-ads: friendly iframe static",
       "interactive_tests": "examples/visual-tests/amphtml-ads/static.js",


### PR DESCRIPTION
Fallback within AMPHTML ad rendered in amp-ad is the source of the flakiness. Given that it is rarely used, it seems fine not being included.

https://github.com/ampproject/amphtml/issues/28975