### PR TITLE
Rollfoward: Make Templates an ampdoc-level service to avoid FIE and shadowdoc conflicts

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -240,10 +240,11 @@ const forbiddenTerms = {
       'src/service/storage-impl.js',
     ],
   },
-  'installTemplatesService': {
+  'installTemplatesServiceForDoc': {
     message: privateServiceFactory,
     allowlist: [
       'src/runtime.js',
+      'src/inabox/inabox-services.js',
       'src/service/core-services.js',
       'src/service/template-impl.js',
     ],
@@ -313,6 +314,7 @@ const forbiddenTerms = {
     allowlist: [
       // Do not allowlist additional "extensions/*" paths.
       // TODO(#22414): Remove paths as they are migrated off of sync API.
+      'extensions/amp-a4a/0.1/amp-ad-template-helper.js',
       'extensions/amp-analytics/0.1/instrumentation.js',
       'extensions/amp-analytics/0.1/variables.js',
       'extensions/amp-fx-collection/0.1/providers/fx-provider.js',
@@ -323,6 +325,7 @@ const forbiddenTerms = {
       'src/service/builder.js',
       'src/service/cid-impl.js',
       'src/service/origin-experiments-impl.js',
+      'src/service/template-impl.js',
       'src/services.js',
       'src/utils/display-observer.js',
       'testing/test-helper.js',

--- a/extensions/amp-a4a/0.1/amp-ad-network-base.js
+++ b/extensions/amp-a4a/0.1/amp-ad-network-base.js
@@ -172,7 +172,12 @@ export class AmpAdNetworkBase extends AMP.BaseElement {
         response.headers.get('AMP-Ad-Response-Type') || 'default';
       devAssert(this.validators_[validatorType], 'Validator never registered!');
       return this.validators_[validatorType]
-        .validate(this.context_, unvalidatedBytes, response.headers)
+        .validate(
+          this.context_,
+          this.element,
+          unvalidatedBytes,
+          response.headers
+        )
         .catch((err) =>
           Promise.reject({type: FailureType.VALIDATOR_ERROR, msg: err})
         );

--- a/extensions/amp-a4a/0.1/amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/amp-ad-template-helper.js
@@ -20,6 +20,10 @@ import {createElementWithAttributes} from '../../../src/dom';
 import {devAssert} from '../../../src/log';
 import {dict} from '../../../src/utils/object';
 import {getMode} from '../../../src/mode';
+import {
+  getServiceForDoc,
+  registerServiceBuilderForDoc,
+} from '../../../src/service';
 import {isArray} from '../../../src/types';
 import {parseUrlDeprecated} from '../../../src/url';
 import {urls} from '../../../src/config';
@@ -34,13 +38,15 @@ const TEMPLATE_CORS_CONFIG = {
   credentials: 'omit',
 };
 
+const SERVICE_ID = 'AmpAdTemplateHelper';
+
 export class AmpAdTemplateHelper {
   /**
-   * @param {!Window} win
+   * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
-  constructor(win) {
-    /** @private {!Window} */
-    this.win_ = win;
+  constructor(ampdoc) {
+    /** @private @const */
+    this.ampdoc_ = ampdoc;
 
     /** @private {LruCache} */
     this.cache_ = new LruCache(5);
@@ -53,14 +59,15 @@ export class AmpAdTemplateHelper {
    * @return {!Promise<string>}
    */
   fetch(templateUrl) {
+    const {win} = this.ampdoc_;
     const proxyUrl =
-      getMode(this.win_).localDev && !isNaN(templateUrl)
-        ? `http://ads.localhost:${this.win_.location.port}` +
+      getMode(win).localDev && !isNaN(templateUrl)
+        ? `http://ads.localhost:${win.location.port}` +
           `/a4a_template/adzerk/${templateUrl}`
         : this.getTemplateProxyUrl_(templateUrl);
     let templatePromise = this.cache_.get(proxyUrl);
     if (!templatePromise) {
-      templatePromise = Services.xhrFor(this.win_)
+      templatePromise = Services.xhrFor(win)
         .fetchText(proxyUrl, TEMPLATE_CORS_CONFIG)
         .then((response) => response.text());
       this.cache_.put(proxyUrl, templatePromise);
@@ -75,7 +82,7 @@ export class AmpAdTemplateHelper {
    * @return {!Promise<!Element>} Promise which resolves after rendering completes.
    */
   render(templateValues, element) {
-    return Services.templatesFor(this.win_).findAndRenderTemplate(
+    return Services.templatesForDoc(this.ampdoc_).findAndRenderTemplate(
       element,
       templateValues
     );
@@ -131,4 +138,16 @@ export class AmpAdTemplateHelper {
           loc.hostname +
           loc.pathname;
   }
+}
+
+/**
+ * @param {!Element|!../../../src/service/ampdoc-impl.AmpDoc} target
+ * @return {!AmpAdTemplateHelper}
+ */
+export function getAmpAdTemplateHelper(target) {
+  registerServiceBuilderForDoc(target, SERVICE_ID, AmpAdTemplateHelper);
+  return /** @type {!AmpAdTemplateHelper} */ (getServiceForDoc(
+    target,
+    SERVICE_ID
+  ));
 }

--- a/extensions/amp-a4a/0.1/amp-ad-type-defs.js
+++ b/extensions/amp-a4a/0.1/amp-ad-type-defs.js
@@ -84,12 +84,18 @@ export let CrossDomainDataDef;
 export class Validator {
   /**
    * @param {!Object} unusedContext
+   * @param {!Element} unusedContainerElement
    * @param {!ArrayBuffer} unusedUnvalidatedBytes
    * @param {!Headers} unusedHeaders
    * @return {!Promise<!ValidatorOutput>}
    * @abstract
    */
-  validate(unusedContext, unusedUnvalidatedBytes, unusedHeaders) {}
+  validate(
+    unusedContext,
+    unusedContainerElement,
+    unusedUnvalidatedBytes,
+    unusedHeaders
+  ) {}
 }
 
 /**

--- a/extensions/amp-a4a/0.1/cryptographic-validator.js
+++ b/extensions/amp-a4a/0.1/cryptographic-validator.js
@@ -62,7 +62,7 @@ export class CryptographicValidator extends Validator {
   }
 
   /** @override */
-  validate(context, unvalidatedBytes, headers) {
+  validate(context, containerElement, unvalidatedBytes, headers) {
     return this.getSignatureVerifier_(context.win)
       .verify(
         unvalidatedBytes,

--- a/extensions/amp-a4a/0.1/template-renderer.js
+++ b/extensions/amp-a4a/0.1/template-renderer.js
@@ -16,7 +16,7 @@
 
 import {Renderer} from './amp-ad-type-defs';
 import {devAssert} from '../../../src/log';
-import {getAmpAdTemplateHelper} from './template-validator';
+import {getAmpAdTemplateHelper} from './amp-ad-template-helper';
 import {renderCreativeIntoFriendlyFrame} from './friendly-frame-util';
 
 /**
@@ -72,7 +72,7 @@ export class TemplateRenderer extends Renderer {
       if (!data) {
         return Promise.resolve();
       }
-      const templateHelper = getAmpAdTemplateHelper(context.win);
+      const templateHelper = getAmpAdTemplateHelper(element);
       return templateHelper
         .render(data, this.getDocument(iframe).body)
         .then((renderedElement) => {

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -15,9 +15,9 @@
  */
 
 import {AdResponseType, Validator, ValidatorResult} from './amp-ad-type-defs';
-import {AmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
 import {Services} from '../../../src/services';
 import {getAmpAdMetadata} from './amp-ad-utils';
+import {getAmpAdTemplateHelper} from './amp-ad-template-helper';
 import {pushIfNotExist} from '../../../src/utils/array';
 import {tryParseJson} from '../../../src/json';
 import {utf8Decode} from '../../../src/utils/bytes';
@@ -27,26 +27,12 @@ export const AMP_TEMPLATED_CREATIVE_HEADER_NAME = 'AMP-Ad-Template-Extension';
 export const DEPRECATED_AMP_TEMPLATED_CREATIVE_HEADER_NAME =
   'AMP-template-amp-creative';
 
-/** @type {?AmpAdTemplateHelper} */
-let ampAdTemplateHelper;
-
-/**
- * Returns the global template helper.
- * @param {!Window} win
- * @return {!AmpAdTemplateHelper}
- */
-export function getAmpAdTemplateHelper(win) {
-  return (
-    ampAdTemplateHelper || (ampAdTemplateHelper = new AmpAdTemplateHelper(win))
-  );
-}
-
 /**
  * Validator for Template ads.
  */
 export class TemplateValidator extends Validator {
   /** @override */
-  validate(context, unvalidatedBytes, headers) {
+  validate(context, containerElement, unvalidatedBytes, headers) {
     const body = utf8Decode(/** @type {!ArrayBuffer} */ (unvalidatedBytes));
     const parsedResponseBody = /** @type {./amp-ad-type-defs.AmpTemplateCreativeDef} */ (tryParseJson(
       body
@@ -75,7 +61,7 @@ export class TemplateValidator extends Validator {
       );
     }
 
-    return getAmpAdTemplateHelper(context.win)
+    return getAmpAdTemplateHelper(containerElement)
       .fetch(parsedResponseBody.templateUrl)
       .then((template) => {
         const creativeMetadata = getAmpAdMetadata(template);

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
@@ -17,6 +17,7 @@
 import {AmpAdTemplateHelper} from '../amp-ad-template-helper';
 import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {Xhr} from '../../../../src/service/xhr-impl';
+import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 
 describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
   const cdnUrl =
@@ -24,7 +25,7 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
     'adserver.com/amp_template_1';
   const canonicalUrl = 'https://adserver.com/amp_template_1';
 
-  let win, doc;
+  let win, doc, ampdoc;
   let fetchTextMock;
   let ampAdTemplateHelper;
 
@@ -32,8 +33,9 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
     win = env.win;
     win.__AMP_MODE = {localDev: false};
     doc = win.document;
+    ampdoc = env.ampdoc;
     fetchTextMock = env.sandbox.stub(Xhr.prototype, 'fetchText');
-    ampAdTemplateHelper = new AmpAdTemplateHelper(win);
+    ampAdTemplateHelper = new AmpAdTemplateHelper(ampdoc);
   });
 
   it('should return a promise resolving to a string template', () => {
@@ -67,11 +69,7 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
   });
 
   it('should render a template with correct values', () => {
-    win.AMP.registerTemplate('amp-mustache', AmpMustache);
-  });
-
-  it('should render a template with correct values', () => {
-    win.AMP.registerTemplate('amp-mustache', AmpMustache);
+    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
     const parentDiv = doc.createElement('div');
     parentDiv./*OK*/ innerHTML =
       '<template type="amp-mustache"><p>{{foo}}</p></template>';

--- a/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-cryptographic-validator.js
@@ -34,10 +34,14 @@ describes.realWin('CryptographicValidator', realWinConfig, (env) => {
   const headers = {'Content-Type': 'application/jwk-set+json'};
   let userErrorStub;
   let validator;
+  let containerElement;
 
   beforeEach(() => {
     validator = new CryptographicValidator();
     userErrorStub = env.sandbox.stub(user(), 'error');
+
+    containerElement = env.win.document.createElement('div');
+    env.win.document.body.appendChild(containerElement);
   });
 
   it('should have AMP validator result', () => {
@@ -47,7 +51,12 @@ describes.realWin('CryptographicValidator', realWinConfig, (env) => {
       verify: () => Promise.resolve(VerificationStatus.OK),
     };
     return validator
-      .validate({win: env.win}, utf8Encode(data.reserialized), headers)
+      .validate(
+        {win: env.win},
+        containerElement,
+        utf8Encode(data.reserialized),
+        headers
+      )
       .then((validatorOutput) => {
         expect(validatorOutput).to.be.ok;
         expect(validatorOutput.type).to.equal(ValidatorResult.AMP);
@@ -66,7 +75,12 @@ describes.realWin('CryptographicValidator', realWinConfig, (env) => {
       verify: () => Promise.resolve(VerificationStatus.UNVERIFIED),
     };
     return validator
-      .validate({win: env.win}, utf8Encode(data.reserialized), headers)
+      .validate(
+        {win: env.win},
+        containerElement,
+        utf8Encode(data.reserialized),
+        headers
+      )
       .then((validatorOutput) => {
         expect(validatorOutput).to.be.ok;
         expect(validatorOutput.type).to.equal(ValidatorResult.NON_AMP);
@@ -88,6 +102,7 @@ describes.realWin('CryptographicValidator', realWinConfig, (env) => {
     return validator
       .validate(
         {win: env.win},
+        containerElement,
         utf8Encode(data.reserializedInvalidOffset),
         headers
       )

--- a/extensions/amp-a4a/0.1/test/test-template-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-template-renderer.js
@@ -17,12 +17,13 @@
 import {
   AMP_TEMPLATED_CREATIVE_HEADER_NAME,
   TemplateValidator,
-  getAmpAdTemplateHelper,
 } from '../template-validator';
 import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {TemplateRenderer} from '../template-renderer';
 import {ValidatorResult} from '../amp-ad-type-defs';
 import {data} from './testdata/valid_css_at_rules_amp.reserialized';
+import {getAmpAdTemplateHelper} from '../amp-ad-template-helper';
+import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 import {utf8Encode} from '../../../../src/utils/bytes';
 
 const realWinConfig = {
@@ -41,7 +42,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
     },
   };
 
-  let doc;
+  let doc, ampdoc;
   let containerElement;
   let context;
   let renderer;
@@ -50,6 +51,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
 
   beforeEach(() => {
     doc = env.win.document;
+    ampdoc = env.ampdoc;
     renderer = new TemplateRenderer();
     validator = new TemplateValidator();
 
@@ -81,7 +83,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
     };
 
     env.sandbox
-      .stub(getAmpAdTemplateHelper(env.win), 'fetch')
+      .stub(getAmpAdTemplateHelper(ampdoc), 'fetch')
       .callsFake((url) => {
         expect(url).to.equal(templateUrl);
         return Promise.resolve(data.adTemplate);
@@ -89,6 +91,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
 
     validatorPromise = validator.validate(
       context,
+      containerElement,
       utf8Encode(
         JSON.stringify({
           templateUrl,
@@ -105,7 +108,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should append iframe child with correct template values', () => {
-    env.win.AMP.registerTemplate('amp-mustache', AmpMustache);
+    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
     return validatorPromise.then((validatorOutput) => {
       // Sanity check. This behavior is tested in test-template-validator.js.
       expect(validatorOutput).to.be.ok;
@@ -131,7 +134,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should set correct attributes on the iframe', () => {
-    env.win.AMP.registerTemplate('amp-mustache', AmpMustache);
+    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
     return validatorPromise.then((validatorOutput) => {
       // Sanity check. This behavior is tested in test-template-validator.js.
       expect(validatorOutput).to.be.ok;
@@ -154,7 +157,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should style body of iframe document to be visible', () => {
-    env.win.AMP.registerTemplate('amp-mustache', AmpMustache);
+    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
     return validatorPromise.then((validatorOutput) => {
       // Sanity check. This behavior is tested in test-template-validator.js.
       expect(validatorOutput).to.be.ok;
@@ -174,9 +177,9 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should insert analytics', () => {
-    env.win.AMP.registerTemplate('amp-mustache', AmpMustache);
+    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
     const insertAnalyticsSpy = env.sandbox.spy(
-      getAmpAdTemplateHelper(env.win),
+      getAmpAdTemplateHelper(ampdoc),
       'insertAnalytics'
     );
     return validatorPromise.then((validatorOutput) => {

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -18,10 +18,10 @@ import {
   AMP_TEMPLATED_CREATIVE_HEADER_NAME,
   DEPRECATED_AMP_TEMPLATED_CREATIVE_HEADER_NAME,
   TemplateValidator,
-  getAmpAdTemplateHelper,
 } from '../template-validator';
 import {AdResponseType, ValidatorResult} from '../amp-ad-type-defs';
 import {data} from './testdata/valid_css_at_rules_amp.reserialized';
+import {getAmpAdTemplateHelper} from '../amp-ad-template-helper';
 import {utf8Encode} from '../../../../src/utils/bytes';
 
 const realWinConfig = {
@@ -39,10 +39,15 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
       }
     },
   };
+
   let validator;
+  let containerElement;
 
   beforeEach(() => {
     validator = new TemplateValidator();
+
+    containerElement = env.win.document.createElement('div');
+    env.win.document.body.appendChild(containerElement);
   });
 
   describe('AMP Result', () => {
@@ -50,7 +55,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
 
     beforeEach(() => {
       env.sandbox
-        .stub(getAmpAdTemplateHelper(env.win), 'fetch')
+        .stub(getAmpAdTemplateHelper(env.ampdoc), 'fetch')
         .callsFake((url) => {
           expect(url).to.equal(templateUrl);
           return Promise.resolve(data.adTemplate);
@@ -58,6 +63,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
 
       validatorPromise = validator.validate(
         {win: env.win},
+        containerElement,
         utf8Encode(
           JSON.stringify({
             templateUrl,
@@ -82,6 +88,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
       validator
         .validate(
           {win: env.win},
+          containerElement,
           utf8Encode(
             JSON.stringify({
               templateUrl,
@@ -141,6 +148,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
       return validator
         .validate(
           {win: env.win},
+          containerElement,
           utf8Encode(
             JSON.stringify({
               templateUrl,
@@ -159,6 +167,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
       return validator
         .validate(
           {win: env.win},
+          containerElement,
           utf8Encode(
             JSON.stringify({
               templateUrl,
@@ -180,6 +189,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
       return validator
         .validate(
           {win: env.win},
+          containerElement,
           utf8Encode(
             JSON.stringify({
               templateUrl,
@@ -198,9 +208,14 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
 
     it('should have the response body as the creative in creativeData', () => {
       return validator
-        .validate({win: env.win}, utf8Encode(JSON.stringify({templateUrl})), {
-          get: () => null,
-        })
+        .validate(
+          {win: env.win},
+          containerElement,
+          utf8Encode(JSON.stringify({templateUrl})),
+          {
+            get: () => null,
+          }
+        )
         .then((validatorOutput) => {
           expect(validatorOutput).to.be.ok;
           expect(validatorOutput.creativeData).to.be.ok;

--- a/extensions/amp-access/0.1/amp-access.js
+++ b/extensions/amp-access/0.1/amp-access.js
@@ -90,7 +90,7 @@ export class AccessService {
     this.viewport_ = Services.viewportForDoc(ampdoc);
 
     /** @private @const {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(ampdoc.win);
+    this.templates_ = Services.templatesForDoc(ampdoc);
 
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
     this.mutator_ = Services.mutatorForDoc(ampdoc);

--- a/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import {
-  AMP_TEMPLATED_CREATIVE_HEADER_NAME,
-  getAmpAdTemplateHelper,
-} from '../../../amp-a4a/0.1/template-validator';
+import {AMP_TEMPLATED_CREATIVE_HEADER_NAME} from '../../../amp-a4a/0.1/template-validator';
 import {AmpAdTemplate} from '../amp-ad-custom';
 import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {data} from '../../../amp-a4a/0.1/test/testdata/valid_css_at_rules_amp.reserialized';
+import {getAmpAdTemplateHelper} from '../../../amp-a4a/0.1/amp-ad-template-helper';
+import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 import {tryParseJson} from '../../../../src/json';
 import {utf8Encode} from '../../../../src/utils/bytes';
 
@@ -33,12 +32,13 @@ const realWinConfig = {
 describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   const templateUrl = '/adzerk/1';
 
-  let doc;
+  let doc, ampdoc;
   let containerElement;
   let impl;
 
   beforeEach(() => {
     doc = env.win.document;
+    ampdoc = env.ampdoc;
     containerElement = doc.createElement('div');
     containerElement.setAttribute('height', 50);
     containerElement.setAttribute('width', 320);
@@ -69,7 +69,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
       impl.element.style.width = width;
       impl.element.style.height = height;
     };
-    env.win.AMP.registerTemplate('amp-mustache', AmpMustache);
+    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
   });
 
   afterEach(() => {
@@ -105,7 +105,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
       });
 
       env.sandbox
-        .stub(getAmpAdTemplateHelper(env.win), 'fetch')
+        .stub(getAmpAdTemplateHelper(ampdoc), 'fetch')
         .callsFake((url) => {
           expect(url).to.equal(templateUrl);
           return Promise.resolve(data.adTemplate);

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -19,9 +19,9 @@ import {
   CreativeMetaDataDef,
   NO_CONTENT_RESPONSE,
 } from '../../amp-a4a/0.1/amp-a4a';
-import {AmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
 import {AmpTemplateCreativeDef} from '../../amp-a4a/0.1/amp-ad-type-defs';
 import {dev, devAssert} from '../../../src/log';
+import {getAmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
 import {getMode} from '../../../src/mode';
 import {tryParseJson} from '../../../src/json';
 import {tryResolve} from '../../../src/utils/promise';
@@ -32,9 +32,6 @@ const TAG = 'amp-ad-network-adzerk-impl';
 
 /** @visibleForTesting @type {string} */
 export const AMP_TEMPLATED_CREATIVE_HEADER_NAME = 'AMP-template-amp-creative';
-
-/** @private {?AmpAdTemplateHelper} */
-let ampAdTemplateHelper;
 
 /**
  * Fast Fetch implementation for AdZerk network that allows AMP creative
@@ -66,9 +63,6 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
 
     /** @private {?../../amp-a4a/0.1/amp-ad-type-defs.AmpTemplateCreativeDef} */
     this.ampCreativeJson_ = null;
-
-    ampAdTemplateHelper =
-      ampAdTemplateHelper || new AmpAdTemplateHelper(this.win);
   }
 
   /**
@@ -110,6 +104,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
         body
       ) || {});
       // TODO(keithwrightbos): macro value validation?  E.g. http invalid?
+      const ampAdTemplateHelper = getAmpAdTemplateHelper(this.element);
       return ampAdTemplateHelper
         .fetch(this.ampCreativeJson_.templateUrl)
         .then((parsedTemplate) => {
@@ -175,6 +170,7 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
   /** @override */
   onCreativeRender(unusedMetadata) {
     if (this.ampCreativeJson_ && this.ampCreativeJson_.data) {
+      const ampAdTemplateHelper = getAmpAdTemplateHelper(this.element);
       ampAdTemplateHelper
         .render(
           this.ampCreativeJson_.data,

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -26,18 +26,20 @@ import {
 import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {createElementWithAttributes} from '../../../../src/dom';
+import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 import {utf8Decode, utf8Encode} from '../../../../src/utils/bytes';
 
 describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
-  let win, doc;
+  let win, doc, ampdoc;
   let element, impl;
   let fetchTextMock;
 
   beforeEach(() => {
     win = env.win;
     win.__AMP_MODE = {localDev: false};
-    win.AMP.registerTemplate('amp-mustache', AmpMustache);
     doc = win.document;
+    ampdoc = env.ampdoc;
+    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
     fetchTextMock = env.sandbox.stub(Xhr.prototype, 'fetchText');
     element = createElementWithAttributes(doc, 'amp-ad', {
       'type': 'adzerk',

--- a/extensions/amp-ad/0.1/amp-ad-custom.js
+++ b/extensions/amp-ad/0.1/amp-ad-custom.js
@@ -123,7 +123,7 @@ export class AmpAdCustom extends AMP.BaseElement {
       this.renderStarted();
 
       try {
-        Services.templatesFor(this.win)
+        Services.templatesForDoc(this.element)
           .findAndRenderTemplate(this.element, templateData)
           .then((renderedElement) => {
             // Get here when the template has been rendered Clear out the

--- a/extensions/amp-autocomplete/0.1/amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/amp-autocomplete.js
@@ -186,8 +186,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
      */
     this.initialAutocompleteAttr_ = null;
 
-    /** @const @private {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(this.win);
+    /** @private {?../../../src/service/template-impl.Templates} */
+    this.templates_ = null;
 
     /**
      * Whether a <template> or <script type="text/plain"> tag is present.
@@ -236,6 +236,8 @@ export class AmpAutocomplete extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.templates_ = Services.templatesForDoc(this.element);
+
     const doc = this.element.ownerDocument;
     const isEmail = doc && isAmp4Email(doc);
     userAssert(

--- a/extensions/amp-date-countdown/0.1/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/0.1/amp-date-countdown.js
@@ -73,8 +73,8 @@ export class AmpDateCountdown extends AMP.BaseElement {
   constructor(element) {
     super(element);
 
-    /** @const {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(this.win);
+    /** @private {?../../../src/service/template-impl.Templates} */
+    this.templates_ = null;
 
     /** @const {function(!Element)} */
     this.boundRendered_ = this.rendered_.bind(this);
@@ -115,6 +115,8 @@ export class AmpDateCountdown extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.templates_ = Services.templatesForDoc(this.element);
+
     // Store this in buildCallback() because `this.element` sometimes
     // is missing attributes in the constructor.
 

--- a/extensions/amp-date-countdown/1.0/amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/amp-date-countdown.js
@@ -49,7 +49,8 @@ class AmpDateCountdown extends BaseElement {
   /** @override */
   checkPropsPostMutations() {
     const templates =
-      this.templates_ || (this.templates_ = Services.templatesFor(this.win));
+      this.templates_ ||
+      (this.templates_ = Services.templatesForDoc(this.element));
     const template = templates.maybeFindTemplate(this.element);
     if (template === this.template_) {
       return;

--- a/extensions/amp-date-display/0.1/amp-date-display.js
+++ b/extensions/amp-date-display/0.1/amp-date-display.js
@@ -95,8 +95,8 @@ export class AmpDateDisplay extends AMP.BaseElement {
     /** @private {string} */
     this.locale_ = '';
 
-    /** @private @const {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(this.win);
+    /** @private {?../../../src/service/template-impl.Templates} */
+    this.templates_ = null;
 
     /** @private {?Element} */
     this.container_ = null;
@@ -104,6 +104,8 @@ export class AmpDateDisplay extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.templates_ = Services.templatesForDoc(this.element);
+
     this.container_ = this.element.ownerDocument.createElement('div');
     this.element.appendChild(devAssert(this.container_));
 

--- a/extensions/amp-date-display/0.1/test/test-amp-date-display.js
+++ b/extensions/amp-date-display/0.1/test/test-amp-date-display.js
@@ -16,7 +16,7 @@
 
 import '../amp-date-display';
 import * as fakeTimers from '@sinonjs/fake-timers';
-import {toggleExperiment} from '../../../../src/experiments';
+import {Services} from '../../../../src/services';
 
 describes.realWin(
   'amp-date-display',
@@ -37,14 +37,14 @@ describes.realWin(
         now: new Date('2018-01-01T08:00:00Z'),
       });
 
-      toggleExperiment(win, 'amp-date-display', true);
       element = win.document.createElement('amp-date-display');
       element.setAttribute('layout', 'fixed');
       element.setAttribute('width', '300');
       element.setAttribute('height', '100');
       win.document.body.appendChild(element);
       impl = await element.getImpl(false);
-      env.sandbox.stub(impl.templates_, 'findAndRenderTemplate').resolves();
+      const templates = Services.templatesForDoc(env.ampdoc);
+      env.sandbox.stub(templates, 'findAndRenderTemplate').resolves();
       env.sandbox.stub(impl, 'boundRendered_');
     });
 

--- a/extensions/amp-date-display/1.0/amp-date-display.js
+++ b/extensions/amp-date-display/1.0/amp-date-display.js
@@ -48,7 +48,8 @@ class AmpDateDisplay extends BaseElement {
   /** @override */
   checkPropsPostMutations() {
     const templates =
-      this.templates_ || (this.templates_ = Services.templatesFor(this.win));
+      this.templates_ ||
+      (this.templates_ = Services.templatesForDoc(this.element));
     const template = templates.maybeFindTemplate(this.element);
     if (template != this.template_) {
       this.template_ = template;

--- a/extensions/amp-date-picker/0.1/amp-date-picker.js
+++ b/extensions/amp-date-picker/0.1/amp-date-picker.js
@@ -232,8 +232,8 @@ export class AmpDatePicker extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private @const */
-    this.templates_ = Services.templatesFor(this.win);
+    /** @private {?../../../src/service/template-impl.Templates} */
+    this.templates_ = null;
 
     /** @private @const */
     this.input_ = Services.inputFor(this.win);
@@ -373,6 +373,8 @@ export class AmpDatePicker extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.templates_ = Services.templatesForDoc(this.element);
+
     const format = this.element.getAttribute('format');
     if (format) {
       this.format_ = format;

--- a/extensions/amp-form/0.1/amp-form.js
+++ b/extensions/amp-form/0.1/amp-form.js
@@ -136,32 +136,32 @@ export class AmpForm {
     /** @const @private {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win_);
 
-    /** @const @private {!../../../src/service/url-replacements-impl.UrlReplacements} */
-    this.urlReplacement_ = Services.urlReplacementsForDoc(element);
-
-    /** @private {?Promise} */
-    this.dependenciesPromise_ = null;
-
     /** @const @private {!HTMLFormElement} */
     this.form_ = element;
 
     /** @const @private {!../../../src/service/ampdoc-impl.AmpDoc}  */
     this.ampdoc_ = Services.ampdoc(this.form_);
 
+    /** @private {?Promise} */
+    this.dependenciesPromise_ = null;
+
+    /** @const @private {!../../../src/service/url-replacements-impl.UrlReplacements} */
+    this.urlReplacement_ = Services.urlReplacementsForDoc(this.ampdoc_);
+
     /** @const @private {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(this.win_);
+    this.templates_ = Services.templatesForDoc(this.ampdoc_);
 
     /** @const @private {!../../../src/service/xhr-impl.Xhr} */
     this.xhr_ = Services.xhrFor(this.win_);
 
     /** @const @private {!../../../src/service/action-impl.ActionService} */
-    this.actions_ = Services.actionServiceForDoc(this.form_);
+    this.actions_ = Services.actionServiceForDoc(this.ampdoc_);
 
     /** @const @private {!../../../src/service/mutator-interface.MutatorInterface} */
-    this.mutator_ = Services.mutatorForDoc(this.form_);
+    this.mutator_ = Services.mutatorForDoc(this.ampdoc_);
 
     /** @const @private {!../../../src/service/viewer-interface.ViewerInterface}  */
-    this.viewer_ = Services.viewerForDoc(this.form_);
+    this.viewer_ = Services.viewerForDoc(this.ampdoc_);
 
     /**
      * @const {!../../../src/ssr-template-helper.SsrTemplateHelper}
@@ -257,7 +257,7 @@ export class AmpForm {
   getXhrUrl_(attribute) {
     const url = this.form_.getAttribute(attribute);
     if (url) {
-      const urlService = Services.urlForDoc(this.form_);
+      const urlService = Services.urlForDoc(this.ampdoc_);
       urlService.assertHttpsUrl(url, this.form_, attribute);
       userAssert(
         !urlService.isProxyOrigin(url),
@@ -476,7 +476,7 @@ export class AmpForm {
 
   /** @private */
   installInputMasking_() {
-    Services.inputmaskServiceForDocOrNull(this.form_).then(
+    Services.inputmaskServiceForDocOrNull(this.ampdoc_).then(
       (inputmaskService) => {
         if (inputmaskService) {
           inputmaskService.install();
@@ -1177,7 +1177,7 @@ export class AmpForm {
         this.form_
       );
       try {
-        const urlService = Services.urlForDoc(this.form_);
+        const urlService = Services.urlForDoc(this.ampdoc_);
         urlService.assertAbsoluteHttpOrHttpsUrl(redirectTo);
         urlService.assertHttpsUrl(redirectTo, 'AMP-Redirect-To', 'Url');
       } catch (e) {
@@ -1188,7 +1188,7 @@ export class AmpForm {
           redirectTo
         );
       }
-      const navigator = Services.navigationForDoc(this.form_);
+      const navigator = Services.navigationForDoc(this.ampdoc_);
       navigator.navigateTo(this.win_, redirectTo, REDIRECT_TO_HEADER);
     }
   }

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -21,7 +21,7 @@ import {Services} from '../../../../../src/services';
 import {installGlobalSubmitListenerForDoc} from '../../../../../src/document-submit';
 import {listenOncePromise} from '../../../../../src/event-helper';
 import {poll} from '../../../../../testing/iframe';
-import {registerExtendedTemplate} from '../../../../../src/service/template-impl';
+import {registerExtendedTemplateForDoc} from '../../../../../src/service/template-impl';
 
 /** @const {number} */
 const RENDER_TIMEOUT = 15000;
@@ -61,7 +61,7 @@ describes.realWin(
       const mustache = document.createElement('script');
       mustache.setAttribute('custom-template', 'amp-mustache');
       doc.body.appendChild(mustache);
-      registerExtendedTemplate(env.win, 'amp-mustache', AmpMustache);
+      registerExtendedTemplateForDoc(env.ampdoc, 'amp-mustache', AmpMustache);
 
       const form = document.createElement('script');
       form.setAttribute('custom-element', 'amp-form');

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -120,8 +120,8 @@ export class AmpList extends AMP.BaseElement {
     /** @private {?Array} */
     this.renderedItems_ = null;
 
-    /** @const {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(this.win);
+    /** @private {?../../../src/service/template-impl.Templates} */
+    this.templates_ = null;
 
     /**
      * Has layoutCallback() been called yet?
@@ -227,6 +227,7 @@ export class AmpList extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    this.templates_ = Services.templatesForDoc(this.element);
     this.action_ = Services.actionServiceForDoc(this.element);
     this.owners_ = Services.ownersForDoc(this.element);
     /** If the element is in an email document,

--- a/extensions/amp-list/0.1/test/test-amp-list-container.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-container.js
@@ -49,7 +49,7 @@ describes.realWin(
         findAndRenderTemplate: env.sandbox.stub(),
         findAndRenderTemplateArray: env.sandbox.stub(),
       };
-      env.sandbox.stub(Services, 'templatesFor').returns(templates);
+      env.sandbox.stub(Services, 'templatesForDoc').returns(templates);
       env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
 
       element = doc.createElement('amp-list');

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -55,7 +55,7 @@ describes.realWin(
         findAndRenderTemplate: env.sandbox.stub(),
         findAndRenderTemplateArray: env.sandbox.stub(),
       };
-      env.sandbox.stub(Services, 'templatesFor').returns(templates);
+      env.sandbox.stub(Services, 'templatesForDoc').returns(templates);
       env.sandbox.stub(AmpDocService.prototype, 'getAmpDoc').returns(ampdoc);
       element = doc.createElement('amp-list');
       list = new AmpList(element);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -66,7 +66,7 @@ describes.repeated(
             findAndRenderTemplate: env.sandbox.stub(),
             findAndRenderTemplateArray: env.sandbox.stub(),
           };
-          env.sandbox.stub(Services, 'templatesFor').returns(templates);
+          env.sandbox.stub(Services, 'templatesForDoc').returns(templates);
           env.sandbox
             .stub(AmpDocService.prototype, 'getAmpDoc')
             .returns(ampdoc);

--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -89,7 +89,7 @@ export class NextPageService {
     this.mutator_ = Services.mutatorForDoc(ampdoc);
 
     /** @private @const {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(this.win_);
+    this.templates_ = Services.templatesForDoc(ampdoc);
 
     /** @private {?Element} */
     this.separator_ = null;

--- a/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
+++ b/extensions/amp-subscriptions/0.1/local-subscription-platform-renderer.js
@@ -39,7 +39,7 @@ export class LocalSubscriptionPlatformRenderer {
     this.dialog_ = dialog;
 
     /** @private @const {!../../../src/service/template-impl.Templates} */
-    this.templates_ = Services.templatesFor(ampdoc.win);
+    this.templates_ = Services.templatesForDoc(ampdoc);
 
     /** @private @const {!./service-adapter.ServiceAdapter} */
     this.serviceAdapter_ = serviceAdapter;

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
@@ -134,7 +134,7 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, (env) => {
     let dialog0, dialog1, dialog2, dialog3;
 
     beforeEach(() => {
-      templatesMock = env.sandbox.mock(Services.templatesFor(win));
+      templatesMock = env.sandbox.mock(Services.templatesForDoc(ampdoc));
       dialogMock = env.sandbox.mock(renderer.dialog_);
       dialog0 = createElementWithAttributes(doc, 'div', {
         'id': 'dialog0',

--- a/src/inabox/inabox-services.js
+++ b/src/inabox/inabox-services.js
@@ -40,8 +40,8 @@ import {rejectServicePromiseForDoc} from '../service';
 export function installAmpdocServicesForInabox(ampdoc) {
   // Order is important!
   installIframeMessagingClient(ampdoc.win); // this is an inabox-only service
-  installTemplatesServiceForDoc(ampdoc);
   installUrlForDoc(ampdoc);
+  installTemplatesServiceForDoc(ampdoc);
   installDocumentInfoServiceForDoc(ampdoc);
   installInaboxCidService(ampdoc);
   installInaboxViewerServiceForDoc(ampdoc);

--- a/src/inabox/inabox-services.js
+++ b/src/inabox/inabox-services.js
@@ -28,6 +28,7 @@ import {installInaboxViewerServiceForDoc} from './inabox-viewer';
 import {installInaboxViewportService} from './inabox-viewport';
 import {installOwnersServiceForDoc} from '../service/owners-impl';
 import {installStandardActionsForDoc} from '../service/standard-actions-impl';
+import {installTemplatesServiceForDoc} from '../service/template-impl';
 import {installUrlForDoc} from '../service/url-impl';
 import {installUrlReplacementsServiceForDoc} from '../service/url-replacements-impl';
 import {rejectServicePromiseForDoc} from '../service';
@@ -39,6 +40,7 @@ import {rejectServicePromiseForDoc} from '../service';
 export function installAmpdocServicesForInabox(ampdoc) {
   // Order is important!
   installIframeMessagingClient(ampdoc.win); // this is an inabox-only service
+  installTemplatesServiceForDoc(ampdoc);
   installUrlForDoc(ampdoc);
   installDocumentInfoServiceForDoc(ampdoc);
   installInaboxCidService(ampdoc);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -39,7 +39,6 @@ import {
 } from './service/extensions-impl';
 import {internalRuntimeVersion} from './internal-version';
 import {isExperimentOn, toggleExperiment} from './experiments';
-import {registerExtendedTemplate} from './service/template-impl';
 import {reportErrorForWin} from './error';
 import {scheduleUpgradeIfNeeded as scheduleInObUpgradeIfNeeded} from './polyfillstub/intersection-observer-stub';
 import {scheduleUpgradeIfNeeded as scheduleResObUpgradeIfNeeded} from './polyfillstub/resize-observer-stub';
@@ -136,9 +135,7 @@ function adoptShared(global, callback) {
    * @param {string} name
    * @param {typeof ./base-template.BaseTemplate} implementationClass
    */
-  global.AMP.registerTemplate = function (name, implementationClass) {
-    registerExtendedTemplate(global, name, implementationClass);
-  };
+  global.AMP.registerTemplate = extensions.addTemplate.bind(extensions);
 
   /**
    * Registers an ampdoc service.

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {adoptServiceForEmbedDoc} from '../service';
+import {
+  adoptServiceFactoryForEmbedDoc,
+  adoptServiceForEmbedDoc,
+} from '../service';
 import {devAssert} from '../log';
 import {installActionServiceForDoc} from './action-impl';
 import {installBatchedXhrService} from './batched-xhr-impl';
@@ -105,8 +108,10 @@ function installAmpdocServicesInternal(ampdoc, isEmbedded) {
   // When making changes to this method:
   // 1. Order is important!
   // 2. Consider to install same services to amp-inabox.js
-  installTemplatesServiceForDoc(ampdoc);
   installUrlForDoc(ampdoc);
+  isEmbedded
+    ? adoptServiceFactoryForEmbedDoc(ampdoc, 'templates')
+    : installTemplatesServiceForDoc(ampdoc);
   isEmbedded
     ? adoptServiceForEmbedDoc(ampdoc, 'documentInfo')
     : installDocumentInfoServiceForDoc(ampdoc);

--- a/src/service/core-services.js
+++ b/src/service/core-services.js
@@ -38,7 +38,7 @@ import {installPreconnectService} from '../preconnect';
 import {installResourcesServiceForDoc} from './resources-impl';
 import {installStandardActionsForDoc} from './standard-actions-impl';
 import {installStorageServiceForDoc} from './storage-impl';
-import {installTemplatesService} from './template-impl';
+import {installTemplatesServiceForDoc} from './template-impl';
 import {installTimerService} from './timer-impl';
 import {installUrlForDoc} from './url-impl';
 import {installUrlReplacementsServiceForDoc} from './url-replacements-impl';
@@ -67,7 +67,6 @@ export function installRuntimeServices(global) {
   installCryptoService(global);
   installBatchedXhrService(global);
   installPlatformService(global);
-  installTemplatesService(global);
   installTimerService(global);
   installVsyncService(global);
   installXhrService(global);
@@ -106,6 +105,7 @@ function installAmpdocServicesInternal(ampdoc, isEmbedded) {
   // When making changes to this method:
   // 1. Order is important!
   // 2. Consider to install same services to amp-inabox.js
+  installTemplatesServiceForDoc(ampdoc);
   installUrlForDoc(ampdoc);
   isEmbedded
     ? adoptServiceForEmbedDoc(ampdoc, 'documentInfo')

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -29,6 +29,7 @@ import {dev, devAssert, rethrowAsync, user} from '../log';
 import {getMode} from '../mode';
 import {installStylesForDoc} from '../style-installer';
 import {map} from '../utils/object';
+import {registerExtendedTemplateForDoc} from './template-impl';
 import {registerServiceBuilder, registerServiceBuilderForDoc} from '../service';
 
 export const LEGACY_ELEMENTS = ['amp-ad', 'amp-embed', 'amp-video'];
@@ -328,6 +329,20 @@ export class Extensions {
     holder.extension.elements[name] = {implementationClass, css};
     this.addDocFactory((ampdoc) => {
       this.installElement_(ampdoc, name, implementationClass, css);
+    });
+  }
+
+  /**
+   * Add a template type to the extension currently being registered. This is a
+   * restricted method and it's allowed to be called only during the overall
+   * extension registration.
+   * @param {string} name
+   * @param {typeof ../base-template.BaseTemplate} implementationClass
+   * @restricted
+   */
+  addTemplate(name, implementationClass) {
+    this.addDocFactory((ampdoc) => {
+      registerExtendedTemplateForDoc(ampdoc, name, implementationClass);
     });
   }
 

--- a/src/service/template-impl.js
+++ b/src/service/template-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {Deferred} from '../utils/promise';
-import {getService, registerServiceBuilder} from '../service';
+import {getServiceForDoc, registerServiceBuilderForDoc} from '../service';
 import {rootNodeFor, scopedQuerySelector} from '../dom';
 import {userAssert} from '../log';
 
@@ -37,10 +37,10 @@ const EMPTY_FUNC = () => {};
 /**
  */
 export class Templates {
-  /** @param {!Window} win */
-  constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+  /** @param {!AmpDoc} ampdoc */
+  constructor(ampdoc) {
+    /** @private @const */
+    this.ampdoc_ = ampdoc;
 
     /**
      * A map from template type to template's class promise.
@@ -255,7 +255,7 @@ export class Templates {
       (templateClass) => {
         // This is ugly workaround for https://github.com/google/closure-compiler/issues/2630.
         const Constr = /** @type {function(new:Object, !Element, !Window)} */ (templateClass);
-        const impl = (element[PROP_] = new Constr(element, this.win_));
+        const impl = (element[PROP_] = new Constr(element, this.ampdoc_.win));
         delete element[PROP_PROMISE_];
         return impl;
       }
@@ -326,21 +326,31 @@ export class Templates {
 }
 
 /**
- * @param {!Window} win
+ * @param {!AmpDoc} ampdoc
  */
-export function installTemplatesService(win) {
-  registerServiceBuilder(win, 'templates', Templates);
+export function installTemplatesServiceForDoc(ampdoc) {
+  registerServiceBuilderForDoc(ampdoc, 'templates', Templates);
 }
 
 /**
  * Registers an extended template. This function should typically be called
  * through the registerTemplate method on the AMP runtime.
- * @param {!Window} win
+ * @param {!AmpDoc} ampdoc
  * @param {string} type
  * @param {typeof ../base-template.BaseTemplate} templateClass
  * @return {undefined}
  */
-export function registerExtendedTemplate(win, type, templateClass) {
-  const templatesService = getService(win, 'templates');
+export function registerExtendedTemplateForDoc(ampdoc, type, templateClass) {
+  const templatesService = getServiceForDoc(ampdoc, 'templates');
   return templatesService.registerTemplate_(type, templateClass);
+}
+
+/**
+ * @param {!Templates} templates
+ * @param {string} type
+ * @return {!Promise<typeof ../base-template.BaseTemplate>|undefined}
+ * @visibleForTesting
+ */
+export function getTemplateClassForTesting(templates, type) {
+  return templates.templateClassMap_[type];
 }

--- a/src/services.js
+++ b/src/services.js
@@ -665,12 +665,12 @@ export class Services {
   }
 
   /**
-   * @param {!Window} window
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
    * @return {!./service/template-impl.Templates}
    */
-  static templatesFor(window) {
-    return /** @type {!./service/template-impl.Templates} */ (getService(
-      window,
+  static templatesForDoc(elementOrAmpDoc) {
+    return /** @type {!./service/template-impl.Templates} */ (getServiceForDoc(
+      elementOrAmpDoc,
       'templates'
     ));
   }

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -21,6 +21,10 @@ import {Extensions} from '../../src/service/extensions-impl';
 import {Services} from '../../src/services';
 import {dispatchCustomEvent} from '../../src/dom';
 import {getServiceForDoc} from '../../src/service';
+import {
+  getTemplateClassForTesting,
+  installTemplatesServiceForDoc,
+} from '../../src/service/template-impl';
 import {installTimerService} from '../../src/service/timer-impl';
 import {user} from '../../src/log';
 
@@ -209,6 +213,66 @@ describes.sandboxed('Extensions', {}, () => {
       expect(unknown.extension.elements['e1'].implementationClass).to.equal(
         ctor
       );
+    });
+
+    it('should add template in registration', async () => {
+      const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
+      installTemplatesServiceForDoc(ampdoc);
+      const templates = Services.templatesForDoc(ampdoc);
+
+      const ctor = function () {};
+      extensions.registerExtension(
+        'amp-ext',
+        () => {
+          extensions.addTemplate('e1', ctor);
+        },
+        {}
+      );
+      await extensions.waitForExtension(win, 'amp-ext');
+
+      const holder = extensions.getExtensionHolder_('amp-ext');
+      expect(holder.docFactories).to.have.length(1);
+
+      const implClass = await getTemplateClassForTesting(templates, 'e1');
+      expect(implClass).to.equal(ctor);
+    });
+
+    it('should add element out of registration', () => {
+      const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
+      installTemplatesServiceForDoc(ampdoc);
+
+      const ctor = function () {};
+      allowConsoleError(() => extensions.addTemplate('e1', ctor));
+      expect(Object.keys(extensions.extensions_)).to.deep.equal(['_UNKNOWN_']);
+    });
+
+    it('should install template in shadow doc', async () => {
+      env.sandbox
+        .stub(Services.ampdocServiceFor(win), 'isSingleDoc')
+        .callsFake(() => false);
+
+      // Resolve the promise.
+      const ctor = function () {};
+      extensions.registerExtension(
+        'amp-test',
+        () => {
+          extensions.addTemplate('amp-test', ctor);
+        },
+        {}
+      );
+
+      // Install into shadow doc.
+      const shadowRoot = document.createDocumentFragment();
+      const ampdoc = new AmpDocShadow(win, 'https://a.org/', shadowRoot);
+      installTemplatesServiceForDoc(ampdoc);
+      await extensions.installExtensionsInDoc(ampdoc, ['amp-test']);
+
+      // Extension is now declared.
+      expect(ampdoc.declaresExtension('amp-test')).to.be.true;
+
+      const templates = Services.templatesForDoc(ampdoc);
+      const implClass = await getTemplateClassForTesting(templates, 'amp-test');
+      expect(implClass).to.equal(ctor);
     });
 
     it('should install auto undeclared elements for single-doc', () => {

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -35,7 +35,7 @@ describes.fakeWin(
     beforeEach(() => {
       ampdoc = env.ampdoc;
       win = env.win;
-      templates = Services.templatesFor(win);
+      templates = Services.templatesForDoc(ampdoc);
       viewer = Services.viewerForDoc(ampdoc);
       viewer.isTrustedViewer = () => Promise.resolve(true);
       hasCapabilityStub = env.sandbox.stub(viewer, 'hasCapability');

--- a/test/unit/test-template.js
+++ b/test/unit/test-template.js
@@ -16,29 +16,27 @@
 
 import {BaseTemplate} from '../../src/base-template';
 import {Services} from '../../src/services';
-import {getServiceForDoc, resetServiceForTesting} from '../../src/service';
+import {getServiceForDoc} from '../../src/service';
 import {
-  installTemplatesService,
-  registerExtendedTemplate,
+  installTemplatesServiceForDoc,
+  registerExtendedTemplateForDoc,
 } from '../../src/service/template-impl';
 
 describes.realWin('Template', {amp: true}, (env) => {
   let templates;
   let doc;
   let win;
+  let ampdoc;
   let container;
 
   beforeEach(() => {
     win = env.win;
-    installTemplatesService(win);
-    templates = Services.templatesFor(win);
     doc = win.document;
+    ampdoc = env.ampdoc;
+    installTemplatesServiceForDoc(ampdoc);
+    templates = Services.templatesForDoc(ampdoc);
     container = doc.createElement('div');
     doc.body.appendChild(container);
-  });
-
-  afterEach(() => {
-    resetServiceForTesting(win, 'templates');
   });
 
   class TemplateImpl extends BaseTemplate {
@@ -75,8 +73,8 @@ describes.realWin('Template', {amp: true}, (env) => {
 
   it('should render immediately', () => {
     const templateElement = createTemplateElement();
-    registerExtendedTemplate(
-      win,
+    registerExtendedTemplateForDoc(
+      ampdoc,
       templateElement.getAttribute('type'),
       TemplateImpl
     );
@@ -87,8 +85,8 @@ describes.realWin('Template', {amp: true}, (env) => {
 
   it('should render as string', () => {
     const templateElement = createTemplateElement();
-    registerExtendedTemplate(
-      win,
+    registerExtendedTemplateForDoc(
+      ampdoc,
       templateElement.getAttribute('type'),
       TemplateImpl
     );
@@ -103,8 +101,8 @@ describes.realWin('Template', {amp: true}, (env) => {
     const templateElement = createTemplateElement();
     // Use TemplateImplCheckingViewer to make sure viewerCanRenderTemplates
     // works correctly when the template is later detached.
-    registerExtendedTemplate(
-      win,
+    registerExtendedTemplateForDoc(
+      ampdoc,
       templateElement.getAttribute('type'),
       TemplateImplCheckingViewer
     );
@@ -123,8 +121,8 @@ describes.realWin('Template', {amp: true}, (env) => {
 
   it('should render array', () => {
     const templateElement = createTemplateElement();
-    registerExtendedTemplate(
-      win,
+    registerExtendedTemplateForDoc(
+      ampdoc,
       templateElement.getAttribute('type'),
       TemplateImpl
     );
@@ -139,15 +137,15 @@ describes.realWin('Template', {amp: true}, (env) => {
 
   it('should NOT allow registering template class twice', () => {
     const templateElement = createTemplateElement();
-    registerExtendedTemplate(
-      win,
+    registerExtendedTemplateForDoc(
+      ampdoc,
       templateElement.getAttribute('type'),
       TemplateImpl
     );
     allowConsoleError(() => {
       expect(() => {
-        registerExtendedTemplate(
-          win,
+        registerExtendedTemplateForDoc(
+          ampdoc,
           templateElement.getAttribute('type'),
           TemplateImpl
         );
@@ -183,8 +181,8 @@ describes.realWin('Template', {amp: true}, (env) => {
     );
     doc.body.appendChild(scriptElement);
     const p = templates.renderTemplate(templateElement, {value: 1});
-    registerExtendedTemplate(
-      win,
+    registerExtendedTemplateForDoc(
+      ampdoc,
       templateElement.getAttribute('type'),
       TemplateImpl
     );
@@ -203,8 +201,8 @@ describes.realWin('Template', {amp: true}, (env) => {
     doc.body.appendChild(scriptElement);
     const p1 = templates.renderTemplate(templateElement, {value: 1});
     const p2 = templates.renderTemplate(templateElement, {value: 2});
-    registerExtendedTemplate(
-      win,
+    registerExtendedTemplateForDoc(
+      ampdoc,
       templateElement.getAttribute('type'),
       TemplateImpl
     );
@@ -227,7 +225,7 @@ describes.realWin('Template', {amp: true}, (env) => {
     const id = type + Math.random();
     templateElement.setAttribute('id', id);
     doc.body.appendChild(templateElement);
-    registerExtendedTemplate(win, type, TemplateImpl);
+    registerExtendedTemplateForDoc(ampdoc, type, TemplateImpl);
 
     const parentElement = doc.createElement('div');
     parentElement.setAttribute('template', id);
@@ -283,7 +281,7 @@ describes.realWin('Template', {amp: true}, (env) => {
   it('should discover template via children', () => {
     const templateElement = createTemplateElement();
     const type = templateElement.getAttribute('type');
-    registerExtendedTemplate(win, type, TemplateImpl);
+    registerExtendedTemplateForDoc(ampdoc, type, TemplateImpl);
 
     const parentElement = doc.createElement('div');
     parentElement.appendChild(templateElement);
@@ -322,7 +320,7 @@ describes.realWin('Template', {amp: true}, (env) => {
 
     const templateElement = createTemplateElement();
     const type = templateElement.getAttribute('type');
-    registerExtendedTemplate(env.win, type, TemplateImpl);
+    registerExtendedTemplateForDoc(env.ampdoc, type, TemplateImpl);
 
     // With template, but different ID
     parentElement.appendChild(templateElement);
@@ -339,7 +337,7 @@ describes.realWin('Template', {amp: true}, (env) => {
     const id = type + Math.random();
     templateElement.setAttribute('id', id);
     doc.body.appendChild(templateElement);
-    registerExtendedTemplate(win, type, TemplateImpl);
+    registerExtendedTemplateForDoc(env.ampdoc, type, TemplateImpl);
 
     const parentElement = doc.createElement('div');
     parentElement.setAttribute('template', id);


### PR DESCRIPTION
This is a rollforward of https://github.com/ampproject/amphtml/pull/32853, with an additional change to use the new `adoptServiceFactoryForEmbedDoc`.