### PR TITLE
🏗 Fix Karma's watch mode for `esbuild` transforms

### DIFF
--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -1741,9 +1741,11 @@ app.use('(/dist)?/rtv/*/v0/analytics-vendors/:vendor.json', (req, res) => {
 });
 
 // Used by test/unit/test-3p.js to test script loading.
-app.use('/test/script', function (req, res) {
+app.use('/test/script', function (req, res, next) {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'text/javascript');
   res.send("typeof require === 'function' && require('foo.js');");
-  res.status(200).send();
+  next();
 });
 
 module.exports = app;

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -460,13 +460,20 @@ async function finishBundle(
  * caching to speed up transforms.
  * @param {string} callerName
  * @param {boolean} enableCache
- * @param {function()} postStep
+ * @param {function()} preSetup
+ * @param {function()} postLoad
  * @return {!Object}
  */
-function getEsbuildBabelPlugin(callerName, enableCache, postStep = () => {}) {
+function getEsbuildBabelPlugin(
+  callerName,
+  enableCache,
+  preSetup = () => {},
+  postLoad = () => {}
+) {
   return {
     name: 'babel',
     async setup(build) {
+      preSetup();
       const transformContents = async (file) => {
         const contents = await fs.promises.readFile(file.path, 'utf-8');
         const babelOptions =
@@ -492,7 +499,7 @@ function getEsbuildBabelPlugin(callerName, enableCache, postStep = () => {}) {
           cache.set(path, promise);
         }
         const transformed = await promise;
-        postStep();
+        postLoad();
         return transformed;
       });
     },

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -171,21 +171,9 @@ async function karmaBrowserComplete_(browser) {
 /**
  * @private
  */
-function karmaBrowsersReady_() {
+function karmaBrowserStart_() {
   console./*OK*/ log('\n');
   log(green('Done. Running tests...'));
-}
-
-/**
- * @private
- */
-function karmaRunStart_() {
-  log(
-    green('Transforming tests with'),
-    cyan('esbuild'),
-    green('and'),
-    cyan('babel') + green('...')
-  );
 }
 
 /**
@@ -206,8 +194,7 @@ async function createKarmaServer(config) {
   });
 
   karmaServer
-    .on('run_start', karmaRunStart_)
-    .on('browsers_ready', karmaBrowsersReady_)
+    .on('browser_start', karmaBrowserStart_)
     .on('browser_complete', karmaBrowserComplete_)
     .on('run_complete', (browsers, results) => {
       browsers_ = browsers;

--- a/build-system/test-configs/karma.conf.js
+++ b/build-system/test-configs/karma.conf.js
@@ -65,6 +65,7 @@ module.exports = {
 
   mochaReporter: {
     output: 'full',
+    divider: false,
     colors: {
       success: 'green',
       error: 'red',


### PR DESCRIPTION
In #32891, we switched Karma's transformer from `browserify` to `esbuild`. Notably, we combined all JS test files into a single file for `esbuild` to transform with `babel`. This PR fixes watch mode while running tests.

**PR highlights:**
- Disable `babel` transform caching in watch mode (so the unified file is re-transformed when a test file is edited)
- Fix logging for start of transforms and start of tests (Karma's trigger events vary between watch and non-watch modes)
- Clean up references to obsolete `argv.w` and `argv.v`
- Bonus fix: Clean up test script response logic so that `test-3p.js` can be run repeatedly in watch mode

With this PR, the watcher is triggered when an edit is made to either a test file or a runtime file consumed by it.

**Screenshot:**

![image](https://user-images.githubusercontent.com/26553114/109740374-2c659680-7b99-11eb-8bdf-1fe69b99104e.png)

**Note:** Babel caching during tests can be re-enabled when we stop using a unified file for `esbuild` transforms. Until then, the only way is to wait for test transforms after each edit.

Follow up to #32891

