### PR TITLE
🏗🚀 Improve jscodeshift execution on sweep-experiments

### DIFF
--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import {red} from 'ansi-colors';
-
 /**
  * Replaces isExperimentOn() and toggleExperiment() calls when they match a name
  * specified by --isExperimentOnExperiment
@@ -38,7 +36,7 @@ import {red} from 'ansi-colors';
  * @param {*} options
  * @return {*}
  */
-export default function transformer(file, api, options) {
+module.exports = function (file, api, options) {
   const j = api.jscodeshift;
 
   const missingOptions = [
@@ -49,7 +47,7 @@ export default function transformer(file, api, options) {
   if (missingOptions.length > 0) {
     throw new Error(
       `Missing options for ${options.transform}\n` +
-        red(JSON.stringify(missingOptions))
+        JSON.stringify(missingOptions)
     );
   }
 
@@ -119,4 +117,4 @@ export default function transformer(file, api, options) {
       path.replace(replacement);
     })
     .toSource();
-}
+};


### PR DESCRIPTION
1. `--no-babel` prevents transformer plugin files from being transpiled by Babel. This speeds up transformer startup.

2. Use `api.report()` to pass parser results through `stdout` instead of writing to temp file.