### PR TITLE
Experiment: disallow a4a on platforms w/o native shadow DOM support

### DIFF
--- a/build-system/global-configs/experiments-const.json
+++ b/build-system/global-configs/experiments-const.json
@@ -1,6 +1,7 @@
 {
   "BENTO_AUTO_UPGRADE": false,
   "INI_LOAD_INOB": false,
+  "NO_SIGNING_RTV": false,
   "V1_IMG_DEFERRED_BUILD": false,
   "WITHIN_VIEWPORT_INOB": false
 }

--- a/examples/a4a.amp.html
+++ b/examples/a4a.amp.html
@@ -67,7 +67,7 @@
     width="300">
   </amp-ad>
 
-  <h2>A4A ad: adsense</h2>
+  <h2>AdSense (may or may not be A4A)</h2>
   <amp-ad
     width="300"
     height="250"

--- a/examples/a4a.amp.html
+++ b/examples/a4a.amp.html
@@ -60,11 +60,19 @@
     width="300">
   </amp-ad>
 
-  <h2>A4A ad</h2>
+  <h2>A4A ad: doubleclick</h2>
   <amp-ad data-slot="/30497360/a4a/a4a_native"
     height="250"
     type="doubleclick"
     width="300">
+  </amp-ad>
+
+  <h2>A4A ad: adsense</h2>
+  <amp-ad
+    width="300"
+    height="250"
+    type="adsense"
+    data-ad-client="ca-pub-5439573510495356">
   </amp-ad>
 </body>
 </html>

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -56,7 +56,7 @@ import {
   getConsentPolicyState,
 } from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
-import {getExperimentBranch} from '../../../src/experiments';
+import {getExperimentBranch, isExperimentOn} from '../../../src/experiments';
 import {getMode} from '../../../src/mode';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {
@@ -71,6 +71,7 @@ import {
 } from '../../../src/utils/intersection';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isArray, isEnumValue, isObject} from '../../../src/types';
+
 import {listenOnce} from '../../../src/event-helper';
 import {
   observeWithSharedInOb,
@@ -914,8 +915,7 @@ export class AmpA4A extends AMP.BaseElement {
    * @return {boolean}
    */
   isInNoSigningExp() {
-    // eslint-disable-next-line no-undef
-    return !!NO_SIGNING_RTV;
+    return NO_SIGNING_RTV;
   }
 
   /**
@@ -945,7 +945,10 @@ export class AmpA4A extends AMP.BaseElement {
     const size = this.extractSize(httpResponse.headers);
     this.creativeSize_ = size || this.creativeSize_;
 
-    if (this.skipClientSideValidation(httpResponse.headers)) {
+    if (
+      !isPlatformSupported(this.win) ||
+      this.skipClientSideValidation(httpResponse.headers)
+    ) {
       return this.handleFallback_(httpResponse, checkStillCurrent);
     }
 
@@ -1100,7 +1103,9 @@ export class AmpA4A extends AMP.BaseElement {
           // via #validateAdResponse_.  See GitHub issue
           // https://github.com/ampproject/amphtml/issues/4187
           let creativeMetaDataDef;
+
           if (
+            !isPlatformSupported(this.win) ||
             !creativeDecoded ||
             !(creativeMetaDataDef = this.getAmpAdMetadata(creativeDecoded))
           ) {
@@ -2560,4 +2565,29 @@ export function signatureVerifierFor(win) {
     win[propertyName] ||
     (win[propertyName] = new SignatureVerifier(win, signingServerURLs))
   );
+}
+
+/**
+ * @param {!Window} win
+ * @return {boolean}
+ * @visibleForTesting
+ */
+export function isPlatformSupported(win) {
+  // Require Shadow DOM support for a4a.
+  if (
+    !isNative(win.Element.prototype.attachShadow) &&
+    isExperimentOn(win, 'disable-a4a-non-sd')
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Returns `true` if the passed function exists and is native to the browser.
+ * @param {Function|undefined} func
+ * @return {boolean}
+ */
+function isNative(func) {
+  return !!func && func.toString().indexOf('[native code]') != -1;
 }

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -71,7 +71,6 @@ import {
 } from '../../../src/utils/intersection';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isArray, isEnumValue, isObject} from '../../../src/types';
-
 import {listenOnce} from '../../../src/event-helper';
 import {
   observeWithSharedInOb,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -61,197 +61,234 @@ import {layoutRectLtwh, layoutSizeFromRect} from '../../../../src/layout-rect';
 import {macroTask} from '../../../../testing/yield';
 import {resetScheduledElementForTesting} from '../../../../src/service/custom-element-registry';
 import {data as testFragments} from './testdata/test_fragments';
+import {toggleExperiment} from '../../../../src/experiments';
 import {data as validCSSAmp} from './testdata/valid_css_at_rules_amp.reserialized';
 
-// eslint-disable-next-line no-undef
-if (NO_SIGNING_RTV) {
-  describes.realWin('no signing', {amp: true}, (env) => {
-    let doc;
-    let element;
-    let a4a;
+describes.realWin('amp-a4a: no signing', {amp: true}, (env) => {
+  let doc;
+  let element;
+  let a4a;
+  let attachShadowStub;
 
-    beforeEach(() => {
-      doc = env.win.document;
-      element = createElementWithAttributes(env.win.document, 'amp-ad', {
-        'width': '300',
-        'height': '250',
-        'type': 'doubleclick',
-        'layout': 'fixed',
-      });
-      doc.body.appendChild(element);
-      a4a = new AmpA4A(element);
-      // Make the ad think it has size.
-      env.sandbox.stub(a4a, 'getIntersectionElementLayoutBox').returns({
-        height: 250,
-        width: 300,
-      });
-      env.sandbox.stub(a4a, 'getAdUrl').returns('https://adnetwork.com');
-      env.fetchMock.mock(
-        'begin:https://adnetwork.com',
-        validCSSAmp.minifiedCreative
-      );
+  beforeEach(() => {
+    doc = env.win.document;
+    env.sandbox.stub(AmpA4A.prototype, 'isInNoSigningExp').returns(true);
+    element = createElementWithAttributes(env.win.document, 'amp-ad', {
+      'width': '300',
+      'height': '250',
+      'type': 'doubleclick',
+      'layout': 'fixed',
     });
-
-    it('should contain the correct csp meta content', async () => {
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      expect(fie.getAttribute('sandbox')).to.equal(
-        'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
-          'allow-same-origin allow-scripts allow-top-navigation'
-      );
-      const cspMeta = fie.contentDocument.querySelector(
-        'meta[http-equiv=Content-Security-Policy]'
-      );
-      expect(cspMeta).to.be.ok;
-      expect(cspMeta.content).to.include('img-src * data:;');
-      expect(cspMeta.content).to.include('media-src *;');
-      expect(cspMeta.content).to.include('font-src *;');
-      expect(cspMeta.content).to.include('connect-src *;');
-      expect(cspMeta.content).to.include(
-        'script-src http://localhost:8000/dist/lts/ ' +
-          'http://localhost:8000/dist/rtv/ ' +
-          'http://localhost:8000/dist/sw/;'
-      );
-      expect(cspMeta.content).to.include("object-src 'none';");
-      expect(cspMeta.content).to.include("child-src 'none';");
-      expect(cspMeta.content).to.include("default-src 'none';");
-      expect(cspMeta.content).to.include(
-        'style-src ' +
-          'https://cdn.materialdesignicons.com ' +
-          'https://cloud.typography.com ' +
-          'https://fast.fonts.net ' +
-          'https://fonts.googleapis.com ' +
-          'https://maxcdn.bootstrapcdn.com https://p.typekit.net https://pro.fontawesome.com ' +
-          'https://use.fontawesome.com ' +
-          'https://use.typekit.net ' +
-          "'unsafe-inline';"
-      );
+    doc.body.appendChild(element);
+    a4a = new AmpA4A(element);
+    // Make the ad think it has size.
+    env.sandbox.stub(a4a, 'getIntersectionElementLayoutBox').returns({
+      height: 250,
+      width: 300,
     });
+    env.sandbox.stub(a4a, 'getAdUrl').returns('https://adnetwork.com');
+    env.fetchMock.mock(
+      'begin:https://adnetwork.com',
+      validCSSAmp.minifiedCreative
+    );
 
-    it('should set the correct sandbox features', async () => {
-      env.sandbox
-        .stub(Services.platformFor(env.win), 'isSafari')
-        .returns(false);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      expect(fie.getAttribute('sandbox')).to.equal(
-        'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
-          'allow-same-origin allow-scripts allow-top-navigation'
-      );
-    });
-
-    it('FIE should contain <base> with adurl', async () => {
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      const base = fie.contentDocument.querySelector('base');
-      expect(base).to.be.ok;
-      expect(base.href).to.equal('https://adnetwork.com/');
-    });
-
-    it('should complete the rendering FIE', async () => {
-      const prioritySpy = env.sandbox.spy(a4a, 'updateLayoutPriority');
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      expect(fie).to.be.ok;
-      expect(fie.contentDocument.body.textContent).to.contain.string(
-        'Hello, world.'
-      );
-      expect(prioritySpy).to.be.calledWith(LayoutPriority.CONTENT);
-    });
-
-    it('should not throw on polyfill scripts', async () => {
-      env.sandbox.stub(mode, 'getMode').returns({localDev: false});
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      const violationSpy = env.sandbox.spy();
-      fie.contentWindow.addEventListener(
-        'securitypolicyviolation',
-        violationSpy
-      );
-      const fakePolyfill = doc.createElement('script');
-      fakePolyfill.src = 'https://cdn.ampproject.org/rtv/some-polyfill.js';
-      fie.contentDocument.head.appendChild(fakePolyfill);
-      await macroTask();
-      expect(violationSpy).not.to.be.called;
-    });
-
-    it('should throw on non-approved injected scripts', async () => {
-      env.sandbox.stub(mode, 'getMode').returns({localDev: false});
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      const violationSpy = env.sandbox.spy();
-      fie.contentWindow.addEventListener(
-        'securitypolicyviolation',
-        violationSpy
-      );
-      const fakePolyfill = doc.createElement('script');
-      fakePolyfill.src = 'https://www.cats.example';
-      fie.contentDocument.head.appendChild(fakePolyfill);
-      await macroTask();
-      expect(violationSpy).to.be.called;
-    });
-
-    it('should collapse on no content', async () => {
-      env.fetchMock.config.overwriteRoutes = true;
-      env.fetchMock.mock('begin:https://adnetwork.com', ''); // no content.
-      const iframe3pInit = env.sandbox
-        .stub(AmpAdXOriginIframeHandler.prototype, 'init')
-        .resolves();
-      const collapseSpy = env.sandbox.spy(a4a, 'forceCollapse');
-
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      expect(collapseSpy).to.be.called;
-      expect(iframe3pInit).not.to.be.called;
-    });
-
-    it('should fallback to x-domain without ⚡️4ads', async () => {
-      env.fetchMock.config.overwriteRoutes = true;
-      env.fetchMock.mock(
-        'begin:https://adnetwork.com',
-        testFragments.minimalDocOneStyle
-      );
-      const iframe3pInit = env.sandbox
-        .stub(AmpAdXOriginIframeHandler.prototype, 'init')
-        .resolves();
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      expect(iframe3pInit).to.be.called;
-    });
-
-    it('should not try to validate if #skipClientSideValidation', async () => {
-      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
-      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(true);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.adPromise_;
-      expect(fallbackSpy).to.be.called;
-    });
-
-    it('should validate if #skipClientSideValidation == false', async () => {
-      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
-      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
-      await a4a.buildCallback();
-      await a4a.onLayoutMeasure();
-      await a4a.adPromise_;
-      expect(fallbackSpy).not.to.be.called;
+    attachShadowStub = env.sandbox.stub(
+      env.win.Element.prototype,
+      'attachShadow'
+    );
+    // Emulate native function.
+    attachShadowStub.value(function () {
+      return '[native code]';
     });
   });
-}
+
+  it('should contain the correct csp meta content', async () => {
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    expect(fie.getAttribute('sandbox')).to.equal(
+      'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
+        'allow-same-origin allow-scripts allow-top-navigation'
+    );
+    const cspMeta = fie.contentDocument.querySelector(
+      'meta[http-equiv=Content-Security-Policy]'
+    );
+    expect(cspMeta).to.be.ok;
+    expect(cspMeta.content).to.include('img-src * data:;');
+    expect(cspMeta.content).to.include('media-src *;');
+    expect(cspMeta.content).to.include('font-src *;');
+    expect(cspMeta.content).to.include('connect-src *;');
+    expect(cspMeta.content).to.include(
+      'script-src http://localhost:8000/dist/lts/ ' +
+        'http://localhost:8000/dist/rtv/ ' +
+        'http://localhost:8000/dist/sw/;'
+    );
+    expect(cspMeta.content).to.include("object-src 'none';");
+    expect(cspMeta.content).to.include("child-src 'none';");
+    expect(cspMeta.content).to.include("default-src 'none';");
+    expect(cspMeta.content).to.include(
+      'style-src ' +
+        'https://cdn.materialdesignicons.com ' +
+        'https://cloud.typography.com ' +
+        'https://fast.fonts.net ' +
+        'https://fonts.googleapis.com ' +
+        'https://maxcdn.bootstrapcdn.com https://p.typekit.net https://pro.fontawesome.com ' +
+        'https://use.fontawesome.com ' +
+        'https://use.typekit.net ' +
+        "'unsafe-inline';"
+    );
+  });
+
+  it('should set the correct sandbox features', async () => {
+    env.sandbox.stub(Services.platformFor(env.win), 'isSafari').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    expect(fie.getAttribute('sandbox')).to.equal(
+      'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
+        'allow-same-origin allow-scripts allow-top-navigation'
+    );
+  });
+
+  it('FIE should contain <base> with adurl', async () => {
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    const base = fie.contentDocument.querySelector('base');
+    expect(base).to.be.ok;
+    expect(base.href).to.equal('https://adnetwork.com/');
+  });
+
+  it('should complete the rendering FIE', async () => {
+    const prioritySpy = env.sandbox.spy(a4a, 'updateLayoutPriority');
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    expect(fie).to.be.ok;
+    expect(fie.contentDocument.body.textContent).to.contain.string(
+      'Hello, world.'
+    );
+    expect(prioritySpy).to.be.calledWith(LayoutPriority.CONTENT);
+  });
+
+  it('should not throw on polyfill scripts', async () => {
+    env.sandbox.stub(mode, 'getMode').returns({localDev: false});
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    const violationSpy = env.sandbox.spy();
+    fie.contentWindow.addEventListener('securitypolicyviolation', violationSpy);
+    const fakePolyfill = doc.createElement('script');
+    fakePolyfill.src = 'https://cdn.ampproject.org/rtv/some-polyfill.js';
+    fie.contentDocument.head.appendChild(fakePolyfill);
+    await macroTask();
+    expect(violationSpy).not.to.be.called;
+  });
+
+  it('should throw on non-approved injected scripts', async () => {
+    env.sandbox.stub(mode, 'getMode').returns({localDev: false});
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    const violationSpy = env.sandbox.spy();
+    fie.contentWindow.addEventListener('securitypolicyviolation', violationSpy);
+    const fakePolyfill = doc.createElement('script');
+    fakePolyfill.src = 'https://www.cats.example';
+    fie.contentDocument.head.appendChild(fakePolyfill);
+    await macroTask();
+    expect(violationSpy).to.be.called;
+  });
+
+  it('should collapse on no content', async () => {
+    env.fetchMock.config.overwriteRoutes = true;
+    env.fetchMock.mock('begin:https://adnetwork.com', ''); // no content.
+    const iframe3pInit = env.sandbox
+      .stub(AmpAdXOriginIframeHandler.prototype, 'init')
+      .resolves();
+    const collapseSpy = env.sandbox.spy(a4a, 'forceCollapse');
+
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    expect(collapseSpy).to.be.called;
+    expect(iframe3pInit).not.to.be.called;
+  });
+
+  it('should fallback to x-domain without ⚡️4ads', async () => {
+    env.fetchMock.config.overwriteRoutes = true;
+    env.fetchMock.mock(
+      'begin:https://adnetwork.com',
+      testFragments.minimalDocOneStyle
+    );
+    const iframe3pInit = env.sandbox
+      .stub(AmpAdXOriginIframeHandler.prototype, 'init')
+      .resolves();
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    expect(iframe3pInit).to.be.called;
+  });
+
+  it('should not try to validate if #skipClientSideValidation', async () => {
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(true);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.be.called;
+  });
+
+  it('should validate if #skipClientSideValidation == false', async () => {
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    await a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).not.to.be.called;
+  });
+
+  it('should fallback when shadow DOM is not supported', async () => {
+    toggleExperiment(env.win, 'disable-a4a-non-sd', true, true);
+    attachShadowStub.value(undefined);
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.be.called;
+  });
+
+  it('should fallback when shadow DOM is polyfilled', async () => {
+    toggleExperiment(env.win, 'disable-a4a-non-sd', true, true);
+    attachShadowStub.value(function () {
+      // A non-native function.
+      return null;
+    });
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.be.called;
+  });
+
+  it('should ignore shadow DOM requirement without an experiment', async () => {
+    toggleExperiment(env.win, 'disable-a4a-non-sd', false, true);
+    attachShadowStub.value(undefined);
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.not.be.called;
+  });
+});
 
 describes.realWin('amp-a4a', {amp: true}, (env) => {
   const IFRAME_SANDBOXING_FLAGS = [
@@ -273,6 +310,8 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
   let getResourceStub;
 
   beforeEach(() => {
+    env.sandbox.stub(AmpA4A.prototype, 'isInNoSigningExp').returns(false);
+
     fetchMock = null;
     getSigningServiceNamesMock = env.sandbox.stub(
       AmpA4A.prototype,
@@ -327,6 +366,16 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
     const ampStyle = doc.createElement('style');
     ampStyle.setAttribute('amp-runtime', 'scratch-fortesting');
     doc.head.appendChild(ampStyle);
+
+    // Emulate native shadow DOM support. Will be reverted for some tests.
+    const attachShadowStub = env.sandbox.stub(
+      fixture.win.Element.prototype,
+      'attachShadow'
+    );
+    attachShadowStub.value(function () {
+      return '[native code]';
+    });
+    return {attachShadowStub};
   }
 
   /**
@@ -688,7 +737,6 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
     it('for requests from insecure HTTP pages', async () => {
       // TODO(ccordry): delete this test when we remove crypto.
-      // eslint-disable-next-line no-undef
       if (NO_SIGNING_RTV) {
         return;
       }
@@ -1359,7 +1407,6 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       const a4a = new MockA4AImpl(a4aElement);
       const renderAmpCreativeSpy = env.sandbox.spy(
         a4a,
-        // eslint-disable-next-line no-undef
         NO_SIGNING_RTV ? 'renderFriendlyTrustless_' : 'renderAmpCreative_'
       );
       a4a.buildCallback();
@@ -1415,7 +1462,6 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
     it('should run end-to-end and render in friendly iframe', async () => {
       // TODO(ccordry): delete this test when no signing launches.
-      // eslint-disable-next-line no-undef
       if (NO_SIGNING_RTV) {
         return;
       }
@@ -1537,6 +1583,98 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       );
     });
 
+    it('should fallback to non-AMP creative if shadow dom not supported', async () => {
+      const fixture = await createIframePromise();
+      const {attachShadowStub} = setupForAdTesting(fixture);
+
+      // Remove attachShadow.
+      attachShadowStub.value(undefined);
+      toggleExperiment(fixture.win, 'disable-a4a-non-sd', true, true);
+
+      fetchMock.getOnce(
+        TEST_URL + '&__amp_source_origin=about%3Asrcdoc',
+        () => adResponse,
+        {name: 'ad'}
+      );
+      const {doc} = fixture;
+      const a4aElement = createA4aElement(doc);
+      a4aElement.setAttribute('rtc-config', true);
+      const a4a = new MockA4AImpl(a4aElement);
+      const rtcResponse = Promise.resolve([
+        {response: 'a', rtcTime: 1, callout: 'https://a.com'},
+      ]);
+
+      installRealTimeConfigServiceForDoc(doc);
+      const maybeExecuteRealTimeConfigStub = env.sandbox
+        .stub()
+        .returns(rtcResponse);
+      const rtc = await Services.realTimeConfigForDoc(doc);
+      env.sandbox
+        .stub(rtc, 'maybeExecuteRealTimeConfig')
+        .callsFake(maybeExecuteRealTimeConfigStub);
+      const renderAmpCreativeSpy = env.sandbox.spy(a4a, 'renderAmpCreative_');
+      const renderNonAmpCreativeSpy = env.sandbox.spy(
+        a4a,
+        'renderNonAmpCreative'
+      );
+
+      a4a.buildCallback();
+      a4a.onLayoutMeasure();
+      await a4a.layoutCallback();
+      expect(renderAmpCreativeSpy).to.not.be.called;
+      expect(renderNonAmpCreativeSpy).to.be.calledOnce;
+      expect(a4aElement.getElementsByTagName('iframe').length).to.equal(1);
+      expect(a4aElement.querySelector('iframe[src]')).to.exist;
+      expect(a4aElement.querySelector('iframe[srcdoc]')).to.be.null;
+    });
+
+    it('should fallback to non-AMP creative if shadow dom is polyfilled', async () => {
+      const fixture = await createIframePromise();
+      const {attachShadowStub} = setupForAdTesting(fixture);
+
+      // Emulate polyfill.
+      attachShadowStub.value(function () {
+        return null;
+      });
+      toggleExperiment(fixture.win, 'disable-a4a-non-sd', true, true);
+
+      fetchMock.getOnce(
+        TEST_URL + '&__amp_source_origin=about%3Asrcdoc',
+        () => adResponse,
+        {name: 'ad'}
+      );
+      const {doc} = fixture;
+      const a4aElement = createA4aElement(doc);
+      a4aElement.setAttribute('rtc-config', true);
+      const a4a = new MockA4AImpl(a4aElement);
+      const rtcResponse = Promise.resolve([
+        {response: 'a', rtcTime: 1, callout: 'https://a.com'},
+      ]);
+
+      installRealTimeConfigServiceForDoc(doc);
+      const maybeExecuteRealTimeConfigStub = env.sandbox
+        .stub()
+        .returns(rtcResponse);
+      const rtc = await Services.realTimeConfigForDoc(doc);
+      env.sandbox
+        .stub(rtc, 'maybeExecuteRealTimeConfig')
+        .callsFake(maybeExecuteRealTimeConfigStub);
+      const renderAmpCreativeSpy = env.sandbox.spy(a4a, 'renderAmpCreative_');
+      const renderNonAmpCreativeSpy = env.sandbox.spy(
+        a4a,
+        'renderNonAmpCreative'
+      );
+
+      a4a.buildCallback();
+      a4a.onLayoutMeasure();
+      await a4a.layoutCallback();
+      expect(renderAmpCreativeSpy).to.not.be.called;
+      expect(renderNonAmpCreativeSpy).to.be.calledOnce;
+      expect(a4aElement.getElementsByTagName('iframe').length).to.equal(1);
+      expect(a4aElement.querySelector('iframe[src]')).to.exist;
+      expect(a4aElement.querySelector('iframe[srcdoc]')).to.be.null;
+    });
+
     it('should update priority for non AMP if in experiment', async () => {
       const fixture = await createIframePromise();
       setupForAdTesting(fixture);
@@ -1586,7 +1724,6 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
     // image within creative can be regenerated.
     it('should prefetch amp images', async () => {
       // TODO(ccordry): delete this test when launched.
-      // eslint-disable-next-line no-undef
       if (NO_SIGNING_RTV) {
         return;
       }
@@ -1767,7 +1904,6 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       if (isValidCreative) {
         expect(promiseResult).to.be.ok;
         // TODO(ccordry): delete this check when launched.
-        // eslint-disable-next-line no-undef
         !NO_SIGNING_RTV && !expect(promiseResult.minifiedCreative).to.be.ok;
       } else {
         expect(promiseResult).to.not.be.ok;
@@ -3198,7 +3334,6 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       // TODO(ccordry): delete crypto tests when launched.
       it('by default not allowed if crypto signature present but no SSL', async () => {
-        // eslint-disable-next-line no-undef
         if (NO_SIGNING_RTV) {
           return;
         }
@@ -3230,7 +3365,6 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       );
 
       it('not allowed if no crypto signature present', async () => {
-        // eslint-disable-next-line no-undef
         if (NO_SIGNING_RTV) {
           return;
         }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -142,7 +142,9 @@ if (NO_SIGNING_RTV) {
     });
 
     it('should set the correct sandbox features', async () => {
-      env.sandbox.stub(Services.platformFor(env.win), 'isSafari').returns(false);
+      env.sandbox
+        .stub(Services.platformFor(env.win), 'isSafari')
+        .returns(false);
       await a4a.buildCallback();
       a4a.onLayoutMeasure();
       await a4a.layoutCallback();
@@ -183,7 +185,10 @@ if (NO_SIGNING_RTV) {
       await a4a.layoutCallback();
       const fie = doc.body.querySelector('iframe[srcdoc]');
       const violationSpy = env.sandbox.spy();
-      fie.contentWindow.addEventListener('securitypolicyviolation', violationSpy);
+      fie.contentWindow.addEventListener(
+        'securitypolicyviolation',
+        violationSpy
+      );
       const fakePolyfill = doc.createElement('script');
       fakePolyfill.src = 'https://cdn.ampproject.org/rtv/some-polyfill.js';
       fie.contentDocument.head.appendChild(fakePolyfill);
@@ -198,7 +203,10 @@ if (NO_SIGNING_RTV) {
       await a4a.layoutCallback();
       const fie = doc.body.querySelector('iframe[srcdoc]');
       const violationSpy = env.sandbox.spy();
-      fie.contentWindow.addEventListener('securitypolicyviolation', violationSpy);
+      fie.contentWindow.addEventListener(
+        'securitypolicyviolation',
+        violationSpy
+      );
       const fakePolyfill = doc.createElement('script');
       fakePolyfill.src = 'https://www.cats.example';
       fie.contentDocument.head.appendChild(fakePolyfill);
@@ -312,6 +320,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
   let getResourceStub;
 
   beforeEach(() => {
+    // TODO(ccordry): remove with no-signing launch or similar.
     env.sandbox.stub(AmpA4A.prototype, 'isInNoSigningExp').returns(false);
 
     fetchMock = null;

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -64,241 +64,231 @@ import {data as testFragments} from './testdata/test_fragments';
 import {toggleExperiment} from '../../../../src/experiments';
 import {data as validCSSAmp} from './testdata/valid_css_at_rules_amp.reserialized';
 
-if (NO_SIGNING_RTV) {
-  describes.realWin('amp-a4a: no signing', {amp: true}, (env) => {
-    let doc;
-    let element;
-    let a4a;
-    let attachShadowStub;
+describes.realWin('amp-a4a: no signing', {amp: true}, (env) => {
+  let doc;
+  let element;
+  let a4a;
+  let attachShadowStub;
 
-    beforeEach(() => {
-      doc = env.win.document;
-      env.sandbox.stub(AmpA4A.prototype, 'isInNoSigningExp').returns(true);
-      element = createElementWithAttributes(env.win.document, 'amp-ad', {
-        'width': '300',
-        'height': '250',
-        'type': 'doubleclick',
-        'layout': 'fixed',
-      });
-      doc.body.appendChild(element);
-      a4a = new AmpA4A(element);
-      // Make the ad think it has size.
-      env.sandbox.stub(a4a, 'getIntersectionElementLayoutBox').returns({
-        height: 250,
-        width: 300,
-      });
-      env.sandbox.stub(a4a, 'getAdUrl').returns('https://adnetwork.com');
-      env.fetchMock.mock(
-        'begin:https://adnetwork.com',
-        validCSSAmp.minifiedCreative
-      );
-
-      attachShadowStub = env.sandbox.stub(
-        env.win.Element.prototype,
-        'attachShadow'
-      );
-      // Emulate native function.
-      attachShadowStub.value(function () {
-        return '[native code]';
-      });
+  beforeEach(() => {
+    doc = env.win.document;
+    env.sandbox.stub(AmpA4A.prototype, 'isInNoSigningExp').returns(true);
+    element = createElementWithAttributes(env.win.document, 'amp-ad', {
+      'width': '300',
+      'height': '250',
+      'type': 'doubleclick',
+      'layout': 'fixed',
     });
-
-    it('should contain the correct csp meta content', async () => {
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      expect(fie.getAttribute('sandbox')).to.equal(
-        'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
-          'allow-same-origin allow-scripts allow-top-navigation'
-      );
-      const cspMeta = fie.contentDocument.querySelector(
-        'meta[http-equiv=Content-Security-Policy]'
-      );
-      expect(cspMeta).to.be.ok;
-      expect(cspMeta.content).to.include('img-src * data:;');
-      expect(cspMeta.content).to.include('media-src *;');
-      expect(cspMeta.content).to.include('font-src *;');
-      expect(cspMeta.content).to.include('connect-src *;');
-      expect(cspMeta.content).to.include(
-        'script-src http://localhost:8000/dist/lts/ ' +
-          'http://localhost:8000/dist/rtv/ ' +
-          'http://localhost:8000/dist/sw/;'
-      );
-      expect(cspMeta.content).to.include("object-src 'none';");
-      expect(cspMeta.content).to.include("child-src 'none';");
-      expect(cspMeta.content).to.include("default-src 'none';");
-      expect(cspMeta.content).to.include(
-        'style-src ' +
-          'https://cdn.materialdesignicons.com ' +
-          'https://cloud.typography.com ' +
-          'https://fast.fonts.net ' +
-          'https://fonts.googleapis.com ' +
-          'https://maxcdn.bootstrapcdn.com https://p.typekit.net https://pro.fontawesome.com ' +
-          'https://use.fontawesome.com ' +
-          'https://use.typekit.net ' +
-          "'unsafe-inline';"
-      );
+    doc.body.appendChild(element);
+    a4a = new AmpA4A(element);
+    // Make the ad think it has size.
+    env.sandbox.stub(a4a, 'getIntersectionElementLayoutBox').returns({
+      height: 250,
+      width: 300,
     });
+    env.sandbox.stub(a4a, 'getAdUrl').returns('https://adnetwork.com');
+    env.fetchMock.mock(
+      'begin:https://adnetwork.com',
+      validCSSAmp.minifiedCreative
+    );
 
-    it('should set the correct sandbox features', async () => {
-      env.sandbox
-        .stub(Services.platformFor(env.win), 'isSafari')
-        .returns(false);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      expect(fie.getAttribute('sandbox')).to.equal(
-        'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
-          'allow-same-origin allow-scripts allow-top-navigation'
-      );
-    });
-
-    it('FIE should contain <base> with adurl', async () => {
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      const base = fie.contentDocument.querySelector('base');
-      expect(base).to.be.ok;
-      expect(base.href).to.equal('https://adnetwork.com/');
-    });
-
-    it('should complete the rendering FIE', async () => {
-      const prioritySpy = env.sandbox.spy(a4a, 'updateLayoutPriority');
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      expect(fie).to.be.ok;
-      expect(fie.contentDocument.body.textContent).to.contain.string(
-        'Hello, world.'
-      );
-      expect(prioritySpy).to.be.calledWith(LayoutPriority.CONTENT);
-    });
-
-    it('should not throw on polyfill scripts', async () => {
-      env.sandbox.stub(mode, 'getMode').returns({localDev: false});
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      const violationSpy = env.sandbox.spy();
-      fie.contentWindow.addEventListener(
-        'securitypolicyviolation',
-        violationSpy
-      );
-      const fakePolyfill = doc.createElement('script');
-      fakePolyfill.src = 'https://cdn.ampproject.org/rtv/some-polyfill.js';
-      fie.contentDocument.head.appendChild(fakePolyfill);
-      await macroTask();
-      expect(violationSpy).not.to.be.called;
-    });
-
-    it('should throw on non-approved injected scripts', async () => {
-      env.sandbox.stub(mode, 'getMode').returns({localDev: false});
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      const fie = doc.body.querySelector('iframe[srcdoc]');
-      const violationSpy = env.sandbox.spy();
-      fie.contentWindow.addEventListener(
-        'securitypolicyviolation',
-        violationSpy
-      );
-      const fakePolyfill = doc.createElement('script');
-      fakePolyfill.src = 'https://www.cats.example';
-      fie.contentDocument.head.appendChild(fakePolyfill);
-      await macroTask();
-      expect(violationSpy).to.be.called;
-    });
-
-    it('should collapse on no content', async () => {
-      env.fetchMock.config.overwriteRoutes = true;
-      env.fetchMock.mock('begin:https://adnetwork.com', ''); // no content.
-      const iframe3pInit = env.sandbox
-        .stub(AmpAdXOriginIframeHandler.prototype, 'init')
-        .resolves();
-      const collapseSpy = env.sandbox.spy(a4a, 'forceCollapse');
-
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      expect(collapseSpy).to.be.called;
-      expect(iframe3pInit).not.to.be.called;
-    });
-
-    it('should fallback to x-domain without ⚡️4ads', async () => {
-      env.fetchMock.config.overwriteRoutes = true;
-      env.fetchMock.mock(
-        'begin:https://adnetwork.com',
-        testFragments.minimalDocOneStyle
-      );
-      const iframe3pInit = env.sandbox
-        .stub(AmpAdXOriginIframeHandler.prototype, 'init')
-        .resolves();
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.layoutCallback();
-      expect(iframe3pInit).to.be.called;
-    });
-
-    it('should not try to validate if #skipClientSideValidation', async () => {
-      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
-      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(true);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.adPromise_;
-      expect(fallbackSpy).to.be.called;
-    });
-
-    it('should validate if #skipClientSideValidation == false', async () => {
-      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
-      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
-      await a4a.buildCallback();
-      await a4a.onLayoutMeasure();
-      await a4a.adPromise_;
-      expect(fallbackSpy).not.to.be.called;
-    });
-
-    it('should fallback when shadow DOM is not supported', async () => {
-      toggleExperiment(env.win, 'disable-a4a-non-sd', true, true);
-      attachShadowStub.value(undefined);
-      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
-      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.adPromise_;
-      expect(fallbackSpy).to.be.called;
-    });
-
-    it('should fallback when shadow DOM is polyfilled', async () => {
-      toggleExperiment(env.win, 'disable-a4a-non-sd', true, true);
-      attachShadowStub.value(function () {
-        // A non-native function.
-        return null;
-      });
-      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
-      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.adPromise_;
-      expect(fallbackSpy).to.be.called;
-    });
-
-    it('should ignore shadow DOM requirement without an experiment', async () => {
-      toggleExperiment(env.win, 'disable-a4a-non-sd', false, true);
-      attachShadowStub.value(undefined);
-      const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
-      env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
-      await a4a.buildCallback();
-      a4a.onLayoutMeasure();
-      await a4a.adPromise_;
-      expect(fallbackSpy).to.not.be.called;
+    attachShadowStub = env.sandbox.stub(
+      env.win.Element.prototype,
+      'attachShadow'
+    );
+    // Emulate native function.
+    attachShadowStub.value(function () {
+      return '[native code]';
     });
   });
-}
+
+  it('should contain the correct csp meta content', async () => {
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    expect(fie.getAttribute('sandbox')).to.equal(
+      'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
+        'allow-same-origin allow-scripts allow-top-navigation'
+    );
+    const cspMeta = fie.contentDocument.querySelector(
+      'meta[http-equiv=Content-Security-Policy]'
+    );
+    expect(cspMeta).to.be.ok;
+    expect(cspMeta.content).to.include('img-src * data:;');
+    expect(cspMeta.content).to.include('media-src *;');
+    expect(cspMeta.content).to.include('font-src *;');
+    expect(cspMeta.content).to.include('connect-src *;');
+    expect(cspMeta.content).to.include(
+      'script-src http://localhost:8000/dist/lts/ ' +
+        'http://localhost:8000/dist/rtv/ ' +
+        'http://localhost:8000/dist/sw/;'
+    );
+    expect(cspMeta.content).to.include("object-src 'none';");
+    expect(cspMeta.content).to.include("child-src 'none';");
+    expect(cspMeta.content).to.include("default-src 'none';");
+    expect(cspMeta.content).to.include(
+      'style-src ' +
+        'https://cdn.materialdesignicons.com ' +
+        'https://cloud.typography.com ' +
+        'https://fast.fonts.net ' +
+        'https://fonts.googleapis.com ' +
+        'https://maxcdn.bootstrapcdn.com https://p.typekit.net https://pro.fontawesome.com ' +
+        'https://use.fontawesome.com ' +
+        'https://use.typekit.net ' +
+        "'unsafe-inline';"
+    );
+  });
+
+  it('should set the correct sandbox features', async () => {
+    env.sandbox.stub(Services.platformFor(env.win), 'isSafari').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    expect(fie.getAttribute('sandbox')).to.equal(
+      'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
+        'allow-same-origin allow-scripts allow-top-navigation'
+    );
+  });
+
+  it('FIE should contain <base> with adurl', async () => {
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    const base = fie.contentDocument.querySelector('base');
+    expect(base).to.be.ok;
+    expect(base.href).to.equal('https://adnetwork.com/');
+  });
+
+  it('should complete the rendering FIE', async () => {
+    const prioritySpy = env.sandbox.spy(a4a, 'updateLayoutPriority');
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    expect(fie).to.be.ok;
+    expect(fie.contentDocument.body.textContent).to.contain.string(
+      'Hello, world.'
+    );
+    expect(prioritySpy).to.be.calledWith(LayoutPriority.CONTENT);
+  });
+
+  it('should not throw on polyfill scripts', async () => {
+    env.sandbox.stub(mode, 'getMode').returns({localDev: false});
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    const violationSpy = env.sandbox.spy();
+    fie.contentWindow.addEventListener('securitypolicyviolation', violationSpy);
+    const fakePolyfill = doc.createElement('script');
+    fakePolyfill.src = 'https://cdn.ampproject.org/rtv/some-polyfill.js';
+    fie.contentDocument.head.appendChild(fakePolyfill);
+    await macroTask();
+    expect(violationSpy).not.to.be.called;
+  });
+
+  it('should throw on non-approved injected scripts', async () => {
+    env.sandbox.stub(mode, 'getMode').returns({localDev: false});
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    const fie = doc.body.querySelector('iframe[srcdoc]');
+    const violationSpy = env.sandbox.spy();
+    fie.contentWindow.addEventListener('securitypolicyviolation', violationSpy);
+    const fakePolyfill = doc.createElement('script');
+    fakePolyfill.src = 'https://www.cats.example';
+    fie.contentDocument.head.appendChild(fakePolyfill);
+    await macroTask();
+    expect(violationSpy).to.be.called;
+  });
+
+  it('should collapse on no content', async () => {
+    env.fetchMock.config.overwriteRoutes = true;
+    env.fetchMock.mock('begin:https://adnetwork.com', ''); // no content.
+    const iframe3pInit = env.sandbox
+      .stub(AmpAdXOriginIframeHandler.prototype, 'init')
+      .resolves();
+    const collapseSpy = env.sandbox.spy(a4a, 'forceCollapse');
+
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    expect(collapseSpy).to.be.called;
+    expect(iframe3pInit).not.to.be.called;
+  });
+
+  it('should fallback to x-domain without ⚡️4ads', async () => {
+    env.fetchMock.config.overwriteRoutes = true;
+    env.fetchMock.mock(
+      'begin:https://adnetwork.com',
+      testFragments.minimalDocOneStyle
+    );
+    const iframe3pInit = env.sandbox
+      .stub(AmpAdXOriginIframeHandler.prototype, 'init')
+      .resolves();
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.layoutCallback();
+    expect(iframe3pInit).to.be.called;
+  });
+
+  it('should not try to validate if #skipClientSideValidation', async () => {
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(true);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.be.called;
+  });
+
+  it('should validate if #skipClientSideValidation == false', async () => {
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    await a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).not.to.be.called;
+  });
+
+  it('should fallback when shadow DOM is not supported', async () => {
+    toggleExperiment(env.win, 'disable-a4a-non-sd', true, true);
+    attachShadowStub.value(undefined);
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.be.called;
+  });
+
+  it('should fallback when shadow DOM is polyfilled', async () => {
+    toggleExperiment(env.win, 'disable-a4a-non-sd', true, true);
+    attachShadowStub.value(function () {
+      // A non-native function.
+      return null;
+    });
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.be.called;
+  });
+
+  it('should ignore shadow DOM requirement without an experiment', async () => {
+    toggleExperiment(env.win, 'disable-a4a-non-sd', false, true);
+    attachShadowStub.value(undefined);
+    const fallbackSpy = env.sandbox.spy(a4a, 'handleFallback_');
+    env.sandbox.stub(a4a, 'skipClientSideValidation').returns(false);
+    await a4a.buildCallback();
+    a4a.onLayoutMeasure();
+    await a4a.adPromise_;
+    expect(fallbackSpy).to.not.be.called;
+  });
+});
 
 describes.realWin('amp-a4a', {amp: true}, (env) => {
   const IFRAME_SANDBOXING_FLAGS = [


### PR DESCRIPTION
Partial for #30952.

Based on the https://github.com/ampproject/amphtml/pull/32943