### PR TITLE
♻️ Support stringifying element args in asserts + split helpers

### DIFF
--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -28,6 +28,19 @@
 export const USER_ERROR_SENTINEL = '\u200B\u200B\u200B';
 
 /**
+ * Converts an element to a readable string; all other types are unchanged.
+ * @param {*} val
+ * @return {*}
+ */
+function elementStringOrPassThru(val) {
+  // Do check equivalent to `val instanceof Element` without cross-window bug
+  if (val?.nodeType == 1) {
+    return val.tagName.toLowerCase() + (val.id ? `#${val.id}` : '');
+  }
+  return val;
+}
+
+/**
  * User error class for use in Preact. Use of sentinel string instead of a
  * boolean to check user errors because errors could be rethrown by some native
  * code as a new error, and only a message would survive. Mirrors errors
@@ -92,12 +105,15 @@ function assertion(errorCls, shouldBeTruthy, opt_message, var_args) {
       firstElement = subValue;
     }
 
-    return subValue;
+    return elementStringOrPassThru(subValue);
   });
 
   const error = new errorCls(message);
   error.messageArray = messageArray;
-  error.associatedElement = firstElement;
+  if (firstElement) {
+    error.associatedElement = firstElement;
+    firstElement.classList.add('i-amphtml-error');
+  }
   throw error;
 }
 

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -14,31 +14,12 @@
  * limitations under the License.
  */
 
+import {
+  USER_ERROR_SENTINEL,
+  elementStringOrPassThru,
+} from './error-message-helpers';
+
 /** @fileoverview Dependency-free assertion helpers for use in Preact. */
-
-/**
- * Triple zero width space.
- *
- * This is added to user error messages, so that we can later identify
- * them, when the only thing that we have is the message. This is the
- * case in many browsers when the global exception handler is invoked.
- *
- * @const {string}
- */
-export const USER_ERROR_SENTINEL = '\u200B\u200B\u200B';
-
-/**
- * Converts an element to a readable string; all other types are unchanged.
- * @param {*} val
- * @return {*}
- */
-function elementStringOrPassThru(val) {
-  // Do check equivalent to `val instanceof Element` without cross-window bug
-  if (val?.nodeType == 1) {
-    return val.tagName.toLowerCase() + (val.id ? `#${val.id}` : '');
-  }
-  return val;
-}
 
 /**
  * User error class for use in Preact. Use of sentinel string instead of a

--- a/src/core/error-message-helpers.js
+++ b/src/core/error-message-helpers.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Triple zero width space.
+ *
+ * This is added to user error messages, so that we can later identify
+ * them, when the only thing that we have is the message. This is the
+ * case in many browsers when the global exception handler is invoked.
+ *
+ * @const {string}
+ */
+export const USER_ERROR_SENTINEL = '\u200B\u200B\u200B';
+
+/**
+ * Converts an element to a readable string; all other types are unchanged.
+ * TODO(rcebulko): Unify with log.js
+ * @param {*} val
+ * @return {*}
+ */
+export function elementStringOrPassThru(val) {
+  // Do check equivalent to `val instanceof Element` without cross-window bug
+  if (val?.nodeType == 1) {
+    return val.tagName.toLowerCase() + (val.id ? `#${val.id}` : '');
+  }
+  return val;
+}

--- a/src/log.js
+++ b/src/log.js
@@ -635,7 +635,7 @@ export class Log {
  * @return {string}
  */
 const stringOrElementString = (val) =>
-  /** @type {string} */ (elementStringOrPassthru(val));
+  /** @type {string} */ (elementStringOrPassThru(val));
 
 /**
  * @param {!Array} array

--- a/src/log.js
+++ b/src/log.js
@@ -125,7 +125,7 @@ const externalMessagesSimpleTableUrl = () =>
  * @return {string}
  */
 const messageArgToEncodedComponent = (arg) =>
-  encodeURIComponent(String(elementStringOrPassthru(arg)));
+  encodeURIComponent(String(elementStringOrPassThru(arg)));
 
 /**
  * Logging class. Use of sentinel string instead of a boolean to check user/dev

--- a/src/log.js
+++ b/src/log.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import {USER_ERROR_SENTINEL} from './core/assert';
+import {
+  USER_ERROR_SENTINEL,
+  elementStringOrPassthru,
+} from './core/error-message-helpers';
 import {getMode} from './mode';
 import {internalRuntimeVersion} from './internal-version';
 import {isArray, isEnumValue} from './types';
@@ -633,18 +636,6 @@ export class Log {
  */
 const stringOrElementString = (val) =>
   /** @type {string} */ (elementStringOrPassthru(val));
-
-/**
- * @param {*} val
- * @return {*}
- */
-function elementStringOrPassthru(val) {
-  // Do check equivalent to `val instanceof Element` without cross-window bug
-  if (val && val.nodeType == 1) {
-    return val.tagName.toLowerCase() + (val.id ? '#' + val.id : '');
-  }
-  return val;
-}
 
 /**
  * @param {!Array} array

--- a/src/log.js
+++ b/src/log.js
@@ -16,7 +16,7 @@
 
 import {
   USER_ERROR_SENTINEL,
-  elementStringOrPassthru,
+  elementStringOrPassThru,
 } from './core/error-message-helpers';
 import {getMode} from './mode';
 import {internalRuntimeVersion} from './internal-version';

--- a/test/unit/test-assert.js
+++ b/test/unit/test-assert.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import {USER_ERROR_SENTINEL} from '../../src/core/error-message-helpers';
 import {
-  USER_ERROR_SENTINEL,
   pureDevAssert as devAssert,
   pureUserAssert as userAssert,
 } from '../../src/core/assert';


### PR DESCRIPTION
Part of broader effort to bring `src/core/assert.js` to feature parity with `src/log.js` and untie fully from runtime deps