### PR TITLE
Allow Service Factories to be adopted by FIE

### DIFF
--- a/extensions/amp-access/0.1/test/test-login-dialog.js
+++ b/extensions/amp-access/0.1/test/test-login-dialog.js
@@ -36,7 +36,7 @@ describes.sandboxed('ViewerLoginDialog', {}, (env) => {
 
     windowApi = {
       __AMP_SERVICES: {
-        'viewer': {obj: viewer},
+        'viewer': {obj: viewer, ctor: Object},
       },
       screen: {width: 1000, height: 1000},
       document: {
@@ -168,7 +168,7 @@ describes.sandboxed('WebLoginDialog', {}, (env) => {
     };
     const windowObj = {
       __AMP_SERVICES: {
-        'viewer': {obj: viewer},
+        'viewer': {obj: viewer, ctor: Object},
       },
       open: () => {},
       document: {

--- a/src/service.js
+++ b/src/service.js
@@ -382,7 +382,7 @@ function getServiceInternal(holder, id) {
  * @param {string} id of the service.
  * @param {?function(new:Object, !Window)|?function(new:Object, !./service/ampdoc-impl.AmpDoc)} ctor Constructor function to new the service. Called with context.
  * @param {boolean=} opt_override
- * @param {boolean=} opt_adopted
+ * @param {boolean=} opt_sharedInstance
  */
 function registerServiceInternal(
   holder,
@@ -390,7 +390,7 @@ function registerServiceInternal(
   id,
   ctor,
   opt_override,
-  opt_adopted
+  opt_sharedInstance
 ) {
   const services = getServices(holder);
   let s = services[id];
@@ -403,7 +403,7 @@ function registerServiceInternal(
       reject: null,
       context: null,
       ctor: null,
-      adopted: opt_adopted || false,
+      sharedInstance: opt_sharedInstance || false,
     };
   }
 
@@ -414,7 +414,7 @@ function registerServiceInternal(
 
   s.ctor = ctor;
   s.context = context;
-  s.adopted = opt_adopted || false;
+  s.sharedInstance = opt_sharedInstance || false;
 
   // The service may have been requested already, in which case there is a
   // pending promise that needs to fulfilled.
@@ -545,7 +545,7 @@ function disposeServicesInternal(holder) {
       continue;
     }
     const serviceHolder = services[id];
-    if (serviceHolder.adopted) {
+    if (serviceHolder.sharedInstance) {
       continue;
     }
     if (serviceHolder.obj) {
@@ -597,7 +597,7 @@ export function adoptServiceForEmbedDoc(ampdoc, id) {
       return service;
     },
     /* override */ false,
-    /* adopted */ true
+    /* sharedInstance */ true
   );
 }
 
@@ -623,9 +623,7 @@ export function adoptServiceFactoryForEmbedDoc(ampdoc, id) {
     getAmpdocServiceHolder(ampdoc),
     ampdoc,
     id,
-    devAssert(service.ctor),
-    /* override */ false,
-    /* adopted */ true
+    devAssert(service.ctor)
   );
 }
 
@@ -647,7 +645,7 @@ export function resetServiceForTesting(holder, id) {
  */
 function isServiceRegistered(holder, id) {
   const service = holder.__AMP_SERVICES && holder.__AMP_SERVICES[id];
-  // All registered services must have an implementation or a constructor.
+  // All registered services must have a constructor.
   return !!(service && service.ctor);
 }
 

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {adoptServiceForEmbedDoc} from '../service';
+import {
+  adoptServiceFactoryForEmbedDoc,
+  adoptServiceForEmbedDoc,
+} from '../service';
 import {devAssert} from '../log';
 import {installActionServiceForDoc} from './action-impl';
 import {installBatchedXhrService} from './batched-xhr-impl';
@@ -107,6 +110,9 @@ function installAmpdocServicesInternal(ampdoc, isEmbedded) {
   // 1. Order is important!
   // 2. Consider to install same services to amp-inabox.js
   installUrlForDoc(ampdoc);
+  isEmbedded
+    ? adoptServiceFactoryForEmbedDoc(ampdoc, 'templates')
+    : installTemplatesServiceForDoc(ampdoc);
   isEmbedded
     ? adoptServiceForEmbedDoc(ampdoc, 'documentInfo')
     : installDocumentInfoServiceForDoc(ampdoc);

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  adoptServiceFactoryForEmbedDoc,
-  adoptServiceForEmbedDoc,
-} from '../service';
+import {adoptServiceForEmbedDoc} from '../service';
 import {devAssert} from '../log';
 import {installActionServiceForDoc} from './action-impl';
 import {installBatchedXhrService} from './batched-xhr-impl';
@@ -110,9 +107,6 @@ function installAmpdocServicesInternal(ampdoc, isEmbedded) {
   // 1. Order is important!
   // 2. Consider to install same services to amp-inabox.js
   installUrlForDoc(ampdoc);
-  isEmbedded
-    ? adoptServiceFactoryForEmbedDoc(ampdoc, 'templates')
-    : installTemplatesServiceForDoc(ampdoc);
   isEmbedded
     ? adoptServiceForEmbedDoc(ampdoc, 'documentInfo')
     : installDocumentInfoServiceForDoc(ampdoc);

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -46,7 +46,7 @@ function actionService() {
       },
     },
     __AMP_SERVICES: {
-      vsync: {obj: {}},
+      vsync: {obj: {}, ctor: Object},
     },
   };
   return new ActionService(new AmpDocSingle(win), document);

--- a/test/unit/test-activity.js
+++ b/test/unit/test-activity.js
@@ -101,6 +101,7 @@ describe('Activity getTotalEngagedTime', () => {
         isSingleDoc: () => true,
         getSingleDoc: () => ampdoc,
       },
+      ctor: Object,
     };
 
     installTimerService(fakeWin);
@@ -330,6 +331,7 @@ describe('Activity getIncrementalEngagedTime', () => {
         isSingleDoc: () => true,
         getSingleDoc: () => ampdoc,
       },
+      ctor: Object,
     };
 
     installTimerService(fakeWin);

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -917,6 +917,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
             obj: {
               preloadExtension: () => {},
             },
+            ctor: Object,
           },
         },
         setInterval() {

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -321,8 +321,8 @@ describes.sandboxed('History install', {}, () => {
     installTimerService(window);
     win = {
       __AMP_SERVICES: {
-        'viewer': {obj: viewer},
-        'timer': {obj: Services.timerFor(window)},
+        'viewer': {obj: viewer, ctor: Object},
+        'timer': {obj: Services.timerFor(window), ctor: Object},
       },
       history: {
         length: 0,

--- a/test/unit/test-preconnect.js
+++ b/test/unit/test-preconnect.js
@@ -53,7 +53,7 @@ describes.sandboxed('preconnect', {}, (env) => {
       const platform = {
         isSafari: () => !!isSafari,
       };
-      iframe.win.__AMP_SERVICES['platform'] = {obj: platform};
+      iframe.win.__AMP_SERVICES['platform'] = {obj: platform, ctor: Object};
       sandbox.stub(Services, 'platformFor').returns(platform);
 
       installPreconnectService(iframe.win);

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -65,7 +65,7 @@ describes.fakeWin(
       ampdocServiceMock = env.sandbox.mock(ampdocService);
       win.AMP = [];
       win.__AMP_SERVICES = {
-        ampdoc: {obj: ampdocService},
+        ampdoc: {obj: ampdocService, ctor: Object},
       };
       const ampdoc = new AmpDocSingle(win);
       ampdocService.getSingleDoc = () => ampdoc;

--- a/test/unit/test-service.js
+++ b/test/unit/test-service.js
@@ -634,22 +634,19 @@ describe('service', () => {
       });
 
       it('should share adoptable instances', () => {
-        const topService = {};
-        registerServiceBuilderForDoc(parentAmpdoc, 'A', function () {
-          return topService;
-        });
+        class Factory {}
+        registerServiceBuilderForDoc(parentAmpdoc, 'A', Factory);
         adoptServiceForEmbedDoc(ampdoc, 'A');
 
-        expect(getServiceForDoc(ampdoc, 'A')).to.equal(topService);
+        const parent = getServiceForDoc(parentAmpdoc, 'A');
+        const child = getServiceForDoc(ampdoc, 'A');
+        expect(parent).to.be.instanceof(Factory);
+        expect(child).to.be.instanceof(Factory);
+        expect(child).to.equal(parent);
       });
 
       it('should share adoptable factories but not instances', () => {
-        const instances = [];
-        class Factory {
-          constructor() {
-            instances.push(this);
-          }
-        }
+        class Factory {}
         registerServiceBuilderForDoc(parentAmpdoc, 'A', Factory);
         adoptServiceFactoryForEmbedDoc(ampdoc, 'A');
 

--- a/test/unit/test-service.js
+++ b/test/unit/test-service.js
@@ -15,6 +15,7 @@
  */
 
 import {
+  adoptServiceFactoryForEmbedDoc,
   adoptServiceForEmbedDoc,
   assertDisposable,
   disposeServicesForDoc,
@@ -190,13 +191,13 @@ describe('service', () => {
       expect(p).to.not.be.null;
     });
 
-    it('should set service builders to null after instantiation', () => {
+    it('should not set service builders to null after instantiation', () => {
       registerServiceBuilder(window, 'a', Class);
       expect(window.__AMP_SERVICES['a'].obj).to.be.null;
       expect(window.__AMP_SERVICES['a'].ctor).to.not.be.null;
       getService(window, 'a');
       expect(window.__AMP_SERVICES['a'].obj).to.not.be.null;
-      expect(window.__AMP_SERVICES['a'].ctor).to.be.null;
+      expect(window.__AMP_SERVICES['a'].ctor).to.not.be.null;
     });
 
     it('should resolve service for a child window', () => {
@@ -610,20 +611,53 @@ describe('service', () => {
 
         // A disposable service.
         registerServiceBuilderForDoc(ampdoc, 'b', disposableFactory);
-        const disposable = getServiceForDoc(node, 'b');
+        const b = getServiceForDoc(node, 'b');
 
-        // An adopted disposable service.
+        // A shared disposable service instance.
         adoptServiceForEmbedDoc(ampdoc, 'a');
-        const adopted = getServiceForDoc(ampdoc, 'a');
+        const shared = getServiceForDoc(ampdoc, 'a');
+
+        // A shared disposable service factory.
+        registerServiceBuilderForDoc(parentAmpdoc, 'f', disposableFactory);
+        adoptServiceFactoryForEmbedDoc(ampdoc, 'f');
+        const f = getServiceForDoc(ampdoc, 'f');
 
         disposeServicesForDoc(ampdoc);
 
         // Parent's services are not disposed.
         expect(parentDisposable.dispose).to.not.be.called;
-        expect(adopted).to.equal(parentDisposable);
+        expect(shared).to.equal(parentDisposable);
 
         // Disposable and initialized are disposed right away.
-        expect(disposable.dispose).to.be.calledOnce;
+        expect(b.dispose).to.be.calledOnce;
+        expect(f.dispose).to.be.calledOnce;
+      });
+
+      it('should share adoptable instances', () => {
+        const topService = {};
+        registerServiceBuilderForDoc(parentAmpdoc, 'A', function () {
+          return topService;
+        });
+        adoptServiceForEmbedDoc(ampdoc, 'A');
+
+        expect(getServiceForDoc(ampdoc, 'A')).to.equal(topService);
+      });
+
+      it('should share adoptable factories but not instances', () => {
+        const instances = [];
+        class Factory {
+          constructor() {
+            instances.push(this);
+          }
+        }
+        registerServiceBuilderForDoc(parentAmpdoc, 'A', Factory);
+        adoptServiceFactoryForEmbedDoc(ampdoc, 'A');
+
+        const parent = getServiceForDoc(parentAmpdoc, 'A');
+        const child = getServiceForDoc(ampdoc, 'A');
+        expect(parent).to.be.instanceof(Factory);
+        expect(child).to.be.instanceof(Factory);
+        expect(child).not.to.equal(parent);
       });
     });
   });

--- a/test/unit/test-shadow-embed.js
+++ b/test/unit/test-shadow-embed.js
@@ -376,8 +376,8 @@ describes.sandboxed('shadow-embed', {}, () => {
           },
         },
         __AMP_SERVICES: {
-          'platform': {obj: platform},
-          'vsync': {obj: {}},
+          'platform': {obj: platform, ctor: Object},
+          'vsync': {obj: {}, ctor: Object},
         },
       };
     });

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -170,7 +170,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
             },
           },
           __AMP_SERVICES: {
-            'viewport': {obj: {}},
+            'viewport': {obj: {}, ctor: Object},
             'cid': {
               promise: Promise.resolve({
                 get: (config) =>


### PR DESCRIPTION
There are several methods of sharing services with FIE, but the 2 main ones are:

1. FIE installs its own factory
2. FIE copies the parent's factory **instance**

https://github.com/ampproject/error-reporting/issues/58 is caused because the FIE is using its own factory instance (which means it has its own `Templates` class code, with private names mangled, in each binary that installs the FIE). But each FIE then uses code shared with v0.js to install a amp-mustache instance. This means we have code compiled in v0.js trying to directly interact with a class that's provided by, eg, amp-ad-custom (a separate binary!). This is never good.

What's really needed here is a 3rd way to share services with FIE:

3. FIE copies the parent's **factory**

FIE can then instantiate its own instance of that factory, which will have its own instance data. And because v0.js we'll reuse the class code already in v0.js, we won't have an issue with private mangling. And, we'll make all of these FIE installers smaller!

Fixes https://github.com/ampproject/error-reporting/issues/58