### PR TITLE
resources: remove inactive experiments

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -12,8 +12,6 @@
   "flexAdSlots": 0.05,
   "intersect-resources": 0,
   "ios-fixed-no-transfer": 1,
-  "remove-task-timeout": 0,
-  "build-in-chunks": 1,
   "visibility-trigger-improvements": 1,
   "ads-initialIntersection": 1,
   "amp-cid-backup": 1,


### PR DESCRIPTION
Removes:
- `remove-task-timeout`
- `build-in-chunks`
- `build-close-to-viewport`

Diff best viewed [without whitespace changes](https://github.com/ampproject/amphtml/pull/33032/files?w=1).