### PR TITLE
Migrate Bento components to V1

### DIFF
--- a/extensions/amp-instagram/1.0/base-element.js
+++ b/extensions/amp-instagram/1.0/base-element.js
@@ -26,6 +26,9 @@ BaseElement['Component'] = Instagram;
 BaseElement['loadable'] = true;
 
 /** @override */
+BaseElement['unloadOnPause'] = true;
+
+/** @override */
 BaseElement['props'] = {
   'captioned': {attr: 'data-captioned'},
   'shortcode': {attr: 'data-shortcode'},

--- a/extensions/amp-instagram/1.0/component.js
+++ b/extensions/amp-instagram/1.0/component.js
@@ -60,10 +60,12 @@ export function InstagramWithRef(
   const onReadyStateRef = useValueRef(onReadyState);
   const setLoaded = useCallback(
     (value) => {
-      loadedRef.current = value;
-      const onReadyState = onReadyStateRef.current;
-      if (onReadyState) {
-        onReadyState(value ? ReadyState.COMPLETE : ReadyState.LOADING);
+      if (value !== loadedRef.current) {
+        loadedRef.current = value;
+        const onReadyState = onReadyStateRef.current;
+        if (onReadyState) {
+          onReadyState(value ? ReadyState.COMPLETE : ReadyState.LOADING);
+        }
       }
     },
     [onReadyStateRef]

--- a/extensions/amp-instagram/1.0/component.js
+++ b/extensions/amp-instagram/1.0/component.js
@@ -16,7 +16,7 @@
 
 import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
-import {Loading} from '../../../src/loading';
+import {Loading} from '../../../src/core/loading-instructions';
 import {ReadyState} from '../../../src/ready-state';
 import {dict} from '../../../src/utils/object';
 import {forwardRef} from '../../../src/preact/compat';

--- a/extensions/amp-instagram/1.0/component.js
+++ b/extensions/amp-instagram/1.0/component.js
@@ -63,9 +63,7 @@ export function InstagramWithRef(
       if (value !== loadedRef.current) {
         loadedRef.current = value;
         const onReadyState = onReadyStateRef.current;
-        if (onReadyState) {
-          onReadyState(value ? ReadyState.COMPLETE : ReadyState.LOADING);
-        }
+        onReadyState?.(value ? ReadyState.COMPLETE : ReadyState.LOADING);
       }
     },
     [onReadyStateRef]
@@ -89,6 +87,8 @@ export function InstagramWithRef(
 
   // Reset readyState to "loading" when an iframe is unloaded. Has to be
   // a `useLayoutEffect` to avoid race condition with a future "load" event.
+  // A race condition can happen when a `useEffect` would be executed
+  // after a future "load" is dispatched.
   useLayoutEffect(() => {
     if (!load) {
       setLoaded(false);

--- a/extensions/amp-instagram/1.0/component.js
+++ b/extensions/amp-instagram/1.0/component.js
@@ -54,7 +54,7 @@ export function InstagramWithRef(
 ) {
   const {playable} = useAmpContext();
   const loading = useLoading(loadingProp);
-  const load = loading !== Loading.UNLOAD;
+  const mount = loading !== Loading.UNLOAD;
 
   const loadedRef = useRef(false);
   // The `onReadyStateRef` is passed via a ref to avoid the changed values
@@ -92,10 +92,10 @@ export function InstagramWithRef(
   // A race condition can happen when a `useEffect` would be executed
   // after a future "load" is dispatched.
   useLayoutEffect(() => {
-    if (!load) {
+    if (!mount) {
       setLoaded(false);
     }
-  }, [load, setLoaded]);
+  }, [mount, setLoaded]);
 
   // Pause if the post goes into a "paused" context.
   useEffect(() => {
@@ -109,7 +109,7 @@ export function InstagramWithRef(
   }, [playable]);
 
   useLayoutEffect(() => {
-    if (!iframeRef.current || !load) {
+    if (!iframeRef.current || !mount) {
       return;
     }
     const messageHandler = (event) => {
@@ -139,11 +139,11 @@ export function InstagramWithRef(
     return () => {
       defaultView.removeEventListener('message', messageHandler);
     };
-  }, [load, requestResize, heightStyle]);
+  }, [mount, requestResize, heightStyle]);
 
   return (
     <ContainWrapper {...rest} wrapperStyle={heightStyle} layout size paint>
-      {load && (
+      {mount && (
         <iframe
           ref={iframeRef}
           src={

--- a/extensions/amp-instagram/1.0/component.type.js
+++ b/extensions/amp-instagram/1.0/component.type.js
@@ -16,13 +16,21 @@
 
 /** @externs */
 
+var InstagramDef = {};
+
 /** @typedef {{
  *   shortcode: string,
  *   captioned: (boolean|undefined),
  *   title: (string|undefined),
  *   requestResize: (function(number):*|undefined),
  *   loading: (string|undefined),
- *   onLoad: (function(!Event)|undefind),
+ *   onReadyState: (function(string, *=)|undefined),
  * }}
  */
-var InstagramPropsDef;
+InstagramDef.Props;
+
+/** @interface */
+InstagramDef.Api = class {
+  /** @return {string} */
+  get readyState() {}
+};

--- a/extensions/amp-instagram/1.0/component.type.js
+++ b/extensions/amp-instagram/1.0/component.type.js
@@ -32,7 +32,7 @@ var InstagramDef = {};
 InstagramDef.Props;
 
 /** @constructor */
-InstagramDef.Api = function() {};
+InstagramDef.Api = function () {};
 
 /** @type {string} */
 InstagramDef.Api.prototype.readyState;

--- a/extensions/amp-instagram/1.0/component.type.js
+++ b/extensions/amp-instagram/1.0/component.type.js
@@ -16,9 +16,11 @@
 
 /** @externs */
 
+/** @const */
 var InstagramDef = {};
 
-/** @typedef {{
+/**
+ * @typedef {{
  *   shortcode: string,
  *   captioned: (boolean|undefined),
  *   title: (string|undefined),
@@ -29,8 +31,8 @@ var InstagramDef = {};
  */
 InstagramDef.Props;
 
-/** @interface */
-InstagramDef.Api = class {
-  /** @return {string} */
-  get readyState() {}
-};
+/** @constructor */
+InstagramDef.Api = function() {};
+
+/** @type {string} */
+InstagramDef.Api.prototype.readyState;

--- a/extensions/amp-instagram/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.amp.js
@@ -51,7 +51,7 @@ export const _default = () => {
 };
 
 export const InsideAccordion = () => {
-  const shortcode = text('shortcode', 'B8QaZW4AQY_');
+  const shortcode = text('shortcode', 'Bp4I3hRhd_v');
   const width = number('width', 300);
   const height = number('height', 200);
   return (

--- a/extensions/amp-instagram/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.amp.js
@@ -69,3 +69,19 @@ export const InsideAccordion = () => {
     </amp-accordion>
   );
 };
+
+export const InsideDetails = () => {
+  const shortcode = text('shortcode', 'Bp4I3hRhd_v');
+  const width = number('width', 300);
+  const height = number('height', 200);
+  return (
+    <details open>
+      <summary>Post</summary>
+      <amp-instagram
+        data-shortcode={shortcode}
+        width={width}
+        height={height}
+      ></amp-instagram>
+    </details>
+  );
+};

--- a/extensions/amp-instagram/1.0/storybook/Basic.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.js
@@ -48,12 +48,12 @@ export const _default = () => {
 };
 
 export const InsideAccordion = () => {
-  const shortcode = text('shortcode', 'B8QaZW4AQY_');
+  const shortcode = text('shortcode', 'Bp4I3hRhd_v');
   const width = number('width', 500);
   const height = number('height', 600);
   return (
     <Accordion expandSingleSection>
-      <AccordionSection key={1} expanded={false}>
+      <AccordionSection key={1} expanded={true}>
         <AccordionHeader>
           <h2>Post</h2>
         </AccordionHeader>

--- a/extensions/amp-video/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video/1.0/storybook/Basic.amp.js
@@ -183,3 +183,27 @@ export const InsideAccordion = () => {
     </amp-accordion>
   );
 };
+
+export const InsideDetails = () => {
+  const width = number('width', 320);
+  const height = number('height', 180);
+  const autoplay = boolean('autoplay', false);
+
+  return (
+    <details open>
+      <summary>Video</summary>
+      <amp-video
+        autoplay={autoplay}
+        controls
+        loop
+        width={width}
+        height={height}
+      >
+        <source
+          type="video/mp4"
+          src="https://amp.dev/static/inline-examples/videos/kitten-playing.mp4"
+        ></source>
+      </amp-video>
+    </details>
+  );
+};

--- a/extensions/amp-video/1.0/storybook/VideoIframe.js
+++ b/extensions/amp-video/1.0/storybook/VideoIframe.js
@@ -33,7 +33,7 @@ export default {
   decorators: [withA11y, withKnobs],
 };
 
-const AmpVideoIframeLike = (props) => {
+const AmpVideoIframeLike = ({unloadOnPause, ...rest}) => {
   const onMessage = useCallback((e) => {
     // Expect HTMLMediaElement events from document in `src` as
     // `{event: 'playing'}`
@@ -61,7 +61,8 @@ const AmpVideoIframeLike = (props) => {
 
   return (
     <VideoWrapper
-      {...props}
+      {...rest}
+      unloadOnPause={unloadOnPause}
       component={VideoIframe}
       allow="autoplay" // this is not safe for a generic frame
       onMessage={onMessage}
@@ -94,6 +95,7 @@ export const UsingVideoIframe = () => {
     'src',
     'https://amp.dev/static/samples/files/amp-video-iframe-videojs.html'
   );
+
   return (
     <AmpVideoIframeLike
       ariaLabel={ariaLabel}
@@ -122,6 +124,7 @@ export const InsideAccordion = () => {
     'src',
     'https://amp.dev/static/samples/files/amp-video-iframe-videojs.html'
   );
+  const unloadOnPause = boolean('unloadOnPause', false);
   return (
     <Accordion expandSingleSection>
       <AccordionSection key={1} expanded>
@@ -135,6 +138,7 @@ export const InsideAccordion = () => {
             loop={true}
             style={{width, height}}
             src={src}
+            unloadOnPause={unloadOnPause}
           />
         </AccordionContent>
       </AccordionSection>

--- a/extensions/amp-video/1.0/test/test-video-iframe.js
+++ b/extensions/amp-video/1.0/test/test-video-iframe.js
@@ -178,6 +178,38 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
     expect(removeEventListener.withArgs('message')).to.have.been.calledOnce;
   });
 
+  it('should reset an unloadOnPause-iframe on pause', () => {
+    const ref = createRef();
+
+    const makeMethodMessageStub = env.sandbox.stub();
+
+    const videoIframe = mount(
+      <VideoIframe
+        ref={ref}
+        src="about:blank"
+        makeMethodMessage={makeMethodMessageStub}
+        unloadOnPause={true}
+      />
+    );
+
+    const iframe = videoIframe.getDOMNode();
+    let iframeSrc = iframe.src;
+    const iframeSrcSetterSpy = env.sandbox.spy();
+    Object.defineProperty(iframe, 'src', {
+      get() {
+        return iframeSrc;
+      },
+      set(value) {
+        iframeSrc = value;
+        iframeSrcSetterSpy(value);
+      },
+    });
+
+    ref.current.pause();
+    expect(iframeSrcSetterSpy).to.be.calledOnce;
+    expect(makeMethodMessageStub).to.not.be.calledWith('pause');
+  });
+
   describe('uses playerStateRef to read the imperative state', () => {
     const makeMethodMessage = (method) => ({makeMethodMessageFor: method});
 

--- a/extensions/amp-video/1.0/test/test-video-iframe.js
+++ b/extensions/amp-video/1.0/test/test-video-iframe.js
@@ -16,6 +16,7 @@
 
 import * as Preact from '../../../../src/preact';
 import {VideoIframe} from '../video-iframe';
+import {createRef} from '../../../../src/preact';
 import {mount} from 'enzyme';
 
 function dispatchMessage(window, opt_event) {
@@ -175,6 +176,72 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
 
     videoIframe.unmount();
     expect(removeEventListener.withArgs('message')).to.have.been.calledOnce;
+  });
+
+  describe('uses playerStateRef to read the imperative state', () => {
+    const makeMethodMessage = (method) => ({makeMethodMessageFor: method});
+
+    it('should NOT fail when player state is not available', () => {
+      const ref = createRef();
+
+      // no value.
+      mount(
+        <VideoIframe
+          ref={ref}
+          src="about:blank"
+          makeMethodMessage={makeMethodMessage}
+        />
+      );
+      expect(ref.current.currentTime).to.be.NaN;
+      expect(ref.current.duration).to.be.NaN;
+
+      // null value.
+      const playerStateRef = createRef();
+      mount(
+        <VideoIframe
+          ref={ref}
+          src="about:blank"
+          makeMethodMessage={makeMethodMessage}
+          playerStateRef={playerStateRef}
+        />
+      );
+      expect(ref.current.currentTime).to.be.NaN;
+      expect(ref.current.duration).to.be.NaN;
+
+      // empty value.
+      playerStateRef.current = {};
+      mount(
+        <VideoIframe
+          ref={ref}
+          src="about:blank"
+          makeMethodMessage={makeMethodMessage}
+          playerStateRef={playerStateRef}
+        />
+      );
+      expect(ref.current.currentTime).to.be.NaN;
+      expect(ref.current.duration).to.be.NaN;
+    });
+
+    it('should return the provided player state', () => {
+      const ref = createRef();
+      const playerStateRef = createRef();
+      playerStateRef.current = {duration: 111, currentTime: 11};
+      mount(
+        <VideoIframe
+          ref={ref}
+          src="about:blank"
+          makeMethodMessage={makeMethodMessage}
+          playerStateRef={playerStateRef}
+        />
+      );
+      expect(ref.current.currentTime).to.equal(11);
+      expect(ref.current.duration).to.equal(111);
+
+      // 0-values are ok.
+      playerStateRef.current = {duration: 0, currentTime: 0};
+      expect(ref.current.currentTime).to.equal(0);
+      expect(ref.current.duration).to.equal(0);
+    });
   });
 
   describe('uses makeMethodMessage to posts imperative handle methods', () => {

--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -110,20 +110,6 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
     expect(api.duration).to.be.NaN;
   });
 
-  it('should render only shell when paused in unloadOnPause', () => {
-    const wrapper = mount(
-      <WithAmpContext playable={false}>
-        <VideoWrapper
-          unloadOnPause={true}
-          component={TestPlayer}
-          sources={<div></div>}
-        />
-      </WithAmpContext>
-    );
-    const player = wrapper.find(TestPlayer);
-    expect(player).to.have.lengthOf(0);
-  });
-
   it('should initialize in a readyState=complete', () => {
     playerReadyState = 1;
     const ref = createRef();
@@ -233,7 +219,6 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
     const wrapper = mount(
       <WithAmpContext playable={true}>
         <VideoWrapper
-          unloadOnPause={true}
           component={TestPlayer}
           sources={<div></div>}
           onPlayingState={onPlayingState}
@@ -242,11 +227,6 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
     );
     await wrapper.find(TestPlayer).invoke('onPlaying')();
     expect(onPlayingState).to.be.calledOnce.calledWith(true);
-
-    // Unmount via unloadOnPause.
-    onPlayingState.resetHistory();
-    wrapper.setProps({playable: false});
-    expect(onPlayingState).to.be.calledOnce.calledWith(false);
   });
 
   describe('MediaSession', () => {

--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -197,6 +197,58 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
     expect(onReadyState).to.be.calledOnce.calledWith('error');
   });
 
+  it('should send playing state on events', async () => {
+    const onPlayingState = env.sandbox.spy();
+    const wrapper = mount(
+      <VideoWrapper
+        component={TestPlayer}
+        sources={<div></div>}
+        onPlayingState={onPlayingState}
+      />
+    );
+    expect(onPlayingState).to.not.be.called;
+
+    // onPlaying
+    await wrapper.find(TestPlayer).invoke('onPlaying')();
+    expect(onPlayingState).to.be.calledOnce.calledWith(true);
+
+    // onPause
+    onPlayingState.resetHistory();
+    await wrapper.find(TestPlayer).invoke('onPause')();
+    expect(onPlayingState).to.be.calledOnce.calledWith(false);
+
+    // onPlaying again
+    onPlayingState.resetHistory();
+    await wrapper.find(TestPlayer).invoke('onPlaying')();
+    expect(onPlayingState).to.be.calledOnce.calledWith(true);
+
+    // onEnded
+    onPlayingState.resetHistory();
+    await wrapper.find(TestPlayer).invoke('onEnded')();
+    expect(onPlayingState).to.be.calledOnce.calledWith(false);
+  });
+
+  it('should reset playing state when component is not mounted', async () => {
+    const onPlayingState = env.sandbox.spy();
+    const wrapper = mount(
+      <WithAmpContext playable={true}>
+        <VideoWrapper
+          unloadOnPause={true}
+          component={TestPlayer}
+          sources={<div></div>}
+          onPlayingState={onPlayingState}
+        />
+      </WithAmpContext>
+    );
+    await wrapper.find(TestPlayer).invoke('onPlaying')();
+    expect(onPlayingState).to.be.calledOnce.calledWith(true);
+
+    // Unmount via unloadOnPause.
+    onPlayingState.resetHistory();
+    wrapper.setProps({playable: false});
+    expect(onPlayingState).to.be.calledOnce.calledWith(false);
+  });
+
   describe('MediaSession', () => {
     let navigator;
 

--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -28,6 +28,7 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
   let intersectionObserverObserved;
   let intersectionObserverCallback;
 
+  let playerReadyState;
   let play;
   let pause;
 
@@ -35,6 +36,9 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
 
   const TestPlayer = forwardRef(({}, ref) => {
     Preact.useImperativeHandle(ref, () => ({
+      get readyState() {
+        return playerReadyState;
+      },
       play,
       pause,
       getMetadata: () => metadata,
@@ -43,6 +47,7 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
   });
 
   beforeEach(() => {
+    playerReadyState = undefined;
     pause = env.sandbox.spy();
     play = env.sandbox.spy();
 
@@ -100,6 +105,7 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
 
     // API is functional but returns 0/NaN values.
     const api = ref.current;
+    expect(api.readyState).to.equal('loading');
     expect(api.currentTime).to.equal(0);
     expect(api.duration).to.be.NaN;
   });
@@ -116,6 +122,79 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
     );
     const player = wrapper.find(TestPlayer);
     expect(player).to.have.lengthOf(0);
+  });
+
+  it('should initialize in a readyState=complete', () => {
+    playerReadyState = 1;
+    const ref = createRef();
+    mount(
+      <VideoWrapper ref={ref} component={TestPlayer} sources={<div></div>} />
+    );
+    const api = ref.current;
+    expect(api.readyState).to.equal('complete');
+  });
+
+  it('should set readyState=complete on canplay', async () => {
+    const ref = createRef();
+    const onReadyState = env.sandbox.spy();
+    const wrapper = mount(
+      <VideoWrapper
+        ref={ref}
+        component={TestPlayer}
+        sources={<div></div>}
+        onReadyState={onReadyState}
+      />
+    );
+    let api = ref.current;
+    expect(api.readyState).to.equal('loading');
+    expect(onReadyState).to.not.be.called;
+
+    await wrapper.find(TestPlayer).invoke('onCanPlay')();
+    api = ref.current;
+    expect(api.readyState).to.equal('complete');
+    expect(onReadyState).to.be.calledOnce.calledWith('complete');
+  });
+
+  it('should set readyState=complete on metadata', async () => {
+    const ref = createRef();
+    const onReadyState = env.sandbox.spy();
+    const wrapper = mount(
+      <VideoWrapper
+        ref={ref}
+        component={TestPlayer}
+        sources={<div></div>}
+        onReadyState={onReadyState}
+      />
+    );
+    let api = ref.current;
+    expect(api.readyState).to.equal('loading');
+    expect(onReadyState).to.not.be.called;
+
+    await wrapper.find(TestPlayer).invoke('onLoadedMetadata')();
+    api = ref.current;
+    expect(api.readyState).to.equal('complete');
+    expect(onReadyState).to.be.calledOnce.calledWith('complete');
+  });
+
+  it('should set readyState=error on error event', async () => {
+    const ref = createRef();
+    const onReadyState = env.sandbox.spy();
+    const wrapper = mount(
+      <VideoWrapper
+        ref={ref}
+        component={TestPlayer}
+        sources={<div></div>}
+        onReadyState={onReadyState}
+      />
+    );
+    let api = ref.current;
+    expect(api.readyState).to.equal('loading');
+    expect(onReadyState).to.not.be.called;
+
+    await wrapper.find(TestPlayer).invoke('onError')();
+    api = ref.current;
+    expect(api.readyState).to.equal('error');
+    expect(onReadyState).to.be.calledOnce.calledWith('error');
   });
 
   describe('MediaSession', () => {

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -67,6 +67,7 @@ function VideoIframeWithRef(
     origin,
     onCanPlay,
     onMessage,
+    playerStateRef,
     makeMethodMessage: makeMethodMessageProp,
     onIframeLoad,
     ...rest
@@ -97,10 +98,20 @@ function VideoIframeWithRef(
   useImperativeHandle(
     ref,
     () => ({
+      get currentTime() {
+        const playerState = playerStateRef && playerStateRef.current;
+        const value = playerState && playerState['currentTime'];
+        return typeof value == 'number' ? value : NaN;
+      },
+      get duration() {
+        const playerState = playerStateRef && playerStateRef.current;
+        const value = playerState && playerState['duration'];
+        return typeof value == 'number' ? value : NaN;
+      },
       play: () => postMethodMessage('play'),
       pause: () => postMethodMessage('pause'),
     }),
-    [postMethodMessage]
+    [playerStateRef, postMethodMessage]
   );
 
   // Keep `onMessage` in a ref to prevent re-listening on every render.

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -61,6 +61,7 @@ function usePropRef(prop) {
 function VideoIframeWithRef(
   {
     loading,
+    unloadOnPause = false,
     sandbox = DEFAULT_SANDBOX,
     muted = false,
     controls = false,
@@ -105,9 +106,18 @@ function VideoIframeWithRef(
         return playerStateRef?.current?.['duration'] ?? NaN;
       },
       play: () => postMethodMessage('play'),
-      pause: () => postMethodMessage('pause'),
+      pause: () => {
+        if (unloadOnPause) {
+          const iframe = iframeRef.current;
+          if (iframe) {
+            iframe.src = iframe.src;
+          }
+        } else {
+          postMethodMessage('pause');
+        }
+      },
     }),
-    [playerStateRef, postMethodMessage]
+    [playerStateRef, postMethodMessage, unloadOnPause]
   );
 
   // Keep `onMessage` in a ref to prevent re-listening on every render.

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -99,14 +99,10 @@ function VideoIframeWithRef(
     ref,
     () => ({
       get currentTime() {
-        const playerState = playerStateRef && playerStateRef.current;
-        const value = playerState && playerState['currentTime'];
-        return typeof value == 'number' ? value : NaN;
+        return playerStateRef?.current?.['currentTime'] ?? NaN;
       },
       get duration() {
-        const playerState = playerStateRef && playerStateRef.current;
-        const value = playerState && playerState['duration'];
-        return typeof value == 'number' ? value : NaN;
+        return playerStateRef?.current?.['duration'] ?? NaN;
       },
       play: () => postMethodMessage('play'),
       pause: () => postMethodMessage('pause'),

--- a/extensions/amp-video/1.0/video-iframe.type.js
+++ b/extensions/amp-video/1.0/video-iframe.type.js
@@ -23,6 +23,7 @@ var VideoIframeDef = {};
  * @mixin VideoWrapperDef.props
  * @typedef {{
  *   loading: (string|undefined),
+ *   unloadOnPause: (boolean|undefined),
  *   sandbox: (string|undefined),
  *   origin: (RegExp|undefined),
  *   onMessage: function(!MessageEvent),

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -17,7 +17,7 @@
 import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Deferred} from '../../../src/utils/promise';
-import {Loading} from '../../../src/loading';
+import {Loading} from '../../../src/core/loading-instructions';
 import {MIN_VISIBILITY_RATIO_FOR_AUTOPLAY} from '../../../src/video-interface';
 import {
   MetadataDef,

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -15,8 +15,9 @@
  */
 
 import * as Preact from '../../../src/preact';
-import {ContainWrapper} from '../../../src/preact/component';
+import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Deferred} from '../../../src/utils/promise';
+import {Loading} from '../../../src/loading';
 import {MIN_VISIBILITY_RATIO_FOR_AUTOPLAY} from '../../../src/video-interface';
 import {
   MetadataDef,
@@ -25,11 +26,12 @@ import {
   parseSchemaImage,
   setMediaSession,
 } from '../../../src/mediasession-helper';
+import {ReadyState} from '../../../src/ready-state';
 import {dict} from '../../../src/utils/object';
 import {fillContentOverlay, fillStretch} from './video-wrapper.css';
 import {forwardRef} from '../../../src/preact/compat';
 import {once} from '../../../src/utils/function';
-import {useAmpContext, useLoad} from '../../../src/preact/context';
+import {useAmpContext, useLoading} from '../../../src/preact/context';
 import {useStyles as useAutoplayStyles} from './autoplay.jss';
 import {
   useCallback,
@@ -78,7 +80,7 @@ const getMetadata = (player, props) =>
 function VideoWrapperWithRef(
   {
     component: Component = 'video',
-    loading,
+    loading: loadingProp,
     unloadOnPause = false,
     autoplay = false,
     controls = false,
@@ -90,14 +92,15 @@ function VideoWrapperWithRef(
     src,
     sources,
     poster,
-    onLoad,
+    onReadyState,
     ...rest
   },
   ref
 ) {
   useResourcesNotify();
   const {playable} = useAmpContext();
-  const load = useLoad(loading, unloadOnPause);
+  const loading = useLoading(loadingProp, unloadOnPause);
+  const load = loading !== Loading.UNLOAD;
 
   const [muted, setMuted] = useState(autoplay);
   const [playing, setPlaying] = useState(false);
@@ -110,6 +113,20 @@ function VideoWrapperWithRef(
   // TODO(alanorozco): We might need an API to notify reload, like when
   // <source>s change.
   const readyDeferred = useMemo(() => new Deferred(), []);
+
+  const [readyState, setReadyState_] = useState(ReadyState.LOADING);
+
+  const onReadyStateRef = useValueRef(onReadyState);
+  const setReadyState = useCallback(
+    (state, opt_failure) => {
+      setReadyState_(state);
+      const onReadyState = onReadyStateRef.current;
+      if (onReadyState) {
+        onReadyState(state, opt_failure);
+      }
+    },
+    [onReadyStateRef]
+  );
 
   const play = useCallback(() => {
     return readyDeferred.promise.then(() => playerRef.current.play());
@@ -129,6 +146,15 @@ function VideoWrapperWithRef(
     setMuted(false);
     setHasUserInteracted(true);
   }, []);
+
+  // Update the initial readyState.
+  useLayoutEffect(() => {
+    const player = playerRef.current;
+    const readyState = player && player.readyState;
+    if (readyState != null) {
+      setReadyState(readyState > 0 ? ReadyState.COMPLETE : ReadyState.LOADING);
+    }
+  }, [setReadyState]);
 
   useLayoutEffect(() => {
     if (mediasession && playing && metadata) {
@@ -152,6 +178,11 @@ function VideoWrapperWithRef(
   useImperativeHandle(
     ref,
     () => ({
+      // Standard Bento
+      get readyState() {
+        return readyState;
+      },
+
       // Standard HTMLMediaElement/Element
       play,
       pause,
@@ -188,6 +219,7 @@ function VideoWrapperWithRef(
       },
     }),
     [
+      readyState,
       play,
       pause,
       requestFullscreen,
@@ -218,9 +250,7 @@ function VideoWrapperWithRef(
           controls={controls && (!autoplay || hasUserInteracted)}
           onCanPlay={() => {
             readyDeferred.resolve();
-            if (onLoad) {
-              onLoad();
-            }
+            setReadyState(ReadyState.COMPLETE);
           }}
           onLoadedMetadata={() => {
             if (mediasession) {
@@ -228,9 +258,11 @@ function VideoWrapperWithRef(
                 setMetadata(getMetadata(playerRef.current, rest));
               });
             }
+            setReadyState(ReadyState.COMPLETE);
           }}
           onPlaying={() => setPlaying(true)}
           onPause={() => setPlaying(false)}
+          onError={(e) => setReadyState(ReadyState.ERROR, e)}
           style={fillStretch}
           src={src}
           poster={poster}

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -175,8 +175,7 @@ function VideoWrapperWithRef(
   // Update the initial readyState. Using `useLayoutEffect` here to avoid
   // race conditions with possible future events.
   useLayoutEffect(() => {
-    const player = playerRef.current;
-    const readyState = player && player.readyState;
+    const readyState = playerRef.current?.readyState;
     if (readyState != null) {
       setReadyState(readyState > 0 ? ReadyState.COMPLETE : ReadyState.LOADING);
     }

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -81,7 +81,6 @@ function VideoWrapperWithRef(
   {
     component: Component = 'video',
     loading: loadingProp,
-    unloadOnPause = false,
     autoplay = false,
     controls = false,
     loop = false,
@@ -100,7 +99,7 @@ function VideoWrapperWithRef(
 ) {
   useResourcesNotify();
   const {playable} = useAmpContext();
-  const loading = useLoading(loadingProp, unloadOnPause);
+  const loading = useLoading(loadingProp);
   const load = loading !== Loading.UNLOAD;
 
   const [muted, setMuted] = useState(autoplay);

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -120,10 +120,12 @@ function VideoWrapperWithRef(
   const onReadyStateRef = useValueRef(onReadyState);
   const setReadyState = useCallback(
     (state, opt_failure) => {
-      readyStateRef.current = state;
-      const onReadyState = onReadyStateRef.current;
-      if (onReadyState) {
-        onReadyState(state, opt_failure);
+      if (state !== readyStateRef.current) {
+        readyStateRef.current = state;
+        const onReadyState = onReadyStateRef.current;
+        if (onReadyState) {
+          onReadyState(state, opt_failure);
+        }
       }
     },
     [onReadyStateRef]

--- a/extensions/amp-video/1.0/video-wrapper.type.js
+++ b/extensions/amp-video/1.0/video-wrapper.type.js
@@ -58,7 +58,7 @@ VideoWrapperDef.PlayerComponent;
  *   artist: (string|undefined),
  *   album: (string|undefined),
  *   artwork: (string|undefined),
- *   onLoad: (function()|undefined),
+ *   onReadyState: (function(string, *=)|undefined),
  * }}
  */
 VideoWrapperDef.Props;

--- a/extensions/amp-video/1.0/video-wrapper.type.js
+++ b/extensions/amp-video/1.0/video-wrapper.type.js
@@ -46,7 +46,6 @@ VideoWrapperDef.PlayerComponent;
  * @typedef {{
  *   component: (!VideoWrapperDef.PlayerComponent|undefined),
  *   loading: (string|undefined),
- *   unloadOnPause: (boolean|undefined),
  *   src: (string|undefined),
  *   sources: (?PreactDef.Renderable|undefined),
  *   autoplay: (boolean|undefined),

--- a/extensions/amp-youtube/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.amp.js
@@ -75,6 +75,25 @@ export const InsideAccordion = () => {
   );
 };
 
+export const InsideDetails = () => {
+  const videoid = text('videoid', 'IAvf-rkzNck');
+  const width = number('width', 300);
+  const height = number('height', 200);
+  const autoplay = boolean('autoplay', false);
+  return (
+    <details open>
+      <summary>YouTube Video</summary>
+      <amp-youtube
+        width={width}
+        height={height}
+        data-videoid={videoid}
+        autoplay={autoplay}
+        loop
+      ></amp-youtube>
+    </details>
+  );
+};
+
 Default.story = {
   name: 'Default',
 };

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -59,6 +59,8 @@ const UpgradeState = {
   UPGRADE_IN_PROGRESS: 4,
 };
 
+const NO_BUBBLES = {bubbles: false};
+
 /**
  * Caches whether the template tag is supported to avoid memory allocations.
  * @type {boolean|undefined}
@@ -669,6 +671,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         case ReadyState.LOADING:
           this.signals_.signal(CommonSignals.LOAD_START);
           this.signals_.reset(CommonSignals.UNLOAD);
+          this.signals_.reset(CommonSignals.LOAD_END);
           this.classList.add('i-amphtml-layout');
           // Potentially start the loading indicator.
           this.toggleLoading(true);
@@ -678,7 +681,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           this.signals_.signal(CommonSignals.LOAD_END);
           this.classList.add('i-amphtml-layout');
           this.toggleLoading(false);
-          dom.dispatchCustomEvent(this, 'load');
+          dom.dispatchCustomEvent(this, 'load', null, NO_BUBBLES);
           this.dispatchCustomEventForTesting(AmpEvents.LOAD_END);
           return;
         case ReadyState.ERROR:
@@ -687,7 +690,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
             /** @type {!Error} */ (opt_failure)
           );
           this.toggleLoading(false);
-          dom.dispatchCustomEvent(this, 'error');
+          dom.dispatchCustomEvent(this, 'error', opt_failure, NO_BUBBLES);
           return;
       }
     }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -202,6 +202,13 @@ export class PreactBaseElement extends AMP.BaseElement {
     return this['usesShadowDom'];
   }
 
+  /** @override @nocollapse */
+  static prerenderAllowed() {
+    // eslint-disable-next-line local/no-static-this
+    const Ctor = this;
+    return !Ctor['loadable'];
+  }
+
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -539,6 +539,9 @@ export class PreactBaseElement extends AMP.BaseElement {
 
     const Ctor = this.constructor;
     if (Ctor['unloadOnPause']) {
+      // These are typically iframe-based elements where we don't know
+      // whether a media is currently playing. So we have to assume that
+      // it is whenever the element is loaded.
       this.updateIsPlaying_(state == ReadyState.COMPLETE);
     }
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -413,9 +413,7 @@ export class PreactBaseElement extends AMP.BaseElement {
   /** @override */
   detachedCallback() {
     discover(this.element);
-    if (this.mediaQueryProps_) {
-      this.mediaQueryProps_.dispose();
-    }
+    this.mediaQueryProps_?.dispose();
   }
 
   /** @override */

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -22,6 +22,7 @@ import {Deferred} from '../utils/promise';
 import {Layout, isLayoutSizeDefined} from '../layout';
 import {Loading} from '../core/loading-instructions';
 import {MediaQueryProps} from '../utils/media-query-props';
+import {ReadyState} from '../ready-state';
 import {Slot, createSlot} from './slot';
 import {WithAmpContext} from './context';
 import {
@@ -29,9 +30,9 @@ import {
   discover,
   setGroupProp,
   setParent,
+  setProp,
   subscribe,
 } from '../context';
-import {cancellation} from '../error';
 import {
   childElementByTag,
   createElementWithAttributes,
@@ -190,10 +191,12 @@ const IS_EMPTY_TEXT_NODE = (node) =>
  * @template API_TYPE
  */
 export class PreactBaseElement extends AMP.BaseElement {
-  /**
-   * @return {boolean}
-   * @nocollapse
-   */
+  /** @override @nocollapse */
+  static V1() {
+    return true;
+  }
+
+  /** @override @nocollapse */
   static requiresShadowDom() {
     // eslint-disable-next-line local/no-static-this
     return this['usesShadowDom'];
@@ -206,17 +209,19 @@ export class PreactBaseElement extends AMP.BaseElement {
     /** @private {!JsonObject} */
     this.defaultProps_ = dict({
       'loading': Loading.AUTO,
-      'onLoad': this.onLoad_.bind(this),
-      'onLoadError': this.onLoadError_.bind(this),
+      'onReadyState': this.onReadyState_.bind(this),
     });
 
     /** @private {!AmpContextDef.ContextType} */
     this.context_ = {
       renderable: false,
-      playable: false,
-      loading: Loading.LAZY,
+      playable: true,
+      loading: Loading.AUTO,
       notify: () => this.mutateElement(() => {}),
     };
+
+    /** @private {boolean} */
+    this.resetLoading_ = false;
 
     /** @private {?API_TYPE} */
     this.apiWrapper_ = null;
@@ -235,6 +240,7 @@ export class PreactBaseElement extends AMP.BaseElement {
         }
       }
       this.currentRef_ = current;
+      this.maybeUpdateReadyState_();
     };
 
     /** @type {?Deferred<!API_TYPE>} */
@@ -263,9 +269,6 @@ export class PreactBaseElement extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.mounted_ = false;
-
-    /** @private {?Deferred} */
-    this.loadDeferred_ = null;
 
     /** @protected {?MutationObserver} */
     this.observer = null;
@@ -360,10 +363,7 @@ export class PreactBaseElement extends AMP.BaseElement {
       (canRender, canPlay, loading) => {
         this.context_.renderable = canRender;
         this.context_.playable = canPlay;
-        // TODO(#30283): trust "loading" completely from the context once it's
-        // fully supported.
-        this.context_.loading =
-          loading == Loading.AUTO ? Loading.LAZY : loading;
+        this.context_.loading = loading;
         this.mounted_ = true;
         this.scheduleRender_();
       }
@@ -379,41 +379,23 @@ export class PreactBaseElement extends AMP.BaseElement {
 
     this.renderDeferred_ = new Deferred();
     this.scheduleRender_();
+
+    if (Ctor['loadable']) {
+      this.setReadyState(ReadyState.LOADING);
+    }
+    this.maybeUpdateReadyState_();
+
     return this.renderDeferred_.promise;
   }
 
   /** @override */
-  layoutCallback() {
+  ensureLoaded() {
     const Ctor = this.constructor;
     if (!Ctor['loadable']) {
-      return super.layoutCallback();
+      return;
     }
-
     this.mutateProps(dict({'loading': Loading.EAGER}));
-
-    // Check if the element has already been loaded.
-    const api = this.currentRef_;
-    if (api && api['complete']) {
-      return Promise.resolve();
-    }
-
-    // If not, wait for `onLoad` callback.
-    this.loadDeferred_ = new Deferred();
-    return this.loadDeferred_.promise;
-  }
-
-  /** @override */
-  unlayoutCallback() {
-    if (this.mediaQueryProps_) {
-      this.mediaQueryProps_.dispose();
-    }
-    const Ctor = this.constructor;
-    if (!Ctor['loadable']) {
-      return super.unlayoutCallback();
-    }
-    this.mutateProps(dict({'loading': Loading.UNLOAD}));
-    this.onLoadError_(cancellation());
-    return true;
+    this.resetLoading_ = true;
   }
 
   /** @override */
@@ -424,6 +406,19 @@ export class PreactBaseElement extends AMP.BaseElement {
   /** @override */
   detachedCallback() {
     discover(this.element);
+    if (this.mediaQueryProps_) {
+      this.mediaQueryProps_.dispose();
+    }
+  }
+
+  /** @override */
+  pauseCallback() {
+    setProp(this.element, CanPlay, this.element, false);
+  }
+
+  /** @override */
+  resumeCallback() {
+    setProp(this.element, CanPlay, this.element, true);
   }
 
   /** @override */
@@ -523,23 +518,27 @@ export class PreactBaseElement extends AMP.BaseElement {
   }
 
   /** @private */
-  onLoad_() {
-    if (this.loadDeferred_) {
-      this.loadDeferred_.resolve();
-      this.loadDeferred_ = null;
-      dispatchCustomEvent(this.element, 'load', null, {bubbles: false});
+  maybeUpdateReadyState_() {
+    const {currentRef_: api} = this;
+
+    const apiReadyState = api && api['readyState'];
+    if (apiReadyState && apiReadyState !== this.element.readyState) {
+      this.onReadyState_(apiReadyState);
     }
   }
 
   /**
-   * @param {*} opt_reason
+   * @param {!ReadyState} state
+   * @param {*=} opt_failure
    * @private
    */
-  onLoadError_(opt_reason) {
-    if (this.loadDeferred_) {
-      this.loadDeferred_.reject(opt_reason || new Error('load error'));
-      this.loadDeferred_ = null;
-      dispatchCustomEvent(this.element, 'error', null, {bubbles: false});
+  onReadyState_(state, opt_failure) {
+    this.setReadyState(state, opt_failure);
+
+    // Reset "loading" property back to "auto".
+    if (state != ReadyState.LOADING && this.resetLoading_) {
+      this.resetLoading_ = false;
+      this.mutateProps({'loading': Loading.AUTO});
     }
   }
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -523,7 +523,7 @@ export class PreactBaseElement extends AMP.BaseElement {
   maybeUpdateReadyState_() {
     const {currentRef_: api} = this;
 
-    const apiReadyState = api && api['readyState'];
+    const apiReadyState = api?.['readyState'];
     if (apiReadyState && apiReadyState !== this.element.readyState) {
       this.onReadyState_(apiReadyState);
     }
@@ -815,10 +815,7 @@ export class PreactBaseElement extends AMP.BaseElement {
       this.resetLoading_ = true;
     } else {
       const {currentRef_: api} = this;
-      const apiPause = api && api['pause'];
-      if (apiPause) {
-        apiPause();
-      }
+      api?.['pause']?.();
     }
   }
 

--- a/src/preact/context.js
+++ b/src/preact/context.js
@@ -16,7 +16,7 @@
 
 import * as Preact from './index';
 import {Loading, reducer as loadingReducer} from '../core/loading-instructions';
-import {createContext, useContext, useMemo, useRef} from './index';
+import {createContext, useContext, useMemo} from './index';
 
 /** @type {PreactDef.Context} */
 let context;
@@ -90,27 +90,9 @@ export function useAmpContext() {
  * Whether the calling component should currently be in the loaded state.
  *
  * @param {!Loading|string} loadingProp
- * @param {boolean} unloadOnPause
  * @return {boolean}
  */
-export function useLoading(loadingProp, unloadOnPause = false) {
-  const {loading: loadingContext, playable} = useAmpContext();
-  const loading = loadingReducer(loadingProp, loadingContext);
-
-  const shouldUnloadOnPauseRef = useRef(false);
-  const triggerUnloadOnPauseRef = useRef(false);
-
-  // Force unload only when the playable goes from true -> false.
-  const shouldUnloadOnPause = !playable && unloadOnPause;
-  if (shouldUnloadOnPause != shouldUnloadOnPauseRef.current) {
-    shouldUnloadOnPauseRef.current = shouldUnloadOnPause;
-    triggerUnloadOnPauseRef.current = shouldUnloadOnPause;
-  }
-
-  // Reset triggerUnloadOnPause when loading becomes eager.
-  if (loading == Loading.EAGER) {
-    triggerUnloadOnPauseRef.current = false;
-  }
-
-  return triggerUnloadOnPauseRef.current ? Loading.UNLOAD : loading;
+export function useLoading(loadingProp) {
+  const {loading: loadingContext} = useAmpContext();
+  return loadingReducer(loadingProp, loadingContext);
 }

--- a/src/preact/storybook/Context.js
+++ b/src/preact/storybook/Context.js
@@ -34,37 +34,31 @@ export const _default = () => {
   const renderable = boolean('top renderable', true);
   const playable = boolean('top playable', true);
   const loading = select('top loading', LOADING_OPTIONS, LOADING_OPTIONS[0]);
-  const unloadOnPause = boolean('unload on pause', false);
   return (
     <WithAmpContext
       renderable={renderable}
       playable={playable}
       loading={loading}
     >
-      <Composite unloadOnPause={unloadOnPause} />
+      <Composite />
     </WithAmpContext>
   );
 };
 
 /**
- * @param {{unloadOnPause: boolean}} props
  * @return {PreactDef.Renderable}
  */
-function Composite({unloadOnPause}) {
+function Composite() {
   return (
     <div class="composite">
-      <Info title="Default" unloadOnPause={unloadOnPause} />
+      <Info title="Default" />
       <WithAmpContext renderable={false}>
-        <Info title="Context: non-renderable" unloadOnPause={unloadOnPause} />
+        <Info title="Context: non-renderable" />
       </WithAmpContext>
       <WithAmpContext playable={false}>
-        <Info title="Context: non-playable" unloadOnPause={unloadOnPause} />
+        <Info title="Context: non-playable" />
       </WithAmpContext>
-      <Info
-        title="Prop: loading = lazy"
-        loading="lazy"
-        unloadOnPause={unloadOnPause}
-      />
+      <Info title="Prop: loading = lazy" loading="lazy" />
     </div>
   );
 }
@@ -73,9 +67,9 @@ function Composite({unloadOnPause}) {
  * @param {{title: string, loading: string}} props
  * @return {PreactDef.Renderable}
  */
-function Info({title, loading: loadingProp, unloadOnPause, ...rest}) {
+function Info({title, loading: loadingProp, ...rest}) {
   const {renderable, playable, loading: loadingContext} = useAmpContext();
-  const loading = useLoading(loadingProp, unloadOnPause);
+  const loading = useLoading(loadingProp);
   const load = loading != 'unload';
   const infoStyle = {border: '1px dotted gray', margin: 8};
   const imgStyle = {
@@ -91,7 +85,6 @@ function Info({title, loading: loadingProp, unloadOnPause, ...rest}) {
         <div>context.renderable: {String(renderable)}</div>
         <div>context.playable: {String(playable)}</div>
         <div>context.loading: {String(loadingContext)}</div>
-        <div>unloadOnPause: {String(unloadOnPause)}</div>
         <div>useLoading.loading: {String(loading)}</div>
         <div>load: {String(load)}</div>
         <div>

--- a/src/preact/storybook/Context.js
+++ b/src/preact/storybook/Context.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../';
-import {WithAmpContext, useAmpContext, useLoad} from '../context';
+import {WithAmpContext, useAmpContext, useLoading} from '../context';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 
 import {withA11y} from '@storybook/addon-a11y';
@@ -34,31 +34,37 @@ export const _default = () => {
   const renderable = boolean('top renderable', true);
   const playable = boolean('top playable', true);
   const loading = select('top loading', LOADING_OPTIONS, LOADING_OPTIONS[0]);
+  const unloadOnPause = boolean('unload on pause', false);
   return (
     <WithAmpContext
       renderable={renderable}
       playable={playable}
       loading={loading}
     >
-      <Composite />
+      <Composite unloadOnPause={unloadOnPause} />
     </WithAmpContext>
   );
 };
 
 /**
+ * @param {{unloadOnPause: boolean}} props
  * @return {PreactDef.Renderable}
  */
-function Composite() {
+function Composite({unloadOnPause}) {
   return (
     <div class="composite">
-      <Info title="Default" />
+      <Info title="Default" unloadOnPause={unloadOnPause} />
       <WithAmpContext renderable={false}>
-        <Info title="Context: non-renderable" />
+        <Info title="Context: non-renderable" unloadOnPause={unloadOnPause} />
       </WithAmpContext>
       <WithAmpContext playable={false}>
-        <Info title="Context: non-playable" />
+        <Info title="Context: non-playable" unloadOnPause={unloadOnPause} />
       </WithAmpContext>
-      <Info title="Prop: loading = lazy" loading="lazy" />
+      <Info
+        title="Prop: loading = lazy"
+        loading="lazy"
+        unloadOnPause={unloadOnPause}
+      />
     </div>
   );
 }
@@ -67,9 +73,10 @@ function Composite() {
  * @param {{title: string, loading: string}} props
  * @return {PreactDef.Renderable}
  */
-function Info({title, loading: loadingProp, ...rest}) {
-  const {renderable, playable, loading} = useAmpContext();
-  const load = useLoad(loadingProp);
+function Info({title, loading: loadingProp, unloadOnPause, ...rest}) {
+  const {renderable, playable, loading: loadingContext} = useAmpContext();
+  const loading = useLoading(loadingProp, unloadOnPause);
+  const load = loading != 'unload';
   const infoStyle = {border: '1px dotted gray', margin: 8};
   const imgStyle = {
     marginLeft: 8,
@@ -83,8 +90,10 @@ function Info({title, loading: loadingProp, ...rest}) {
       <div>
         <div>context.renderable: {String(renderable)}</div>
         <div>context.playable: {String(playable)}</div>
-        <div>context.loading: {String(loading)}</div>
-        <div>useLoad.load: {String(load)}</div>
+        <div>context.loading: {String(loadingContext)}</div>
+        <div>unloadOnPause: {String(unloadOnPause)}</div>
+        <div>useLoading.loading: {String(loading)}</div>
+        <div>load: {String(load)}</div>
         <div>
           img: {String(load)}
           <img src={load ? IMG_SRC : undefined} style={imgStyle} />

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1200,7 +1200,7 @@ export class ResourcesImpl {
       for (let i = 0; i < this.resources_.length; i++) {
         const r = this.resources_[i];
         const requested = r.isMeasureRequested();
-        if (r.hasOwner() && !requested) {
+        if ((r.hasOwner() && !requested) || r.element.V1()) {
           continue;
         }
         const premeasured = r.hasBeenPremeasured();

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -20,9 +20,9 @@ import {Slot} from '../../../src/preact/slot';
 import {createElementWithAttributes} from '../../../src/dom';
 import {htmlFor} from '../../../src/static-template';
 import {omit} from '../../../src/utils/object';
+import {testElementV1} from '../../../testing/element-v1';
 import {upgradeOrRegisterElement} from '../../../src/service/custom-element-registry';
 import {waitFor} from '../../../testing/test-helper';
-import {testElementV1} from '../../../testing/element-v1';
 
 const spec = {amp: true, frameStyle: {width: '300px'}};
 

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -22,6 +22,7 @@ import {htmlFor} from '../../../src/static-template';
 import {omit} from '../../../src/utils/object';
 import {upgradeOrRegisterElement} from '../../../src/service/custom-element-registry';
 import {waitFor} from '../../../testing/test-helper';
+import {testElementV1} from '../../../testing/element-v1';
 
 const spec = {amp: true, frameStyle: {width: '300px'}};
 
@@ -73,6 +74,20 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       return new Promise((resolve) => setTimeout(resolve, 32));
     });
   }
+
+  describe('V1', () => {
+    it('testElementV1', () => {
+      testElementV1(PreactBaseElement);
+    });
+
+    it('by default prerenderAllowed is tied to the "loadable" flag', () => {
+      Impl['loadable'] = false;
+      expect(Impl.prerenderAllowed()).to.be.true;
+
+      Impl['loadable'] = true;
+      expect(Impl.prerenderAllowed()).to.be.false;
+    });
+  });
 
   describe('layout mapping', () => {
     let element;

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -23,6 +23,7 @@ import {
 import {Slot} from '../../../src/preact/slot';
 import {forwardRef} from '../../../src/preact/compat';
 import {htmlFor} from '../../../src/static-template';
+import {installResizeObserverStub} from '../../../testing/resize-observer-stub';
 import {removeElement} from '../../../src/dom';
 import {subscribe} from '../../../src/context';
 import {upgradeOrRegisterElement} from '../../../src/service/custom-element-registry';
@@ -242,22 +243,114 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       await waitFor(() => component.callCount > 0, 'component rerendered');
       expect(lastLoading).to.equal('auto');
     });
+  });
 
-    it('should pause and resume', async () => {
+  describe('pause', () => {
+    let element;
+    let resizeObserverStub;
+
+    beforeEach(() => {
+      element = html`
+        <amp-preact layout="fixed" width="100" height="100">
+          <div id="child1" slot="slot1"></div>
+          <div id="child2"></div>
+        </amp-preact>
+      `;
+      doc.body.appendChild(element);
+
+      resizeObserverStub = installResizeObserverStub(env.sandbox, win);
+    });
+
+    it('should call pause API on pauseCallback', async () => {
+      const pauseStub = env.sandbox.stub();
+      api = {pause: pauseStub};
+
       await element.buildInternal();
-      expect(lastContext.playable).to.be.true;
 
-      // Pause.
-      component.resetHistory();
       element.pauseCallback();
-      await waitFor(() => component.callCount > 0, 'component rerendered');
-      expect(lastContext.playable).to.be.false;
+      expect(pauseStub).to.be.calledOnce;
+    });
 
-      // Resume.
+    it('should unload on pauseCallback with unloadOnPause', async () => {
+      Impl['unloadOnPause'] = true;
+
+      await element.buildInternal();
+      await waitFor(() => component.callCount > 0, 'component rendered');
+
+      element.pauseCallback();
+
       component.resetHistory();
-      element.resumeCallback();
-      await waitFor(() => component.callCount > 0, 'component rerendered');
-      expect(lastContext.playable).to.be.true;
+      await waitFor(() => component.callCount > 0, 'component rendered');
+      expect(lastLoading).to.equal('unload');
+
+      // Reset loading after pause.
+      component.resetHistory();
+      lastProps.onReadyState('loading');
+      await waitFor(() => component.callCount > 0, 'component rendered');
+      expect(lastLoading).to.equal('auto');
+    });
+
+    it('should NOT track size until playing', async () => {
+      await element.buildInternal();
+      await waitFor(() => component.callCount > 0, 'component rendered');
+
+      expect(resizeObserverStub.isObserved(element)).to.be.false;
+
+      lastProps.onPlayingState(true);
+      expect(resizeObserverStub.isObserved(element)).to.be.true;
+
+      lastProps.onPlayingState(false);
+      expect(resizeObserverStub.isObserved(element)).to.be.false;
+    });
+
+    it('should track size when unloadOnPause when loaded', async () => {
+      Impl['unloadOnPause'] = true;
+
+      await element.buildInternal();
+      await waitFor(() => component.callCount > 0, 'component rendered');
+
+      expect(resizeObserverStub.isObserved(element)).to.be.false;
+
+      lastProps.onReadyState('complete');
+      expect(resizeObserverStub.isObserved(element)).to.be.true;
+
+      lastProps.onReadyState('loading');
+      expect(resizeObserverStub.isObserved(element)).to.be.false;
+    });
+
+    it('should NOT track size when disconnected', async () => {
+      await element.buildInternal();
+      await waitFor(() => component.callCount > 0, 'component rendered');
+      lastProps.onPlayingState(true);
+      expect(resizeObserverStub.isObserved(element)).to.be.true;
+
+      element.parentNode.removeChild(element);
+      expect(resizeObserverStub.isObserved(element)).to.be.false;
+    });
+
+    it('should pause element when size becomes zero', async () => {
+      const pauseStub = env.sandbox.stub();
+      api = {pause: pauseStub};
+
+      await element.buildInternal();
+      await waitFor(() => component.callCount > 0, 'component rendered');
+      lastProps.onPlayingState(true);
+      expect(resizeObserverStub.isObserved(element)).to.be.true;
+      expect(pauseStub).to.not.be.called;
+
+      // Non-zero size.
+      resizeObserverStub.notifySync({
+        target: element,
+        contentRect: {width: 10, height: 10},
+      });
+      expect(pauseStub).to.not.be.called;
+
+      // Zero size.
+      resizeObserverStub.notifySync({
+        target: element,
+        contentRect: {width: 0, height: 0},
+      });
+      expect(pauseStub).to.be.calledOnce;
     });
   });
 

--- a/test/unit/preact/test-context.js
+++ b/test/unit/preact/test-context.js
@@ -25,7 +25,7 @@ import {mount} from 'enzyme';
 describes.sandboxed('preact/context', {}, () => {
   function Component(props) {
     const context = useAmpContext();
-    const loading = useLoading(props.loading, props.unloadOnPause);
+    const loading = useLoading(props.loading);
     return <ContextReader {...context} computedLoading={loading} />;
   }
 
@@ -72,71 +72,6 @@ describes.sandboxed('preact/context', {}, () => {
       playable: false,
       loading: 'auto',
       computedLoading: 'auto',
-    });
-  });
-
-  it('should disable loading when not playable and unloadOnPause', () => {
-    const wrapper = mount(
-      <WithAmpContext playable={false}>
-        <Component unloadOnPause={true} />
-      </WithAmpContext>
-    );
-    expect(wrapper.find(ContextReader).props()).to.contain({
-      renderable: true,
-      playable: false,
-      loading: 'auto',
-      computedLoading: 'unload',
-    });
-  });
-
-  it('should restore loading when unloadOnPause but eager', () => {
-    const wrapper = mount(
-      <WithAmpContext playable={false}>
-        <Component unloadOnPause={true} />
-      </WithAmpContext>
-    );
-    expect(wrapper.find(ContextReader).props()).to.contain({
-      renderable: true,
-      playable: false,
-      loading: 'auto',
-      computedLoading: 'unload',
-    });
-
-    // Going to "lazy" doesn't change anything.
-    wrapper.setProps({loading: 'lazy'});
-    expect(wrapper.find(ContextReader).props()).to.contain({
-      renderable: true,
-      playable: false,
-      loading: 'lazy',
-      computedLoading: 'unload',
-    });
-
-    // Going to "eager" restores the loading.
-    wrapper.setProps({loading: 'eager'});
-    expect(wrapper.find(ContextReader).props()).to.contain({
-      renderable: true,
-      playable: false,
-      loading: 'eager',
-      computedLoading: 'eager',
-    });
-
-    // Going back to "auto" keeps "auto".
-    wrapper.setProps({loading: 'auto'});
-    expect(wrapper.find(ContextReader).props()).to.contain({
-      renderable: true,
-      playable: false,
-      loading: 'auto',
-      computedLoading: 'auto',
-    });
-
-    // Resetting playable goes back to "unload".
-    wrapper.setProps({playable: true});
-    wrapper.setProps({playable: false});
-    expect(wrapper.find(ContextReader).props()).to.contain({
-      renderable: true,
-      playable: false,
-      loading: 'auto',
-      computedLoading: 'unload',
     });
   });
 

--- a/test/unit/preact/test-context.js
+++ b/test/unit/preact/test-context.js
@@ -18,15 +18,15 @@ import * as Preact from '../../../src/preact/index';
 import {
   WithAmpContext,
   useAmpContext,
-  useLoad,
+  useLoading,
 } from '../../../src/preact/context';
 import {mount} from 'enzyme';
 
 describes.sandboxed('preact/context', {}, () => {
   function Component(props) {
     const context = useAmpContext();
-    const load = useLoad(props.loading, props.unloadOnPause);
-    return <ContextReader {...context} load={load} />;
+    const loading = useLoading(props.loading, props.unloadOnPause);
+    return <ContextReader {...context} computedLoading={loading} />;
   }
 
   function ContextReader() {
@@ -43,7 +43,7 @@ describes.sandboxed('preact/context', {}, () => {
       renderable: true,
       playable: true,
       loading: 'auto',
-      load: true,
+      computedLoading: 'auto',
     });
   });
 
@@ -57,7 +57,7 @@ describes.sandboxed('preact/context', {}, () => {
       renderable: false,
       playable: false,
       loading: 'lazy',
-      load: false,
+      computedLoading: 'lazy',
     });
   });
 
@@ -71,7 +71,7 @@ describes.sandboxed('preact/context', {}, () => {
       renderable: true,
       playable: false,
       loading: 'auto',
-      load: true,
+      computedLoading: 'auto',
     });
   });
 
@@ -85,7 +85,58 @@ describes.sandboxed('preact/context', {}, () => {
       renderable: true,
       playable: false,
       loading: 'auto',
-      load: false,
+      computedLoading: 'unload',
+    });
+  });
+
+  it('should restore loading when unloadOnPause but eager', () => {
+    const wrapper = mount(
+      <WithAmpContext playable={false}>
+        <Component unloadOnPause={true} />
+      </WithAmpContext>
+    );
+    expect(wrapper.find(ContextReader).props()).to.contain({
+      renderable: true,
+      playable: false,
+      loading: 'auto',
+      computedLoading: 'unload',
+    });
+
+    // Going to "lazy" doesn't change anything.
+    wrapper.setProps({loading: 'lazy'});
+    expect(wrapper.find(ContextReader).props()).to.contain({
+      renderable: true,
+      playable: false,
+      loading: 'lazy',
+      computedLoading: 'unload',
+    });
+
+    // Going to "eager" restores the loading.
+    wrapper.setProps({loading: 'eager'});
+    expect(wrapper.find(ContextReader).props()).to.contain({
+      renderable: true,
+      playable: false,
+      loading: 'eager',
+      computedLoading: 'eager',
+    });
+
+    // Going back to "auto" keeps "auto".
+    wrapper.setProps({loading: 'auto'});
+    expect(wrapper.find(ContextReader).props()).to.contain({
+      renderable: true,
+      playable: false,
+      loading: 'auto',
+      computedLoading: 'auto',
+    });
+
+    // Resetting playable goes back to "unload".
+    wrapper.setProps({playable: true});
+    wrapper.setProps({playable: false});
+    expect(wrapper.find(ContextReader).props()).to.contain({
+      renderable: true,
+      playable: false,
+      loading: 'auto',
+      computedLoading: 'unload',
     });
   });
 
@@ -99,7 +150,7 @@ describes.sandboxed('preact/context', {}, () => {
       renderable: true,
       playable: true,
       loading: 'lazy',
-      load: false,
+      computedLoading: 'lazy',
     });
   });
 
@@ -113,7 +164,7 @@ describes.sandboxed('preact/context', {}, () => {
       renderable: true,
       playable: true,
       loading: 'eager',
-      load: true,
+      computedLoading: 'eager',
     });
   });
 
@@ -127,7 +178,7 @@ describes.sandboxed('preact/context', {}, () => {
       renderable: true,
       playable: true,
       loading: 'eager',
-      load: false,
+      computedLoading: 'unload',
     });
   });
 
@@ -139,13 +190,13 @@ describes.sandboxed('preact/context', {}, () => {
     );
     expect(wrapper.find(ContextReader).props()).to.contain({
       loading: 'auto',
-      load: true,
+      computedLoading: 'auto',
     });
 
     wrapper.setProps({loading: 'lazy'});
     expect(wrapper.find(ContextReader).props()).to.contain({
       loading: 'lazy',
-      load: true,
+      computedLoading: 'lazy',
     });
   });
 
@@ -157,13 +208,13 @@ describes.sandboxed('preact/context', {}, () => {
     );
     expect(wrapper.find(ContextReader).props()).to.contain({
       loading: 'auto',
-      load: true,
+      computedLoading: 'auto',
     });
 
     wrapper.setProps({loading: 'unload'});
     expect(wrapper.find(ContextReader).props()).to.contain({
       loading: 'unload',
-      load: false,
+      computedLoading: 'unload',
     });
   });
 });

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -532,6 +532,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(element.toggleLoading).to.be.calledOnce.calledWith(true);
       expect(element.signals().get(CommonSignals.LOAD_START)).to.exist;
       expect(element.signals().get(CommonSignals.UNLOAD)).to.be.null;
+      expect(element.signals().get(CommonSignals.LOAD_END)).to.be.null;
       expect(element).to.have.class('i-amphtml-layout');
     });
 
@@ -550,6 +551,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(element.signals().get(CommonSignals.LOAD_END)).to.exist;
       expect(element).to.have.class('i-amphtml-layout');
       expect(loadEventSpy).to.be.calledOnce;
+      expect(loadEventSpy.firstCall.firstArg.bubbles).to.be.false;
     });
 
     it('should update error state', () => {
@@ -566,6 +568,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(element.toggleLoading).to.be.calledOnce.calledWith(false);
       expect(element.signals().get(CommonSignals.LOAD_END)).to.equal(error);
       expect(errorEventSpy).to.be.calledOnce;
+      expect(errorEventSpy.firstCall.firstArg.bubbles).to.be.false;
     });
 
     it('should not duplicate events', () => {
@@ -578,6 +581,16 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       // Repeat.
       element.setReadyStateInternal('complete');
       expect(loadEventSpy).to.be.calledOnce; // no change.
+    });
+
+    it('should return back to loading after complete', () => {
+      element.setReadyStateInternal('complete');
+      expect(element.readyState).equal('complete');
+      expect(element.signals().get(CommonSignals.LOAD_END)).to.exist;
+
+      element.setReadyStateInternal('loading');
+      expect(element.readyState).equal('loading');
+      expect(element.signals().get(CommonSignals.LOAD_END)).to.be.null;
     });
   });
 

--- a/testing/resize-observer-stub.js
+++ b/testing/resize-observer-stub.js
@@ -37,6 +37,16 @@ class ResizeObservers {
     });
   }
 
+  /**
+   * @param {!Element} target
+   * @return {boolean}
+   */
+  isObserved(target) {
+    return Array.from(this.observers).some((observer) =>
+      observer.elements.has(target)
+    );
+  }
+
   notifySync(entryOrEntries) {
     const entries = Array.isArray(entryOrEntries)
       ? entryOrEntries


### PR DESCRIPTION
Partial for #30283.

The main general changes are in the `src/preact/base-element.js` and they are simple:
1. `layoutCallback` is gone.
2. `ensureLoaded` is added. Works via `loading=eager`
3. Loading is started immediately when the Preact component is rendered the first time.
4. The ready state is propagated from the Preact component to AMP element using `Ref<Api>` and `onReadyState` event.

Other changes include:
1. `unloadOnPause` is changed to allow reloading.
2. `VideoWrapper` and `Instagram` components have been updated to V1 protocol.
