### PR TITLE
Fix ensureLoaded-vs-build race condition in stable

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -526,7 +526,11 @@ function createBaseCustomElementClass(win) {
      * @final
      */
     ensureLoaded(opt_parentPriority) {
-      return this.whenBuilt().then(() => {
+      // Very ugly! The "built" signal must be resolved from the Resource
+      // and not the element itself because the Resource has not correctly
+      // set its state for the downstream to process it correctly.
+      const resource = this.getResource_();
+      return resource.whenBuilt().then(() => {
         const resource = this.getResource_();
         if (resource.getState() == ResourceState.LAYOUT_COMPLETE) {
           return;

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1598,7 +1598,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
             .once();
 
           const promise = element.ensureLoaded(parentPriority);
-          await element.buildInternal();
+          await resource.build();
           await element.layoutCallback();
 
           await promise;
@@ -1613,7 +1613,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           container.appendChild(element);
           const resource = element.getResource_();
 
-          await element.buildInternal();
+          await resource.build();
           expect(element.isBuilt()).to.be.true;
 
           const parentPriority = 1;
@@ -1640,7 +1640,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           container.appendChild(element);
           const resource = element.getResource_();
 
-          await element.buildInternal();
+          await resource.build();
           resource.measure();
           resource.layoutScheduled(Date.now());
           await resource.startLayout();
@@ -1658,7 +1658,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           container.appendChild(element);
           const resource = element.getResource_();
 
-          await element.buildInternal();
+          await resource.build();
           resource.measure();
           resource.layoutScheduled(Date.now());
           const layoutCallbackStub = env.sandbox.stub(
@@ -1692,7 +1692,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           const element = new ElementClass();
           element.setAttribute('layout', 'nodisplay');
           container.appendChild(element);
-          await element.buildInternal();
+
+          const resource = element.getResource_();
+          await resource.build();
 
           resourcesMock.expects('scheduleLayoutOrPreload').never();
 
@@ -1703,8 +1705,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
           const element = new ElementClass();
           element.setAttribute('layout', 'nodisplay');
           container.appendChild(element);
+
           const resource = element.getResource_();
-          await element.buildInternal();
+          await resource.build();
 
           const measureSpy = env.sandbox.spy(resource, 'measure');
           resourcesMock.expects('scheduleLayoutOrPreload').never();


### PR DESCRIPTION
Closes #32978

The problem is due to the race condition when a `Resource` correctly updates its state vs when an element knows reliably it has been built. This will be a non-issue for V1/Bento, but for classical elements this duality is still the case.

Note! This is a PR against release-2102130314000 branch.