### PR TITLE
Multi-versioned extensions: propagate version info in the binaries

### DIFF
--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -36,6 +36,8 @@ exports.mainBinary =
 
 exports.extension = function (
   name,
+  version,
+  latest,
   isModule,
   loadPriority,
   intermediateDeps,
@@ -71,7 +73,8 @@ exports.extension = function (
   // Use a numeric value instead of boolean. "m" stands for "module"
   const m = isModule ? 1 : 0;
   return (
-    `(self.AMP=self.AMP||[]).push({n:"${name}",${priority}${deps}` +
+    `(self.AMP=self.AMP||[]).push({n:"${name}",ev:"${version}",l:${latest},` +
+    `${priority}${deps}` +
     `v:"${VERSION}",m:${m},f:(function(AMP,_){${opt_splitMarker}\n` +
     '<%= contents %>\n})});'
   );

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -523,6 +523,7 @@ function buildExtensionCss(path, name, version, options) {
  */
 async function buildExtensionJs(path, name, version, latestVersion, options) {
   const filename = options.filename || name + '.js';
+  const latest = version === latestVersion;
   await compileJs(
     path + '/',
     filename,
@@ -530,7 +531,8 @@ async function buildExtensionJs(path, name, version, latestVersion, options) {
     Object.assign(options, {
       toName: `${name}-${version}.max.js`,
       minifiedName: `${name}-${version}.js`,
-      latestName: version === latestVersion ? `${name}-latest.js` : '',
+      latestName: latest ? `${name}-latest.js` : '',
+      esmPassCompilation: argv.esm || argv.sxg || false,
       // Wrapper that either registers the extension or schedules it for
       // execution after the main binary comes back.
       // The `function` is wrapped in `()` to avoid lazy parsing it,
@@ -538,7 +540,13 @@ async function buildExtensionJs(path, name, version, latestVersion, options) {
       // See https://github.com/ampproject/amphtml/issues/3977
       wrapper: options.noWrapper
         ? ''
-        : wrappers.extension(name, argv.esm, options.loadPriority),
+        : wrappers.extension(
+            name,
+            version,
+            latest,
+            argv.esm,
+            options.loadPriority
+          ),
     })
   );
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -532,7 +532,6 @@ async function buildExtensionJs(path, name, version, latestVersion, options) {
       toName: `${name}-${version}.max.js`,
       minifiedName: `${name}-${version}.js`,
       latestName: latest ? `${name}-latest.js` : '',
-      esmPassCompilation: argv.esm || argv.sxg || false,
       // Wrapper that either registers the extension or schedules it for
       // execution after the main binary comes back.
       // The `function` is wrapped in `()` to avoid lazy parsing it,


### PR DESCRIPTION
Partial for #33001.

For multi-version support we need to know what version the extension is being registered and whether or not it's the "latest" version.
