### PR TITLE
[amp-story-player] Fix duplicate player loading scenario

### DIFF
--- a/spec/amp-story-player.md
+++ b/spec/amp-story-player.md
@@ -137,9 +137,9 @@ Also note that the element must be connected to the DOM before calling `load()`.
 
 ```javascript
 const playerEl = document.createElement('amp-story-player');
-const player = new AmpStoryPlayer(window, playerEl);
+new AmpStoryPlayer(window, playerEl);
 document.body.appendChild(playerEl);
-player.load();
+playerEl.load();
 ```
 
 #### go

--- a/spec/amp-story-player.md
+++ b/spec/amp-story-player.md
@@ -123,7 +123,7 @@ URL pointing to the story.
 
 ## Programmatic Control
 
-Call the player's various methods to programmatically control the player. These methods are exposed on the HTML element, `const playerEl = document.querySelector('amp-story-player')` and on instances of the global class variable, `const player = new AmpStoryPlayer(window, playerEl)`.
+Call the player's various methods to programmatically control the player. These methods are exposed on the HTML element, `const playerEl = document.querySelector('amp-story-player')`.
 
 ### Methods
 

--- a/spec/amp-story-player.md
+++ b/spec/amp-story-player.md
@@ -129,13 +129,16 @@ Call the player's various methods to programmatically control the player. These 
 
 #### load
 
-Will initialize the player manually. This can be useful when the player is dynamically.
+Will initialize the player manually. This can be useful when creating the player dynamically.
 
-Note that the element must be connected to the DOM before calling `load()`.
+Note that the amp-story-player JS will automatically do this when the player is already in the HTML markup, so only do this when you really need to.
+
+Also note that the element must be connected to the DOM before calling `load()`.
 
 ```javascript
-const playerEl = document.body.querySelector('amp-story-player');
+const playerEl = document.createElement('amp-story-player');
 const player = new AmpStoryPlayer(window, playerEl);
+document.body.appendChild(playerEl);
 player.load();
 ```
 

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -31,18 +31,16 @@ export class AmpStoryComponentManager {
 
   /**
    * Calls layoutCallback on the element when it is close to the viewport.
-   * @param {!AmpStoryPlayer|!AmpStoryEntryPoint} elImpl
+   * @param {!Element} element
    * @private
    */
-  layoutEl_(elImpl) {
-    new AmpStoryPlayerViewportObserver(
-      this.win_,
-      elImpl.getElement(),
-      elImpl.layoutCallback.bind(elImpl)
+  layoutEl_(element) {
+    new AmpStoryPlayerViewportObserver(this.win_, element, () =>
+      element.layoutCallback()
     );
 
     const scrollHandler = () => {
-      elImpl.layoutCallback();
+      element.layoutCallback();
       this.win_.removeEventListener('scroll', scrollHandler);
     };
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -246,6 +246,7 @@ export class AmpStoryPlayer {
   attachCallbacksToElement_() {
     this.element_.buildCallback = this.buildCallback.bind(this);
     this.element_.layoutCallback = this.layoutCallback.bind(this);
+    this.element_.getElement = this.getElement.bind(this);
     this.element_.getStories = this.getStories.bind(this);
     this.element_.load = this.load.bind(this);
     this.element_.show = this.show.bind(this);

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -366,7 +366,6 @@ export class AmpStoryPlayer {
   /** @public */
   buildCallback() {
     if (!!this.element_.isBuilt_) {
-      console.log('skipping');
       return;
     }
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -199,12 +199,6 @@ export class AmpStoryPlayer {
     /** @private {?Element} */
     this.rootEl_ = null;
 
-    /** @private {boolean} */
-    this.isLaidOut_ = false;
-
-    /** @private {boolean} */
-    this.isBuilt_ = false;
-
     /** @private {number} */
     this.currentIdx_ = 0;
 
@@ -241,6 +235,8 @@ export class AmpStoryPlayer {
 
     /** @private {boolean} */
     this.autoplay_ = true;
+
+    return this.element_;
   }
 
   /**
@@ -248,6 +244,8 @@ export class AmpStoryPlayer {
    * @private
    */
   attachCallbacksToElement_() {
+    this.element_.buildCallback = this.buildCallback.bind(this);
+    this.element_.layoutCallback = this.layoutCallback.bind(this);
     this.element_.getStories = this.getStories.bind(this);
     this.element_.load = this.load.bind(this);
     this.element_.show = this.show.bind(this);
@@ -270,6 +268,9 @@ export class AmpStoryPlayer {
       throw new Error(
         `[${TAG}] element must be connected to the DOM before calling load().`
       );
+    }
+    if (!!this.element_.isBuilt_) {
+      throw new Error(`[${TAG}] calling load() on an already loaded element.`);
     }
     this.buildCallback();
     this.layoutCallback();
@@ -364,7 +365,8 @@ export class AmpStoryPlayer {
 
   /** @public */
   buildCallback() {
-    if (this.isBuilt_) {
+    if (!!this.element_.isBuilt_) {
+      console.log('skipping');
       return;
     }
 
@@ -378,7 +380,7 @@ export class AmpStoryPlayer {
     this.initializePageScroll_();
     this.initializeCircularWrapping_();
     this.signalReady_();
-    this.isBuilt_ = true;
+    this.element_.isBuilt_ = true;
   }
 
   /**
@@ -681,7 +683,7 @@ export class AmpStoryPlayer {
    * @public
    */
   layoutCallback() {
-    if (this.isLaidOut_) {
+    if (!!this.element_.isLaidOut_) {
       return;
     }
 
@@ -691,7 +693,7 @@ export class AmpStoryPlayer {
 
     this.render_();
 
-    this.isLaidOut_ = true;
+    this.element_.isLaidOut_ = true;
   }
 
   /**


### PR DESCRIPTION
Closes #32826

Fixes duplicate player loading scenario by 
1. Throwing an error when trying to instantiate a player on a DOM element that already has one.
2. Calling `new AmpStoryPlayer(...)` should return the player DOM element instead of the class instance, so we have consistency between doing `querySelector('amp-story-player')` on a Player that was in the initial HTML, and calling `new AmpStoryPlayer(...)`
3. Revise our documentation examples to show that

There's no breaking change to these updates. 
<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
