### PR TITLE
♻️  stub.resolves() instead of stub.returns(Promise.resolve())

### DIFF
--- a/ads/google/a4a/test/test-line-delimited-response-handler.js
+++ b/ads/google/a4a/test/test-line-delimited-response-handler.js
@@ -149,7 +149,7 @@ describe('#line-delimited-response-handler', () => {
           {'stream': true}
         );
         const done = chunk * CHUNK_SIZE >= responseString.length - 1;
-        readStub.onCall(chunk).returns(Promise.resolve({value, done}));
+        readStub.onCall(chunk).resolves({value, done});
       } while (chunk++ * CHUNK_SIZE < responseString.length);
     }
 

--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -893,11 +893,11 @@ describe('Google A4A utils', () => {
             validLifetimeSecs: '5678',
           })
         );
-        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
+        env.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .resolves({
             whenPolicyResolved: () => CONSENT_POLICY_STATE.SUFFICIENT,
-          })
-        );
+          });
         return getIdentityToken(env.win, env.ampdoc, 'default').then((result) =>
           expect(result.token).to.equal('abc')
         );
@@ -908,11 +908,9 @@ describe('Google A4A utils', () => {
         .run('should not fetch if INSUFFICIENT consent', () => {
           env.sandbox
             .stub(Services, 'consentPolicyServiceForDocOrNull')
-            .returns(
-              Promise.resolve({
-                whenPolicyResolved: () => CONSENT_POLICY_STATE.INSUFFICIENT,
-              })
-            );
+            .resolves({
+              whenPolicyResolved: () => CONSENT_POLICY_STATE.INSUFFICIENT,
+            });
           return expect(
             getIdentityToken(env.win, env.ampdoc, 'default')
           ).to.eventually.jsonEqual({});
@@ -923,11 +921,9 @@ describe('Google A4A utils', () => {
         .run('should not fetch if UNKNOWN consent', () => {
           env.sandbox
             .stub(Services, 'consentPolicyServiceForDocOrNull')
-            .returns(
-              Promise.resolve({
-                whenPolicyResolved: () => CONSENT_POLICY_STATE.UNKNOWN,
-              })
-            );
+            .resolves({
+              whenPolicyResolved: () => CONSENT_POLICY_STATE.UNKNOWN,
+            });
           return expect(
             getIdentityToken(env.win, env.ampdoc, 'default')
           ).to.eventually.jsonEqual({});
@@ -1085,18 +1081,14 @@ describe('Google A4A utils', () => {
     });
 
     it('should return if doc is served from a defined geo group', async () => {
-      env.sandbox
-        .stub(Services, 'geoForDocOrNull')
-        .returns(Promise.resolve(geoService));
+      env.sandbox.stub(Services, 'geoForDocOrNull').resolves(geoService);
       element.setAttribute('always-serve-npa', 'gdpr,usca');
       expect(await getServeNpaPromise(element)).to.true;
     });
 
     it('should return false when doc is in an undefined group or not in', async () => {
       const warnSpy = env.sandbox.stub(user(), 'warn');
-      env.sandbox
-        .stub(Services, 'geoForDocOrNull')
-        .returns(Promise.resolve(geoService));
+      env.sandbox.stub(Services, 'geoForDocOrNull').resolves(geoService);
 
       // Undefined group
       element.setAttribute('always-serve-npa', 'tx');
@@ -1111,9 +1103,7 @@ describe('Google A4A utils', () => {
 
     it('should return true when geoService is null', async () => {
       geoService = null;
-      env.sandbox
-        .stub(Services, 'geoForDocOrNull')
-        .returns(Promise.resolve(geoService));
+      env.sandbox.stub(Services, 'geoForDocOrNull').resolves(geoService);
       element.setAttribute('always-serve-npa', 'gdpr');
       expect(await getServeNpaPromise(element)).to.true;
     });

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1888,10 +1888,10 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         // TODO(ccordry): remove renderAmpCreative_ when no signing launched.
         env.sandbox
           .stub(a4a, 'renderAmpCreative_')
-          .returns(Promise.reject('amp render failure'));
+          .rejects('amp render failure');
         env.sandbox
           .stub(a4a, 'renderFriendlyTrustless_')
-          .returns(Promise.reject('amp render failure'));
+          .rejects('amp render failure');
       }
       a4a.buildCallback();
       a4a.onLayoutMeasure();

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -321,7 +321,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
     onCreativeRenderSpy = env.sandbox.spy(AmpA4A.prototype, 'onCreativeRender');
     getSigningServiceNamesMock.returns(['google']);
     whenVisibleMock = env.sandbox.stub(AmpDoc.prototype, 'whenFirstVisible');
-    whenVisibleMock.returns(Promise.resolve());
+    whenVisibleMock.resolves();
     getResourceStub = env.sandbox.stub(AmpA4A.prototype, 'getResource');
     getResourceStub.returns({
       getUpgradeDelayMs: () => 12345,
@@ -1701,9 +1701,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         a4a,
         'renderNonAmpCreative'
       );
-      env.sandbox
-        .stub(a4a, 'maybeValidateAmpCreative')
-        .returns(Promise.resolve());
+      env.sandbox.stub(a4a, 'maybeValidateAmpCreative').resolves();
       a4a.onLayoutMeasure();
       a4a.uiHandler = {
         getScrollPromiseForStickyAd: () => Promise.resolve(null),
@@ -2663,8 +2661,8 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         'attemptChangeSize'
       );
       // Expect called twice: one for resize and second for reverting.
-      attemptChangeSizeStub.withArgs(123, 456).returns(Promise.resolve());
-      attemptChangeSizeStub.withArgs(200, 50).returns(Promise.resolve());
+      attemptChangeSizeStub.withArgs(123, 456).resolves();
+      attemptChangeSizeStub.withArgs(200, 50).resolves();
       a4a.attemptChangeSize(123, 456);
       a4a.layoutCallback(() => {
         expect(a4aElement.querySelector('iframe')).to.be.ok;
@@ -2733,13 +2731,13 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         const policyPromise = new Promise(
           (resolver) => (inResolver = resolver)
         );
-        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
+        env.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .resolves({
             whenPolicyResolved: () => policyPromise,
             getConsentStringInfo: () => consentString,
             getConsentMetadataInfo: () => consentMetadata,
-          })
-        );
+          });
 
         const getAdUrlSpy = env.sandbox.spy(a4a, 'getAdUrl');
         const tryExecuteRealTimeConfigSpy = env.sandbox.spy(
@@ -2789,14 +2787,14 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         env.sandbox
           .stub(AMP.BaseElement.prototype, 'getConsentPolicy')
           .returns('default');
-        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
+        env.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .resolves({
             whenPolicyResolved: () =>
               Promise.resolve(CONSENT_POLICY_STATE.SUFFICIENT),
             getConsentStringInfo: () => consentString,
             getConsentMetadataInfo: () => consentMetadata,
-          })
-        );
+          });
 
         const getAdUrlSpy = env.sandbox.spy(a4a, 'getAdUrl');
         const tryExecuteRealTimeConfigSpy = env.sandbox.spy(
@@ -2829,8 +2827,9 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         env.sandbox
           .stub(AMP.BaseElement.prototype, 'getConsentPolicy')
           .returns('default');
-        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
+        env.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .resolves({
             whenPolicyResolved: () => {
               throw new Error('consent err!');
             },
@@ -2840,8 +2839,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
             getConsentMetadata: () => {
               throw new Error('consent err!');
             },
-          })
-        );
+          });
 
         const getAdUrlSpy = env.sandbox.spy(a4a, 'getAdUrl');
         const tryExecuteRealTimeConfigSpy = env.sandbox.spy(
@@ -3046,18 +3044,14 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       });
 
       it('should return if doc is served from a defined geo group', async () => {
-        env.sandbox
-          .stub(Services, 'geoForDocOrNull')
-          .returns(Promise.resolve(geoService));
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves(geoService);
         element.setAttribute('block-rtc', 'gdpr,usca');
         expect(await a4a.getBlockRtc_()).to.true;
       });
 
       it('should return false when doc is in an undefined group or not in', async () => {
         const warnSpy = env.sandbox.stub(user(), 'warn');
-        env.sandbox
-          .stub(Services, 'geoForDocOrNull')
-          .returns(Promise.resolve(geoService));
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves(geoService);
 
         // Undefined group
         element.setAttribute('block-rtc', 'tx');
@@ -3072,9 +3066,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       it('should throw an error when there is no geoService', async () => {
         geoService = null;
-        env.sandbox
-          .stub(Services, 'geoForDocOrNull')
-          .returns(Promise.resolve(geoService));
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves(geoService);
         element.setAttribute('block-rtc', 'usca');
         await expect(a4a.getBlockRtc_()).to.be.rejectedWith(
           /requires <amp-geo> to use `block-rtc`/
@@ -3082,9 +3074,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       });
 
       it('should not execute RealTimeConfig if the attribute is valid', async () => {
-        env.sandbox
-          .stub(Services, 'geoForDocOrNull')
-          .returns(Promise.resolve(geoService));
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves(geoService);
 
         const realTimeConfigStub = env.sandbox.stub(
           Services,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1888,10 +1888,10 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         // TODO(ccordry): remove renderAmpCreative_ when no signing launched.
         env.sandbox
           .stub(a4a, 'renderAmpCreative_')
-          .rejects('amp render failure');
+          .returns(Promise.reject('amp render failure'));
         env.sandbox
           .stub(a4a, 'renderFriendlyTrustless_')
-          .rejects('amp render failure');
+          .returns(Promise.reject('amp render failure'));
       }
       a4a.buildCallback();
       a4a.onLayoutMeasure();

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
@@ -47,12 +47,10 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
         ampCors: false,
         credentials: 'omit',
       })
-      .returns(
-        Promise.resolve({
-          headers: {},
-          text: () => template,
-        })
-      );
+      .resolves({
+        headers: {},
+        text: () => template,
+      });
     return ampAdTemplateHelper
       .fetch(canonicalUrl)
       .then((fetchedTemplate) => expect(fetchedTemplate).to.equal(template));

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -168,15 +168,15 @@ describes.fakeWin(
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .returns(
-            Promise.reject({
+          .rejects(
+            {
               response: {
                 status: 402,
                 json() {
                   return Promise.resolve({access: false});
                 },
               },
-            })
+            }
           )
           .once();
         emptyContainerStub.resolves();

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -168,14 +168,16 @@ describes.fakeWin(
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .rejects({
-            response: {
-              status: 402,
-              json() {
-                return Promise.resolve({access: false});
+          .returns(
+            Promise.reject({
+              response: {
+                status: 402,
+                json() {
+                  return Promise.resolve({access: false});
+                },
               },
-            },
-          })
+            })
+          )
           .once();
         emptyContainerStub.resolves();
         return vendor.authorize().then((err) => {

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -168,16 +168,14 @@ describes.fakeWin(
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .rejects(
-            {
-              response: {
-                status: 402,
-                json() {
-                  return Promise.resolve({access: false});
-                },
+          .rejects({
+            response: {
+              status: 402,
+              json() {
+                return Promise.resolve({access: false});
               },
-            }
-          )
+            },
+          })
           .once();
         emptyContainerStub.resolves();
         return vendor.authorize().then((err) => {

--- a/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.1/test/test-amp-access-laterpay.js
@@ -85,17 +85,15 @@ describes.fakeWin(
       it('uses a non default region', () => {
         const buildUrl = accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve(''))
+          .resolves('')
           .once();
         xhrMock
           .expects('fetchJson')
-          .returns(
-            Promise.resolve({
-              json() {
-                return Promise.resolve({access: true});
-              },
-            })
-          )
+          .resolves({
+            json() {
+              return Promise.resolve({access: true});
+            },
+          })
           .once();
         return vendor.authorize().then(() => {
           expect(
@@ -112,24 +110,22 @@ describes.fakeWin(
             'https://baseurl?param&article_title=test%20title',
             false
           )
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .returns(
-            Promise.resolve({
-              json() {
-                return Promise.resolve({access: true});
-              },
-            })
-          )
+          .resolves({
+            json() {
+              return Promise.resolve({access: true});
+            },
+          })
           .once();
         return vendor.authorize().then((resp) => {
           expect(resp.access).to.be.true;
@@ -140,18 +136,18 @@ describes.fakeWin(
       it('authorization fails due to lack of server config', () => {
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .returns(Promise.resolve({status: 204}))
+          .resolves({status: 204})
           .once();
         return vendor.authorize().catch((err) => {
           expect(err.message).to.exist;
@@ -161,11 +157,11 @@ describes.fakeWin(
       it('authorization response from server fails', () => {
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
@@ -183,7 +179,7 @@ describes.fakeWin(
             })
           )
           .once();
-        emptyContainerStub.returns(Promise.resolve());
+        emptyContainerStub.resolves();
         return vendor.authorize().then((err) => {
           expect(err.access).to.be.false;
         });
@@ -278,7 +274,7 @@ describes.fakeWin(
         container.querySelector('input').dispatchEvent(changeEv);
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock.expects('loginWithUrl').once();
         const clickEv = new Event('click');
@@ -289,10 +285,7 @@ describes.fakeWin(
       });
 
       it('sends request for already purchased', (done) => {
-        accessSourceMock
-          .expects('buildUrl')
-          .returns(Promise.resolve('https://apllink'))
-          .once();
+        accessSourceMock.expects('buildUrl').resolves('https://apllink').once();
         accessSourceMock.expects('loginWithUrl').once();
         const clickEv = new Event('click');
         container

--- a/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
@@ -175,22 +175,20 @@ describes.fakeWin(
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .rejects(
-            {
-              response: {
-                status: 402,
-                json() {
-                  return Promise.resolve({
-                    'purchase_options': [
-                      {'sales_model': 'single_purchase'},
-                      {'sales_model': 'timepass'},
-                      {'sales_model': 'subscription'},
-                    ],
-                  });
-                },
+          .rejects({
+            response: {
+              status: 402,
+              json() {
+                return Promise.resolve({
+                  'purchase_options': [
+                    {'sales_model': 'single_purchase'},
+                    {'sales_model': 'timepass'},
+                    {'sales_model': 'subscription'},
+                  ],
+                });
               },
-            }
-          )
+            },
+          })
           .once();
         emptyContainerStub.resolves();
         return vendor.authorize().then((err) => {

--- a/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
@@ -175,20 +175,22 @@ describes.fakeWin(
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .rejects({
-            response: {
-              status: 402,
-              json() {
-                return Promise.resolve({
-                  'purchase_options': [
-                    {'sales_model': 'single_purchase'},
-                    {'sales_model': 'timepass'},
-                    {'sales_model': 'subscription'},
-                  ],
-                });
+          .returns(
+            Promise.reject({
+              response: {
+                status: 402,
+                json() {
+                  return Promise.resolve({
+                    'purchase_options': [
+                      {'sales_model': 'single_purchase'},
+                      {'sales_model': 'timepass'},
+                      {'sales_model': 'subscription'},
+                    ],
+                  });
+                },
               },
-            },
-          })
+            })
+          )
           .once();
         emptyContainerStub.resolves();
         return vendor.authorize().then((err) => {

--- a/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
@@ -92,17 +92,15 @@ describes.fakeWin(
       it('uses a non default region', () => {
         const buildUrl = accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve(''))
+          .resolves('')
           .once();
         xhrMock
           .expects('fetchJson')
-          .returns(
-            Promise.resolve({
-              json() {
-                return Promise.resolve({access: true});
-              },
-            })
-          )
+          .resolves({
+            json() {
+              return Promise.resolve({access: true});
+            },
+          })
           .once();
         return vendor.authorize().then(() => {
           expect(
@@ -119,24 +117,22 @@ describes.fakeWin(
             'https://baseurl?param&article_title=test%20title',
             false
           )
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .returns(
-            Promise.resolve({
-              json() {
-                return Promise.resolve({access: true});
-              },
-            })
-          )
+          .resolves({
+            json() {
+              return Promise.resolve({access: true});
+            },
+          })
           .once();
         return vendor.authorize().then((resp) => {
           expect(resp.access).to.be.true;
@@ -147,18 +143,18 @@ describes.fakeWin(
       it('authorization fails due to lack of server config', () => {
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .returns(Promise.resolve({status: 204}))
+          .resolves({status: 204})
           .once();
         return vendor.authorize().catch((err) => {
           expect(err.message).to.exist;
@@ -168,11 +164,11 @@ describes.fakeWin(
       it('authorization response from server fails', () => {
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
@@ -196,7 +192,7 @@ describes.fakeWin(
             })
           )
           .once();
-        emptyContainerStub.returns(Promise.resolve());
+        emptyContainerStub.resolves();
         return vendor.authorize().then((err) => {
           expect(err.access).to.be.false;
           expect(vendor.purchaseOptions_.singlePurchases).to.have.lengthOf(1);
@@ -339,7 +335,7 @@ describes.fakeWin(
         container.querySelector('input').dispatchEvent(changeEv);
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock.expects('loginWithUrl').once();
         const clickEv = new Event('click');
@@ -350,10 +346,7 @@ describes.fakeWin(
       });
 
       it('sends request for already purchased', (done) => {
-        accessSourceMock
-          .expects('buildUrl')
-          .returns(Promise.resolve('https://apllink'))
-          .once();
+        accessSourceMock.expects('buildUrl').resolves('https://apllink').once();
         accessSourceMock.expects('loginWithUrl').once();
         const clickEv = new Event('click');
         container

--- a/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
+++ b/extensions/amp-access-laterpay/0.2/test/test-amp-access-laterpay.js
@@ -175,8 +175,8 @@ describes.fakeWin(
           .withExactArgs('https://builturl', {
             credentials: 'include',
           })
-          .returns(
-            Promise.reject({
+          .rejects(
+            {
               response: {
                 status: 402,
                 json() {
@@ -189,7 +189,7 @@ describes.fakeWin(
                   });
                 },
               },
-            })
+            }
           )
           .once();
         emptyContainerStub.resolves();

--- a/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
@@ -85,21 +85,19 @@ describes.fakeWin(
         accessSourceMock
           .expects('buildUrl')
           .withExactArgs('https://baseurl?param&iid=amp-test-article', false)
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
-          .returns(
-            Promise.resolve({
-              json() {
-                return Promise.resolve({access: true});
-              },
-            })
-          )
+          .resolves({
+            json() {
+              return Promise.resolve({access: true});
+            },
+          })
           .once();
         return vendor.authorize().then((resp) => {
           expect(resp.access).to.be.true;
@@ -109,21 +107,19 @@ describes.fakeWin(
       it('authorization fails because of wrong or missing server config', () => {
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         accessSourceMock
           .expects('getLoginUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')
-          .returns(
-            Promise.resolve({
-              json() {
-                return Promise.resolve({access: true});
-              },
-            })
-          )
+          .resolves({
+            json() {
+              return Promise.resolve({access: true});
+            },
+          })
           .once();
         return vendor.authorize().catch((err) => {
           expect(err.message).to.exist;
@@ -133,7 +129,7 @@ describes.fakeWin(
       it('authorization response fails - 402 error', () => {
         accessSourceMock
           .expects('buildUrl')
-          .returns(Promise.resolve('https://builturl'))
+          .resolves('https://builturl')
           .once();
         xhrMock
           .expects('fetchJson')

--- a/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
@@ -133,12 +133,12 @@ describes.fakeWin(
           .once();
         xhrMock
           .expects('fetchJson')
-          .returns(
-            Promise.reject({
+          .rejects(
+            {
               response: {
                 status: 402,
               },
-            })
+            }
           )
           .once();
         return vendor.authorize().then((err) => {

--- a/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
@@ -133,13 +133,11 @@ describes.fakeWin(
           .once();
         xhrMock
           .expects('fetchJson')
-          .rejects(
-            {
-              response: {
-                status: 402,
-              },
-            }
-          )
+          .rejects({
+            response: {
+              status: 402,
+            },
+          })
           .once();
         return vendor.authorize().then((err) => {
           expect(err.access).to.be.false;

--- a/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
+++ b/extensions/amp-access-poool/0.1/test/test-amp-access-poool.js
@@ -133,11 +133,13 @@ describes.fakeWin(
           .once();
         xhrMock
           .expects('fetchJson')
-          .rejects({
-            response: {
-              status: 402,
-            },
-          })
+          .returns(
+            Promise.reject({
+              response: {
+                status: 402,
+              },
+            })
+          )
           .once();
         return vendor.authorize().then((err) => {
           expect(err.access).to.be.false;

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -163,20 +163,18 @@ describes.realWin(
               'https://acme.com/a?rid=READER_ID',
               /* useAuthData */ false
             )
-            .returns(Promise.resolve('https://acme.com/a?rid=reader1'))
+            .resolves('https://acme.com/a?rid=reader1')
             .once();
           xhrMock
             .expects('fetchJson')
             .withExactArgs('https://acme.com/a?rid=reader1', {
               credentials: 'include',
             })
-            .returns(
-              Promise.resolve({
-                json() {
-                  return Promise.resolve({access: 'A'});
-                },
-              })
-            )
+            .resolves({
+              json() {
+                return Promise.resolve({access: 'A'});
+              },
+            })
             .once();
           return adapter.authorize().then((response) => {
             expect(response).to.exist;
@@ -191,7 +189,7 @@ describes.realWin(
               'https://acme.com/a?rid=READER_ID',
               /* useAuthData */ false
             )
-            .returns(Promise.resolve('https://acme.com/a?rid=reader1'))
+            .resolves('https://acme.com/a?rid=reader1')
             .once();
           xhrMock
             .expects('fetchJson')
@@ -217,7 +215,7 @@ describes.realWin(
               'https://acme.com/a?rid=READER_ID',
               /* useAuthData */ false
             )
-            .returns(Promise.resolve('https://acme.com/a?rid=reader1'))
+            .resolves('https://acme.com/a?rid=reader1')
             .once();
           xhrMock
             .expects('fetchJson')
@@ -251,7 +249,7 @@ describes.realWin(
               'https://acme.com/p?rid=READER_ID',
               /* useAuthData */ true
             )
-            .returns(Promise.resolve('https://acme.com/p?rid=reader1'))
+            .resolves('https://acme.com/p?rid=reader1')
             .once();
           xhrMock
             .expects('sendSignal')
@@ -267,7 +265,7 @@ describes.realWin(
                 );
               })
             )
-            .returns(Promise.resolve())
+            .resolves()
             .once();
           return adapter.pingback();
         });
@@ -279,7 +277,7 @@ describes.realWin(
               'https://acme.com/p?rid=READER_ID',
               /* useAuthData */ true
             )
-            .returns(Promise.resolve('https://acme.com/p?rid=reader1'))
+            .resolves('https://acme.com/p?rid=reader1')
             .once();
           xhrMock
             .expects('sendSignal')

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -196,7 +196,7 @@ describes.realWin(
             .withExactArgs('https://acme.com/a?rid=reader1', {
               credentials: 'include',
             })
-            .rejects('intentional')
+            .returns(Promise.reject('intentional'))
             .once();
           return adapter.authorize().then(
             () => {
@@ -293,7 +293,7 @@ describes.realWin(
                 );
               })
             )
-            .rejects('intentional')
+            .returns(Promise.reject('intentional'))
             .once();
           return adapter.pingback().then(
             () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-client.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-client.js
@@ -196,7 +196,7 @@ describes.realWin(
             .withExactArgs('https://acme.com/a?rid=reader1', {
               credentials: 'include',
             })
-            .returns(Promise.reject('intentional'))
+            .rejects('intentional')
             .once();
           return adapter.authorize().then(
             () => {
@@ -293,7 +293,7 @@ describes.realWin(
                 );
               })
             )
-            .returns(Promise.reject('intentional'))
+            .rejects('intentional')
             .once();
           return adapter.pingback().then(
             () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-iframe.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-iframe.js
@@ -137,17 +137,15 @@ describes.fakeWin(
         contextMock
           .expects('collectUrlVars')
           .withExactArgs('VAR1&VAR2', false)
-          .returns(
-            Promise.resolve({
-              'VAR1': 'A',
-              'VAR2': 'B',
-            })
-          )
+          .resolves({
+            'VAR1': 'A',
+            'VAR2': 'B',
+          })
           .once();
         validConfig['iframeVars'] = ['VAR1', 'VAR2'];
         const sendStub = env.sandbox
           .stub(Messenger.prototype, 'sendCommandRsvp')
-          .returns(Promise.resolve({}));
+          .resolves({});
         const adapter = new AccessIframeAdapter(ampdoc, validConfig, context);
         const promise = adapter.connect();
         adapter.handleCommand_('connect');
@@ -203,7 +201,7 @@ describes.fakeWin(
               'protocol': 'amp-access',
               'config': validConfig,
             })
-            .returns(Promise.resolve())
+            .resolves()
             .once();
           adapter.connect();
           adapter.handleCommand_('connect');
@@ -213,7 +211,7 @@ describes.fakeWin(
           messengerMock
             .expects('sendCommandRsvp')
             .withExactArgs('authorize', {})
-            .returns(Promise.resolve({a: 1}))
+            .resolves({a: 1})
             .once();
           return adapter.authorize().then((result) => {
             expect(result).to.deep.equal({a: 1});
@@ -248,7 +246,7 @@ describes.fakeWin(
           messengerMock
             .expects('sendCommandRsvp')
             .withExactArgs('authorize', {})
-            .returns(Promise.resolve(data))
+            .resolves(data)
             .once();
           return adapter.authorize().then(() => {
             // Skip a microtask.
@@ -363,7 +361,7 @@ describes.fakeWin(
               'protocol': 'amp-access',
               'config': validConfig,
             })
-            .returns(Promise.resolve())
+            .resolves()
             .once();
           adapter.connect();
           adapter.handleCommand_('connect');
@@ -373,7 +371,7 @@ describes.fakeWin(
           messengerMock
             .expects('sendCommandRsvp')
             .withExactArgs('pingback', {})
-            .returns(Promise.resolve())
+            .resolves()
             .once();
           return adapter.pingback();
         });

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -272,7 +272,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
           })
-          .returns(Promise.reject('intentional'))
+          .rejects('intentional')
           .once();
         const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
@@ -423,7 +423,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
           .withExactArgs('https://acme.com/a?rid=r1', {
             credentials: 'include',
           })
-          .returns(Promise.reject('intentional'))
+          .rejects('intentional')
           .once();
         jwtMock.expects('decode').never();
         return adapter.fetchJwt_().then(

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -272,7 +272,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
           })
-          .rejects('intentional')
+          .returns(Promise.reject('intentional'))
           .once();
         const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
@@ -423,7 +423,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
           .withExactArgs('https://acme.com/a?rid=r1', {
             credentials: 'include',
           })
-          .rejects('intentional')
+          .returns(Promise.reject('intentional'))
           .once();
         jwtMock.expects('decode').never();
         return adapter.fetchJwt_().then(

--- a/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server-jwt.js
@@ -237,7 +237,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
           })
-          .returns(Promise.resolve(responseDoc))
+          .resolves(responseDoc)
           .once();
         const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
@@ -388,20 +388,18 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(Promise.resolve('https://acme.com/a?rid=r1'))
+          .resolves('https://acme.com/a?rid=r1')
           .once();
         xhrMock
           .expects('fetchText')
           .withExactArgs('https://acme.com/a?rid=r1', {
             credentials: 'include',
           })
-          .returns(
-            Promise.resolve({
-              text() {
-                return Promise.resolve(encoded);
-              },
-            })
-          )
+          .resolves({
+            text() {
+              return Promise.resolve(encoded);
+            },
+          })
           .once();
         jwtMock.expects('decode').withExactArgs(encoded).returns(jwt).once();
         env.sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => false);
@@ -418,7 +416,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(Promise.resolve('https://acme.com/a?rid=r1'))
+          .resolves('https://acme.com/a?rid=r1')
           .once();
         xhrMock
           .expects('fetchText')
@@ -446,7 +444,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(Promise.resolve('https://acme.com/a?rid=r1'))
+          .resolves('https://acme.com/a?rid=r1')
           .once();
         xhrMock
           .expects('fetchText')
@@ -484,38 +482,34 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(Promise.resolve('https://acme.com/a?rid=r1'))
+          .resolves('https://acme.com/a?rid=r1')
           .once();
         xhrMock
           .expects('fetchText')
           .withExactArgs('https://acme.com/a?rid=r1', {
             credentials: 'include',
           })
-          .returns(
-            Promise.resolve({
-              text() {
-                return Promise.resolve(encoded);
-              },
-            })
-          )
+          .resolves({
+            text() {
+              return Promise.resolve(encoded);
+            },
+          })
           .once();
         xhrMock
           .expects('fetchText')
           .withExactArgs('https://acme.com/pk')
-          .returns(
-            Promise.resolve({
-              text() {
-                return pemPromise;
-              },
-            })
-          )
+          .resolves({
+            text() {
+              return pemPromise;
+            },
+          })
           .once();
         jwtMock.expects('decode').withExactArgs(encoded).returns(jwt).once();
         jwtMock.expects('isVerificationSupported').returns(true).once();
         jwtMock
           .expects('decodeAndVerify')
           .withExactArgs(encoded, pemPromise)
-          .returns(Promise.resolve(jwt))
+          .resolves(jwt)
           .once();
         env.sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
         const validateStub = env.sandbox.stub(adapter, 'validateJwt_');
@@ -538,20 +532,18 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(Promise.resolve('https://acme.com/a?rid=r1'))
+          .resolves('https://acme.com/a?rid=r1')
           .once();
         xhrMock
           .expects('fetchText')
           .withExactArgs('https://acme.com/a?rid=r1', {
             credentials: 'include',
           })
-          .returns(
-            Promise.resolve({
-              text() {
-                return Promise.resolve(encoded);
-              },
-            })
-          )
+          .resolves({
+            text() {
+              return Promise.resolve(encoded);
+            },
+          })
           .once();
         xhrMock
           .expects('fetchText')
@@ -569,7 +561,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
               return true;
             })
           )
-          .returns(Promise.resolve(jwt))
+          .resolves(jwt)
           .once();
         env.sandbox.stub(adapter, 'shouldBeValidated_').callsFake(() => true);
         const validateStub = env.sandbox.stub(adapter, 'validateJwt_');
@@ -596,20 +588,18 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(Promise.resolve('https://acme.com/a?rid=r1'))
+          .resolves('https://acme.com/a?rid=r1')
           .once();
         xhrMock
           .expects('fetchText')
           .withExactArgs('https://acme.com/a?rid=r1', {
             credentials: 'include',
           })
-          .returns(
-            Promise.resolve({
-              text() {
-                return Promise.resolve(encoded);
-              },
-            })
-          )
+          .resolves({
+            text() {
+              return Promise.resolve(encoded);
+            },
+          })
           .once();
         jwtMock.expects('decode').withExactArgs(encoded).returns(jwt).once();
         jwtMock.expects('isVerificationSupported').returns(false).once();
@@ -706,7 +696,7 @@ describes.realWin('AccessServerJwtAdapter', {amp: true}, (env) => {
 
     describe('pingback', () => {
       it('should always send client pingback', () => {
-        clientAdapterMock.expects('pingback').returns(Promise.resolve()).once();
+        clientAdapterMock.expects('pingback').resolves().once();
         adapter.pingback();
       });
     });

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -163,12 +163,10 @@ describes.realWin('AccessServerAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(
-            Promise.resolve({
-              'READER_ID': 'reader1',
-              'OTHER': 123,
-            })
-          )
+          .resolves({
+            'READER_ID': 'reader1',
+            'OTHER': 123,
+          })
           .once();
         const request = {
           'url': removeFragment(win.location.href),
@@ -187,7 +185,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, (env) => {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
           })
-          .returns(Promise.resolve(responseDoc))
+          .resolves(responseDoc)
           .once();
         const replaceSectionsStub = env.sandbox
           .stub(adapter, 'replaceSections_')
@@ -209,12 +207,10 @@ describes.realWin('AccessServerAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(
-            Promise.resolve({
-              'READER_ID': 'reader1',
-              'OTHER': 123,
-            })
-          )
+          .resolves({
+            'READER_ID': 'reader1',
+            'OTHER': 123,
+          })
           .once();
         const request = {
           'url': removeFragment(win.location.href),
@@ -253,12 +249,10 @@ describes.realWin('AccessServerAdapter', {amp: true}, (env) => {
             'https://acme.com/a?rid=READER_ID',
             /* useAuthData */ false
           )
-          .returns(
-            Promise.resolve({
-              'READER_ID': 'reader1',
-              'OTHER': 123,
-            })
-          )
+          .resolves({
+            'READER_ID': 'reader1',
+            'OTHER': 123,
+          })
           .once();
         const request = {
           'url': removeFragment(win.location.href),
@@ -325,7 +319,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, (env) => {
 
     describe('pingback', () => {
       it('should always send client pingback', () => {
-        clientAdapterMock.expects('pingback').returns(Promise.resolve()).once();
+        clientAdapterMock.expects('pingback').resolves().once();
         adapter.pingback();
       });
     });

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -229,7 +229,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, (env) => {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
           })
-          .rejects('intentional')
+          .returns(Promise.reject('intentional'))
           .once();
         return adapter.authorize().then(
           () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-server.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-server.js
@@ -229,7 +229,7 @@ describes.realWin('AccessServerAdapter', {amp: true}, (env) => {
               'Content-Type': 'application/x-www-form-urlencoded',
             },
           })
-          .returns(Promise.reject('intentional'))
+          .rejects('intentional')
           .once();
         return adapter.authorize().then(
           () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-source.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-source.js
@@ -416,7 +416,7 @@ describes.fakeWin(
       adapterMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({access: true}))
+        .resolves({access: true})
         .once();
       return source.runAuthorization().then(() => {
         return source.whenFirstAuthorized();

--- a/extensions/amp-access/0.1/test/test-amp-access-vendor.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-vendor.js
@@ -95,7 +95,7 @@ describes.realWin('AccessVendorAdapter', {amp: true}, (env) => {
         vendorMock
           .expects('authorize')
           .withExactArgs()
-          .returns(Promise.resolve({access: 'A'}))
+          .resolves({access: 'A'})
           .once();
         return adapter.authorize().then((response) => {
           expect(response).to.exist;
@@ -122,11 +122,7 @@ describes.realWin('AccessVendorAdapter', {amp: true}, (env) => {
 
     describe('pingback', () => {
       it('should send pingback signal', () => {
-        vendorMock
-          .expects('pingback')
-          .withExactArgs()
-          .returns(Promise.resolve())
-          .once();
+        vendorMock.expects('pingback').withExactArgs().resolves().once();
         return adapter.pingback();
       });
 

--- a/extensions/amp-access/0.1/test/test-amp-access-vendor.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-vendor.js
@@ -107,7 +107,7 @@ describes.realWin('AccessVendorAdapter', {amp: true}, (env) => {
         vendorMock
           .expects('authorize')
           .withExactArgs()
-          .returns(Promise.reject('intentional'))
+          .rejects('intentional')
           .once();
         return adapter.authorize().then(
           () => {
@@ -130,7 +130,7 @@ describes.realWin('AccessVendorAdapter', {amp: true}, (env) => {
         vendorMock
           .expects('pingback')
           .withExactArgs()
-          .returns(Promise.reject('intentional'))
+          .rejects('intentional')
           .once();
         return adapter.pingback().then(
           () => {

--- a/extensions/amp-access/0.1/test/test-amp-access-vendor.js
+++ b/extensions/amp-access/0.1/test/test-amp-access-vendor.js
@@ -107,7 +107,7 @@ describes.realWin('AccessVendorAdapter', {amp: true}, (env) => {
         vendorMock
           .expects('authorize')
           .withExactArgs()
-          .rejects('intentional')
+          .returns(Promise.reject('intentional'))
           .once();
         return adapter.authorize().then(
           () => {
@@ -130,7 +130,7 @@ describes.realWin('AccessVendorAdapter', {amp: true}, (env) => {
         vendorMock
           .expects('pingback')
           .withExactArgs()
-          .rejects('intentional')
+          .returns(Promise.reject('intentional'))
           .once();
         return adapter.pingback().then(
           () => {

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -443,7 +443,7 @@ describes.fakeWin(
       adapterMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.reject('intentional'))
+        .rejects('intentional')
         .once();
       const promise = service.runAuthorization_();
       expect(document.documentElement).to.have.class('amp-access-loading');
@@ -1073,7 +1073,7 @@ describes.fakeWin(
       adapterMock
         .expects('pingback')
         .withExactArgs()
-        .returns(Promise.reject('intentional'))
+        .rejects('intentional')
         .once();
       return service
         .reportViewToServer_()
@@ -1490,7 +1490,7 @@ describes.fakeWin(
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
-        .returns(Promise.reject('abort'))
+        .rejects('abort')
         .once();
       return service
         .loginWithType_('')
@@ -1923,7 +1923,7 @@ describes.fakeWin(
       adapterBeerMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.reject('rejected'))
+        .rejects('rejected')
         .once();
       adapterDonutsMock
         .expects('authorize')

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -307,7 +307,7 @@ describes.fakeWin(
       document.body.appendChild(elementError);
 
       env.sandbox.stub(ampdoc, 'isVisible').returns(true);
-      env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
+      env.sandbox.stub(ampdoc, 'whenFirstVisible').resolves();
       env.sandbox.stub(ampdoc, 'onVisibilityChanged').returns(function () {});
 
       service = new AccessService(ampdoc);
@@ -376,7 +376,7 @@ describes.fakeWin(
           {scope: 'amp-access', createCookieIfNotPresent: true},
           env.sandbox.match(() => true)
         )
-        .returns(Promise.resolve(result))
+        .resolves(result)
         .once();
     }
 
@@ -411,7 +411,7 @@ describes.fakeWin(
       adapterMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({access: true}))
+        .resolves({access: true})
         .once();
       expectGetReaderId('reader1');
       source.buildLoginUrls_ = env.sandbox.spy();
@@ -478,7 +478,7 @@ describes.fakeWin(
       adapterMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({access: true}))
+        .resolves({access: true})
         .once();
       const early = createElements();
       const later = createElements();
@@ -512,7 +512,7 @@ describes.fakeWin(
       adapterMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({access: true}))
+        .resolves({access: true})
         .once();
 
       const applyAuthorizationsStub = env.sandbox.stub();
@@ -660,12 +660,12 @@ describes.fakeWin(
         templatesMock
           .expects('renderTemplate')
           .withExactArgs(template1, {access: true})
-          .returns(Promise.resolve(result1))
+          .resolves(result1)
           .once();
         templatesMock
           .expects('renderTemplate')
           .withExactArgs(template2, {access: true})
-          .returns(Promise.resolve(result2))
+          .resolves(result2)
           .once();
         const p = service.applyAuthorizationToElement_(elementOn, {
           access: true,
@@ -760,7 +760,7 @@ describes.fakeWin(
       document.documentElement.classList.remove('amp-access-error');
 
       isVisibleStub = env.sandbox.stub(ampdoc, 'isVisible').returns(true);
-      env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
+      env.sandbox.stub(ampdoc, 'whenFirstVisible').resolves();
       visibilityChanged = new Observable();
       env.sandbox
         .stub(ampdoc, 'onVisibilityChanged')
@@ -814,7 +814,7 @@ describes.fakeWin(
           {scope: 'amp-access', createCookieIfNotPresent: true},
           env.sandbox.match(() => true)
         )
-        .returns(Promise.resolve(result))
+        .resolves(result)
         .once();
     }
 
@@ -1049,11 +1049,7 @@ describes.fakeWin(
 
     it('should send POST pingback', () => {
       expectGetReaderId('reader1');
-      adapterMock
-        .expects('pingback')
-        .withExactArgs()
-        .returns(Promise.resolve())
-        .once();
+      adapterMock.expects('pingback').withExactArgs().resolves().once();
       return service
         .reportViewToServer_()
         .then(
@@ -1101,9 +1097,7 @@ describes.fakeWin(
     });
 
     it('should broadcast "viewed" signal to other documents', () => {
-      service.reportViewToServer_ = env.sandbox
-        .stub()
-        .returns(Promise.resolve());
+      service.reportViewToServer_ = env.sandbox.stub().resolves();
       const broadcastStub = env.sandbox.stub(service.viewer_, 'broadcast');
       const p = service.reportWhenViewed_(/* timeToView */ 2000);
       return Promise.resolve()
@@ -1308,7 +1302,7 @@ describes.fakeWin(
           {scope: 'amp-access', createCookieIfNotPresent: true},
           env.sandbox.match(() => true)
         )
-        .returns(Promise.resolve('reader1'))
+        .resolves('reader1')
         .once();
       return service.sources_[0].buildLoginUrls_().then((urls) => {
         const {url} = urls[0];
@@ -1329,7 +1323,7 @@ describes.fakeWin(
           {scope: 'amp-access', createCookieIfNotPresent: true},
           env.sandbox.match(() => true)
         )
-        .returns(Promise.resolve('reader1'))
+        .resolves('reader1')
         .atLeast(1);
       return source.buildLoginUrls_().then((urls) => {
         expect(urls).to.have.length(2);
@@ -1368,7 +1362,7 @@ describes.fakeWin(
           {scope: 'amp-access', createCookieIfNotPresent: true},
           env.sandbox.match(() => true)
         )
-        .returns(Promise.resolve('reader1'))
+        .resolves('reader1')
         .once();
       return source.buildLoginUrls_().then((urls) => {
         const {url} = urls[0];
@@ -1410,7 +1404,7 @@ describes.fakeWin(
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
-        .returns(Promise.resolve('#success=true'))
+        .resolves('#success=true')
         .once();
       return service.loginWithType_('').then(() => {
         expect(source.getAdapter().postAction).to.be.calledOnce;
@@ -1442,7 +1436,7 @@ describes.fakeWin(
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
-        .returns(Promise.resolve('#success=no'))
+        .resolves('#success=no')
         .once();
       return service.loginWithType_('').then(() => {
         expect(source.loginPromise_).to.not.exist;
@@ -1466,7 +1460,7 @@ describes.fakeWin(
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
-        .returns(Promise.resolve(''))
+        .resolves('')
         .once();
       return service.loginWithType_('').then(() => {
         expect(source.loginPromise_).to.not.exist;
@@ -1534,7 +1528,7 @@ describes.fakeWin(
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l2?rid=R')
-        .returns(Promise.resolve('#success=true'))
+        .resolves('#success=true')
         .once();
       return service.loginWithType_('login2').then(() => {
         expect(service.loginPromise_).to.not.exist;
@@ -1607,7 +1601,7 @@ describes.fakeWin(
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
-        .returns(Promise.resolve('#success=true'))
+        .resolves('#success=true')
         .once();
       return service.loginWithType_('').then(() => {
         expect(source.loginPromise_).to.not.exist;
@@ -1886,7 +1880,7 @@ describes.fakeWin(
           {scope: 'amp-access', createCookieIfNotPresent: true},
           env.sandbox.match(() => true)
         )
-        .returns(Promise.resolve(result))
+        .resolves(result)
         .once();
     }
 
@@ -1895,12 +1889,12 @@ describes.fakeWin(
       adapterBeerMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({access: false}))
+        .resolves({access: false})
         .once();
       adapterDonutsMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({access: true}))
+        .resolves({access: true})
         .once();
 
       const promise = service.runAuthorization_();
@@ -1934,7 +1928,7 @@ describes.fakeWin(
       adapterDonutsMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({access: true}))
+        .resolves({access: true})
         .once();
       service.runAuthorization_();
       return Promise.all([
@@ -1963,7 +1957,7 @@ describes.fakeWin(
       sourceBeerMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=reader1')
-        .returns(Promise.resolve('#success=true'))
+        .resolves('#success=true')
         .once();
       sourceBeer.analyticsEvent_ = env.sandbox.spy();
       return sourceBeer
@@ -1999,7 +1993,7 @@ describes.fakeWin(
       sourceDonutsMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=reader1')
-        .returns(Promise.resolve('#success=true'))
+        .resolves('#success=true')
         .once();
       sourceDonuts.analyticsEvent_ = env.sandbox.spy();
       return sourceDonuts

--- a/extensions/amp-access/0.1/test/test-amp-access.js
+++ b/extensions/amp-access/0.1/test/test-amp-access.js
@@ -443,7 +443,7 @@ describes.fakeWin(
       adapterMock
         .expects('authorize')
         .withExactArgs()
-        .rejects('intentional')
+        .returns(Promise.reject('intentional'))
         .once();
       const promise = service.runAuthorization_();
       expect(document.documentElement).to.have.class('amp-access-loading');
@@ -1073,7 +1073,7 @@ describes.fakeWin(
       adapterMock
         .expects('pingback')
         .withExactArgs()
-        .rejects('intentional')
+        .returns(Promise.reject('intentional'))
         .once();
       return service
         .reportViewToServer_()
@@ -1490,7 +1490,7 @@ describes.fakeWin(
       sourceMock
         .expects('openLoginDialog_')
         .withExactArgs('https://acme.com/l?rid=R')
-        .rejects('abort')
+        .returns(Promise.reject('abort'))
         .once();
       return service
         .loginWithType_('')
@@ -1923,7 +1923,7 @@ describes.fakeWin(
       adapterBeerMock
         .expects('authorize')
         .withExactArgs()
-        .rejects('rejected')
+        .returns(Promise.reject('rejected'))
         .once();
       adapterDonutsMock
         .expects('authorize')

--- a/extensions/amp-access/0.1/test/test-iframe-api.js
+++ b/extensions/amp-access/0.1/test/test-iframe-api.js
@@ -55,7 +55,7 @@ describes.fakeWin(
       controllerMock
         .expects('connect')
         .withExactArgs('TARGET_ORIGIN', 'protocol1', config)
-        .returns(Promise.resolve(1))
+        .resolves(1)
         .once();
       const promise = iframeApi.connect();
       iframeApi.handleCommand_('start', {
@@ -69,7 +69,7 @@ describes.fakeWin(
       controllerMock
         .expects('authorize')
         .withExactArgs()
-        .returns(Promise.resolve({a: 1}))
+        .resolves({a: 1})
         .once();
       return iframeApi.handleCommand_('authorize', {}).then((result) => {
         expect(result).to.deep.equal({a: 1});
@@ -77,11 +77,7 @@ describes.fakeWin(
     });
 
     it('should pingback', () => {
-      controllerMock
-        .expects('pingback')
-        .withExactArgs()
-        .returns(Promise.resolve())
-        .once();
+      controllerMock.expects('pingback').withExactArgs().resolves().once();
       return iframeApi.handleCommand_('pingback', {});
     });
 

--- a/extensions/amp-access/0.1/test/test-jwt.js
+++ b/extensions/amp-access/0.1/test/test-jwt.js
@@ -231,7 +231,7 @@ describe('JwtHelper', () => {
           /* extractable */ false,
           /* uses */ ['verify']
         )
-        .returns(Promise.resolve(key))
+        .resolves(key)
         .once();
       subtleMock
         .expects('verify')
@@ -241,7 +241,7 @@ describe('JwtHelper', () => {
           /* sig */ window.sandbox.match(() => true),
           /* verifiable */ window.sandbox.match(() => true)
         )
-        .returns(Promise.resolve(true))
+        .resolves(true)
         .once();
       return helper.decodeAndVerify(TOKEN, Promise.resolve(PEM)).then((tok) => {
         expect(tok['name']).to.equal('John Do');

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -1113,14 +1113,12 @@ describes.realWin(
           height: VIEWPORT_HEIGHT,
         });
         didAttemptSizeChange = false;
-        env.sandbox.stub(element, 'getImpl').returns(
-          Promise.resolve({
-            attemptChangeSize: () => {
-              didAttemptSizeChange = true;
-              return Promise.resolve();
-            },
-          })
-        );
+        env.sandbox.stub(element, 'getImpl').resolves({
+          attemptChangeSize: () => {
+            didAttemptSizeChange = true;
+            return Promise.resolve();
+          },
+        });
 
         didMeasure = false;
         didMutate = false;
@@ -1245,9 +1243,7 @@ describes.realWin(
             width: '320',
             height: '150',
           });
-          env.sandbox
-            .stub(adsense, 'attemptChangeSize')
-            .returns(Promise.resolve());
+          env.sandbox.stub(adsense, 'attemptChangeSize').resolves();
 
           const promise = adsense.buildCallback();
           expect(promise).to.exist;
@@ -1279,9 +1275,7 @@ describes.realWin(
             width: '320',
             height: '150',
           });
-          env.sandbox
-            .stub(adsense, 'attemptChangeSize')
-            .returns(Promise.resolve());
+          env.sandbox.stub(adsense, 'attemptChangeSize').resolves();
 
           const promise = adsense.buildCallback();
           expect(promise).to.exist;
@@ -1456,7 +1450,7 @@ describes.realWin(
       it('should call super if missing Algorithm header', () => {
         env.sandbox
           .stub(AmpA4A.prototype, 'maybeValidateAmpCreative')
-          .returns(Promise.resolve('foo'));
+          .resolves('foo');
         const creative = '<html><body>This is some text</body></html>';
         const mockHeaders = {
           get: (key) => {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-responsive-state.js
@@ -85,14 +85,12 @@ describes.realWin(
         .stub(element, 'getLayoutBox')
         .returns(layoutRectLtwh(50, 200, 375, 100));
 
-      env.sandbox.stub(element, 'getImpl').returns(
-        Promise.resolve({
-          attemptChangeSize: (h, w) => {
-            lastSizeChangeAttempt = {height: h, width: w};
-            return Promise.resolve();
-          },
-        })
-      );
+      env.sandbox.stub(element, 'getImpl').resolves({
+        attemptChangeSize: (h, w) => {
+          lastSizeChangeAttempt = {height: h, width: w};
+          return Promise.resolve();
+        },
+      });
 
       const viewport = Services.viewportForDoc(doc);
       env.sandbox.stub(viewport, 'getSize').returns({width: 375, height: 667});

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -115,12 +115,10 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
             credentials: 'omit',
           }
         )
-        .returns(
-          Promise.resolve({
-            headers: {},
-            text: () => template,
-          })
-        );
+        .resolves({
+          headers: {},
+          text: () => template,
+        });
       return impl
         .maybeValidateAmpCreative(
           utf8Encode(JSON.stringify(adResponseBody)).buffer,
@@ -176,12 +174,10 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
             credentials: 'omit',
           }
         )
-        .returns(
-          Promise.resolve({
-            headers: {},
-            text: () => template,
-          })
-        );
+        .resolves({
+          headers: {},
+          text: () => template,
+        });
     });
 
     it('should auto add amp-analytics if required', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -655,7 +655,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       // inabox-viewer.getReferrerUrl() returns Promise<string>.
       env.sandbox
         .stub(viewer, 'getReferrerUrl')
-        .returns(Promise.resolve('http://fake.example/?foo=bar'));
+        .resolves('http://fake.example/?foo=bar');
 
       const impl = new AmpAdNetworkDoubleclickImpl(element);
       const impl2 = new AmpAdNetworkDoubleclickImpl(element);
@@ -1362,7 +1362,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       // Stub ini load otherwise FIE could delay test
       env.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
-        .returns(Promise.resolve());
+        .resolves();
       impl.buildCallback();
       impl.onLayoutMeasure();
       return impl.layoutCallback().then(() => {
@@ -1451,7 +1451,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       // Stub ini load otherwise FIE could delay test
       env.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
-        .returns(Promise.resolve());
+        .resolves();
       // This would normally be set in AmpA4a#buildCallback.
       impl.creativeSize_ = {width: 200, height: 50};
       impl.buildCallback();
@@ -1494,7 +1494,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       // Stub ini load otherwise FIE could delay test
       env.sandbox
         ./*OK*/ stub(FriendlyIframeEmbed.prototype, 'whenIniLoaded')
-        .returns(Promise.resolve());
+        .resolves();
       impl.buildCallback();
       impl.onLayoutMeasure();
       return impl.layoutCallback().then(() => {
@@ -1767,7 +1767,7 @@ describes.realWin(
           'type': 'doubleclick',
         });
         impl = new AmpAdNetworkDoubleclickImpl(element);
-        env.sandbox.stub(impl, 'whenWithinViewport').returns(Promise.resolve());
+        env.sandbox.stub(impl, 'whenWithinViewport').resolves();
       });
 
       it('should use experiment value', () => {
@@ -1811,9 +1811,7 @@ describes.realWin(
         impl = new AmpAdNetworkDoubleclickImpl(element);
         impl.postAdResponseExperimentFeatures['render-idle-vp'] = '4';
         impl.postAdResponseExperimentFeatures['render-idle-throttle'] = 'true';
-        env.sandbox
-          .stub(AmpA4A.prototype, 'renderNonAmpCreative')
-          .returns(Promise.resolve());
+        env.sandbox.stub(AmpA4A.prototype, 'renderNonAmpCreative').resolves();
       });
 
       // TODO(jeffkaufman, #13422): this test was silently failing
@@ -2093,7 +2091,7 @@ describes.realWin(
       it('should call super if missing Algorithm header', () => {
         env.sandbox
           .stub(AmpA4A.prototype, 'maybeValidateAmpCreative')
-          .returns(Promise.resolve('foo'));
+          .resolves('foo');
         const creative = '<html><body>This is some text</body></html>';
         const mockHeaders = {
           get: (key) => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -298,7 +298,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
     env.sandbox.stub(impl, 'setCssPosition_').resolves();
-    env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
+    env.sandbox.stub(impl, 'attemptChangeHeight').rejects();
     const delayedImpressionSpy = env.sandbox.spy(
       impl,
       'fireDelayedImpressions'
@@ -320,7 +320,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
     env.sandbox.stub(impl, 'setCssPosition_').resolves();
-    env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
+    env.sandbox.stub(impl, 'attemptChangeHeight').rejects();
     const delayedImpressionSpy = env.sandbox.spy(
       impl,
       'fireDelayedImpressions'
@@ -341,7 +341,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
       impl,
       'attemptChangeHeight'
     );
-    attemptChangeHeightStub.returns(Promise.reject());
+    attemptChangeHeightStub.rejects();
     env.sandbox.stub(impl, 'setCssPosition_').resolves();
     env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     impl.buildCallback();
@@ -404,7 +404,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
       'attemptChangeHeight'
     );
     const mutateElementStub = env.sandbox.stub(impl, 'mutateElement');
-    attemptChangeHeightStub.returns(Promise.reject());
+    attemptChangeHeightStub.rejects();
     mutateElementStub.resolves();
     env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     impl.buildCallback();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -81,12 +81,10 @@ function createScaffoldingForFluidRendering(impl, sandbox, resize = true) {
   impl.attemptChangeHeight = resize
     ? () => Promise.resolve()
     : () => Promise.reject('Creative in viewport');
-  sandbox.stub(impl, 'sendXhrRequest').returns(
-    Promise.resolve({
-      arrayBuffer: () => Promise.resolve(utf8Encode(rawCreative)),
-      headers: {has: () => false, get: () => undefined},
-    })
-  );
+  sandbox.stub(impl, 'sendXhrRequest').resolves({
+    arrayBuffer: () => Promise.resolve(utf8Encode(rawCreative)),
+    headers: {has: () => false, get: () => undefined},
+  });
   impl.sentinel = 'sentinel';
   impl.initiateAdRequest();
   impl.safeframeApi_ = new SafeframeHostApi(impl, true, impl.creativeSize_);
@@ -299,7 +297,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
   it('should fire impression for AMP fluid creative, if partly visible', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    env.sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
+    env.sandbox.stub(impl, 'setCssPosition_').resolves();
     env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = env.sandbox.spy(
       impl,
@@ -321,7 +319,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
   it('should not fire impression for AMP fluid creative', () => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
-    env.sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
+    env.sandbox.stub(impl, 'setCssPosition_').resolves();
     env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = env.sandbox.spy(
       impl,
@@ -344,10 +342,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
       'attemptChangeHeight'
     );
     attemptChangeHeightStub.returns(Promise.reject());
-    env.sandbox.stub(impl, 'setCssPosition_').returns(Promise.resolve());
-    env.sandbox
-      .stub(impl, 'attemptToRenderCreative')
-      .returns(Promise.resolve());
+    env.sandbox.stub(impl, 'setCssPosition_').resolves();
+    env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
@@ -364,10 +360,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
       impl,
       'attemptChangeHeight'
     );
-    attemptChangeHeightStub.returns(Promise.resolve());
-    env.sandbox
-      .stub(impl, 'attemptToRenderCreative')
-      .returns(Promise.resolve());
+    attemptChangeHeightStub.resolves();
+    env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     env.sandbox.stub(impl, 'setCssPosition_').returns(mockPromise);
     impl.buildCallback();
     impl.isFluidRequest_ = true;
@@ -388,11 +382,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
       'attemptChangeHeight'
     );
     const mutateElementStub = env.sandbox.stub(impl, 'mutateElement');
-    attemptChangeHeightStub.returns(Promise.resolve());
-    mutateElementStub.returns(Promise.resolve());
-    env.sandbox
-      .stub(impl, 'attemptToRenderCreative')
-      .returns(Promise.resolve());
+    attemptChangeHeightStub.resolves();
+    mutateElementStub.resolves();
+    env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;
@@ -413,10 +405,8 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
     );
     const mutateElementStub = env.sandbox.stub(impl, 'mutateElement');
     attemptChangeHeightStub.returns(Promise.reject());
-    mutateElementStub.returns(Promise.resolve());
-    env.sandbox
-      .stub(impl, 'attemptToRenderCreative')
-      .returns(Promise.resolve());
+    mutateElementStub.resolves();
+    env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     impl.buildCallback();
     impl.isFluidRequest_ = true;
     impl.isVerifiedAmpCreative_ = true;

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -298,7 +298,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
     env.sandbox.stub(impl, 'setCssPosition_').resolves();
-    env.sandbox.stub(impl, 'attemptChangeHeight').rejects();
+    env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = env.sandbox.spy(
       impl,
       'fireDelayedImpressions'
@@ -320,7 +320,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
     impl.iframe = impl.win.document.createElement('iframe');
     impl.win.document.body.appendChild(impl.iframe);
     env.sandbox.stub(impl, 'setCssPosition_').resolves();
-    env.sandbox.stub(impl, 'attemptChangeHeight').rejects();
+    env.sandbox.stub(impl, 'attemptChangeHeight').returns(Promise.reject());
     const delayedImpressionSpy = env.sandbox.spy(
       impl,
       'fireDelayedImpressions'
@@ -341,7 +341,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
       impl,
       'attemptChangeHeight'
     );
-    attemptChangeHeightStub.rejects();
+    attemptChangeHeightStub.returns(Promise.reject());
     env.sandbox.stub(impl, 'setCssPosition_').resolves();
     env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     impl.buildCallback();
@@ -404,7 +404,7 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
       'attemptChangeHeight'
     );
     const mutateElementStub = env.sandbox.stub(impl, 'mutateElement');
-    attemptChangeHeightStub.rejects();
+    attemptChangeHeightStub.returns(Promise.reject());
     mutateElementStub.resolves();
     env.sandbox.stub(impl, 'attemptToRenderCreative').resolves();
     impl.buildCallback();

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -497,7 +497,9 @@ describes.realWin('Doubleclick SRA', config, (env) => {
         }
       );
       if (opt_xhrFail) {
-        xhrWithArgs.rejects(new TypeError('some random network error'));
+        xhrWithArgs.returns(
+          Promise.reject(new TypeError('some random network error'))
+        );
       } else if (opt_allInvalid) {
         xhrWithArgs.throws(new Error('invalid should not make xhr!'));
       } else {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -497,8 +497,8 @@ describes.realWin('Doubleclick SRA', config, (env) => {
         }
       );
       if (opt_xhrFail) {
-        xhrWithArgs.returns(
-          Promise.reject(new TypeError('some random network error'))
+        xhrWithArgs.rejects(
+          new TypeError('some random network error')
         );
       } else if (opt_allInvalid) {
         xhrWithArgs.throws(new Error('invalid should not make xhr!'));

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -497,9 +497,7 @@ describes.realWin('Doubleclick SRA', config, (env) => {
         }
       );
       if (opt_xhrFail) {
-        xhrWithArgs.rejects(
-          new TypeError('some random network error')
-        );
+        xhrWithArgs.rejects(new TypeError('some random network error'));
       } else if (opt_allInvalid) {
         xhrWithArgs.throws(new Error('invalid should not make xhr!'));
       } else {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -503,24 +503,22 @@ describes.realWin('Doubleclick SRA', config, (env) => {
       } else if (opt_allInvalid) {
         xhrWithArgs.throws(new Error('invalid should not make xhr!'));
       } else {
-        xhrWithArgs.returns(
-          Promise.resolve({
-            arrayBuffer: () => {
-              throw new Error('Expected SRA!');
-            },
-            bodyUsed: false,
-            text: () => {
-              let slotDataString = '';
-              responses.forEach((slot) => {
-                slotDataString += `${JSON.stringify(slot.headers)}\n${
-                  slot.creative
-                }\n`;
-              });
-              return Promise.resolve(slotDataString);
-            },
-            headers,
-          })
-        );
+        xhrWithArgs.resolves({
+          arrayBuffer: () => {
+            throw new Error('Expected SRA!');
+          },
+          bodyUsed: false,
+          text: () => {
+            let slotDataString = '';
+            responses.forEach((slot) => {
+              slotDataString += `${JSON.stringify(slot.headers)}\n${
+                slot.creative
+              }\n`;
+            });
+            return Promise.resolve(slotDataString);
+          },
+          headers,
+        });
       }
     }
 
@@ -541,19 +539,17 @@ describes.realWin('Doubleclick SRA', config, (env) => {
           method: 'GET',
           credentials: 'include',
         })
-        .returns(
-          Promise.resolve({
-            arrayBuffer: () => Promise.resolve(utf8Encode(creative)),
-            bodyUsed: false,
-            headers: {
-              get: (header) => headers[header],
-              has: (header) => header in headers,
-            },
-            text: () => {
-              throw new Error('should not be SRA!');
-            },
-          })
-        );
+        .resolves({
+          arrayBuffer: () => Promise.resolve(utf8Encode(creative)),
+          bodyUsed: false,
+          headers: {
+            get: (header) => headers[header],
+            has: (header) => header in headers,
+          },
+          text: () => {
+            throw new Error('should not be SRA!');
+          },
+        });
     }
 
     /**
@@ -631,7 +627,7 @@ describes.realWin('Doubleclick SRA', config, (env) => {
       });
       env.sandbox
         .stub(AmpAdNetworkDoubleclickImpl.prototype, 'groupSlotsForSra')
-        .returns(Promise.resolve(groupingPromises));
+        .resolves(groupingPromises);
       let idx = 0;
       const layoutCallbacks = [];
       const getLayoutCallback = (impl, creative, isSra, noRender) => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -128,7 +128,7 @@ describes.realWin('Ad loader', {amp: true}, (env) => {
         const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
-          .returns(Promise.reject(new Error('I failed!')));
+          .rejects(new Error('I failed!'));
         ampAd = new AmpAd(ampAdElement);
         env.sandbox.stub(ampAd.user(), 'error');
         return ampAd.upgradeCallback().then((baseElement) => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -168,7 +168,7 @@ describes.realWin('Ad loader', {amp: true}, (env) => {
         const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
-          .returns(Promise.resolve(zortConstructor));
+          .resolves(zortConstructor);
         ampAd = new AmpAd(ampAdElement);
         return ampAd.upgradeCallback().then((baseElement) => {
           expect(extensionsStub).to.be.called;
@@ -197,7 +197,7 @@ describes.realWin('Ad loader', {amp: true}, (env) => {
         const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
-          .returns(Promise.resolve(zortConstructor));
+          .resolves(zortConstructor);
         ampAd = new AmpAd(ampAdElement);
         return ampAd.upgradeCallback().then((baseElement) => {
           expect(extensionsStub).to.be.called;
@@ -221,7 +221,7 @@ describes.realWin('Ad loader', {amp: true}, (env) => {
         const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
-          .returns(Promise.resolve(zortConstructor));
+          .resolves(zortConstructor);
         ampAd = new AmpAd(ampAdElement);
         return ampAd.upgradeCallback().then((baseElement) => {
           expect(extensionsStub).to.be.called;

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -128,7 +128,7 @@ describes.realWin('Ad loader', {amp: true}, (env) => {
         const extensionsStub = env.sandbox
           .stub(extensions, 'loadElementClass')
           .withArgs('amp-ad-network-zort-impl')
-          .rejects(new Error('I failed!'));
+          .returns(Promise.reject(new Error('I failed!')));
         ampAd = new AmpAd(ampAdElement);
         env.sandbox.stub(ampAd.user(), 'error');
         return ampAd.upgradeCallback().then((baseElement) => {

--- a/extensions/amp-analytics/0.1/test/test-amp-analytics.js
+++ b/extensions/amp-analytics/0.1/test/test-amp-analytics.js
@@ -805,25 +805,23 @@ describes.realWin(
 
     describe('optout by function', () => {
       beforeEach(() => {
-        env.sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').returns(
-          Promise.resolve({
-            'requests': {
-              'foo': {
-                baseUrl: 'https://example.test/bar',
-              },
+        env.sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').resolves({
+          'requests': {
+            'foo': {
+              baseUrl: 'https://example.test/bar',
             },
-            'triggers': {
-              'pageview': {'on': 'visible', 'request': 'foo'},
-            },
-            'transport': {
-              'image': true,
-              'xhrpost': false,
-              'beacon': false,
-            },
-            'vars': {},
-            'optout': 'foo.bar',
-          })
-        );
+          },
+          'triggers': {
+            'pageview': {'on': 'visible', 'request': 'foo'},
+          },
+          'transport': {
+            'image': true,
+            'xhrpost': false,
+            'beacon': false,
+          },
+          'vars': {},
+          'optout': 'foo.bar',
+        });
       });
 
       it('works for vendor config when optout returns false', function () {
@@ -858,25 +856,23 @@ describes.realWin(
 
     describe('optout by id', () => {
       beforeEach(() => {
-        env.sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').returns(
-          Promise.resolve({
-            'requests': {
-              'foo': {
-                baseUrl: 'https://example.test/bar',
-              },
+        env.sandbox.stub(AnalyticsConfig.prototype, 'loadConfig').resolves({
+          'requests': {
+            'foo': {
+              baseUrl: 'https://example.test/bar',
             },
-            'triggers': {
-              'pageview': {'on': 'visible', 'request': 'foo'},
-            },
-            'transport': {
-              'image': true,
-              'xhrpost': false,
-              'beacon': false,
-            },
-            'vars': {},
-            'optoutElementId': 'elementId',
-          })
-        );
+          },
+          'triggers': {
+            'pageview': {'on': 'visible', 'request': 'foo'},
+          },
+          'transport': {
+            'image': true,
+            'xhrpost': false,
+            'beacon': false,
+          },
+          'vars': {},
+          'optoutElementId': 'elementId',
+        });
       });
 
       it('doesnt send hit when config optout id is found', function () {
@@ -993,7 +989,7 @@ describes.realWin(
       it('allows a request through', () => {
         const analytics = getAnalyticsTag(getConfig(1));
 
-        env.sandbox.stub(crypto, 'uniform').returns(Promise.resolve(0.005));
+        env.sandbox.stub(crypto, 'uniform').resolves(0.005);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest('/test1=1');
         });
@@ -1011,10 +1007,7 @@ describes.realWin(
           async: 0,
           sync: 0,
         });
-        env.sandbox
-          .stub(crypto, 'uniform')
-          .withArgs('0')
-          .returns(Promise.resolve(0.005));
+        env.sandbox.stub(crypto, 'uniform').withArgs('0').resolves(0.005);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest('/test1=1');
         });
@@ -1023,7 +1016,7 @@ describes.realWin(
       it('does not allow a request through', () => {
         const analytics = getAnalyticsTag(getConfig(1));
 
-        env.sandbox.stub(crypto, 'uniform').returns(Promise.resolve(0.1));
+        env.sandbox.stub(crypto, 'uniform').resolves(0.1);
         return waitForNoSendRequest(analytics);
       });
 
@@ -1682,9 +1675,9 @@ describes.realWin(
         env.sandbox
           .stub(crypto, 'uniform')
           .withArgs('0')
-          .returns(Promise.resolve(0.005))
+          .resolves(0.005)
           .withArgs('CLIENT_ID')
-          .returns(Promise.resolve(0.5));
+          .resolves(0.5);
         return waitForSendRequest(analytics).then(() => {
           requestVerifier.verifyRequest('/test1=1');
         });
@@ -1738,7 +1731,7 @@ describes.realWin(
 
         env.sandbox
           .stub(AnalyticsConfig.prototype, 'loadConfig')
-          .returns(Promise.resolve(sampleconfig));
+          .resolves(sampleconfig);
 
         analytics.buildCallback();
         analytics.preconnectCallback();

--- a/extensions/amp-analytics/0.1/test/test-config.js
+++ b/extensions/amp-analytics/0.1/test/test-config.js
@@ -957,16 +957,14 @@ describes.realWin(
 
         const usrObj = user();
         const spy = env.sandbox.spy(usrObj, 'warn');
-        xhrStub.returns(
-          Promise.resolve({
-            json: () => {
-              return {
-                'warningMessage':
-                  'The config you are working with has been deprecated',
-              };
-            },
-          })
-        );
+        xhrStub.resolves({
+          json: () => {
+            return {
+              'warningMessage':
+                'The config you are working with has been deprecated',
+            };
+          },
+        });
 
         return new AnalyticsConfig(element).loadConfig().then((config) => {
           expect(spy).callCount(1);

--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -2205,16 +2205,13 @@ describes.realWin('Events', {amp: 1}, (env) => {
       });
 
       it('with waitFor INI_LOAD', () => {
-        iniLoadTrackerMock
-          .expects('getRootSignal')
-          .returns(Promise.resolve())
-          .twice();
+        iniLoadTrackerMock.expects('getRootSignal').resolves().twice();
         const promise = tracker.getReadyPromise('ini-load');
         return promise.then(() => {
           iniLoadTrackerMock
             .expects('getElementSignal')
             .withExactArgs('ini-load', target)
-            .returns(Promise.resolve())
+            .resolves()
             .once();
           const promise2 = tracker.getReadyPromise('ini-load', target);
           return promise2;
@@ -2232,14 +2229,14 @@ describes.realWin('Events', {amp: 1}, (env) => {
         signalTrackerMock
           .expects('getRootSignal')
           .withExactArgs('render-start')
-          .returns(Promise.resolve())
+          .resolves()
           .twice();
         const promise = tracker.getReadyPromise('render-start');
         return promise.then(() => {
           signalTrackerMock
             .expects('getElementSignal')
             .withExactArgs('render-start', target)
-            .returns(Promise.resolve())
+            .resolves()
             .once();
           const promise2 = tracker.getReadyPromise('render-start', target);
           return promise2;
@@ -2278,14 +2275,14 @@ describes.realWin('Events', {amp: 1}, (env) => {
           iniLoadTrackerMock
             .expects('getElementSignal')
             .withExactArgs('ini-load', element)
-            .returns(Promise.resolve())
+            .resolves()
             .once();
 
           await tracker.getReadyPromise('render-start', element);
           signalTrackerMock
             .expects('getElementSignal')
             .withExactArgs('render-start')
-            .returns(Promise.resolve())
+            .resolves()
             .once();
         });
       });

--- a/extensions/amp-analytics/0.1/test/test-requests.js
+++ b/extensions/amp-analytics/0.1/test/test-requests.js
@@ -620,7 +620,7 @@ describes.realWin('Requests', {amp: 1}, (env) => {
     });
     env.sandbox
       .stub(ResourceTiming, 'getResourceTiming')
-      .returns(Promise.resolve('resource-timing'));
+      .resolves('resource-timing');
     handler.send({}, {}, expansionOptions);
     yield macroTask();
     expect(spy).to.be.calledWith('r1&resource-timing');

--- a/extensions/amp-analytics/0.1/test/test-variables.js
+++ b/extensions/amp-analytics/0.1/test/test-variables.js
@@ -445,8 +445,9 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
     });
 
     it('replaces CONSENT_METADATA', () => {
-      window.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-        Promise.resolve({
+      window.sandbox
+        .stub(Services, 'consentPolicyServiceForDocOrNull')
+        .resolves({
           getConsentMetadataInfo: () => {
             return Promise.resolve({
               'gdprApplies': true,
@@ -454,8 +455,7 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
               'consentStringType': 1,
             });
           },
-        })
-      );
+        });
 
       return check(
         'CONSENT_METADATA(gdprApplies)&CONSENT_METADATA(additionalConsent)&CONSENT_METADATA(consentStringType)&CONSENT_METADATA(invalid_key)',
@@ -464,13 +464,13 @@ describes.fakeWin('amp-analytics.VariableService', {amp: true}, (env) => {
     });
 
     it('replaces CONSENT_STRING', () => {
-      window.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-        Promise.resolve({
+      window.sandbox
+        .stub(Services, 'consentPolicyServiceForDocOrNull')
+        .resolves({
           getConsentStringInfo: () => {
             return Promise.resolve('userConsentString');
           },
-        })
-      );
+        });
 
       return check('a=CONSENT_STRING', 'a=userConsentString');
     });

--- a/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/test/test-amp-apester-media.js
@@ -83,14 +83,12 @@ describes.realWin(
 
       xhrMock = env.sandbox.mock(Services.xhrFor(win));
       if (attributes) {
-        xhrMock.expects('fetchJson').returns(
-          Promise.resolve({
-            status: 200,
-            json() {
-              return Promise.resolve(currentResopnse);
-            },
-          })
-        );
+        xhrMock.expects('fetchJson').resolves({
+          status: 200,
+          json() {
+            return Promise.resolve(currentResopnse);
+          },
+        });
       } else {
         xhrMock.expects('fetchJson').never();
       }

--- a/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
+++ b/extensions/amp-app-banner/0.1/test/test-amp-app-banner.js
@@ -87,13 +87,11 @@ describes.realWin(
         env.sandbox
           .mock(Services.xhrFor(win))
           .expects('fetchJson')
-          .returns(
-            Promise.resolve({
-              json() {
-                return Promise.resolve(manifestObj.content);
-              },
-            })
-          );
+          .resolves({
+            json() {
+              return Promise.resolve(manifestObj.content);
+            },
+          });
       }
 
       const banner = doc.createElement('amp-app-banner');

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -86,7 +86,7 @@ describes.realWin(
       const extensions = Services.extensionsFor(win);
       env.sandbox
         .stub(extensions, 'loadElementClass')
-        .returns(Promise.resolve((el) => new FakeA4A(el)));
+        .resolves((el) => new FakeA4A(el));
 
       const viewportMock = env.sandbox.mock(Services.viewportForDoc(doc));
       viewportMock
@@ -170,7 +170,7 @@ describes.realWin(
       env.sandbox.spy(xhr, 'fetchJson');
 
       whenVisible = env.sandbox.stub(env.ampdoc, 'whenFirstVisible');
-      whenVisible.returns(Promise.resolve());
+      whenVisible.resolves();
     });
 
     function getAmpAutoAds(type) {

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -280,7 +280,7 @@ describes.realWin(
         const rendered = getRenderedSuggestions();
         const ssrSpy = env.sandbox
           .stub(impl.getSsrTemplateHelper(), 'ssr')
-          .returns(Promise.resolve({rendered}));
+          .resolves({rendered});
         await impl.getRemoteData_();
         expect(ssrSpy).to.be.calledOnce;
       });
@@ -332,7 +332,7 @@ describes.realWin(
           renderSpy = env.sandbox.spy(impl, 'renderResults_');
           env.sandbox
             .stub(impl.getSsrTemplateHelper(), 'applySsrOrCsrTemplate')
-            .returns(Promise.resolve(getRenderedSuggestions()));
+            .resolves(getRenderedSuggestions());
         });
 
         it('should add objToJson property to objects', async () => {
@@ -368,7 +368,7 @@ describes.realWin(
         const data = ['apple', 'mango', 'pear'];
         env.sandbox
           .stub(impl.getSsrTemplateHelper(), 'applySsrOrCsrTemplate')
-          .returns(Promise.resolve(getRenderedSuggestions()));
+          .resolves(getRenderedSuggestions());
         await impl.renderResults_(data, impl.container_);
         expect(impl.getSsrTemplateHelper().applySsrOrCsrTemplate).to.be
           .calledOnce;
@@ -405,7 +405,7 @@ describes.realWin(
         impl = await buildAmpAutocomplete(true);
         const renderTemplateSpy = env.sandbox
           .stub(impl.getSsrTemplateHelper(), 'applySsrOrCsrTemplate')
-          .returns(Promise.resolve(getRenderedSuggestions()));
+          .resolves(getRenderedSuggestions());
         await impl.renderResults_(sourceData, impl.container_);
         expect(impl.container_.children).to.have.length(3);
         expect(impl.container_.children[0].getAttribute('data-value')).to.equal(
@@ -1068,7 +1068,7 @@ describes.realWin(
       rendered[2].setAttribute('data-disabled', '');
       env.sandbox
         .stub(impl.getSsrTemplateHelper(), 'applySsrOrCsrTemplate')
-        .returns(Promise.resolve(rendered));
+        .resolves(rendered);
 
       await impl.renderResults_(sourceData, impl.container_);
       expect(impl.container_.children).to.have.length(3);

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -1089,7 +1089,7 @@ describes.realWin(
         toggleFallbackSpy = env.sandbox.spy(impl, 'toggleFallback');
         getDataSpy = env.sandbox
           .stub(impl, 'getRemoteData_')
-          .returns(Promise.reject('Error for test'));
+          .rejects('Error for test');
       });
 
       it('should throw error when fallback is not provided', () => {

--- a/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
+++ b/extensions/amp-autocomplete/0.1/test/test-amp-autocomplete.js
@@ -1089,7 +1089,7 @@ describes.realWin(
         toggleFallbackSpy = env.sandbox.spy(impl, 'toggleFallback');
         getDataSpy = env.sandbox
           .stub(impl, 'getRemoteData_')
-          .rejects('Error for test');
+          .returns(Promise.reject('Error for test'));
       });
 
       it('should throw error when fallback is not provided', () => {

--- a/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
+++ b/extensions/amp-bind/0.1/test/integration/test-bind-impl.js
@@ -909,9 +909,7 @@ describe
 
           describe('with trusted viewer', () => {
             beforeEach(() => {
-              window.sandbox
-                .stub(viewer, 'isTrustedViewer')
-                .returns(Promise.resolve(true));
+              window.sandbox.stub(viewer, 'isTrustedViewer').resolves(true);
             });
 
             it('should replace history on AMP.setState()', () => {

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -64,9 +64,7 @@ describes.realWin(
 
       // TODO(choumx): Remove stubbing of private function fetch_() once
       // batchFetchJsonFor() is easily stub-able.
-      env.sandbox
-        .stub(ampState, 'fetch_')
-        .returns(Promise.resolve({remote: 'data'}));
+      env.sandbox.stub(ampState, 'fetch_').resolves({remote: 'data'});
 
       bind = {setState: env.sandbox.stub()};
       env.sandbox.stub(Services, 'bindForDocOrNull').resolves(bind);

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -105,7 +105,7 @@ describes.realWin(
     });
 
     it('should trigger "fetch-error" if fetch fails', async () => {
-      ampState.fetch_.returns(Promise.reject());
+      ampState.fetch_.rejects();
 
       const actions = {trigger: env.sandbox.spy()};
       env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);

--- a/extensions/amp-bind/0.1/test/test-amp-state.js
+++ b/extensions/amp-bind/0.1/test/test-amp-state.js
@@ -105,7 +105,7 @@ describes.realWin(
     });
 
     it('should trigger "fetch-error" if fetch fails', async () => {
-      ampState.fetch_.rejects();
+      ampState.fetch_.returns(Promise.reject());
 
       const actions = {trigger: env.sandbox.spy()};
       env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);

--- a/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/test/test-amp-byside-content.js
@@ -55,7 +55,7 @@ describes.realWin(
         .then(() => elem.getImpl())
         .then((impl) => {
           urlMock.expandUrlAsync
-            .returns(Promise.resolve(impl.baseUrl_))
+            .resolves(impl.baseUrl_)
             .withArgs(env.sandbox.match.any);
           if (opt_beforeLayoutCallback) {
             opt_beforeLayoutCallback(elem);

--- a/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
@@ -67,13 +67,11 @@ describes.realWin(
           url,
           env.sandbox.match((init) => init.credentials == 'include')
         )
-        .returns(
-          Promise.resolve({
-            json() {
-              return Promise.resolve(response);
-            },
-          })
-        );
+        .resolves({
+          json() {
+            return Promise.resolve(response);
+          },
+        });
     }
 
     function expectHyperlinkToBe(callTrackingEl, href, textContent) {

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -1634,7 +1634,7 @@ describes.realWin(
             await ampConsent.buildCallback();
             window.sandbox
               .stub(ampConsent.consentStateManager_, 'getConsentInstanceInfo')
-              .returns(Promise.resolve({}));
+              .resolves({});
             const spy = window.sandbox.spy(
               ampConsent,
               'checkGranularConsentRequired_'

--- a/extensions/amp-consent/0.1/test/test-consent-config.js
+++ b/extensions/amp-consent/0.1/test/test-consent-config.js
@@ -116,13 +116,11 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
           'postPromptUI': 'test',
         })
       );
-      env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-        Promise.resolve({
-          isInCountryGroup() {
-            return false;
-          },
-        })
-      );
+      env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+        isInCountryGroup() {
+          return false;
+        },
+      });
       const consentConfig = new ConsentConfig(element);
       expect(await consentConfig.getConsentConfigPromise()).to.deep.equal(
         dict({
@@ -164,13 +162,11 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
           'postPromptUI': 'test',
         })
       );
-      env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-        Promise.resolve({
-          isInCountryGroup() {
-            return GEO_IN_GROUP.IN;
-          },
-        })
-      );
+      env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+        isInCountryGroup() {
+          return GEO_IN_GROUP.IN;
+        },
+      });
       const consentConfig = new ConsentConfig(element);
       expect(await consentConfig.getConsentConfigPromise()).to.deep.equal(
         dict({
@@ -211,13 +207,11 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
           'postPromptUI': 'test',
         })
       );
-      env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-        Promise.resolve({
-          isInCountryGroup() {
-            return false;
-          },
-        })
-      );
+      env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+        isInCountryGroup() {
+          return false;
+        },
+      });
       element.setAttribute('type', '_ping_');
       const consentConfig = new ConsentConfig(element);
       // Make a deep copy of the config to avoid error when deleting fields
@@ -277,13 +271,11 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
 
       it('should return the original config if no geo matches', async () => {
         appendConfigScriptElement(doc, element, geoConfig);
-        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-          Promise.resolve({
-            isInCountryGroup() {
-              return GEO_IN_GROUP.NOT_IN;
-            },
-          })
-        );
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+          isInCountryGroup() {
+            return GEO_IN_GROUP.NOT_IN;
+          },
+        });
 
         const consentConfig = new ConsentConfig(element);
         return expect(
@@ -297,16 +289,14 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
 
       it('should work with single field override', async () => {
         appendConfigScriptElement(doc, element, geoConfig);
-        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-          Promise.resolve({
-            isInCountryGroup(geoGroup) {
-              if (geoGroup === 'nafta') {
-                return GEO_IN_GROUP.IN;
-              }
-              return GEO_IN_GROUP.NOT_IN;
-            },
-          })
-        );
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+          isInCountryGroup(geoGroup) {
+            if (geoGroup === 'nafta') {
+              return GEO_IN_GROUP.IN;
+            }
+            return GEO_IN_GROUP.NOT_IN;
+          },
+        });
 
         const consentConfig = new ConsentConfig(element);
         expect(await consentConfig.getConsentConfigPromise()).to.deep.equal({
@@ -318,16 +308,14 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
 
       it('should work with multiple fields override', async () => {
         appendConfigScriptElement(doc, element, geoConfig);
-        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-          Promise.resolve({
-            isInCountryGroup(geoGroup) {
-              if (geoGroup === 'waldo') {
-                return GEO_IN_GROUP.IN;
-              }
-              return GEO_IN_GROUP.NOT_IN;
-            },
-          })
-        );
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+          isInCountryGroup(geoGroup) {
+            if (geoGroup === 'waldo') {
+              return GEO_IN_GROUP.IN;
+            }
+            return GEO_IN_GROUP.NOT_IN;
+          },
+        });
 
         const consentConfig = new ConsentConfig(element);
         expect(await consentConfig.getConsentConfigPromise()).to.deep.equal({
@@ -348,16 +336,14 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
           },
         };
         appendConfigScriptElement(doc, element, geoConfig);
-        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-          Promise.resolve({
-            isInCountryGroup(geoGroup) {
-              if (geoGroup === 'geoGroupUnknown') {
-                return GEO_IN_GROUP.IN;
-              }
-              return GEO_IN_GROUP.NOT_IN;
-            },
-          })
-        );
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+          isInCountryGroup(geoGroup) {
+            if (geoGroup === 'geoGroupUnknown') {
+              return GEO_IN_GROUP.IN;
+            }
+            return GEO_IN_GROUP.NOT_IN;
+          },
+        });
 
         const consentConfig = new ConsentConfig(element);
         expect(await consentConfig.getConsentConfigPromise()).to.deep.equal({
@@ -386,16 +372,14 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
           'consentInstanceId': 'abc',
           'promptIfUnknownForGeoGroup': 'na',
         };
-        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-          Promise.resolve({
-            isInCountryGroup(geoGroup) {
-              if (geoGroup === 'na') {
-                return GEO_IN_GROUP.IN;
-              }
-              return GEO_IN_GROUP.NOT_IN;
-            },
-          })
-        );
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+          isInCountryGroup(geoGroup) {
+            if (geoGroup === 'na') {
+              return GEO_IN_GROUP.IN;
+            }
+            return GEO_IN_GROUP.NOT_IN;
+          },
+        });
         appendConfigScriptElement(doc, element, geoConfig);
         const consentConfig = new ConsentConfig(element);
         expect(await consentConfig.getConsentConfigPromise()).to.deep.equal({
@@ -408,16 +392,14 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
       it('should not override consentInstanceId', async () => {
         expectAsyncConsoleError(/consentInstanceId/, 1);
         appendConfigScriptElement(doc, element, geoConfig);
-        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-          Promise.resolve({
-            isInCountryGroup(geoGroup) {
-              if (geoGroup === 'invalid') {
-                return GEO_IN_GROUP.IN;
-              }
-              return GEO_IN_GROUP.NOT_IN;
-            },
-          })
-        );
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+          isInCountryGroup(geoGroup) {
+            if (geoGroup === 'invalid') {
+              return GEO_IN_GROUP.IN;
+            }
+            return GEO_IN_GROUP.NOT_IN;
+          },
+        });
         const consentConfig = new ConsentConfig(element);
         expect(await consentConfig.getConsentConfigPromise()).to.deep.equal({
           'consentInstanceId': 'abc',
@@ -447,13 +429,11 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
         'amp-consent/consent-config: ' +
         '`checkConsentHref` must be specified if `consentRequired` is remote';
 
-      env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-        Promise.resolve({
-          isInCountryGroup() {
-            return false;
-          },
-        })
-      );
+      env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+        isInCountryGroup() {
+          return false;
+        },
+      });
 
       const scriptElement = doc.createElement('script');
       scriptElement.textContent = JSON.stringify(defaultConfig);

--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -138,13 +138,13 @@ describes.realWin(
       const stub = env.sandbox.stub(variant, 'allocateVariant');
       stub
         .withArgs(ampdoc, 'experiment-1', config['experiment-1'])
-        .returns(Promise.resolve('variant-a'));
+        .resolves('variant-a');
       stub
         .withArgs(ampdoc, 'experiment-2', config['experiment-2'])
-        .returns(Promise.resolve('variant-d'));
+        .resolves('variant-d');
       stub
         .withArgs(ampdoc, 'experiment-3', config['experiment-3'])
-        .returns(Promise.resolve(null));
+        .resolves(null);
 
       experiment.buildCallback();
       return Services.variantsForDocOrNull(ampdoc.getHeadNode())

--- a/extensions/amp-experiment/0.1/test/test-variant.js
+++ b/extensions/amp-experiment/0.1/test/test-variant.js
@@ -45,14 +45,9 @@ describes.sandboxed('allocateVariant', {}, (env) => {
     fakeHead = {};
 
     getCidStub = env.sandbox.stub();
-    env.sandbox
-      .stub(Services, 'cidForDoc')
-      .withArgs(ampdoc)
-      .returns(
-        Promise.resolve({
-          get: getCidStub,
-        })
-      );
+    env.sandbox.stub(Services, 'cidForDoc').withArgs(ampdoc).resolves({
+      get: getCidStub,
+    });
 
     uniformStub = env.sandbox.stub();
     env.sandbox.stub(Services, 'cryptoFor').withArgs(fakeWin).returns({
@@ -63,11 +58,9 @@ describes.sandboxed('allocateVariant', {}, (env) => {
     env.sandbox
       .stub(Services, 'userNotificationManagerForDoc')
       .withArgs(fakeHead)
-      .returns(
-        Promise.resolve({
-          getNotification: getNotificationStub,
-        })
-      );
+      .resolves({
+        getNotification: getNotificationStub,
+      });
 
     env.sandbox.stub(Services, 'viewerForDoc').withArgs(ampdoc).returns({});
 
@@ -262,8 +255,8 @@ describes.sandboxed('allocateVariant', {}, (env) => {
         scope: 'amp-experiment',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('name:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, 'name', {
         variants: {
@@ -280,8 +273,8 @@ describes.sandboxed('allocateVariant', {}, (env) => {
         scope: 'custom-scope',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('name:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, 'name', {
         cidScope: 'custom-scope',
@@ -299,8 +292,8 @@ describes.sandboxed('allocateVariant', {}, (env) => {
         scope: 'amp-experiment',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('custom-group:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('custom-group:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, 'name', {
         group: 'custom-group',
@@ -313,21 +306,19 @@ describes.sandboxed('allocateVariant', {}, (env) => {
   });
 
   it('should have variant allocated if consent is given', () => {
-    getNotificationStub.withArgs('notif-1').returns(
-      Promise.resolve({
-        isDismissed: () => {
-          return Promise.resolve(true);
-        },
-      })
-    );
+    getNotificationStub.withArgs('notif-1').resolves({
+      isDismissed: () => {
+        return Promise.resolve(true);
+      },
+    });
 
     getCidStub
       .withArgs({
         scope: 'amp-experiment',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('name:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, 'name', {
         consentNotificationId: 'notif-1',
@@ -340,7 +331,7 @@ describes.sandboxed('allocateVariant', {}, (env) => {
   });
 
   it('should have no variant allocated if notification not found', () => {
-    getNotificationStub.withArgs('notif-1').returns(Promise.resolve(null));
+    getNotificationStub.withArgs('notif-1').resolves(null);
 
     return expect(
       allocateVariant(ampdoc, 'name', {
@@ -354,16 +345,14 @@ describes.sandboxed('allocateVariant', {}, (env) => {
   });
 
   it('should have no variant allocated if consent is missing', () => {
-    getNotificationStub.withArgs('notif-1').returns(
-      Promise.resolve({
-        isDismissed: () => {
-          return Promise.resolve(false);
-        },
-      })
-    );
+    getNotificationStub.withArgs('notif-1').resolves({
+      isDismissed: () => {
+        return Promise.resolve(false);
+      },
+    });
 
-    getCidStub.returns(Promise.resolve('123abc'));
-    uniformStub.returns(Promise.resolve(0.4));
+    getCidStub.resolves('123abc');
+    uniformStub.resolves(0.4);
     return expect(
       allocateVariant(ampdoc, 'name', {
         consentNotificationId: 'notif-1',

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -94,13 +94,13 @@ describes.realWin(
       const stub = env.sandbox.stub(variant, 'allocateVariant');
       stub
         .withArgs(ampdoc, viewer, 'experiment-1', config['experiment-1'])
-        .returns(Promise.resolve('variant-a'));
+        .resolves('variant-a');
       stub
         .withArgs(ampdoc, viewer, 'experiment-2', config['experiment-2'])
-        .returns(Promise.resolve('variant-d'));
+        .resolves('variant-d');
       stub
         .withArgs(ampdoc, viewer, 'experiment-3', config['experiment-3'])
-        .returns(Promise.resolve(null));
+        .resolves(null);
       return stub;
     }
 
@@ -166,7 +166,7 @@ describes.realWin(
       stubAllocateVariant(env.sandbox, config);
       const applyStub = env.sandbox
         .stub(applyExperiment, 'applyExperimentToVariant')
-        .returns(Promise.resolve());
+        .resolves();
 
       experiment.buildCallback();
       return Services.variantsForDocOrNull(ampdoc.getHeadNode())
@@ -190,7 +190,7 @@ describes.realWin(
         stubAllocateVariant(env.sandbox, config);
         const applyStub = env.sandbox
           .stub(applyExperiment, 'applyExperimentToVariant')
-          .returns(Promise.resolve());
+          .resolves();
 
         env.sandbox.stub(ampdoc, 'getParam').returns('true');
 

--- a/extensions/amp-experiment/1.0/test/test-variant.js
+++ b/extensions/amp-experiment/1.0/test/test-variant.js
@@ -46,14 +46,9 @@ describes.sandboxed('allocateVariant', {}, (env) => {
     fakeHead = {};
 
     getCidStub = env.sandbox.stub();
-    env.sandbox
-      .stub(Services, 'cidForDoc')
-      .withArgs(ampdoc)
-      .returns(
-        Promise.resolve({
-          get: getCidStub,
-        })
-      );
+    env.sandbox.stub(Services, 'cidForDoc').withArgs(ampdoc).resolves({
+      get: getCidStub,
+    });
 
     uniformStub = env.sandbox.stub();
     env.sandbox.stub(Services, 'cryptoFor').withArgs(fakeWin).returns({
@@ -64,11 +59,9 @@ describes.sandboxed('allocateVariant', {}, (env) => {
     env.sandbox
       .stub(Services, 'userNotificationManagerForDoc')
       .withArgs(fakeHead)
-      .returns(
-        Promise.resolve({
-          getNotification: getNotificationStub,
-        })
-      );
+      .resolves({
+        getNotification: getNotificationStub,
+      });
 
     fakeViewer = {};
 
@@ -367,8 +360,8 @@ describes.sandboxed('allocateVariant', {}, (env) => {
         scope: 'amp-experiment',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('name:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, fakeViewer, 'name', {
         variants: {
@@ -391,8 +384,8 @@ describes.sandboxed('allocateVariant', {}, (env) => {
         scope: 'custom-scope',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('name:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, fakeViewer, 'name', {
         cidScope: 'custom-scope',
@@ -416,8 +409,8 @@ describes.sandboxed('allocateVariant', {}, (env) => {
         scope: 'amp-experiment',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('custom-group:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('custom-group:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, fakeViewer, 'name', {
         group: 'custom-group',
@@ -436,21 +429,19 @@ describes.sandboxed('allocateVariant', {}, (env) => {
   });
 
   it('should have variant allocated if consent is given', () => {
-    getNotificationStub.withArgs('notif-1').returns(
-      Promise.resolve({
-        isDismissed: () => {
-          return Promise.resolve(true);
-        },
-      })
-    );
+    getNotificationStub.withArgs('notif-1').resolves({
+      isDismissed: () => {
+        return Promise.resolve(true);
+      },
+    });
 
     getCidStub
       .withArgs({
         scope: 'amp-experiment',
         createCookieIfNotPresent: true,
       })
-      .returns(Promise.resolve('123abc'));
-    uniformStub.withArgs('name:123abc').returns(Promise.resolve(0.4));
+      .resolves('123abc');
+    uniformStub.withArgs('name:123abc').resolves(0.4);
     return expect(
       allocateVariant(ampdoc, fakeViewer, 'name', {
         consentNotificationId: 'notif-1',
@@ -469,7 +460,7 @@ describes.sandboxed('allocateVariant', {}, (env) => {
   });
 
   it('should have no variant allocated if notification not found', () => {
-    getNotificationStub.withArgs('notif-1').returns(Promise.resolve(null));
+    getNotificationStub.withArgs('notif-1').resolves(null);
 
     return expect(
       allocateVariant(ampdoc, fakeViewer, 'name', {
@@ -489,16 +480,14 @@ describes.sandboxed('allocateVariant', {}, (env) => {
   });
 
   it('should have no variant allocated if consent is missing', () => {
-    getNotificationStub.withArgs('notif-1').returns(
-      Promise.resolve({
-        isDismissed: () => {
-          return Promise.resolve(false);
-        },
-      })
-    );
+    getNotificationStub.withArgs('notif-1').resolves({
+      isDismissed: () => {
+        return Promise.resolve(false);
+      },
+    });
 
-    getCidStub.returns(Promise.resolve('123abc'));
-    uniformStub.returns(Promise.resolve(0.4));
+    getCidStub.resolves('123abc');
+    uniformStub.resolves(0.4);
     return expect(
       allocateVariant(ampdoc, fakeViewer, 'name', {
         consentNotificationId: 'notif-1',

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -66,7 +66,7 @@ describes.repeated(
         it('should timeout while loading custom font', function () {
           env.sandbox
             .stub(FontLoader.prototype, 'load')
-            .returns(Promise.reject('mock rejection'));
+            .rejects('mock rejection');
           return getAmpFont().then(() => {
             expect(root).to.have.class('comic-amp-font-missing');
             expect(root).to.not.have.class('comic-amp-font-loading');

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -74,9 +74,7 @@ describes.repeated(
         });
 
         it('should load custom font', function () {
-          env.sandbox
-            .stub(FontLoader.prototype, 'load')
-            .returns(Promise.resolve());
+          env.sandbox.stub(FontLoader.prototype, 'load').resolves();
           return getAmpFont().then(() => {
             expect(root).to.have.class('comic-amp-font-loaded');
             expect(root).to.not.have.class('comic-amp-font-loading');

--- a/extensions/amp-font/0.1/test/test-amp-font.js
+++ b/extensions/amp-font/0.1/test/test-amp-font.js
@@ -66,7 +66,7 @@ describes.repeated(
         it('should timeout while loading custom font', function () {
           env.sandbox
             .stub(FontLoader.prototype, 'load')
-            .rejects('mock rejection');
+            .returns(Promise.reject('mock rejection'));
           return getAmpFont().then(() => {
             expect(root).to.have.class('comic-amp-font-missing');
             expect(root).to.not.have.class('comic-amp-font-loading');

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -52,11 +52,9 @@ describes.realWin(
     beforeEach(() => {
       doc = env.win.document;
 
-      env.sandbox.stub(Services, 'formSubmitForDoc').returns(
-        Promise.resolve(() => {
-          fire: () => {};
-        })
-      );
+      env.sandbox.stub(Services, 'formSubmitForDoc').resolves(() => {
+        fire: () => {};
+      });
 
       const mustache = document.createElement('script');
       mustache.setAttribute('custom-template', 'amp-mustache');

--- a/extensions/amp-form/0.1/test/test-amp-form-textarea.js
+++ b/extensions/amp-form/0.1/test/test-amp-form-textarea.js
@@ -177,9 +177,7 @@ describes.realWin(
           },
         };
         env.sandbox.stub(Services, 'resourcesForDoc').returns(fakeResources);
-        env.sandbox
-          .stub(eventHelper, 'listenOncePromise')
-          .returns(Promise.resolve());
+        env.sandbox.stub(eventHelper, 'listenOncePromise').resolves();
 
         let mouseDownEvent;
         if (doc.createEvent) {

--- a/extensions/amp-form/0.1/test/test-amp-form.js
+++ b/extensions/amp-form/0.1/test/test-amp-form.js
@@ -254,7 +254,7 @@ describes.repeated(
                 .returns(true);
               env.sandbox
                 .stub(ampForm.viewer_, 'isTrustedViewer')
-                .returns(Promise.resolve(true));
+                .resolves(true);
 
               return ampForm;
             });

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -183,7 +183,7 @@ describes.fakeWin('amp-form async verification', {}, (env) => {
           },
         };
         const xhrStub = env.sandbox.stub();
-        xhrStub.onCall(0).rejects({response: errorResponse});
+        xhrStub.onCall(0).returns(Promise.reject({response: errorResponse}));
         xhrStub.onCall(1).resolves();
 
         const form = getForm(env.win.document);

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -183,7 +183,7 @@ describes.fakeWin('amp-form async verification', {}, (env) => {
           },
         };
         const xhrStub = env.sandbox.stub();
-        xhrStub.onCall(0).returns(Promise.reject({response: errorResponse}));
+        xhrStub.onCall(0).rejects({response: errorResponse});
         xhrStub.onCall(1).resolves();
 
         const form = getForm(env.win.document);

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -184,7 +184,7 @@ describes.fakeWin('amp-form async verification', {}, (env) => {
         };
         const xhrStub = env.sandbox.stub();
         xhrStub.onCall(0).returns(Promise.reject({response: errorResponse}));
-        xhrStub.onCall(1).returns(Promise.resolve());
+        xhrStub.onCall(1).resolves();
 
         const form = getForm(env.win.document);
         const verifier = getFormVerifier(form, xhrStub);

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -978,14 +978,14 @@ describes.realWin(
         const consentPolicyState = 'baz-consentPolicyState';
         const consentPolicySharedData = 'foo-consentPolicySharedData';
 
-        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
+        env.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .resolves({
             getConsentMetadataInfo: () => Promise.resolve(consentMetadata),
             getConsentStringInfo: () => Promise.resolve(consentString),
             whenPolicyResolved: () => Promise.resolve(consentPolicyState),
             getMergedSharedData: () => Promise.resolve(consentPolicySharedData),
-          })
-        );
+          });
 
         iframe.contentWindow.postMessage(
           {
@@ -1017,7 +1017,7 @@ describes.realWin(
       it('is sent with empty fields when consent service not available', async () => {
         env.sandbox
           .stub(Services, 'consentPolicyServiceForDocOrNull')
-          .returns(Promise.resolve(null));
+          .resolves(null);
 
         iframe.contentWindow.postMessage(
           {

--- a/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
+++ b/extensions/amp-image-lightbox/0.1/test/test-amp-image-lightbox.js
@@ -333,11 +333,9 @@ describes.realWin(
         },
       };
       lightboxMock = env.sandbox.mock(lightbox);
-      loadPromiseStub = env.sandbox.stub().returns(Promise.resolve());
+      loadPromiseStub = env.sandbox.stub().resolves();
 
-      env.sandbox
-        .stub(Services.timerFor(win), 'promise')
-        .returns(Promise.resolve());
+      env.sandbox.stub(Services.timerFor(win), 'promise').resolves();
       imageViewer = new ImageViewer(lightbox, win, loadPromiseStub);
       doc.body.appendChild(imageViewer.getElement());
     });

--- a/extensions/amp-list/0.1/test/test-amp-list-container.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-container.js
@@ -70,7 +70,7 @@ describes.realWin(
       doc.body.appendChild(element);
 
       env.sandbox.stub(list, 'getOverflowElement').returns(null);
-      env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+      env.sandbox.stub(list, 'fetchList_').resolves();
       list.element.applySize = () => {};
       list.buildCallback();
 

--- a/extensions/amp-list/0.1/test/test-amp-list-load-more.js
+++ b/extensions/amp-list/0.1/test/test-amp-list-load-more.js
@@ -85,7 +85,7 @@ describes.realWin(
       list.element.applySize = () => {};
 
       env.sandbox.stub(list, 'getOverflowElement').returns(null);
-      env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+      env.sandbox.stub(list, 'fetchList_').resolves();
 
       allowConsoleError(() => {
         expect(() => list.buildCallback()).to.throw(
@@ -116,7 +116,7 @@ describes.realWin(
         doc.body.appendChild(element);
 
         env.sandbox.stub(list, 'getOverflowElement').returns(null);
-        env.sandbox.stub(list, 'fetchList_').returns(Promise.resolve());
+        env.sandbox.stub(list, 'fetchList_').resolves();
         list.element.applySize = () => {};
         list.buildCallback();
       });
@@ -202,13 +202,13 @@ describes.realWin(
         env.sandbox.stub(list, 'getOverflowElement').returns(null);
         env.sandbox
           .stub(list, 'prepareAndSendFetch_')
-          .returns(Promise.resolve(HAS_MORE_ITEMS_PAYLOAD));
+          .resolves(HAS_MORE_ITEMS_PAYLOAD);
         list.element.applySize = () => {};
         list.buildCallback();
       });
 
       it('should update the next loading src', async () => {
-        env.sandbox.stub(list, 'scheduleRender_').returns(Promise.resolve());
+        env.sandbox.stub(list, 'scheduleRender_').resolves();
         await list.layoutCallback();
         expect(element.getAttribute('src')).to.equal(
           '/list/infinite-scroll?items=2&left=1'
@@ -227,18 +227,16 @@ describes.realWin(
         div2.textContent = '2';
         env.sandbox
           .stub(list.ssrTemplateHelper_, 'applySsrOrCsrTemplate')
-          .returns(Promise.resolve([]));
+          .resolves([]);
         const updateBindingsStub = env.sandbox.stub(list, 'updateBindings_');
-        env.sandbox
-          .stub(list, 'maybeRenderLoadMoreTemplates_')
-          .returns(Promise.resolve([]));
-        updateBindingsStub.onCall(0).returns(Promise.resolve([div1, div2]));
+        env.sandbox.stub(list, 'maybeRenderLoadMoreTemplates_').resolves([]);
+        updateBindingsStub.onCall(0).resolves([div1, div2]);
 
         const div3 = doc.createElement('div');
         div3.textContent = '3';
         const div4 = doc.createElement('div');
         div4.textContent = '4';
-        updateBindingsStub.onCall(1).returns(Promise.resolve([div3, div4]));
+        updateBindingsStub.onCall(1).resolves([div3, div4]);
 
         const renderSpy = env.sandbox.spy(list, 'render_');
         await list.layoutCallback();
@@ -258,18 +256,16 @@ describes.realWin(
       it('should call focus on the last focusable element after load more is clicked', async () => {
         env.sandbox
           .stub(list.ssrTemplateHelper_, 'applySsrOrCsrTemplate')
-          .returns(Promise.resolve([]));
+          .resolves([]);
         const updateBindingsStub = env.sandbox.stub(list, 'updateBindings_');
-        env.sandbox
-          .stub(list, 'maybeRenderLoadMoreTemplates_')
-          .returns(Promise.resolve([]));
+        env.sandbox.stub(list, 'maybeRenderLoadMoreTemplates_').resolves([]);
 
         const el1 = doc.createElement('div');
         el1.textContent = '1';
         const el2 = doc.createElement('a');
         el2.setAttribute('href', 'https://google.com/');
         el2.textContent = '2';
-        updateBindingsStub.onCall(0).returns(Promise.resolve([el1, el2]));
+        updateBindingsStub.onCall(0).resolves([el1, el2]);
         const focusSpy = env.sandbox.spy(el2, 'focus');
 
         await list.layoutCallback();
@@ -278,7 +274,7 @@ describes.realWin(
         el3.textContent = '3';
         const el4 = doc.createElement('div');
         el4.textContent = '4';
-        updateBindingsStub.onCall(1).returns(Promise.resolve([el3, el4]));
+        updateBindingsStub.onCall(1).resolves([el3, el4]);
 
         await list.loadMoreCallback_(
           /* opt_reload */ false,

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -168,7 +168,7 @@ describes.repeated(
           listMock
             .expects('fetch_')
             .withExactArgs(!!opts.refresh)
-            .returns(Promise.resolve(fetched))
+            .resolves(fetched)
             .atLeast(1);
 
           // If "reset-on-refresh" is set, show loading/placeholder before fetch.
@@ -190,7 +190,7 @@ describes.repeated(
           }
           ssrTemplateHelper.applySsrOrCsrTemplate
             .withArgs(element, itemsToRender)
-            .returns(Promise.resolve(rendered));
+            .resolves(rendered);
         }
 
         function expectRender() {
@@ -249,7 +249,7 @@ describes.repeated(
             listMock
               .expects('attemptChangeHeight')
               .withExactArgs(1337)
-              .returns(Promise.resolve());
+              .resolves();
 
             return list.layoutCallback();
           });
@@ -340,10 +340,8 @@ describes.repeated(
                   listMock
                     .expects('attemptChangeHeight')
                     .withExactArgs(1337)
-                    .returns(Promise.resolve());
-                  listMock
-                    .expects('maybeResizeListToFitItems_')
-                    .returns(Promise.resolve(true));
+                    .resolves();
+                  listMock.expects('maybeResizeListToFitItems_').resolves(true);
                   listMock.expects('unlockHeightInsideMutate_').once();
                   return list.layoutCallback();
                 });
@@ -359,7 +357,7 @@ describes.repeated(
                     .returns(Promise.reject(false));
                   listMock
                     .expects('maybeResizeListToFitItems_')
-                    .returns(Promise.resolve(false));
+                    .resolves(false);
                   listMock.expects('unlockHeightInsideMutate_').never();
                   return list.layoutCallback();
                 });
@@ -372,10 +370,8 @@ describes.repeated(
                   listMock
                     .expects('attemptChangeHeight')
                     .withExactArgs(1337)
-                    .returns(Promise.resolve());
-                  listMock
-                    .expects('maybeResizeListToFitItems_')
-                    .returns(Promise.resolve(null));
+                    .resolves();
+                  listMock.expects('maybeResizeListToFitItems_').resolves(null);
                   listMock.expects('unlockHeightInsideMutate_').never();
                   return list.layoutCallback();
                 });
@@ -392,7 +388,7 @@ describes.repeated(
             listMock
               .expects('attemptChangeHeight')
               .withExactArgs(1337)
-              .returns(Promise.resolve());
+              .resolves();
 
             return list.layoutCallback().then(() => {
               expect(list.container_.contains(itemElement)).to.be.true;
@@ -568,7 +564,7 @@ describes.repeated(
 
           it('should fail to load b/c data array is absent', () => {
             expectAsyncConsoleError(/Response must contain an array/, 1);
-            listMock.expects('fetch_').returns(Promise.resolve({})).once();
+            listMock.expects('fetch_').resolves({}).once();
             listMock.expects('toggleLoading').withExactArgs(false).once();
             return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
               /Response must contain an array/
@@ -581,7 +577,7 @@ describes.repeated(
               1
             );
             element.setAttribute('single-item', 'true');
-            listMock.expects('fetch_').returns(Promise.resolve()).once();
+            listMock.expects('fetch_').resolves().once();
             listMock.expects('toggleLoading').withExactArgs(false).once();
             return expect(list.layoutCallback()).to.eventually.be.rejectedWith(
               /Response must contain an array or object/
@@ -699,7 +695,7 @@ describes.repeated(
 
               ssrTemplateHelper.applySsrOrCsrTemplate
                 .withArgs(element, newData)
-                .returns(Promise.resolve([second]));
+                .resolves([second]);
               await list.mutatedAttributesCallback({src: newData});
             }
 
@@ -785,7 +781,7 @@ describes.repeated(
               listMock
                 .expects('attemptChangeHeight')
                 .withExactArgs(1337)
-                .returns(Promise.resolve())
+                .resolves()
                 .twice();
 
               const itemElement = doc.createElement('div');
@@ -845,9 +841,7 @@ describes.repeated(
 
             it('should error if proxied fetch returns invalid data', () => {
               expectAsyncConsoleError(/received no response/, 1);
-              env.sandbox
-                .stub(ssrTemplateHelper, 'ssr')
-                .returns(Promise.resolve(undefined));
+              env.sandbox.stub(ssrTemplateHelper, 'ssr').resolves(undefined);
               listMock.expects('toggleLoading').withExactArgs(false).once();
               return expect(
                 list.layoutCallback()
@@ -858,7 +852,7 @@ describes.repeated(
               expectAsyncConsoleError(/received no response/, 1);
               env.sandbox
                 .stub(ssrTemplateHelper, 'ssr')
-                .returns(Promise.resolve({init: {status: 400}}));
+                .resolves({init: {status: 400}});
               listMock.expects('toggleLoading').withExactArgs(false).once();
               return expect(
                 list.layoutCallback()
@@ -884,16 +878,12 @@ describes.repeated(
               listItem.setAttribute('role', 'item');
               listContainer.appendChild(listItem);
 
-              env.sandbox
-                .stub(ssrTemplateHelper, 'ssr')
-                .returns(Promise.resolve({html}));
-              ssrTemplateHelper.applySsrOrCsrTemplate.returns(
-                Promise.resolve(rendered)
-              );
+              env.sandbox.stub(ssrTemplateHelper, 'ssr').resolves({html});
+              ssrTemplateHelper.applySsrOrCsrTemplate.resolves(rendered);
 
               listMock
                 .expects('updateBindings_')
-                .returns(Promise.resolve(listContainer))
+                .resolves(listContainer)
                 .once();
               const renderSpy = env.sandbox.spy();
               listMock
@@ -988,8 +978,8 @@ describes.repeated(
 
             it('should hide fallback element on fetch success', () => {
               // Stub fetch and render to succeed.
-              listMock.expects('fetch_').returns(Promise.resolve([])).once();
-              templates.findAndRenderTemplate.returns(Promise.resolve([]));
+              listMock.expects('fetch_').resolves([]).once();
+              templates.findAndRenderTemplate.resolves([]);
               // Act as if a fallback is already displayed.
               env.sandbox.stub(list, 'fallbackDisplayed_').callsFake(true);
 
@@ -1081,7 +1071,7 @@ describes.repeated(
                   /*append*/ false,
                   callFunctionResult
                 )
-                .returns(Promise.resolve())
+                .resolves()
                 .once();
 
               await list.layoutCallback();
@@ -1101,7 +1091,7 @@ describes.repeated(
               listMock
                 .expects('scheduleRender_')
                 .withExactArgs([3, 2, 1], /*append*/ false, {items: [3, 2, 1]})
-                .returns(Promise.resolve())
+                .resolves()
                 .once();
 
               await list.layoutCallback();
@@ -1114,7 +1104,7 @@ describes.repeated(
 
           beforeEach(() => {
             bind = {
-              rescan: env.sandbox.stub().returns(Promise.resolve()),
+              rescan: env.sandbox.stub().resolves(),
               signals: () => {
                 return {get: (unusedName) => false};
               },
@@ -1171,7 +1161,7 @@ describes.repeated(
             listMock
               .expects('scheduleRender_')
               .withArgs([bar])
-              .returns(Promise.resolve())
+              .resolves()
               .once();
 
             element.setAttribute('src', 'https://foo.com/list.json');
@@ -1489,7 +1479,7 @@ describes.repeated(
             });
 
             it('should log an error if amp-bind was not included', async () => {
-              Services.bindForDocOrNull.returns(Promise.resolve(null));
+              Services.bindForDocOrNull.resolves(null);
 
               const ampStateEl = doc.createElement('amp-state');
               ampStateEl.setAttribute('id', 'okapis');
@@ -1516,7 +1506,7 @@ describes.repeated(
               listMock
                 .expects('scheduleRender_')
                 .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
-                .returns(Promise.resolve())
+                .resolves()
                 .once();
 
               await list.layoutCallback();
@@ -1536,7 +1526,7 @@ describes.repeated(
               listMock
                 .expects('scheduleRender_')
                 .withExactArgs([1, 2, 3], /*append*/ false, {items: [1, 2, 3]})
-                .returns(Promise.resolve())
+                .resolves()
                 .once();
 
               const layoutPromise = list.layoutCallback();

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -354,7 +354,7 @@ describes.repeated(
                   listMock
                     .expects('attemptChangeHeight')
                     .withExactArgs(1337)
-                    .rejects(false);
+                    .returns(Promise.reject(false));
                   listMock
                     .expects('maybeResizeListToFitItems_')
                     .resolves(false);
@@ -650,7 +650,7 @@ describes.repeated(
 
           it('should not show placeholder on fetch failure', function* () {
             // Stub fetch_() to fail.
-            listMock.expects('fetch_').rejects().once();
+            listMock.expects('fetch_').returns(Promise.reject()).once();
             listMock.expects('toggleLoading').withExactArgs(false).once();
             listMock.expects('togglePlaceholder').never();
 
@@ -662,7 +662,7 @@ describes.repeated(
             env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
             // Stub fetch_() to fail.
-            listMock.expects('fetch_').rejects().once();
+            listMock.expects('fetch_').returns(Promise.reject()).once();
             listMock.expects('toggleLoading').withExactArgs(false).once();
 
             yield list.layoutCallback();
@@ -828,7 +828,7 @@ describes.repeated(
             it('should error if proxied fetch fails', () => {
               env.sandbox
                 .stub(ssrTemplateHelper, 'ssr')
-                .rejects(new Error('error'));
+                .returns(Promise.reject(new Error('error')));
 
               listMock.expects('toggleLoading').withExactArgs(false).once();
 
@@ -990,7 +990,7 @@ describes.repeated(
 
             it('should hide placeholder and show fallback on fetch failure', () => {
               // Stub fetch_() to fail.
-              listMock.expects('fetch_').rejects().once();
+              listMock.expects('fetch_').returns(Promise.reject()).once();
 
               listMock.expects('togglePlaceholder').withExactArgs(false).once();
               listMock.expects('toggleFallback').withExactArgs(true).once();

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -354,7 +354,7 @@ describes.repeated(
                   listMock
                     .expects('attemptChangeHeight')
                     .withExactArgs(1337)
-                    .returns(Promise.reject(false));
+                    .rejects(false);
                   listMock
                     .expects('maybeResizeListToFitItems_')
                     .resolves(false);
@@ -650,7 +650,7 @@ describes.repeated(
 
           it('should not show placeholder on fetch failure', function* () {
             // Stub fetch_() to fail.
-            listMock.expects('fetch_').returns(Promise.reject()).once();
+            listMock.expects('fetch_').rejects().once();
             listMock.expects('toggleLoading').withExactArgs(false).once();
             listMock.expects('togglePlaceholder').never();
 
@@ -662,7 +662,7 @@ describes.repeated(
             env.sandbox.stub(Services, 'actionServiceForDoc').returns(actions);
 
             // Stub fetch_() to fail.
-            listMock.expects('fetch_').returns(Promise.reject()).once();
+            listMock.expects('fetch_').rejects().once();
             listMock.expects('toggleLoading').withExactArgs(false).once();
 
             yield list.layoutCallback();
@@ -828,7 +828,7 @@ describes.repeated(
             it('should error if proxied fetch fails', () => {
               env.sandbox
                 .stub(ssrTemplateHelper, 'ssr')
-                .returns(Promise.reject(new Error('error')));
+                .rejects(new Error('error'));
 
               listMock.expects('toggleLoading').withExactArgs(false).once();
 
@@ -990,7 +990,7 @@ describes.repeated(
 
             it('should hide placeholder and show fallback on fetch failure', () => {
               // Stub fetch_() to fail.
-              listMock.expects('fetch_').returns(Promise.reject()).once();
+              listMock.expects('fetch_').rejects().once();
 
               listMock.expects('togglePlaceholder').withExactArgs(false).once();
               listMock.expects('toggleFallback').withExactArgs(true).once();

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -44,9 +44,7 @@ describes.fakeWin('LiveListManager', {amp: true}, (env) => {
       ready = resolve;
     });
     env.sandbox.stub(manager, 'whenDocReady_').returns(docReadyPromise);
-    env.sandbox
-      .stub(LiveListManager, 'forDoc')
-      .returns(Promise.resolve(manager));
+    env.sandbox.stub(LiveListManager, 'forDoc').resolves(manager);
 
     liveList = getLiveList({'data-sort-time': '1111'});
     env.sandbox.stub(liveList, 'getInterval').callsFake(() => 5000);
@@ -813,9 +811,7 @@ describes.realWin(
       ampdoc = env.ampdoc;
       extensions = env.extensions;
       manager = new LiveListManager(ampdoc);
-      env.sandbox
-        .stub(LiveListManager, 'forDoc')
-        .returns(Promise.resolve(manager));
+      env.sandbox.stub(LiveListManager, 'forDoc').resolves(manager);
     });
 
     it('should install newly discovered script tags on xhr doc', () => {

--- a/extensions/amp-live-list/0.1/test/test-poller.js
+++ b/extensions/amp-live-list/0.1/test/test-poller.js
@@ -55,7 +55,7 @@ describe('Poller', () => {
   });
 
   it('should execute work', () => {
-    workStub.returns(Promise.resolve());
+    workStub.resolves();
     expect(workStub).to.have.not.been.called;
     poller.start();
     clock.tick(4000);
@@ -75,7 +75,7 @@ describe('Poller', () => {
   });
 
   it('should execute work w/o initial delay', () => {
-    workStub.returns(Promise.resolve());
+    workStub.resolves();
     expect(workStub).to.have.not.been.called;
     poller.start(true);
     expect(workStub).to.be.calledOnce;
@@ -98,7 +98,7 @@ describe('Poller', () => {
   });
 
   it('should not double any work if already started', () => {
-    workStub.returns(Promise.resolve());
+    workStub.resolves();
     expect(workStub).to.have.not.been.called;
     poller.start();
     clock.tick(4000);
@@ -120,12 +120,12 @@ describe('Poller', () => {
   it('should run backoff and recover on retriable error', () => {
     const retriableErr = new Error('HTTP Error');
     retriableErr.retriable = true;
-    workStub.onCall(0).returns(Promise.resolve());
-    workStub.onCall(1).returns(Promise.resolve());
+    workStub.onCall(0).resolves();
+    workStub.onCall(1).resolves();
     workStub.onCall(2).returns(Promise.reject(retriableErr));
     workStub.onCall(3).returns(Promise.reject(retriableErr));
     workStub.onCall(4).returns(Promise.reject(retriableErr));
-    workStub.returns(Promise.resolve());
+    workStub.resolves();
     expect(workStub).to.have.not.been.called;
 
     poller.start();
@@ -179,7 +179,7 @@ describe('Poller', () => {
   });
 
   it('should stop work if stopped', () => {
-    workStub.returns(Promise.resolve());
+    workStub.resolves();
     expect(workStub).to.have.not.been.called;
     poller.start();
     clock.tick(4000);
@@ -248,7 +248,7 @@ describe('Poller', () => {
     retriableErr.retriable = true;
     workStub.onCall(0).returns(Promise.reject(retriableErr));
     workStub.onCall(1).returns(Promise.reject(retriableErr));
-    workStub.returns(Promise.resolve());
+    workStub.resolves();
     const clearSpy = window.sandbox.spy(timer, 'cancel');
 
     expect(poller.lastTimeoutId_).to.be.null;

--- a/extensions/amp-live-list/0.1/test/test-poller.js
+++ b/extensions/amp-live-list/0.1/test/test-poller.js
@@ -122,9 +122,9 @@ describe('Poller', () => {
     retriableErr.retriable = true;
     workStub.onCall(0).resolves();
     workStub.onCall(1).resolves();
-    workStub.onCall(2).returns(Promise.reject(retriableErr));
-    workStub.onCall(3).returns(Promise.reject(retriableErr));
-    workStub.onCall(4).returns(Promise.reject(retriableErr));
+    workStub.onCall(2).rejects(retriableErr);
+    workStub.onCall(3).rejects(retriableErr);
+    workStub.onCall(4).rejects(retriableErr);
     workStub.resolves();
     expect(workStub).to.have.not.been.called;
 
@@ -206,7 +206,7 @@ describe('Poller', () => {
   it('should shutoff backoff if stopped', () => {
     const retriableErr = new Error('HTTP Error');
     retriableErr.retriable = true;
-    workStub.returns(Promise.reject(retriableErr));
+    workStub.rejects(retriableErr);
     expect(workStub).to.have.not.been.called;
     poller.start();
     clock.tick(4000);
@@ -246,8 +246,8 @@ describe('Poller', () => {
     const delaySpy = window.sandbox.spy(timer, 'delay');
     const retriableErr = new Error('HTTP Error');
     retriableErr.retriable = true;
-    workStub.onCall(0).returns(Promise.reject(retriableErr));
-    workStub.onCall(1).returns(Promise.reject(retriableErr));
+    workStub.onCall(0).rejects(retriableErr);
+    workStub.onCall(1).rejects(retriableErr);
     workStub.resolves();
     const clearSpy = window.sandbox.spy(timer, 'cancel');
 

--- a/extensions/amp-live-list/0.1/test/test-poller.js
+++ b/extensions/amp-live-list/0.1/test/test-poller.js
@@ -122,9 +122,9 @@ describe('Poller', () => {
     retriableErr.retriable = true;
     workStub.onCall(0).resolves();
     workStub.onCall(1).resolves();
-    workStub.onCall(2).rejects(retriableErr);
-    workStub.onCall(3).rejects(retriableErr);
-    workStub.onCall(4).rejects(retriableErr);
+    workStub.onCall(2).returns(Promise.reject(retriableErr));
+    workStub.onCall(3).returns(Promise.reject(retriableErr));
+    workStub.onCall(4).returns(Promise.reject(retriableErr));
     workStub.resolves();
     expect(workStub).to.have.not.been.called;
 
@@ -206,7 +206,7 @@ describe('Poller', () => {
   it('should shutoff backoff if stopped', () => {
     const retriableErr = new Error('HTTP Error');
     retriableErr.retriable = true;
-    workStub.rejects(retriableErr);
+    workStub.returns(Promise.reject(retriableErr));
     expect(workStub).to.have.not.been.called;
     poller.start();
     clock.tick(4000);
@@ -246,8 +246,8 @@ describe('Poller', () => {
     const delaySpy = window.sandbox.spy(timer, 'delay');
     const retriableErr = new Error('HTTP Error');
     retriableErr.retriable = true;
-    workStub.onCall(0).rejects(retriableErr);
-    workStub.onCall(1).rejects(retriableErr);
+    workStub.onCall(0).returns(Promise.reject(retriableErr));
+    workStub.onCall(1).returns(Promise.reject(retriableErr));
     workStub.resolves();
     const clearSpy = window.sandbox.spy(timer, 'cancel');
 

--- a/extensions/amp-next-page/0.1/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/0.1/test/test-amp-next-page.js
@@ -352,27 +352,25 @@ describes.realWin(
         fetchDocumentMock
           .expects('fetchDocument')
           .withExactArgs(win, url, {credentials: 'include'})
-          .returns(
-            Promise.resolve(
-              createXmlDoc(`
+          .resolves(
+            createXmlDoc(`
 <GSP VER="3.2">
-  <ADS>
-    <AD n="1" type="text/narrow"
-        url="https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article"
-        visible_url="https://example.com/article">
-    <LINE1>
-      Page title
-    </LINE1>
-    <LINE2/>
-    <LINE3/>
-    <BIDTYPE>CPM</BIDTYPE>
-    <MEDIA_TEMPLATE_DATA>
-    [ { "core_image_url" : "https://example.com/image.png" } ];
-    </MEDIA_TEMPLATE_DATA>
-    </AD>
-  </ADS>
+<ADS>
+  <AD n="1" type="text/narrow"
+      url="https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article"
+      visible_url="https://example.com/article">
+  <LINE1>
+    Page title
+  </LINE1>
+  <LINE2/>
+  <LINE3/>
+  <BIDTYPE>CPM</BIDTYPE>
+  <MEDIA_TEMPLATE_DATA>
+  [ { "core_image_url" : "https://example.com/image.png" } ];
+  </MEDIA_TEMPLATE_DATA>
+  </AD>
+</ADS>
 </GSP>`)
-            )
           );
 
         const config = {
@@ -402,7 +400,7 @@ describes.realWin(
         fetchDocumentMock
           .expects('fetchDocument')
           .withExactArgs(win, url, {credentials: 'omit'})
-          .returns(Promise.resolve());
+          .resolves();
         element.setAttribute('data-block-on-consent', true);
         yield nextPage.buildCallback();
       });
@@ -411,53 +409,51 @@ describes.realWin(
         fetchDocumentMock
           .expects('fetchDocument')
           .withExactArgs(win, url, {credentials: 'include'})
-          .returns(
-            Promise.resolve(
-              createXmlDoc(`
+          .resolves(
+            createXmlDoc(`
 <GSP VER="3.2">
-  <ADS>
-    <AD n="1" type="text/narrow"
-        url="https://googleads.g.doubleclick.net/aclk?adurl=https://other.com/article"
-        visible_url="https://other.com/article">
-    <LINE1>
-      Other 1
-    </LINE1>
-    <LINE2/>
-    <LINE3/>
-    <BIDTYPE>CPM</BIDTYPE>
-    <MEDIA_TEMPLATE_DATA>
-    [ { "core_image_url" : "https://other.com/image1.png" } ];
-    </MEDIA_TEMPLATE_DATA>
-    </AD>
-    <AD n="2" type="text/narrow"
-        url="https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article"
-        visible_url="https://example.com/article">
-    <LINE1>
-      Example 1
-    </LINE1>
-    <LINE2/>
-    <LINE3/>
-    <BIDTYPE>CPM</BIDTYPE>
-    <MEDIA_TEMPLATE_DATA>
-    [ { "core_image_url" : "https://example.com/image2.png" } ];
-    </MEDIA_TEMPLATE_DATA>
-    </AD>
-    <AD n="3" type="text/narrow"
-        url="https://googleads.g.doubleclick.net/aclk?adurl=https://other2.com/article"
-        visible_url="https://other2.com/article">
-    <LINE1>
-      Other 2
-    </LINE1>
-    <LINE2/>
-    <LINE3/>
-    <BIDTYPE>CPM</BIDTYPE>
-    <MEDIA_TEMPLATE_DATA>
-    [ { "core_image_url" : "https://other2.com/image3.png" } ];
-    </MEDIA_TEMPLATE_DATA>
-    </AD>
-  </ADS>
+<ADS>
+  <AD n="1" type="text/narrow"
+      url="https://googleads.g.doubleclick.net/aclk?adurl=https://other.com/article"
+      visible_url="https://other.com/article">
+  <LINE1>
+    Other 1
+  </LINE1>
+  <LINE2/>
+  <LINE3/>
+  <BIDTYPE>CPM</BIDTYPE>
+  <MEDIA_TEMPLATE_DATA>
+  [ { "core_image_url" : "https://other.com/image1.png" } ];
+  </MEDIA_TEMPLATE_DATA>
+  </AD>
+  <AD n="2" type="text/narrow"
+      url="https://googleads.g.doubleclick.net/aclk?adurl=https://example.com/article"
+      visible_url="https://example.com/article">
+  <LINE1>
+    Example 1
+  </LINE1>
+  <LINE2/>
+  <LINE3/>
+  <BIDTYPE>CPM</BIDTYPE>
+  <MEDIA_TEMPLATE_DATA>
+  [ { "core_image_url" : "https://example.com/image2.png" } ];
+  </MEDIA_TEMPLATE_DATA>
+  </AD>
+  <AD n="3" type="text/narrow"
+      url="https://googleads.g.doubleclick.net/aclk?adurl=https://other2.com/article"
+      visible_url="https://other2.com/article">
+  <LINE1>
+    Other 2
+  </LINE1>
+  <LINE2/>
+  <LINE3/>
+  <BIDTYPE>CPM</BIDTYPE>
+  <MEDIA_TEMPLATE_DATA>
+  [ { "core_image_url" : "https://other2.com/image3.png" } ];
+  </MEDIA_TEMPLATE_DATA>
+  </AD>
+</ADS>
 </GSP>`)
-            )
           );
 
         const config = {

--- a/extensions/amp-onetap-google/0.1/test/test-amp-onetap-google.js
+++ b/extensions/amp-onetap-google/0.1/test/test-amp-onetap-google.js
@@ -77,9 +77,7 @@ describes.realWin(
       };
 
       // build waits for visibility, force it.
-      env.sandbox
-        .stub(AmpDoc.prototype, 'whenFirstVisible')
-        .returns(Promise.resolve());
+      env.sandbox.stub(AmpDoc.prototype, 'whenFirstVisible').resolves();
 
       // make sync
       env.sandbox

--- a/extensions/amp-skimlinks/0.1/test/helpers.js
+++ b/extensions/amp-skimlinks/0.1/test/helpers.js
@@ -39,7 +39,7 @@ const helpersFactory = (env) => {
       };
 
       return {
-        fetchJson: env.sandbox.stub().returns(Promise.resolve(response)),
+        fetchJson: env.sandbox.stub().resolves(response),
       };
     },
 

--- a/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
@@ -103,7 +103,7 @@ describes.fakeWin(
             .expects('fetchDomainResolverApi')
             .once()
             .withArgs(['merchant1.com', 'non-merchant.com', 'merchant2.com'])
-            .returns(Promise.resolve({}));
+            .resolves({});
 
           resolver.resolveUnknownAnchors(anchorList);
         });
@@ -116,7 +116,7 @@ describes.fakeWin(
             .expects('fetchDomainResolverApi')
             .once()
             .withArgs(['merchant1.com', 'non-merchant.com', 'merchant2.com'])
-            .returns(Promise.resolve({}));
+            .resolves({});
 
           resolver.resolveUnknownAnchors(anchorList);
         });
@@ -129,7 +129,7 @@ describes.fakeWin(
             .expects('fetchDomainResolverApi')
             .once()
             .withArgs(['non-merchant-new.com', 'merchant-new'])
-            .returns(Promise.resolve({}));
+            .resolves({});
 
           resolver.resolveUnknownAnchors(
             [
@@ -159,7 +159,7 @@ describes.fakeWin(
             .expects('fetchDomainResolverApi')
             .once()
             .withArgs(['merchant1.com', 'non-merchant.com', 'merchant2.com'])
-            .returns(Promise.resolve({}));
+            .resolves({});
 
           resolver.resolveUnknownAnchors(
             [helpers.createAnchor('https://www.excluded-merchant.com')].concat(
@@ -225,11 +225,7 @@ describes.fakeWin(
             json: () => Promise.resolve({}),
           };
 
-          mock
-            .expects('fetchJson')
-            .once()
-            .withArgs(url)
-            .returns(Promise.resolve(response));
+          mock.expects('fetchJson').once().withArgs(url).resolves(response);
 
           resolver.fetchDomainResolverApi(domains);
         });
@@ -262,7 +258,7 @@ describes.fakeWin(
             // Ideally only focused on fetchOptions but using sinon.match.any
             // as the first arg makes the test fail for some reasons.
             .withArgs(url, fetchOptions)
-            .returns(Promise.resolve(response));
+            .resolves(response);
 
           resolver.fetchDomainResolverApi(domains);
         });

--- a/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
+++ b/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
@@ -65,7 +65,9 @@ describes.fakeWin(
         ampSkimlinks = helpers.createAmpSkimlinks({
           'publisher-code': 'pubIdXdomainId',
         });
-        env.sandbox.stub(DocumentReady, 'whenDocumentReady').rejects();
+        env.sandbox
+          .stub(DocumentReady, 'whenDocumentReady')
+          .returns(Promise.reject());
         expect(() => {
           ampSkimlinks.buildCallback();
         }).to.not.throw();

--- a/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
+++ b/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
@@ -65,9 +65,7 @@ describes.fakeWin(
         ampSkimlinks = helpers.createAmpSkimlinks({
           'publisher-code': 'pubIdXdomainId',
         });
-        env.sandbox
-          .stub(DocumentReady, 'whenDocumentReady')
-          .rejects();
+        env.sandbox.stub(DocumentReady, 'whenDocumentReady').rejects();
         expect(() => {
           ampSkimlinks.buildCallback();
         }).to.not.throw();

--- a/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
+++ b/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
@@ -67,7 +67,7 @@ describes.fakeWin(
         });
         env.sandbox
           .stub(DocumentReady, 'whenDocumentReady')
-          .returns(Promise.reject());
+          .rejects();
         expect(() => {
           ampSkimlinks.buildCallback();
         }).to.not.throw();

--- a/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
+++ b/extensions/amp-skimlinks/0.1/test/test-amp-skimlinks.js
@@ -76,9 +76,7 @@ describes.fakeWin(
 
     describe('When loading the amp-skimlinks extension', () => {
       it('Should start skimcore on buildCallback', () => {
-        env.sandbox
-          .stub(DocumentReady, 'whenDocumentReady')
-          .returns(Promise.resolve());
+        env.sandbox.stub(DocumentReady, 'whenDocumentReady').resolves();
         env.sandbox.stub(ampSkimlinks, 'startSkimcore_');
         return ampSkimlinks.buildCallback().then(() => {
           expect(ampSkimlinks.startSkimcore_.calledOnce).to.be.true;
@@ -86,9 +84,7 @@ describes.fakeWin(
       });
 
       it('Should parse options', () => {
-        env.sandbox
-          .stub(DocumentReady, 'whenDocumentReady')
-          .returns(Promise.resolve());
+        env.sandbox.stub(DocumentReady, 'whenDocumentReady').resolves();
         env.sandbox.spy(SkimOptionsModule, 'getAmpSkimlinksOptions');
         const options = {
           'publisher-code': '666X666',
@@ -286,9 +282,7 @@ describes.fakeWin(
         });
 
         it('Should make the fallback call', () => {
-          ampSkimlinks.sendImpressionTracking_ = env.sandbox
-            .stub()
-            .returns(Promise.resolve());
+          ampSkimlinks.sendImpressionTracking_ = env.sandbox.stub().resolves();
 
           return ampSkimlinks.onPageScanned_().then(() => {
             const stub =
@@ -347,9 +341,7 @@ describes.fakeWin(
         });
 
         it('Should not make the fallback call', () => {
-          ampSkimlinks.sendImpressionTracking_ = env.sandbox
-            .stub()
-            .returns(Promise.resolve());
+          ampSkimlinks.sendImpressionTracking_ = env.sandbox.stub().resolves();
           return ampSkimlinks.onPageScanned_().then(() => {
             const stub =
               ampSkimlinks.affiliateLinkResolver_.fetchDomainResolverApi;

--- a/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
+++ b/extensions/amp-skimlinks/0.1/test/test-link-rewriter.js
@@ -185,9 +185,7 @@ describes.fakeWin('LinkRewriterManager', {amp: true}, (env) => {
     });
 
     it('Should call .onDomUpdate() after registering linkRewriter', () => {
-      env.sandbox
-        .stub(LinkRewriter.prototype, 'onDomUpdated')
-        .returns(Promise.resolve());
+      env.sandbox.stub(LinkRewriter.prototype, 'onDomUpdated').resolves();
       const linkRewriter = linkRewriterManager.registerLinkRewriter(
         'vendor',
         env.sandbox.stub(),
@@ -454,9 +452,7 @@ describes.fakeWin('Link Rewriter', {amp: true}, (env) => {
       resolveFunction = resolveFunction || createResolveResponseHelper();
       options = options || {};
       // Prevent scanning the page in the constructor
-      env.sandbox
-        .stub(LinkRewriter.prototype, 'scanLinksOnPage_')
-        .returns(Promise.resolve());
+      env.sandbox.stub(LinkRewriter.prototype, 'scanLinksOnPage_').resolves();
       const linkRewriter = new LinkRewriter(
         rootDocument,
         'test',
@@ -595,9 +591,7 @@ describes.fakeWin('Link Rewriter', {amp: true}, (env) => {
     describe('In dynamic page', () => {
       it('Should scan the when onDomUpdated() is called', () => {
         const linkRewriter = createLinkRewriterHelper();
-        env.sandbox
-          .stub(linkRewriter, 'scanLinksOnPage_')
-          .returns(Promise.resolve());
+        env.sandbox.stub(linkRewriter, 'scanLinksOnPage_').resolves();
         linkRewriter.onDomUpdated();
         expect(linkRewriter.scanLinksOnPage_.calledOnce).to.be.true;
       });

--- a/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
@@ -141,7 +141,7 @@ describes.fakeWin(
       it('should not call downstream methods with invalid configuration', () => {
         env.sandbox
           .stub(ampSmartlinks, 'getLinkmateOptions_')
-          .returns(Promise.resolve(undefined));
+          .resolves(undefined);
         env.sandbox.spy(ampSmartlinks, 'postPageImpression_');
         env.sandbox.spy(ampSmartlinks, 'initLinkRewriter_');
 
@@ -156,7 +156,7 @@ describes.fakeWin(
       it('Should call postPageImpression_', () => {
         env.sandbox
           .stub(ampSmartlinks, 'getLinkmateOptions_')
-          .returns(Promise.resolve({'publisher_id': 999}));
+          .resolves({'publisher_id': 999});
         env.sandbox.spy(ampSmartlinks, 'postPageImpression_');
 
         return ampSmartlinks.buildCallback().then(() => {
@@ -169,7 +169,7 @@ describes.fakeWin(
       it('Should call initLinkRewriter_', () => {
         env.sandbox
           .stub(ampSmartlinks, 'getLinkmateOptions_')
-          .returns(Promise.resolve({'publisher_id': 999}));
+          .resolves({'publisher_id': 999});
         env.sandbox.spy(ampSmartlinks, 'initLinkRewriter_');
 
         return ampSmartlinks.buildCallback().then(() => {
@@ -235,7 +235,7 @@ describes.fakeWin(
         ampSmartlinks = helpers.createAmpSmartlinks(options);
         env.sandbox
           .stub(ampSmartlinks, 'getLinkmateOptions_')
-          .returns(Promise.resolve({'publisher_id': 999}));
+          .resolves({'publisher_id': 999});
       });
 
       it('Should register link rewriter', () => {

--- a/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
@@ -45,7 +45,7 @@ describes.fakeWin(
       helpers = helpersFactory(env);
       env.sandbox
         .stub(DocumentReady, 'whenDocumentReady')
-        .returns(Promise.reject());
+        .rejects();
     });
 
     afterEach(() => {

--- a/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
@@ -43,7 +43,9 @@ describes.fakeWin(
     beforeEach(() => {
       xhr = Services.xhrFor(env.win);
       helpers = helpersFactory(env);
-      env.sandbox.stub(DocumentReady, 'whenDocumentReady').rejects();
+      env.sandbox
+        .stub(DocumentReady, 'whenDocumentReady')
+        .returns(Promise.reject());
     });
 
     afterEach(() => {

--- a/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
+++ b/extensions/amp-smartlinks/0.1/test/test-amp-smartlinks.js
@@ -43,9 +43,7 @@ describes.fakeWin(
     beforeEach(() => {
       xhr = Services.xhrFor(env.win);
       helpers = helpersFactory(env);
-      env.sandbox
-        .stub(DocumentReady, 'whenDocumentReady')
-        .rejects();
+      env.sandbox.stub(DocumentReady, 'whenDocumentReady').rejects();
     });
 
     afterEach(() => {

--- a/extensions/amp-smartlinks/0.1/test/test-linkmate.js
+++ b/extensions/amp-smartlinks/0.1/test/test-linkmate.js
@@ -57,7 +57,7 @@ describes.fakeWin(
     beforeEach(() => {
       env.sandbox
         .stub(DocumentReady, 'whenDocumentReady')
-        .returns(Promise.reject());
+        .rejects();
     });
 
     afterEach(() => {

--- a/extensions/amp-smartlinks/0.1/test/test-linkmate.js
+++ b/extensions/amp-smartlinks/0.1/test/test-linkmate.js
@@ -55,7 +55,9 @@ describes.fakeWin(
     });
 
     beforeEach(() => {
-      env.sandbox.stub(DocumentReady, 'whenDocumentReady').rejects();
+      env.sandbox
+        .stub(DocumentReady, 'whenDocumentReady')
+        .returns(Promise.reject());
     });
 
     afterEach(() => {

--- a/extensions/amp-smartlinks/0.1/test/test-linkmate.js
+++ b/extensions/amp-smartlinks/0.1/test/test-linkmate.js
@@ -55,9 +55,7 @@ describes.fakeWin(
     });
 
     beforeEach(() => {
-      env.sandbox
-        .stub(DocumentReady, 'whenDocumentReady')
-        .rejects();
+      env.sandbox.stub(DocumentReady, 'whenDocumentReady').rejects();
     });
 
     afterEach(() => {

--- a/extensions/amp-smartlinks/0.1/test/test-linkmate.js
+++ b/extensions/amp-smartlinks/0.1/test/test-linkmate.js
@@ -100,10 +100,7 @@ describes.fakeWin(
         env.sandbox.spy(linkmate, 'postToLinkmate_');
         env.sandbox.stub(linkmate, 'mapLinks_');
 
-        mockFetch
-          .expects('fetchJson')
-          .once()
-          .returns(Promise.resolve(response));
+        mockFetch.expects('fetchJson').once().resolves(response);
 
         const linkmateResponse = linkmate.runLinkmate(anchorList);
 
@@ -115,10 +112,7 @@ describes.fakeWin(
         env.sandbox.spy(linkmate, 'postToLinkmate_');
         env.sandbox.stub(linkmate, 'mapLinks_');
 
-        mockFetch
-          .expects('fetchJson')
-          .once()
-          .returns(Promise.resolve(response));
+        mockFetch.expects('fetchJson').once().resolves(response);
         const linkmateResponse = linkmate.runLinkmate(anchorList);
 
         linkmate.anchorList_ = anchorList;
@@ -131,10 +125,7 @@ describes.fakeWin(
           },
         ].map(helpers.createAnchor);
 
-        mockFetch
-          .expects('fetchJson')
-          .once()
-          .returns(Promise.resolve(response));
+        mockFetch.expects('fetchJson').once().resolves(response);
         const linkmateResponse2 = linkmate.runLinkmate(newAnchorList);
 
         expect(linkmate.postToLinkmate_.calledTwice).to.be.true;
@@ -146,10 +137,7 @@ describes.fakeWin(
         env.sandbox.spy(linkmate, 'postToLinkmate_');
         env.sandbox.spy(linkmate, 'mapLinks_');
 
-        mockFetch
-          .expects('fetchJson')
-          .once()
-          .returns(Promise.resolve(response));
+        mockFetch.expects('fetchJson').once().resolves(response);
         const linkmateResponse = linkmate.runLinkmate(anchorList);
 
         linkmate.anchorList_ = anchorList;
@@ -163,10 +151,7 @@ describes.fakeWin(
           },
         ].map(helpers.createAnchor);
 
-        mockFetch
-          .expects('fetchJson')
-          .once()
-          .returns(Promise.resolve(response));
+        mockFetch.expects('fetchJson').once().resolves(response);
         const linkmateResponse2 = linkmate.runLinkmate(newAnchorList);
 
         expect(linkmate.postToLinkmate_.calledTwice).to.be.true;
@@ -179,10 +164,7 @@ describes.fakeWin(
         env.sandbox.spy(linkmate, 'postToLinkmate_');
         env.sandbox.stub(linkmate, 'mapLinks_');
 
-        mockFetch
-          .expects('fetchJson')
-          .once()
-          .returns(Promise.resolve(response));
+        mockFetch.expects('fetchJson').once().resolves(response);
         const linkmateResponse = linkmate.runLinkmate(anchorList);
 
         linkmate.anchorList_ = anchorList;
@@ -221,10 +203,7 @@ describes.fakeWin(
         env.sandbox.spy(linkmate, 'postToLinkmate_');
         env.sandbox.stub(linkmate, 'buildLinksPayload_').returns({});
         env.sandbox.stub(linkmate, 'getEditInfo_').returns({});
-        mockFetch
-          .expects('fetchJson')
-          .once()
-          .returns(Promise.resolve(response));
+        mockFetch.expects('fetchJson').once().resolves(response);
         linkmate.postToLinkmate_();
 
         expect(linkmate.buildLinksPayload_.calledOnce).to.be.true;

--- a/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-binary-poll.js
+++ b/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-binary-poll.js
@@ -61,7 +61,7 @@ describes.realWin(
       const localizationService = new LocalizationService(win.document.body);
       env.sandbox
         .stub(Services, 'localizationServiceForOrNull')
-        .returns(Promise.resolve(localizationService));
+        .resolves(localizationService);
 
       storyEl = win.document.createElement('amp-story');
       const storyPage = win.document.createElement('amp-story-page');

--- a/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-poll.js
+++ b/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-poll.js
@@ -61,7 +61,7 @@ describes.realWin(
       const localizationService = new LocalizationService(win.document.body);
       env.sandbox
         .stub(Services, 'localizationServiceForOrNull')
-        .returns(Promise.resolve(localizationService));
+        .resolves(localizationService);
 
       storyEl = win.document.createElement('amp-story');
       const storyPage = win.document.createElement('amp-story-page');

--- a/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-quiz.js
+++ b/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-quiz.js
@@ -82,7 +82,7 @@ describes.realWin(
       const localizationService = new LocalizationService(win.document.body);
       env.sandbox
         .stub(Services, 'localizationServiceForOrNull')
-        .returns(Promise.resolve(localizationService));
+        .resolves(localizationService);
 
       storyEl = win.document.createElement('amp-story');
       const storyPage = win.document.createElement('amp-story-page');

--- a/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-results.js
+++ b/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive-results.js
@@ -69,7 +69,7 @@ describes.realWin(
       const localizationService = new LocalizationService(win.document.body);
       env.sandbox
         .stub(Services, 'localizationServiceForOrNull')
-        .returns(Promise.resolve(localizationService));
+        .resolves(localizationService);
 
       storyEl = win.document.createElement('amp-story');
       const storyPage = win.document.createElement('amp-story-page');

--- a/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive.js
+++ b/extensions/amp-story-interactive/0.1/test/test-amp-story-interactive.js
@@ -177,7 +177,7 @@ describes.realWin(
       const localizationService = new LocalizationService(win.document.body);
       env.sandbox
         .stub(Services, 'localizationServiceForOrNull')
-        .returns(Promise.resolve(localizationService));
+        .resolves(localizationService);
 
       storyEl = win.document.createElement('amp-story');
       const storyPage = win.document.createElement('amp-story-page');

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -179,7 +179,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
   });
 
   it('should perform media operations when state becomes active', (done) => {
-    env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
+    env.sandbox.stub(page, 'loadPromise').resolves();
 
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp3');
@@ -198,7 +198,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
         mediaPoolMock
           .expects('preload')
           .withExactArgs(videoEl)
-          .returns(Promise.resolve())
+          .resolves()
           .once();
 
         mediaPoolMock.expects('play').withExactArgs(videoEl).once();
@@ -216,7 +216,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
   });
 
   it('should unmute audio when state becomes active', (done) => {
-    env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
+    env.sandbox.stub(page, 'loadPromise').resolves();
 
     storeService.dispatch(Action.TOGGLE_MUTED, false);
 
@@ -251,7 +251,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
       url: 'https://amp.dev',
       html: '<video src="https://example.com/video.mp3"></video>',
     });
-    env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
+    env.sandbox.stub(page, 'loadPromise').resolves();
 
     fiePromise.then((fie) => {
       const fieDoc = fie.win.document;
@@ -270,7 +270,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
           mediaPoolMock
             .expects('preload')
             .withExactArgs(videoEl)
-            .returns(Promise.resolve())
+            .resolves()
             .once();
 
           mediaPoolMock.expects('play').withExactArgs(videoEl).once();
@@ -590,10 +590,8 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
   });
 
   it('play message should have role="button" to prevent story page navigation', async () => {
-    env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
-    env.sandbox
-      .stub(VideoUtils, 'isAutoplaySupported')
-      .returns(Promise.resolve(false));
+    env.sandbox.stub(page, 'loadPromise').resolves();
+    env.sandbox.stub(VideoUtils, 'isAutoplaySupported').resolves(false);
     const videoEl = win.document.createElement('video');
     videoEl.setAttribute('src', 'https://example.com/video.mp4');
     gridLayerEl.appendChild(videoEl);

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -599,7 +599,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     page.buildCallback();
     const mediaPool = await page.mediaPoolPromise_;
     const mediaPoolPlay = env.sandbox.stub(mediaPool, 'play');
-    mediaPoolPlay.returns(Promise.reject());
+    mediaPoolPlay.rejects();
 
     page.layoutCallback();
 

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -599,7 +599,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     page.buildCallback();
     const mediaPool = await page.mediaPoolPromise_;
     const mediaPoolPlay = env.sandbox.stub(mediaPool, 'play');
-    mediaPoolPlay.rejects();
+    mediaPoolPlay.returns(Promise.reject());
 
     page.layoutCallback();
 

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -439,7 +439,7 @@ describes.realWin('amp-story animations', {}, (env) => {
       env.sandbox.stub(Services, 'vsyncFor').returns({});
       env.sandbox
         .stub(Services, 'webAnimationServiceFor')
-        .returns(Promise.resolve(webAnimationService));
+        .resolves(webAnimationService);
 
       runner = {
         applyFirstFrame: env.sandbox.spy(() => Promise.resolve()),

--- a/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test/test-amp-subscriptions-google.js
@@ -676,7 +676,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, (env) => {
     serviceAdapterMock
       .expects('delegateActionToLocal')
       .withExactArgs(Action.LOGIN, null)
-      .returns(Promise.resolve(false))
+      .resolves(false)
       .once();
     callback(callbacks.loginRequest)({linkRequested: false});
     expect(methods.linkAccount).to.not.be.called;
@@ -687,7 +687,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, (env) => {
     serviceAdapterMock
       .expects('delegateActionToLocal')
       .withExactArgs(Action.LOGIN, null)
-      .returns(Promise.resolve(false))
+      .resolves(false)
       .once();
     callback(callbacks.loginRequest)({linkRequested: true});
     expect(methods.linkAccount).to.not.be.called;
@@ -816,7 +816,7 @@ describes.realWin('amp-subscriptions-google', {amp: true}, (env) => {
     serviceAdapterMock
       .expects('delegateActionToLocal')
       .withExactArgs(Action.SUBSCRIBE, null)
-      .returns(Promise.resolve(false))
+      .resolves(false)
       .once();
     callback(callbacks.subscribeRequest)();
   });

--- a/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-amp-subscriptions.js
@@ -889,7 +889,7 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
     it('should fetch entitlements on paid pages', async () => {
       const getEntitlementsStub = env.sandbox
         .stub(subscriptionService, 'getEntitlements_')
-        .returns(Promise.resolve(new Entitlement.empty('local')));
+        .resolves(new Entitlement.empty('local'));
       await subscriptionService.initialize_();
 
       await subscriptionService.fetchEntitlements_(platform);
@@ -1079,10 +1079,10 @@ describes.fakeWin('AmpSubscriptions', {amp: true}, (env) => {
       subscriptionService.platformStore_ = new PlatformStore(products);
       const getGrantStatusStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantStatus')
-        .returns(Promise.resolve());
+        .resolves();
       const getGrantEntitlementStub = env.sandbox
         .stub(subscriptionService.platformStore_, 'getGrantEntitlement')
-        .returns(Promise.resolve());
+        .resolves();
       const selectAndActivateStub = env.sandbox.stub(
         subscriptionService,
         'selectAndActivatePlatform_'

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscription-rendering.js
@@ -196,7 +196,7 @@ describes.realWin('local-subscriptions-rendering', {amp: true}, (env) => {
       templatesMock
         .expects('renderTemplate')
         .withExactArgs(dialog2, data)
-        .returns(Promise.resolve(rendered))
+        .resolves(rendered)
         .once();
       let content;
       dialogMock

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions-iframe-platform.js
@@ -202,12 +202,10 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, (env) => {
       builderMock
         .expects('collectUrlVars')
         .withExactArgs('VAR1&VAR2', false)
-        .returns(
-          Promise.resolve({
-            'VAR1': 'A',
-            'VAR2': 'B',
-          })
-        )
+        .resolves({
+          'VAR1': 'A',
+          'VAR2': 'B',
+        })
         .once();
       const expectedConfigWithVars = {...expectedConfig};
       expectedConfigWithVars.config.iframeVars = {VAR1: 'A', VAR2: 'B'};
@@ -219,7 +217,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, (env) => {
       );
       const sendStub = env.sandbox
         .stub(localSubscriptionPlatform.messenger_, 'sendCommandRsvp')
-        .returns(Promise.resolve({}));
+        .resolves({});
       const promise = localSubscriptionPlatform.connect();
       localSubscriptionPlatform.handleCommand_('connect');
 
@@ -253,7 +251,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, (env) => {
         messengerMock
           .expects('sendCommandRsvp')
           .withExactArgs('start', expectedConfig)
-          .returns(Promise.resolve())
+          .resolves()
           .once();
         localSubscriptionPlatform.connect();
         localSubscriptionPlatform.handleCommand_('connect');
@@ -263,12 +261,10 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, (env) => {
         messengerMock
           .expects('sendCommandRsvp')
           .withExactArgs('authorize', {})
-          .returns(
-            Promise.resolve({
-              granted: true,
-              grantReason: 'SUBSCRIBER',
-            })
-          )
+          .resolves({
+            granted: true,
+            grantReason: 'SUBSCRIBER',
+          })
           .once();
 
         const result = await localSubscriptionPlatform.getEntitlements();
@@ -284,7 +280,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, (env) => {
         messengerMock
           .expects('sendCommandRsvp')
           .withExactArgs('start', expectedConfig)
-          .returns(Promise.resolve())
+          .resolves()
           .once();
         localSubscriptionPlatform.connect();
         localSubscriptionPlatform.handleCommand_('connect');
@@ -294,7 +290,7 @@ describes.fakeWin('LocalSubscriptionsIframePlatform', {amp: true}, (env) => {
         messengerMock
           .expects('sendCommandRsvp')
           .withExactArgs('pingback', {entitlement: {}})
-          .returns(Promise.resolve())
+          .resolves()
           .once();
 
         await localSubscriptionPlatform.pingback({});

--- a/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
+++ b/extensions/amp-subscriptions/0.1/test/test-local-subscriptions.js
@@ -231,14 +231,12 @@ describes.fakeWin('LocalSubscriptionsPlatform', {amp: true}, (env) => {
       ...json,
       metering: {state: meteringState},
     };
-    env.sandbox.stub(localSubscriptionPlatform.xhr_, 'fetchJson').returns(
-      Promise.resolve({
-        json: () => Promise.resolve(responseWithMeteringState),
-      })
-    );
+    env.sandbox.stub(localSubscriptionPlatform.xhr_, 'fetchJson').resolves({
+      json: () => Promise.resolve(responseWithMeteringState),
+    });
     const saveMeteringStateStub = env.sandbox
       .stub(localSubscriptionPlatform.serviceAdapter_, 'saveMeteringState')
-      .returns(Promise.resolve());
+      .resolves();
 
     await localSubscriptionPlatform.getEntitlements();
     expect(saveMeteringStateStub).to.be.calledWith(meteringState);

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -159,7 +159,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(true))
+        .resolves(true)
         .once();
       impl.isDismissed().then((dismissed) => {
         expect(dismissed).to.be.true;
@@ -175,7 +175,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(null))
+        .resolves(null)
         .once();
       impl.isDismissed().then((dismissed) => {
         expect(dismissed).to.be.false;
@@ -221,7 +221,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(true))
+        .resolves(true)
         .once();
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(false);
@@ -238,15 +238,13 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(true))
+        .resolves(true)
         .never();
 
-      const cidStub = env.sandbox
-        .stub(impl, 'getAsyncCid_')
-        .returns(Promise.resolve('12345'));
+      const cidStub = env.sandbox.stub(impl, 'getAsyncCid_').resolves('12345');
       const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
-        .returns(Promise.resolve({showNotification: true}));
+        .resolves({showNotification: true});
 
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(true);
@@ -286,15 +284,13 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(false))
+        .resolves(false)
         .once();
 
-      const cidStub = env.sandbox
-        .stub(impl, 'getAsyncCid_')
-        .returns(Promise.resolve('12345'));
+      const cidStub = env.sandbox.stub(impl, 'getAsyncCid_').resolves('12345');
       const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
-        .returns(Promise.resolve({showNotification: true}));
+        .resolves({showNotification: true});
 
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(true);
@@ -312,15 +308,13 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(false))
+        .resolves(false)
         .once();
 
-      const cidStub = env.sandbox
-        .stub(impl, 'getAsyncCid_')
-        .returns(Promise.resolve('12345'));
+      const cidStub = env.sandbox.stub(impl, 'getAsyncCid_').resolves('12345');
       const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
-        .returns(Promise.resolve({showNotification: false}));
+        .resolves({showNotification: false});
 
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(false);
@@ -339,7 +333,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(undefined))
+        .resolves(undefined)
         .once();
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(true);
@@ -361,12 +355,10 @@ describes.realWin(
         .returns(Promise.reject('intentional'))
         .once();
 
-      const cidStub = env.sandbox
-        .stub(impl, 'getAsyncCid_')
-        .returns(Promise.resolve('12345'));
+      const cidStub = env.sandbox.stub(impl, 'getAsyncCid_').resolves('12345');
       const showEndpointStub = env.sandbox
         .stub(impl, 'getShowEndpoint_')
-        .returns(Promise.resolve({showNotification: true}));
+        .resolves({showNotification: true});
 
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(true);
@@ -404,7 +396,7 @@ describes.realWin(
       storageMock
         .expects('set')
         .withExactArgs('amp-user-notification:n1', true)
-        .returns(Promise.resolve())
+        .resolves()
         .once();
       const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
@@ -423,7 +415,7 @@ describes.realWin(
       storageMock
         .expects('set')
         .withExactArgs('amp-user-notification:n1', true)
-        .returns(Promise.resolve())
+        .resolves()
         .once();
       const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
@@ -443,7 +435,7 @@ describes.realWin(
       storageMock
         .expects('set')
         .withExactArgs('amp-user-notification:n1', true)
-        .returns(Promise.resolve())
+        .resolves()
         .never();
       const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
@@ -466,7 +458,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(false))
+        .resolves(false)
         .once();
 
       return impl.shouldShow().then((shouldShow) => {
@@ -487,7 +479,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(false))
+        .resolves(false)
         .once();
 
       return impl.shouldShow().then((shouldShow) => {
@@ -508,7 +500,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.resolve(false))
+        .resolves(false)
         .once();
 
       return impl.shouldShow().then((shouldShow) => {
@@ -585,7 +577,7 @@ describes.realWin(
       storageMock
         .expects('set')
         .withExactArgs('amp-user-notification:n1', true)
-        .returns(Promise.resolve())
+        .resolves()
         .never();
       const postDismissStub = env.sandbox.stub(impl, 'postDismissEnpoint_');
 
@@ -599,10 +591,10 @@ describes.realWin(
     it('should have class `amp-active`', async () => {
       env.sandbox
         .stub(AmpUserNotification.prototype, 'getAsyncCid_')
-        .returns(Promise.resolve('12345'));
+        .resolves('12345');
       env.sandbox
         .stub(AmpUserNotification.prototype, 'getShowEndpoint_')
-        .returns(Promise.resolve({showNotification: true}));
+        .resolves({showNotification: true});
 
       const el = getUserNotification(dftAttrs);
       const impl = await el.getImpl(false);
@@ -628,10 +620,10 @@ describes.realWin(
     it('should not have `amp-active`', async () => {
       env.sandbox
         .stub(AmpUserNotification.prototype, 'getAsyncCid_')
-        .returns(Promise.resolve('12345'));
+        .resolves('12345');
       env.sandbox
         .stub(AmpUserNotification.prototype, 'getShowEndpoint_')
-        .returns(Promise.resolve({showNotification: false}));
+        .resolves({showNotification: false});
 
       const el = getUserNotification(dftAttrs);
       const impl = await el.getImpl(false);
@@ -653,13 +645,13 @@ describes.realWin(
     it('should have `amp-hidden` and no `amp-active`', async () => {
       env.sandbox
         .stub(AmpUserNotification.prototype, 'getAsyncCid_')
-        .returns(Promise.resolve('12345'));
+        .resolves('12345');
       env.sandbox
         .stub(AmpUserNotification.prototype, 'getShowEndpoint_')
-        .returns(Promise.resolve({showNotification: true}));
+        .resolves({showNotification: true});
       const stub2 = env.sandbox
         .stub(AmpUserNotification.prototype, 'postDismissEnpoint_')
-        .returns(Promise.resolve());
+        .resolves();
 
       const el = getUserNotification(dftAttrs);
       const impl = await el.getImpl(false);

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -204,7 +204,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .rejects('intentional')
+        .returns(Promise.reject('intentional'))
         .once();
       impl.isDismissed().then((dismissed) => {
         expect(dismissed).to.be.false;
@@ -352,7 +352,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .rejects('intentional')
+        .returns(Promise.reject('intentional'))
         .once();
 
       const cidStub = env.sandbox.stub(impl, 'getAsyncCid_').resolves('12345');
@@ -380,7 +380,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .rejects('intentional')
+        .returns(Promise.reject('intentional'))
         .once();
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(true);

--- a/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
+++ b/extensions/amp-user-notification/0.1/test/test-amp-user-notification.js
@@ -204,7 +204,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.reject('intentional'))
+        .rejects('intentional')
         .once();
       impl.isDismissed().then((dismissed) => {
         expect(dismissed).to.be.false;
@@ -352,7 +352,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.reject('intentional'))
+        .rejects('intentional')
         .once();
 
       const cidStub = env.sandbox.stub(impl, 'getAsyncCid_').resolves('12345');
@@ -380,7 +380,7 @@ describes.realWin(
       storageMock
         .expects('get')
         .withExactArgs('amp-user-notification:n1')
-        .returns(Promise.reject('intentional'))
+        .rejects('intentional')
         .once();
       return impl.shouldShow().then((shouldShow) => {
         expect(shouldShow).to.equal(true);

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -721,9 +721,7 @@ describes.realWin('video docking', {amp: true}, (env) => {
       const video = {};
       const target = {};
 
-      const dock = env.sandbox
-        .stub(docking, 'dock_')
-        .returns(Promise.resolve());
+      const dock = env.sandbox.stub(docking, 'dock_').resolves();
 
       await docking.dockInTransferLayerStep_(video, target);
 
@@ -1043,9 +1041,7 @@ describes.realWin('video docking', {amp: true}, (env) => {
       placeElementLtwh(video, 0, 0, 400, 300);
 
       setCurrentlyDocked = env.sandbox.stub(docking, 'setCurrentlyDocked_');
-      placeAt = env.sandbox
-        .stub(docking, 'placeAt_')
-        .returns(Promise.resolve());
+      placeAt = env.sandbox.stub(docking, 'placeAt_').resolves();
 
       env.sandbox.stub(docking, 'getDims_').returns(targetDims);
     });
@@ -1190,9 +1186,7 @@ describes.realWin('video docking', {amp: true}, (env) => {
       trigger = env.sandbox.stub(docking, 'trigger_');
       resetOnUndock = env.sandbox.stub(docking, 'resetOnUndock_');
 
-      placeAt = env.sandbox
-        .stub(docking, 'placeAt_')
-        .returns(Promise.resolve());
+      placeAt = env.sandbox.stub(docking, 'placeAt_').resolves();
 
       docking.currentlyDocked_ = {target: 'foo'};
 

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -283,14 +283,14 @@ describes.realWin(
         const consentPolicyState = 'baz-consentPolicyState';
         const consentPolicySharedData = 'foo-consentPolicySharedData';
 
-        env.sandbox.stub(Services, 'consentPolicyServiceForDocOrNull').returns(
-          Promise.resolve({
+        env.sandbox
+          .stub(Services, 'consentPolicyServiceForDocOrNull')
+          .resolves({
             getConsentMetadataInfo: () => Promise.resolve(consentMetadata),
             getConsentStringInfo: () => Promise.resolve(consentString),
             whenPolicyResolved: () => Promise.resolve(consentPolicyState),
             getMergedSharedData: () => Promise.resolve(consentPolicySharedData),
-          })
-        );
+          });
 
         const id = 1234;
 

--- a/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/test/test-amp-vimeo.js
@@ -31,7 +31,7 @@ describes.realWin(
       win = env.win;
       doc = win.document;
       videoUtilsMock = env.sandbox.stub(VideoUtils, 'isAutoplaySupported');
-      videoUtilsMock.returns(Promise.resolve(true));
+      videoUtilsMock.resolves(true);
     });
 
     async function getVimeo(

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -531,7 +531,7 @@ describes.realWin(
         );
         iframeWindowControllerMock
           .expects('waitUntilWorkerControlsPage')
-          .returns(Promise.resolve(true));
+          .resolves(true);
         env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushHelperFrame,
@@ -620,7 +620,7 @@ describes.realWin(
             .expects('register')
             .once()
             .withArgs(swUrl, {scope: swScope})
-            .returns(Promise.resolve(true));
+            .resolves(true);
           return webPush.registerServiceWorker();
         })
         .then(() => {
@@ -637,7 +637,7 @@ describes.realWin(
         );
         iframeWindowControllerMock
           .expects('waitUntilWorkerControlsPage')
-          .returns(Promise.resolve(true));
+          .resolves(true);
         env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushHelperFrame,
@@ -779,7 +779,7 @@ describes.realWin(
         );
         iframeWindowControllerMock
           .expects('waitUntilWorkerControlsPage')
-          .returns(Promise.resolve(true));
+          .resolves(true);
         env.sandbox
           ./*OK*/ stub(
             iframeWindow._ampWebPushHelperFrame,

--- a/test/integration/test-amp-pixel.js
+++ b/test/integration/test-amp-pixel.js
@@ -136,7 +136,7 @@ describes.fakeWin('amp-pixel with img (inabox)', {amp: true}, (env) => {
       createElementWithAttributes(env.win.document, 'img', {src})
     );
     env.win.document.body.appendChild(pixelElem);
-    env.sandbox.stub(env.ampdoc, 'whenFirstVisible').returns(Promise.resolve());
+    env.sandbox.stub(env.ampdoc, 'whenFirstVisible').resolves();
     const pixel = new AmpPixel(pixelElem);
     pixel.buildCallback();
     expect(pixelElem.querySelectorAll('img').length).to.equal(1);

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -165,7 +165,7 @@ t.run('Viewer Visibility State', () => {
             env.sandbox.stub(impl, 'isRelayoutNeeded').callsFake(() => true);
             env.sandbox.stub(impl, 'isLayoutSupported').callsFake(() => true);
 
-            layoutCallback.returns(Promise.resolve());
+            layoutCallback.resolves();
             unlayoutCallback.returns(true);
           });
       });

--- a/test/unit/ads/test-csa.js
+++ b/test/unit/ads/test-csa.js
@@ -165,7 +165,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, (env) => {
 
       const requestResizeSpy = env.sandbox
         .stub(win.context, 'requestResize')
-        .returns(Promise.reject());
+        .rejects();
 
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
@@ -193,7 +193,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, (env) => {
       // Set up
       const requestResizeSpy = env.sandbox
         .stub(win.context, 'requestResize')
-        .returns(Promise.reject());
+        .rejects();
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
 

--- a/test/unit/ads/test-csa.js
+++ b/test/unit/ads/test-csa.js
@@ -165,7 +165,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, (env) => {
 
       const requestResizeSpy = env.sandbox
         .stub(win.context, 'requestResize')
-        .rejects();
+        .returns(Promise.reject());
 
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
@@ -193,7 +193,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, (env) => {
       // Set up
       const requestResizeSpy = env.sandbox
         .stub(win.context, 'requestResize')
-        .rejects();
+        .returns(Promise.reject());
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
 

--- a/test/unit/ads/test-csa.js
+++ b/test/unit/ads/test-csa.js
@@ -219,7 +219,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, (env) => {
       // Set up
       const requestResizeSpy = env.sandbox
         .stub(win.context, 'requestResize')
-        .returns(Promise.resolve());
+        .resolves();
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
 
@@ -247,7 +247,7 @@ describes.fakeWin('amp-ad-csa-impl', {}, (env) => {
       // Set up
       const requestResizeSpy = env.sandbox
         .stub(win.context, 'requestResize')
-        .returns(Promise.resolve());
+        .resolves();
       // Try to resize when ads are loaded
       resizeIframe(win, 'csacontainer');
 

--- a/test/unit/inabox/test-inabox-viewport.js
+++ b/test/unit/inabox/test-inabox-viewport.js
@@ -236,7 +236,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, (env) => {
 
     const prepareContainer = env.sandbox
       .stub(binding, 'prepareBodyForOverlay_')
-      .returns(Promise.resolve());
+      .resolves();
 
     const makeRequest = stubIframeClientMakeRequest(
       'full-overlay-frame',
@@ -270,7 +270,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, (env) => {
   it('should reset content and request resize on leave overlay mode', () => {
     const resetContainer = env.sandbox
       .stub(binding, 'resetBodyForOverlay_')
-      .returns(Promise.resolve());
+      .resolves();
 
     const makeRequest = stubIframeClientMakeRequest(
       'cancel-full-overlay-frame',
@@ -308,9 +308,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, (env) => {
       /* opt_once */ true
     );
 
-    env.sandbox
-      .stub(binding, 'prepareBodyForOverlay_')
-      .returns(Promise.resolve());
+    env.sandbox.stub(binding, 'prepareBodyForOverlay_').resolves();
 
     yield binding.updateLightboxMode(true);
 
@@ -339,9 +337,7 @@ describes.fakeWin('inabox-viewport', {amp: {}}, (env) => {
       /* opt_once */ true
     );
 
-    env.sandbox
-      .stub(binding, 'resetBodyForOverlay_')
-      .returns(Promise.resolve());
+    env.sandbox.stub(binding, 'resetBodyForOverlay_').resolves();
 
     yield binding.updateLightboxMode(false);
 
@@ -379,12 +375,8 @@ describes.fakeWin('inabox-viewport', {amp: {}}, (env) => {
     const updateBoxRectStub = env.sandbox
       .stub(bindingFriendly, 'updateBoxRect_')
       .callsFake(NOOP);
-    env.sandbox
-      .stub(bindingFriendly, 'prepareBodyForOverlay_')
-      .returns(Promise.resolve());
-    env.sandbox
-      .stub(bindingFriendly, 'resetBodyForOverlay_')
-      .returns(Promise.resolve());
+    env.sandbox.stub(bindingFriendly, 'prepareBodyForOverlay_').resolves();
+    env.sandbox.stub(bindingFriendly, 'resetBodyForOverlay_').resolves();
 
     yield bindingFriendly.updateLightboxMode(true);
 

--- a/test/unit/test-batched-json.js
+++ b/test/unit/test-batched-json.js
@@ -50,11 +50,9 @@ describe('batchFetchJsonFor', () => {
       .stub(Services, 'urlReplacementsForDoc')
       .returns(urlReplacements);
 
-    fetchJson = window.sandbox.stub().returns(
-      Promise.resolve({
-        json: () => Promise.resolve(data),
-      })
-    );
+    fetchJson = window.sandbox.stub().resolves({
+      json: () => Promise.resolve(data),
+    });
 
     xhr = {xssiJson: () => Promise.resolve(data)};
     window.sandbox.stub(Services, 'xhrFor').returns(xhr);
@@ -82,7 +80,7 @@ describe('batchFetchJsonFor', () => {
 
         urlReplacements.expandUrlAsync
           .withArgs('https://data.com?x=FOO&y=BAR')
-          .returns(Promise.resolve('https://data.com?x=abc&y=BAR'));
+          .resolves('https://data.com?x=abc&y=BAR');
         urlReplacements.collectDisallowedVarsSync.withArgs(el).returns(['BAR']);
 
         const optIn = UrlReplacementPolicy.OPT_IN;
@@ -98,7 +96,7 @@ describe('batchFetchJsonFor', () => {
 
       urlReplacements.expandUrlAsync
         .withArgs('https://data.com?x=FOO&y=BAR')
-        .returns(Promise.resolve('https://data.com?x=abc&y=BAR'));
+        .resolves('https://data.com?x=abc&y=BAR');
 
       const userError = window.sandbox.stub(user(), 'error');
       const all = UrlReplacementPolicy.ALL;

--- a/test/unit/test-cache-cid-api.js
+++ b/test/unit/test-cache-cid-api.js
@@ -76,15 +76,13 @@ describes.realWin('cacheCidApi', {amp: true}, (env) => {
       });
 
       it('should use client ID API from api if everything great', () => {
-        fetchJsonStub.returns(
-          Promise.resolve({
-            json: () => {
-              return Promise.resolve({
-                publisherClientId: 'publisher-client-id-from-cache',
-              });
-            },
-          })
-        );
+        fetchJsonStub.resolves({
+          json: () => {
+            return Promise.resolve({
+              publisherClientId: 'publisher-client-id-from-cache',
+            });
+          },
+        });
         return api.getScopedCid('AMP_ECID_GOOGLE').then((cid) => {
           expect(cid).to.equal(
             'amp-mJW1ZjoviqBJydzRI8KnitWEpqyhQqDegGCl' +
@@ -106,15 +104,13 @@ describes.realWin('cacheCidApi', {amp: true}, (env) => {
       });
 
       it('should return null if opted out', () => {
-        fetchJsonStub.returns(
-          Promise.resolve({
-            json: () => {
-              return Promise.resolve({
-                optOut: true,
-              });
-            },
-          })
-        );
+        fetchJsonStub.resolves({
+          json: () => {
+            return Promise.resolve({
+              optOut: true,
+            });
+          },
+        });
         return api.getScopedCid('AMP_ECID_GOOGLE').then((cid) => {
           expect(cid).to.equal(null);
           expect(fetchJsonStub).to.be.calledWith(
@@ -133,25 +129,20 @@ describes.realWin('cacheCidApi', {amp: true}, (env) => {
       });
 
       it('should try alternative url if API provides', () => {
-        fetchJsonStub.onCall(0).returns(
-          Promise.resolve({
-            json: () => {
-              return Promise.resolve({
-                alternateUrl:
-                  'https://ampcid.google.co.uk/v1/cache:getClientId',
-              });
-            },
-          })
-        );
-        fetchJsonStub.onCall(1).returns(
-          Promise.resolve({
-            json: () => {
-              return Promise.resolve({
-                publisherClientId: 'publisher-client-id-from-cache',
-              });
-            },
-          })
-        );
+        fetchJsonStub.onCall(0).resolves({
+          json: () => {
+            return Promise.resolve({
+              alternateUrl: 'https://ampcid.google.co.uk/v1/cache:getClientId',
+            });
+          },
+        });
+        fetchJsonStub.onCall(1).resolves({
+          json: () => {
+            return Promise.resolve({
+              publisherClientId: 'publisher-client-id-from-cache',
+            });
+          },
+        });
         return api.getScopedCid('AMP_ECID_GOOGLE').then((cid) => {
           expect(cid).to.equal(
             'amp-mJW1ZjoviqBJydzRI8KnitWEpqyhQqDegGCl' +

--- a/test/unit/test-cid-api.js
+++ b/test/unit/test-cid-api.js
@@ -46,16 +46,14 @@ describes.realWin('test-cid-api', {amp: true}, (env) => {
 
   describe('getScopedCid', () => {
     it('should get CID when no AMP_TOKEN exists', () => {
-      fetchJsonStub.returns(
-        Promise.resolve({
-          json: () => {
-            return {
-              clientId: 'amp-12345',
-              securityToken: 'amp-token-123',
-            };
-          },
-        })
-      );
+      fetchJsonStub.resolves({
+        json: () => {
+          return {
+            clientId: 'amp-12345',
+            securityToken: 'amp-token-123',
+          };
+        },
+      });
       return api.getScopedCid('api-key', 'scope-a').then((cid) => {
         expect(cid).to.equal('amp-12345');
         expect(getCookie(win, 'AMP_TOKEN')).to.equal('amp-token-123');
@@ -77,15 +75,13 @@ describes.realWin('test-cid-api', {amp: true}, (env) => {
 
     it('should get CID when AMP_TOKEN exists', () => {
       persistCookie('AMP_TOKEN', 'amp-token-123');
-      fetchJsonStub.returns(
-        Promise.resolve({
-          json: () => {
-            return {
-              clientId: 'amp-12345',
-            };
-          },
-        })
-      );
+      fetchJsonStub.resolves({
+        json: () => {
+          return {
+            clientId: 'amp-12345',
+          };
+        },
+      });
       return api.getScopedCid('api-key', 'scope-a').then((cid) => {
         expect(cid).to.equal('amp-12345');
         expect(getCookie(win, 'AMP_TOKEN')).to.equal('amp-token-123');
@@ -108,15 +104,13 @@ describes.realWin('test-cid-api', {amp: true}, (env) => {
   });
 
   it('should return $OPT_OUT if API returns optOut', () => {
-    fetchJsonStub.returns(
-      Promise.resolve({
-        json: () => {
-          return {
-            optOut: true,
-          };
-        },
-      })
-    );
+    fetchJsonStub.resolves({
+      json: () => {
+        return {
+          optOut: true,
+        };
+      },
+    });
     return api.getScopedCid('api-key', 'scope-a').then((cid) => {
       expect(cid).to.equal('$OPT_OUT');
       expect(getCookie(win, 'AMP_TOKEN')).to.equal('$OPT_OUT');
@@ -124,13 +118,11 @@ describes.realWin('test-cid-api', {amp: true}, (env) => {
   });
 
   it('should return null if API returns no CID', () => {
-    fetchJsonStub.returns(
-      Promise.resolve({
-        json: () => {
-          return {};
-        },
-      })
-    );
+    fetchJsonStub.resolves({
+      json: () => {
+        return {};
+      },
+    });
     return api.getScopedCid('api-key', 'scope-a').then((cid) => {
       expect(cid).to.be.null;
       expect(getCookie(win, 'AMP_TOKEN')).to.equal('$NOT_FOUND');
@@ -138,25 +130,20 @@ describes.realWin('test-cid-api', {amp: true}, (env) => {
   });
 
   it('should try alternative url if API provides', () => {
-    fetchJsonStub.onCall(0).returns(
-      Promise.resolve({
-        json: () => {
-          return {
-            alternateUrl:
-              'https://ampcid.google.co.uk/v1/publisher:getClientId',
-          };
-        },
-      })
-    );
-    fetchJsonStub.onCall(1).returns(
-      Promise.resolve({
-        json: () => {
-          return {
-            clientId: 'amp-alt-12345',
-          };
-        },
-      })
-    );
+    fetchJsonStub.onCall(0).resolves({
+      json: () => {
+        return {
+          alternateUrl: 'https://ampcid.google.co.uk/v1/publisher:getClientId',
+        };
+      },
+    });
+    fetchJsonStub.onCall(1).resolves({
+      json: () => {
+        return {
+          clientId: 'amp-alt-12345',
+        };
+      },
+    });
     return api.getScopedCid('api-key', 'scope-a').then((cid) => {
       expect(cid).to.equal('amp-alt-12345');
       expect(fetchJsonStub.getCall(1).args[0]).to.equal(
@@ -199,16 +186,14 @@ describes.realWin('test-cid-api', {amp: true}, (env) => {
     'should fetch CID from API if AMP_TOKEN=$NOT_FOUND ' +
       'and document referrer is proxy origin',
     () => {
-      fetchJsonStub.returns(
-        Promise.resolve({
-          json: () => {
-            return {
-              clientId: 'amp-12345',
-              securityToken: 'amp-token-123',
-            };
-          },
-        })
-      );
+      fetchJsonStub.resolves({
+        json: () => {
+          return {
+            clientId: 'amp-12345',
+            securityToken: 'amp-token-123',
+          };
+        },
+      });
       const windowInterface = mockWindowInterface(env.sandbox);
       windowInterface.getDocumentReferrer.returns(
         'https://cdn.ampproject.org/'

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -317,9 +317,7 @@ describes.sandboxed('cid', {}, (env) => {
       });
 
       it('should return empty if opted out', () => {
-        storageGetStub
-          .withArgs('amp-cid-optout')
-          .returns(Promise.resolve(true));
+        storageGetStub.withArgs('amp-cid-optout').resolves(true);
 
         storage['amp-cid'] = JSON.stringify({
           cid: 'YYY',
@@ -859,9 +857,7 @@ describes.realWin('cid', {amp: true}, (env) => {
   it.configure().skipSafari(
     'should store CID in cookie when not in Viewer',
     function* () {
-      env.sandbox
-        .stub(cid.viewerCidApi_, 'isSupported')
-        .returns(Promise.resolve(false));
+      env.sandbox.stub(cid.viewerCidApi_, 'isSupported').resolves(false);
       setCookie(win, 'foo', '', 0);
       const fooCid = yield cid.get(
         {
@@ -885,9 +881,7 @@ describes.realWin('cid', {amp: true}, (env) => {
   describe('CID backup', () => {
     beforeEach(() => {
       cid.isBackupCidExpOn = true;
-      env.sandbox
-        .stub(cid.viewerCidApi_, 'isSupported')
-        .returns(Promise.resolve(false));
+      env.sandbox.stub(cid.viewerCidApi_, 'isSupported').resolves(false);
     });
 
     it('generates a new CID and backup', async () => {
@@ -996,19 +990,20 @@ describes.realWin('cid', {amp: true}, (env) => {
   });
 
   it('get method should return CID when in Viewer ', () => {
-    env.sandbox
-      .stub(cid.viewerCidApi_, 'isSupported')
-      .returns(Promise.resolve(true));
+    env.sandbox.stub(cid.viewerCidApi_, 'isSupported').resolves(true);
     win.parent = {};
     stubServiceForDoc(
       env.sandbox,
       ampdoc,
       'viewer',
       'sendMessageAwaitResponse'
-    ).returns(Promise.resolve('cid-from-viewer'));
-    stubServiceForDoc(env.sandbox, ampdoc, 'viewer', 'isTrustedViewer').returns(
-      Promise.resolve(true)
-    );
+    ).resolves('cid-from-viewer');
+    stubServiceForDoc(
+      env.sandbox,
+      ampdoc,
+      'viewer',
+      'isTrustedViewer'
+    ).resolves(true);
     stubServiceForDoc(env.sandbox, ampdoc, 'viewer', 'hasCapability')
       .withArgs('cid')
       .returns(true);
@@ -1019,9 +1014,7 @@ describes.realWin('cid', {amp: true}, (env) => {
   });
 
   it('get method should time out when in Viewer', function* () {
-    env.sandbox
-      .stub(cid.viewerCidApi_, 'isSupported')
-      .returns(Promise.resolve(true));
+    env.sandbox.stub(cid.viewerCidApi_, 'isSupported').resolves(true);
     win.parent = {};
     stubServiceForDoc(
       env.sandbox,
@@ -1029,9 +1022,12 @@ describes.realWin('cid', {amp: true}, (env) => {
       'viewer',
       'sendMessageAwaitResponse'
     ).returns(new Promise(() => {}));
-    stubServiceForDoc(env.sandbox, ampdoc, 'viewer', 'isTrustedViewer').returns(
-      Promise.resolve(true)
-    );
+    stubServiceForDoc(
+      env.sandbox,
+      ampdoc,
+      'viewer',
+      'isTrustedViewer'
+    ).resolves(true);
     storage['amp-cid-optout'] = false;
     env.sandbox.stub(url, 'isProxyOrigin').returns(true);
     let scopedCid = undefined;
@@ -1067,7 +1063,7 @@ describes.realWin('cid', {amp: true}, (env) => {
       it('should use cid api on pub origin if opted in', () => {
         cid.apiKeyMap_ = {'AMP_ECID_GOOGLE': 'cid-api-key'};
         const getScopedCidStub = env.sandbox.stub(cid.cidApi_, 'getScopedCid');
-        getScopedCidStub.returns(Promise.resolve('cid-from-api'));
+        getScopedCidStub.resolves('cid-from-api');
         return cid
           .get(
             {
@@ -1088,9 +1084,7 @@ describes.realWin('cid', {amp: true}, (env) => {
       });
 
       it('should fallback to cookie if cid api returns nothing', () => {
-        env.sandbox
-          .stub(cid.cidApi_, 'getScopedCid')
-          .returns(Promise.resolve());
+        env.sandbox.stub(cid.cidApi_, 'getScopedCid').resolves();
         return cid
           .get(
             {
@@ -1107,9 +1101,7 @@ describes.realWin('cid', {amp: true}, (env) => {
       });
 
       it('should respect CID API opt out', () => {
-        env.sandbox
-          .stub(cid.cidApi_, 'getScopedCid')
-          .returns(Promise.resolve('$OPT_OUT'));
+        env.sandbox.stub(cid.cidApi_, 'getScopedCid').resolves('$OPT_OUT');
         return cid
           .get(
             {
@@ -1135,7 +1127,7 @@ describes.realWin('cid', {amp: true}, (env) => {
             cid.cidApi_,
             'getScopedCid'
           );
-          getScopedCidStub.returns(Promise.resolve('cid-from-api'));
+          getScopedCidStub.resolves('cid-from-api');
           return cid.get(
             {
               scope: 'AMP_ECID_GOOGLE',
@@ -1230,14 +1222,14 @@ describes.fakeWin('cid optout:', {amp: true}, (env) => {
 
   describe('isOptedOutOfCid()', () => {
     it('should return true if bit is set in storage', () => {
-      storageGetStub.withArgs('amp-cid-optout').returns(Promise.resolve(true));
+      storageGetStub.withArgs('amp-cid-optout').resolves(true);
       return isOptedOutOfCid(ampdoc).then((isOut) => {
         expect(isOut).to.be.true;
       });
     });
 
     it('should return false if bit is not set in storage', () => {
-      storageGetStub.withArgs('amp-cid-optout').returns(Promise.resolve(null));
+      storageGetStub.withArgs('amp-cid-optout').resolves(null);
       return isOptedOutOfCid(ampdoc).then((isOut) => {
         expect(isOut).to.be.false;
       });

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -1215,7 +1215,7 @@ describes.fakeWin('cid optout:', {amp: true}, (env) => {
     });
 
     it('should reject promise if storage set fails', () => {
-      storageSetStub.rejects('failed!');
+      storageSetStub.returns(Promise.reject('failed!'));
       return optOutOfCid(ampdoc).should.eventually.be.rejectedWith('failed!');
     });
   });
@@ -1236,7 +1236,7 @@ describes.fakeWin('cid optout:', {amp: true}, (env) => {
     });
 
     it('should return false if storage get fails', () => {
-      storageGetStub.withArgs('amp-cid-optout').rejects('Fail');
+      storageGetStub.withArgs('amp-cid-optout').returns(Promise.reject('Fail'));
       return isOptedOutOfCid(ampdoc).then((isOut) => {
         expect(isOut).to.be.false;
       });

--- a/test/unit/test-cid.js
+++ b/test/unit/test-cid.js
@@ -1215,7 +1215,7 @@ describes.fakeWin('cid optout:', {amp: true}, (env) => {
     });
 
     it('should reject promise if storage set fails', () => {
-      storageSetStub.returns(Promise.reject('failed!'));
+      storageSetStub.rejects('failed!');
       return optOutOfCid(ampdoc).should.eventually.be.rejectedWith('failed!');
     });
   });
@@ -1236,7 +1236,7 @@ describes.fakeWin('cid optout:', {amp: true}, (env) => {
     });
 
     it('should return false if storage get fails', () => {
-      storageGetStub.withArgs('amp-cid-optout').returns(Promise.reject('Fail'));
+      storageGetStub.withArgs('amp-cid-optout').rejects('Fail');
       return isOptedOutOfCid(ampdoc).then((isOut) => {
         expect(isOut).to.be.false;
       });

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -193,9 +193,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
       it('Element - createdCallback', () => {
         const element = new ElementClass();
-        const build = env.sandbox
-          .stub(element, 'buildInternal')
-          .returns(Promise.resolve());
+        const build = env.sandbox.stub(element, 'buildInternal').resolves();
 
         expect(element.isBuilt()).to.equal(false);
         expect(element.hasAttributes()).to.equal(false);
@@ -322,7 +320,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       it('Element - should NOT reset on 2nd attachedCallback w/o request', () => {
         clock.tick(1);
         const element = new ElementClass();
-        env.sandbox.stub(element, 'buildInternal').returns(Promise.resolve());
+        env.sandbox.stub(element, 'buildInternal').resolves();
         container.appendChild(element);
         container.removeChild(element);
 

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -2125,9 +2125,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         });
 
         it('should toggle loading off after layout failed', () => {
-          env.sandbox
-            .stub(TestElement.prototype, 'layoutCallback')
-            .rejects();
+          env.sandbox.stub(TestElement.prototype, 'layoutCallback').rejects();
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');
           container.appendChild(element);
@@ -2149,9 +2147,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         });
 
         it('should disable toggle loading on after layout failed', () => {
-          env.sandbox
-            .stub(TestElement.prototype, 'layoutCallback')
-            .rejects();
+          env.sandbox.stub(TestElement.prototype, 'layoutCallback').rejects();
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');
           container.appendChild(element);

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1763,7 +1763,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
             element,
             'layoutCallback'
           );
-          layoutCallbackStub.returns(Promise.reject(new Error('intentional')));
+          layoutCallbackStub.rejects(new Error('intentional'));
           try {
             await resource.startLayout();
           } catch (e) {
@@ -2127,7 +2127,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         it('should toggle loading off after layout failed', () => {
           env.sandbox
             .stub(TestElement.prototype, 'layoutCallback')
-            .returns(Promise.reject());
+            .rejects();
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');
           container.appendChild(element);
@@ -2151,7 +2151,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         it('should disable toggle loading on after layout failed', () => {
           env.sandbox
             .stub(TestElement.prototype, 'layoutCallback')
-            .returns(Promise.reject());
+            .rejects();
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');
           container.appendChild(element);

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1763,7 +1763,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
             element,
             'layoutCallback'
           );
-          layoutCallbackStub.rejects(new Error('intentional'));
+          layoutCallbackStub.returns(Promise.reject(new Error('intentional')));
           try {
             await resource.startLayout();
           } catch (e) {
@@ -2125,7 +2125,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         });
 
         it('should toggle loading off after layout failed', () => {
-          env.sandbox.stub(TestElement.prototype, 'layoutCallback').rejects();
+          env.sandbox
+            .stub(TestElement.prototype, 'layoutCallback')
+            .returns(Promise.reject());
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');
           container.appendChild(element);
@@ -2147,7 +2149,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         });
 
         it('should disable toggle loading on after layout failed', () => {
-          env.sandbox.stub(TestElement.prototype, 'layoutCallback').rejects();
+          env.sandbox
+            .stub(TestElement.prototype, 'layoutCallback')
+            .returns(Promise.reject());
           element.setAttribute('height', '10');
           element.setAttribute('width', '10');
           container.appendChild(element);

--- a/test/unit/test-error.js
+++ b/test/unit/test-error.js
@@ -171,9 +171,7 @@ describe('reportErrorToServerOrViewer', () => {
   });
 
   it('should report to server if viewer is not trusted', () => {
-    window.sandbox
-      .stub(viewer, 'isTrustedViewer')
-      .returns(Promise.resolve(false));
+    window.sandbox.stub(viewer, 'isTrustedViewer').resolves(false);
     return reportErrorToServerOrViewer(win, data).then(() => {
       expect(createXhr).to.be.calledOnce;
       expect(sendMessageStub).to.not.have.been.called;

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -212,7 +212,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     extensionsMock
       .expects('preloadExtension')
       .withExactArgs('amp-test')
-      .returns(Promise.resolve())
+      .resolves()
       .once();
     extensionsMock
       .expects('preinstallEmbed')
@@ -221,7 +221,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     extensionsMock
       .expects('installExtensionsInDoc')
       .withExactArgs(ampdoc, ['amp-test'])
-      .returns(Promise.resolve())
+      .resolves()
       .once();
 
     let renderCompleteResolver = null;
@@ -299,7 +299,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     extensionsMock
       .expects('preloadExtension')
       .withExactArgs('amp-test')
-      .returns(Promise.resolve())
+      .resolves()
       .once();
     extensionsMock
       .expects('preinstallEmbed')
@@ -308,7 +308,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     extensionsMock
       .expects('installExtensionsInDoc')
       .withExactArgs(ampdoc, ['amp-test'])
-      .returns(Promise.resolve())
+      .resolves()
       .once();
 
     let renderCompleteResolver = null;
@@ -351,7 +351,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     extensionsMock
       .expects('preloadExtension')
       .withExactArgs('amp-test')
-      .returns(Promise.resolve())
+      .resolves()
       .atLeast(1);
 
     await installFriendlyIframeEmbed(
@@ -426,7 +426,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
 
     env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'whenRenderStarted')
-      .returns(Promise.resolve());
+      .resolves();
 
     const embed = await installFriendlyIframeEmbed(
       iframe,
@@ -515,7 +515,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     extensionsMock
       .expects('preloadExtension')
       .withExactArgs('amp-test')
-      .returns(Promise.resolve())
+      .resolves()
       .once();
     extensionsMock
       .expects('preinstallEmbed')
@@ -524,12 +524,12 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
     extensionsMock
       .expects('installExtensionsInDoc')
       .withExactArgs(ampdoc, ['amp-test'])
-      .returns(Promise.resolve())
+      .resolves()
       .once();
 
     env.sandbox
       .stub(FriendlyIframeEmbed.prototype, 'whenRenderStarted')
-      .returns(Promise.resolve());
+      .resolves();
 
     const embedPromise = installFriendlyIframeEmbed(
       iframe,
@@ -582,7 +582,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
             arg.height == iframe.contentWindow.innerHeight
         )
       )
-      .returns(Promise.resolve([]))
+      .resolves([])
       .once();
     const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
       url: 'https://acme.org/url1',
@@ -621,7 +621,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
             arg.height == 200
         )
       )
-      .returns(Promise.resolve([]))
+      .resolves([])
       .once();
     const embedPromise = installFriendlyIframeEmbed(iframe, document.body, {
       url: 'https://acme.org/url1',

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -297,7 +297,7 @@ describes.sandboxed('History install', {}, () => {
   beforeEach(() => {
     viewer = {
       isOvertakeHistory: () => false,
-      onMessage: () => (function() {}),
+      onMessage: () => function () {},
     };
 
     installTimerService(window);

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -297,7 +297,7 @@ describes.sandboxed('History install', {}, () => {
   beforeEach(() => {
     viewer = {
       isOvertakeHistory: () => false,
-      onMessage: () => function () {},
+      onMessage: () => (function() {}),
     };
 
     installTimerService(window);

--- a/test/unit/test-history.js
+++ b/test/unit/test-history.js
@@ -73,10 +73,7 @@ describes.fakeWin(
 
     it('should push new state', () => {
       const onPop = env.sandbox.spy();
-      bindingMock
-        .expects('push')
-        .returns(Promise.resolve({stackIndex: 11}))
-        .once();
+      bindingMock.expects('push').resolves({stackIndex: 11}).once();
       return history.push(onPop).then((unusedHistoryId) => {
         expect(history.stackIndex_).to.equal(11);
         expect(history.stackOnPop_.length).to.equal(12);
@@ -87,14 +84,11 @@ describes.fakeWin(
 
     it('should pop previously pushed state', () => {
       const onPop = env.sandbox.spy();
-      bindingMock
-        .expects('push')
-        .returns(Promise.resolve({stackIndex: 11}))
-        .once();
+      bindingMock.expects('push').resolves({stackIndex: 11}).once();
       bindingMock
         .expects('pop')
         .withExactArgs(11)
-        .returns(Promise.resolve({stackIndex: 10}))
+        .resolves({stackIndex: 10})
         .once();
       return history.push(onPop).then((historyId) => {
         expect(historyId).to.equal(11);
@@ -115,12 +109,12 @@ describes.fakeWin(
       bindingMock
         .expects('push')
         .withExactArgs(undefined)
-        .returns(Promise.resolve({stackIndex: 11}))
+        .resolves({stackIndex: 11})
         .once();
       bindingMock
         .expects('pop')
         .withExactArgs(11)
-        .returns(Promise.resolve({stackIndex: 10}))
+        .resolves({stackIndex: 10})
         .once();
       return history.push(onPop).then((stackIndex) => {
         expect(onPop).to.have.not.been.called;
@@ -140,12 +134,12 @@ describes.fakeWin(
       bindingMock
         .expects('push')
         .withExactArgs(undefined)
-        .returns(Promise.resolve({stackIndex: 11}))
+        .resolves({stackIndex: 11})
         .once();
       bindingMock
         .expects('pop')
         .withExactArgs(11)
-        .returns(Promise.resolve({stackIndex: 10, title}))
+        .resolves({stackIndex: 10, title})
         .once();
       return history.push(onPop).then((stackIndex) => {
         expect(onPop).to.have.not.been.called;
@@ -169,12 +163,12 @@ describes.fakeWin(
       bindingMock
         .expects('push')
         .withExactArgs(pushState)
-        .returns(Promise.resolve({stackIndex: 11}))
+        .resolves({stackIndex: 11})
         .once();
       bindingMock
         .expects('replace')
         .withExactArgs(replaceState)
-        .returns(Promise.resolve())
+        .resolves()
         .once();
       return history.push(onPop, pushState).then((historyId) => {
         expect(historyId).to.equal(11);
@@ -197,11 +191,11 @@ describes.fakeWin(
       bindingMock
         .expects('push')
         .withExactArgs(state)
-        .returns(Promise.resolve({...state, stackIndex: 11}))
+        .resolves({...state, stackIndex: 11})
         .once();
       bindingMock
         .expects('get')
-        .returns(Promise.resolve({...state, stackIndex: 11}))
+        .resolves({...state, stackIndex: 11})
         .once();
       return history.push(onPop, state).then((historyId) => {
         expect(historyId).to.equal(11);
@@ -218,14 +212,8 @@ describes.fakeWin(
     });
 
     it('should push a new state and replace it for target', () => {
-      bindingMock
-        .expects('push')
-        .returns(Promise.resolve({stackIndex: 11}))
-        .once();
-      bindingMock
-        .expects('pop')
-        .returns(Promise.resolve({stackIndex: 10}))
-        .once();
+      bindingMock.expects('push').resolves({stackIndex: 11}).once();
+      bindingMock.expects('pop').resolves({stackIndex: 10}).once();
       bindingMock.expects('replaceStateForTarget').withExactArgs('#hello');
       return history.replaceStateForTarget('#hello').then(() => {
         return history.pop(history.stackIndex_).then(() => {
@@ -238,14 +226,11 @@ describes.fakeWin(
     it('should pop previously pushed state via goBack', () => {
       const onPop = env.sandbox.spy();
       const popState = {title: 'title'};
-      bindingMock
-        .expects('push')
-        .returns(Promise.resolve({stackIndex: 11}))
-        .once();
+      bindingMock.expects('push').resolves({stackIndex: 11}).once();
       bindingMock
         .expects('pop')
         .withExactArgs(11)
-        .returns(Promise.resolve({...popState, stackIndex: 10}))
+        .resolves({...popState, stackIndex: 10})
         .once();
       return history.push(onPop).then((historyId) => {
         expect(historyId).to.equal(11);
@@ -270,10 +255,7 @@ describes.fakeWin(
     });
 
     it('should call pop if stack is empty and passed true', () => {
-      bindingMock
-        .expects('pop')
-        .once()
-        .returns(Promise.resolve({stackIndex: 0}));
+      bindingMock.expects('pop').once().resolves({stackIndex: 0});
 
       return history.goBack(true);
     });
@@ -289,7 +271,7 @@ describes.fakeWin(
       bindingMock
         .expects('getFragment')
         .withExactArgs()
-        .returns(Promise.resolve('fragment'))
+        .resolves('fragment')
         .once();
       return history.getFragment().then((fragment) => {
         expect(fragment).to.be.equal('fragment');
@@ -300,7 +282,7 @@ describes.fakeWin(
       bindingMock
         .expects('updateFragment')
         .withExactArgs('fragment')
-        .returns(Promise.resolve())
+        .resolves()
         .once();
       return history.updateFragment('fragment').then(() => {});
     });
@@ -658,7 +640,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
     capabilityStub = env.sandbox.stub();
     viewer = {
       onMessage: env.sandbox.stub().returns(() => {}),
-      sendMessageAwaitResponse: env.sandbox.stub().returns(Promise.resolve()),
+      sendMessageAwaitResponse: env.sandbox.stub().resolves(),
       hasCapability: capabilityStub,
     };
     history = new HistoryBindingVirtual_(window, viewer);
@@ -699,7 +681,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
       const title = 'title';
       viewer.sendMessageAwaitResponse
         .withArgs('pushHistory', {stackIndex: 1, title})
-        .returns(Promise.resolve({stackIndex: 1, title}));
+        .resolves({stackIndex: 1, title});
 
       return history.push({title}).then((state) => {
         expect(viewer.sendMessageAwaitResponse).to.be.calledOnce;
@@ -719,7 +701,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
       const title = 'title';
       viewer.sendMessageAwaitResponse
         .withArgs('pushHistory', {stackIndex: 1, title})
-        .returns(Promise.resolve(true));
+        .resolves(true);
 
       return history.push({title}).then((state) => {
         expect(viewer.sendMessageAwaitResponse).to.be.calledOnce;
@@ -750,7 +732,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
     it('viewer supports responses', () => {
       viewer.sendMessageAwaitResponse
         .withArgs('popHistory', env.sandbox.match({stackIndex: 0}))
-        .returns(Promise.resolve({stackIndex: -123, title: 'title'}));
+        .resolves({stackIndex: -123, title: 'title'});
 
       return history.pop(0).then((state) => {
         expect(state).to.deep.equal({stackIndex: -123, title: 'title'});
@@ -767,7 +749,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
     it('handles bad viewer responses', () => {
       viewer.sendMessageAwaitResponse
         .withArgs('popHistory', env.sandbox.match({stackIndex: 0}))
-        .returns(Promise.resolve(true));
+        .resolves(true);
 
       return history.pop(0).then((state) => {
         expect(state).to.deep.equal({stackIndex: -1});
@@ -799,7 +781,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
     it('viewer supports responses', () => {
       viewer.sendMessageAwaitResponse
         .withArgs('replaceHistory', {stackIndex: 123, title: 'title'})
-        .returns(Promise.resolve({stackIndex: 123, title: 'different'}));
+        .resolves({stackIndex: 123, title: 'different'});
 
       return history
         .replace({stackIndex: 123, title: 'title'})
@@ -818,7 +800,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
     it('handles bad viewer responses', () => {
       viewer.sendMessageAwaitResponse
         .withArgs('replaceHistory', {stackIndex: 123, title: 'title'})
-        .returns(Promise.resolve(true));
+        .resolves(true);
 
       return history
         .replace({stackIndex: 123, title: 'title'})
@@ -843,14 +825,12 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
           url: '/page',
           fragment: 'fr2',
         })
-        .returns(
-          Promise.resolve({
-            stackIndex: 123,
-            title: 'different',
-            url: '/otherpage',
-            fragment: 'fr2',
-          })
-        );
+        .resolves({
+          stackIndex: 123,
+          title: 'different',
+          url: '/otherpage',
+          fragment: 'fr2',
+        });
 
       return history
         .replace({
@@ -896,7 +876,7 @@ describes.sandboxed('HistoryBindingVirtual', {}, (env) => {
       const title = 'title';
       viewer.sendMessageAwaitResponse
         .withArgs('pushHistory', {stackIndex: 1, title})
-        .returns(Promise.resolve({stackIndex: 1, title}));
+        .resolves({stackIndex: 1, title});
 
       return history.push({title}).then((state) => {
         expect(viewer.sendMessageAwaitResponse).to.be.calledOnce;
@@ -1002,12 +982,12 @@ describes.fakeWin(
         .expects('sendMessageAwaitResponse')
         .withExactArgs('pushHistory', {stackIndex: startIndex + 1})
         .once()
-        .returns(Promise.resolve({stackIndex: startIndex + 1}));
+        .resolves({stackIndex: startIndex + 1});
       viewerMock
         .expects('sendMessageAwaitResponse')
         .withArgs('popHistory', {stackIndex: startIndex + 1})
         .once()
-        .returns(Promise.resolve({stackIndex: startIndex}));
+        .resolves({stackIndex: startIndex});
       return history.replaceStateForTarget('#hello').then(() => {
         clock.tick(1);
         expect(env.win.location.hash).to.equal('#hello');
@@ -1113,7 +1093,7 @@ describes.fakeWin('Get and update fragment', {}, (env) => {
         .expects('sendMessageAwaitResponse')
         .withExactArgs('getFragment', undefined, true)
         .once()
-        .returns(Promise.resolve('from-viewer'));
+        .resolves('from-viewer');
       return history.getFragment().then((fragment) => {
         expect(fragment).to.equal('from-viewer');
       });
@@ -1156,7 +1136,7 @@ describes.fakeWin('Get and update fragment', {}, (env) => {
         .expects('sendMessageAwaitResponse')
         .withExactArgs('getFragment', undefined, true)
         .once()
-        .returns(Promise.resolve());
+        .resolves();
       return history.getFragment().then((fragment) => {
         expect(fragment).to.equal('');
       });

--- a/test/unit/test-impression.js
+++ b/test/unit/test-impression.js
@@ -50,14 +50,12 @@ describes.realWin('impression', {amp: true}, (env) => {
     const stub = env.sandbox.stub(xhr, 'fetchJson');
     warnStub = env.sandbox.stub(user(), 'warn');
     env.sandbox.stub(dev(), 'warn');
-    stub.returns(
-      Promise.resolve({
-        json() {
-          return Promise.resolve(null);
-        },
-      })
-    );
-    env.sandbox.stub(ampdoc, 'whenFirstVisible').returns(Promise.resolve());
+    stub.resolves({
+      json() {
+        return Promise.resolve(null);
+      },
+    });
+    env.sandbox.stub(ampdoc, 'whenFirstVisible').resolves();
     isTrustedViewer = false;
     env.sandbox.stub(viewer, 'isTrustedViewer').callsFake(() => {
       return Promise.resolve(isTrustedViewer);
@@ -115,15 +113,13 @@ describes.realWin('impression', {amp: true}, (env) => {
           return Promise.resolve({'replaceUrl': undefined});
         }
       });
-    xhr.fetchJson.returns(
-      Promise.resolve({
-        json() {
-          return Promise.resolve({
-            'location': '',
-          });
-        },
-      })
-    );
+    xhr.fetchJson.resolves({
+      json() {
+        return Promise.resolve({
+          'location': '',
+        });
+      },
+    });
     maybeTrackImpression(window);
     return expect(getTrackImpressionPromise()).to.eventually.be.fulfilled;
   });
@@ -226,12 +222,10 @@ describes.realWin('impression', {amp: true}, (env) => {
     it('should resolve if get no content response', function* () {
       toggleExperiment(window, 'alp', true);
       viewer.getParam.withArgs('click').returns('https://www.example.com');
-      xhr.fetchJson.returns(
-        Promise.resolve({
-          // No-content response
-          status: 204,
-        })
-      );
+      xhr.fetchJson.resolves({
+        // No-content response
+        status: 204,
+      });
       maybeTrackImpression(window);
       return getTrackImpressionPromise().then(() => {
         expect(warnStub).to.not.be.called;
@@ -241,11 +235,9 @@ describes.realWin('impression', {amp: true}, (env) => {
     it('should still resolve on request error', function* () {
       toggleExperiment(window, 'alp', true);
       viewer.getParam.withArgs('click').returns('https://www.example.com');
-      xhr.fetchJson.returns(
-        Promise.resolve({
-          status: 404,
-        })
-      );
+      xhr.fetchJson.resolves({
+        status: 404,
+      });
       maybeTrackImpression(window);
       return getTrackImpressionPromise().then(() => {
         expect(warnStub).to.be.calledOnce;
@@ -256,15 +248,13 @@ describes.realWin('impression', {amp: true}, (env) => {
       toggleExperiment(window, 'alp', true);
       viewer.getParam.withArgs('click').returns('https://www.example.com');
       viewer.hasCapability.withArgs('replaceUrl').returns(false);
-      xhr.fetchJson.returns(
-        Promise.resolve({
-          json() {
-            return Promise.resolve({
-              'location': '',
-            });
-          },
-        })
-      );
+      xhr.fetchJson.resolves({
+        json() {
+          return Promise.resolve({
+            'location': '',
+          });
+        },
+      });
       maybeTrackImpression(window);
       return expect(getTrackImpressionPromise()).to.eventually.be.fulfilled;
     });
@@ -273,15 +263,13 @@ describes.realWin('impression', {amp: true}, (env) => {
       toggleExperiment(window, 'alp', true);
       viewer.getParam.withArgs('click').returns('https://www.example.com');
 
-      xhr.fetchJson.returns(
-        Promise.resolve({
-          json() {
-            return Promise.resolve({
-              'location': 'test_location?gclid=123456&foo=bar&example=123',
-            });
-          },
-        })
-      );
+      xhr.fetchJson.resolves({
+        json() {
+          return Promise.resolve({
+            'location': 'test_location?gclid=123456&foo=bar&example=123',
+          });
+        },
+      });
 
       const location = {
         hash: '',

--- a/test/unit/test-owners.js
+++ b/test/unit/test-owners.js
@@ -318,8 +318,8 @@ describes.realWin(
           if (!resource) {
             return;
           }
-          env.sandbox.stub(resource, 'whenBuilt').returns(Promise.resolve());
-          env.sandbox.stub(resource, 'loadedOnce').returns(Promise.resolve());
+          env.sandbox.stub(resource, 'whenBuilt').resolves();
+          env.sandbox.stub(resource, 'loadedOnce').resolves();
           env.sandbox.stub(element, 'ensureLoaded').resolves(resource.getId());
         });
       });

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -224,9 +224,7 @@ describes.realWin('performance', {amp: true}, (env) => {
       describe('channel established', () => {
         it('should flush events when channel is ready', () => {
           env.sandbox.stub(viewer, 'getParam').withArgs('csi').returns(null);
-          env.sandbox
-            .stub(viewer, 'whenMessagingReady')
-            .returns(Promise.resolve());
+          env.sandbox.stub(viewer, 'whenMessagingReady').resolves();
           expect(perf.isMessagingReady_).to.be.false;
           const promise = perf.coreServicesAvailable();
           expect(perf.events_.length).to.equal(0);
@@ -415,9 +413,7 @@ describes.realWin('performance', {amp: true}, (env) => {
         beforeEach(() => {
           env.sandbox.stub(viewer, 'getParam').withArgs('csi').returns('1');
           env.sandbox.stub(viewer, 'isEmbedded').returns(true);
-          env.sandbox
-            .stub(viewer, 'whenMessagingReady')
-            .returns(Promise.resolve());
+          env.sandbox.stub(viewer, 'whenMessagingReady').resolves();
         });
 
         it('should forward all queued tick events', () => {
@@ -531,10 +527,10 @@ describes.realWin('performance', {amp: true}, (env) => {
 
   it('should wait for visible resources', () => {
     const resources = Services.resourcesForDoc(ampdoc);
-    env.sandbox.stub(resources, 'whenFirstPass').returns(Promise.resolve());
+    env.sandbox.stub(resources, 'whenFirstPass').resolves();
     const whenContentIniLoadStub = env.sandbox
       .stub(IniLoad, 'whenContentIniLoad')
-      .returns(Promise.resolve());
+      .resolves();
     perf.resources_ = resources;
 
     return perf.whenViewportLayoutComplete_().then(() => {
@@ -574,7 +570,7 @@ describes.realWin('performance', {amp: true}, (env) => {
 
     beforeEach(() => {
       viewer = Services.viewerForDoc(ampdoc);
-      env.sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
+      env.sandbox.stub(viewer, 'whenMessagingReady').resolves();
       viewerSendMessageStub = env.sandbox.stub(viewer, 'sendMessage');
 
       tickSpy = env.sandbox.spy(perf, 'tick');
@@ -751,7 +747,7 @@ describes.realWin('performance with experiment', {amp: true}, (env) => {
     win = env.win;
     const viewer = Services.viewerForDoc(env.ampdoc);
     viewerSendMessageStub = env.sandbox.stub(viewer, 'sendMessage');
-    env.sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
+    env.sandbox.stub(viewer, 'whenMessagingReady').resolves();
     env.sandbox.stub(viewer, 'getParam').withArgs('csi').returns('1');
     env.sandbox.stub(viewer, 'isEmbedded').returns(true);
     installPlatformService(win);
@@ -1469,7 +1465,7 @@ describes.realWin('log canonicalUrl', {amp: true}, (env) => {
     win = env.win;
     const viewer = Services.viewerForDoc(env.ampdoc);
     viewerSendMessageStub = env.sandbox.stub(viewer, 'sendMessage');
-    env.sandbox.stub(viewer, 'whenMessagingReady').returns(Promise.resolve());
+    env.sandbox.stub(viewer, 'whenMessagingReady').resolves();
     env.sandbox.stub(viewer, 'getParam').withArgs('csi').returns('1');
     env.sandbox.stub(viewer, 'isEmbedded').returns(true);
     env.sandbox.stub(Services, 'documentInfoForDoc').returns({canonicalUrl});

--- a/test/unit/test-real-time-config.js
+++ b/test/unit/test-real-time-config.js
@@ -78,12 +78,10 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
           ? Promise.resolve(JSON.stringify(response))
           : Promise.resolve(response);
       };
-      fetchJsonStub.withArgs(params).returns(
-        Promise.resolve({
-          status: 200,
-          text: textFunction,
-        })
-      );
+      fetchJsonStub.withArgs(params).resolves({
+        status: 200,
+        text: textFunction,
+      });
     }
   }
 

--- a/test/unit/test-render-delaying-services.js
+++ b/test/unit/test-render-delaying-services.js
@@ -43,9 +43,7 @@ describe('waitForServices', () => {
       },
     };
     variantResolve = waitForService(getService, 'variant', variantService);
-    variantStub = window.sandbox
-      .stub(variantService, 'whenReady')
-      .returns(Promise.resolve());
+    variantStub = window.sandbox.stub(variantService, 'whenReady').resolves();
 
     return createIframePromise().then((iframe) => {
       win = iframe.win;

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -116,7 +116,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
       resource.premeasure({left: 0, top: 0, width: 100, height: 100});
       resource.measure(/* usePremeasuredRect */ true);
       elementMock.expects('isUpgraded').returns(true).atLeast(1);
-      elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+      elementMock.expects('buildInternal').resolves().once();
       elementMock.expects('onMeasure').withArgs(/* sizeChanged */ true).once();
       return resource.build().then(() => {
         expect(resource.getState()).to.equal(ResourceState.READY_FOR_LAYOUT);
@@ -145,7 +145,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
     elementMock.expects('isBuilt').returns(false).once();
     elementMock.expects('isBuilding').returns(true).once();
     elementMock.expects('isUpgraded').returns(true).once();
-    elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+    elementMock.expects('buildInternal').resolves().once();
     const r = new Resource(2, element, resources);
     expect(r.isBuilding()).to.be.true;
   });
@@ -176,7 +176,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   it('should mark as not ready for layout even if already measured', () => {
     const box = layoutRectLtwh(0, 0, 100, 200);
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+    elementMock.expects('buildInternal').resolves().once();
     resource.layoutBox_ = box;
     return resource.build().then(() => {
       expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
@@ -185,7 +185,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should mark as not laid out if not yet measured', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+    elementMock.expects('buildInternal').resolves().once();
     return resource.build().then(() => {
       expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
     });
@@ -193,7 +193,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should track size changes on measure', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+    elementMock.expects('buildInternal').resolves().once();
     return resource.build().then(() => {
       elementMock
         .expects('getBoundingClientRect')
@@ -215,7 +215,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   it('should track no size changes on measure', () => {
     layoutRectLtwh(0, 0, 0, 0);
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+    elementMock.expects('buildInternal').resolves().once();
     return resource.build().then(() => {
       elementMock
         .expects('getBoundingClientRect')
@@ -261,7 +261,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should measure and update state', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+    elementMock.expects('buildInternal').resolves().once();
     return resource.build().then(() => {
       elementMock
         .expects('getBoundingClientRect')
@@ -288,7 +288,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should update initial box only on first measure', () => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
-    elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+    elementMock.expects('buildInternal').resolves().once();
     return resource.build().then(() => {
       element.getBoundingClientRect = () => ({
         left: 11,
@@ -489,7 +489,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
       });
       element.parentElement.__AMP__RESOURCE = {};
       elementMock.expects('isUpgraded').returns(true).atLeast(1);
-      elementMock.expects('buildInternal').returns(Promise.resolve()).once();
+      elementMock.expects('buildInternal').resolves().once();
       rect = {left: 11, top: 12, width: 111, height: 222};
       resource = new Resource(1, element, resources);
       return resource.build();
@@ -614,7 +614,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   });
 
   it('should force startLayout for first layout', () => {
-    elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
+    elementMock.expects('layoutCallback').resolves().once();
 
     resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
@@ -655,7 +655,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   });
 
   it('should force startLayout for re-layout when opt-in', () => {
-    elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
+    elementMock.expects('layoutCallback').resolves().once();
 
     resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
@@ -666,7 +666,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   });
 
   it('should complete startLayout', () => {
-    elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
+    elementMock.expects('layoutCallback').resolves().once();
 
     resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};
@@ -683,7 +683,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
   });
 
   it('should complete startLayout with height == 0', () => {
-    elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
+    elementMock.expects('layoutCallback').resolves().once();
     elementMock.expects('getLayout').returns('fluid').once();
 
     resource.state_ = ResourceState.LAYOUT_SCHEDULED;
@@ -919,7 +919,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
       resource.unlayout();
 
       resource.state_ = ResourceState.LAYOUT_SCHEDULED;
-      elementMock.expects('layoutCallback').returns(Promise.resolve()).once();
+      elementMock.expects('layoutCallback').resolves().once();
       resource.measure();
       resource.startLayout();
     });

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -157,7 +157,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     elementMock
       .expects('buildInternal')
-      .rejects(new Error('intentional'))
+      .returns(Promise.reject(new Error('intentional')))
       .once();
     elementMock.expects('updateLayoutBox').never();
     const buildPromise = resource.build();
@@ -702,7 +702,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should fail startLayout', () => {
     const error = new Error('intentional');
-    elementMock.expects('layoutCallback').rejects(error).once();
+    elementMock.expects('layoutCallback').returns(Promise.reject(error)).once();
 
     resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -157,7 +157,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
     elementMock.expects('isUpgraded').returns(true).atLeast(1);
     elementMock
       .expects('buildInternal')
-      .returns(Promise.reject(new Error('intentional')))
+      .rejects(new Error('intentional'))
       .once();
     elementMock.expects('updateLayoutBox').never();
     const buildPromise = resource.build();
@@ -702,7 +702,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
 
   it('should fail startLayout', () => {
     const error = new Error('intentional');
-    elementMock.expects('layoutCallback').returns(Promise.reject(error)).once();
+    elementMock.expects('layoutCallback').rejects(error).once();
 
     resource.state_ = ResourceState.LAYOUT_SCHEDULED;
     resource.layoutBox_ = {left: 11, top: 12, width: 10, height: 10};

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -1391,7 +1391,7 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, (env) => {
         return signals;
       },
     };
-    element.buildInternal = sandbox.stub().returns(Promise.resolve());
+    element.buildInternal = sandbox.stub().resolves();
     return element;
   }
 

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1314,13 +1314,11 @@ describes.realWin(
         extensionsMock
           .expects('preloadExtension')
           .withExactArgs('amp-ext1', '0.1')
-          .returns(
-            Promise.resolve({
-              elements: {
-                'amp-ext1': function () {},
-              },
-            })
-          )
+          .resolves({
+            elements: {
+              'amp-ext1': function () {},
+            },
+          })
           .once();
 
         const scriptEl = win.document.createElement('script');
@@ -1339,13 +1337,11 @@ describes.realWin(
         extensionsMock
           .expects('preloadExtension')
           .withExactArgs('amp-ext1', '0.1')
-          .returns(
-            Promise.resolve({
-              elements: {
-                'amp-ext1': function () {},
-              },
-            })
-          )
+          .resolves({
+            elements: {
+              'amp-ext1': function () {},
+            },
+          })
           .once();
 
         const mod = win.document.createElement('script');
@@ -1374,13 +1370,11 @@ describes.realWin(
         extensionsMock
           .expects('preloadExtension')
           .withExactArgs('amp-ext1', '1.0')
-          .returns(
-            Promise.resolve({
-              elements: {
-                'amp-ext1': function () {},
-              },
-            })
-          )
+          .resolves({
+            elements: {
+              'amp-ext1': function () {},
+            },
+          })
           .once();
 
         const scriptEl = win.document.createElement('script');
@@ -1399,7 +1393,7 @@ describes.realWin(
         extensionsMock
           .expects('preloadExtension')
           .withExactArgs('amp-ext1', '0.1')
-          .returns(Promise.resolve({elements: {}}))
+          .resolves({elements: {}})
           .once();
 
         const scriptEl = win.document.createElement('script');
@@ -1762,13 +1756,11 @@ describes.realWin(
           extensionsMock
             .expects('preloadExtension')
             .withExactArgs('amp-ext1', '0.1')
-            .returns(
-              Promise.resolve({
-                elements: {
-                  'amp-ext1': function () {},
-                },
-              })
-            )
+            .resolves({
+              elements: {
+                'amp-ext1': function () {},
+              },
+            })
             .once();
           writer.write(
             '<script custom-element="amp-ext1" src="https://cdn.ampproject.org/v0/amp-ext1-0.1.js"></script>'
@@ -1787,7 +1779,7 @@ describes.realWin(
           extensionsMock
             .expects('preloadExtension')
             .withExactArgs('amp-ext1', '0.1')
-            .returns(Promise.resolve({elements: {}}))
+            .resolves({elements: {}})
             .once();
           writer.write(
             '<script custom-template="amp-ext1" src="https://cdn.ampproject.org/v0/amp-ext1-0.1.js"></script>'
@@ -2028,7 +2020,7 @@ describes.realWin(
           });
 
         it('should send message', () => {
-          doc1.onMessage.returns(Promise.resolve());
+          doc1.onMessage.resolves();
           return doc1.viewer
             .sendMessageAwaitResponse('test3', {test: 3})
             .then(() => {

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -109,7 +109,7 @@ describes.fakeWin(
         };
         const sendMessage = env.sandbox
           .stub(viewer, 'sendMessageAwaitResponse')
-          .returns(Promise.resolve({}));
+          .resolves({});
         maybeFindTemplateStub.returns(null);
         const templates = {
           successTemplate: {'innerHTML': '<div>much success</div>'},

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -710,7 +710,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
       beforeEach(() => {
         navigateToStub = env.sandbox
           .stub(standardActions, 'handleNavigateTo_')
-          .returns(Promise.resolve());
+          .resolves();
 
         closeOrNavigateToSpy = env.sandbox.spy(
           standardActions,
@@ -814,11 +814,11 @@ describes.sandboxed('StandardActions', {}, (env) => {
       const bind = {invoke: env.sandbox.stub()};
       // Bind.invoke() doesn't actually resolve with a value,
       // but add one here to check that the promise is chained.
-      bind.invoke.returns(Promise.resolve('set-state-complete'));
+      bind.invoke.resolves('set-state-complete');
       env.sandbox
         .stub(Services, 'bindForDocOrNull')
         .withArgs(element)
-        .returns(Promise.resolve(bind));
+        .resolves(bind);
 
       invocation.method = 'setState';
       invocation.args = {
@@ -839,11 +839,11 @@ describes.sandboxed('StandardActions', {}, (env) => {
       const bind = {invoke: env.sandbox.stub()};
       // Bind.invoke() doesn't actually resolve with a value,
       // but add one here to check that the promise is chained.
-      bind.invoke.returns(Promise.resolve('push-state-complete'));
+      bind.invoke.resolves('push-state-complete');
       env.sandbox
         .stub(Services, 'bindForDocOrNull')
         .withArgs(element)
-        .returns(Promise.resolve(bind));
+        .resolves(bind);
 
       invocation.method = 'pushState';
       invocation.args = {

--- a/test/unit/test-storage.js
+++ b/test/unit/test-storage.js
@@ -184,7 +184,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.reject('intentional'))
+          .rejects('intentional')
           .once();
         expect(storage.storePromise_).to.not.exist;
         const promise = storage.get('key1');
@@ -741,7 +741,7 @@ describes.sandboxed('ViewerStorageBinding', {}, (env) => {
           return arg['origin'] == 'https://acme.com';
         })
       )
-      .returns(Promise.reject('unknown'))
+      .rejects('unknown')
       .once();
     return binding
       .loadBlob('https://acme.com')
@@ -775,7 +775,7 @@ describes.sandboxed('ViewerStorageBinding', {}, (env) => {
         'saveStore',
         env.sandbox.match(() => true)
       )
-      .returns(Promise.reject('unknown'))
+      .rejects('unknown')
       .once();
     return binding
       .saveBlob('https://acme.com', 'BLOB1')

--- a/test/unit/test-storage.js
+++ b/test/unit/test-storage.js
@@ -85,7 +85,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .once();
         return storage
           .get('key1')
@@ -101,7 +101,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(null))
+          .resolves(null)
           .once();
         return storage
           .get('key1')
@@ -121,7 +121,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .once();
         return storage
           .get('key1')
@@ -141,7 +141,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .once();
         expect(storage.storePromise_).to.not.exist;
         const promise = storage.get('key1');
@@ -162,7 +162,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(null))
+          .resolves(null)
           .once();
         expect(storage.storePromise_).to.not.exist;
         const promise = storage.get('key1');
@@ -199,7 +199,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve('UNKNOWN FORMAT'))
+          .resolves('UNKNOWN FORMAT')
           .once();
         expect(storage.storePromise_).to.not.exist;
         const promise = storage.get('key1');
@@ -216,7 +216,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .once();
         bindingMock
           .expects('saveBlob')
@@ -230,7 +230,7 @@ describes.sandboxed('Storage', {}, (env) => {
               );
             })
           )
-          .returns(Promise.resolve())
+          .resolves()
           .twice();
         viewerMock
           .expects('broadcast')
@@ -270,7 +270,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .once();
         bindingMock
           .expects('saveBlob')
@@ -281,7 +281,7 @@ describes.sandboxed('Storage', {}, (env) => {
               return store2.get('key1') === undefined;
             })
           )
-          .returns(Promise.resolve())
+          .resolves()
           .twice();
         viewerMock
           .expects('broadcast')
@@ -325,7 +325,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .once();
         bindingMock
           .expects('saveBlob')
@@ -336,7 +336,7 @@ describes.sandboxed('Storage', {}, (env) => {
               return store2.get('key1') === undefined;
             })
           )
-          .returns(Promise.resolve())
+          .resolves()
           .twice();
         viewerMock
           .expects('broadcast')
@@ -361,7 +361,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .twice();
         return storage.get('key1').then((value) => {
           expect(value).to.equal('value1');
@@ -387,7 +387,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .returns(Promise.resolve(btoa(JSON.stringify(store1.obj))))
+          .resolves(btoa(JSON.stringify(store1.obj)))
           .twice();
         return storage.get('key1').then((value) => {
           expect(value).to.equal('value1');
@@ -709,7 +709,7 @@ describes.sandboxed('ViewerStorageBinding', {}, (env) => {
           return arg['origin'] == 'https://acme.com';
         })
       )
-      .returns(Promise.resolve({'blob': 'BLOB1'}))
+      .resolves({'blob': 'BLOB1'})
       .once();
     return binding.loadBlob('https://acme.com').then((blob) => {
       expect(blob).to.equal('BLOB1');
@@ -725,7 +725,7 @@ describes.sandboxed('ViewerStorageBinding', {}, (env) => {
           return arg['origin'] == 'https://acme.com';
         })
       )
-      .returns(Promise.resolve({}))
+      .resolves({})
       .once();
     return binding.loadBlob('https://acme.com').then((blob) => {
       expect(blob).to.not.exist;
@@ -763,7 +763,7 @@ describes.sandboxed('ViewerStorageBinding', {}, (env) => {
           return arg['origin'] == 'https://acme.com' && arg['blob'] == 'BLOB1';
         })
       )
-      .returns(Promise.resolve())
+      .resolves()
       .once();
     return binding.saveBlob('https://acme.com', 'BLOB1');
   });

--- a/test/unit/test-storage.js
+++ b/test/unit/test-storage.js
@@ -184,7 +184,7 @@ describes.sandboxed('Storage', {}, (env) => {
         bindingMock
           .expects('loadBlob')
           .withExactArgs('https://acme.com')
-          .rejects('intentional')
+          .returns(Promise.reject('intentional'))
           .once();
         expect(storage.storePromise_).to.not.exist;
         const promise = storage.get('key1');
@@ -741,7 +741,7 @@ describes.sandboxed('ViewerStorageBinding', {}, (env) => {
           return arg['origin'] == 'https://acme.com';
         })
       )
-      .rejects('unknown')
+      .returns(Promise.reject('unknown'))
       .once();
     return binding
       .loadBlob('https://acme.com')
@@ -775,7 +775,7 @@ describes.sandboxed('ViewerStorageBinding', {}, (env) => {
         'saveStore',
         env.sandbox.match(() => true)
       )
-      .rejects('unknown')
+      .returns(Promise.reject('unknown'))
       .once();
     return binding
       .saveBlob('https://acme.com', 'BLOB1')

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -67,9 +67,7 @@ describe('Styles', () => {
       expect(getStyle(doc.body, 'animation')).to.equal('');
       expect(ampdoc.signals().get('render-start')).to.be.null;
 
-      waitForServicesStub
-        .withArgs(win)
-        .returns(Promise.resolve(['service1', 'service2']));
+      waitForServicesStub.withArgs(win).resolves(['service1', 'service2']);
       styles.makeBodyVisible(doc);
       return new Promise((resolve) => {
         setTimeout(resolve, 0);
@@ -84,7 +82,7 @@ describe('Styles', () => {
     });
 
     it('should skip schedulePass if no render delaying services', () => {
-      waitForServicesStub.withArgs(win).returns(Promise.resolve([]));
+      waitForServicesStub.withArgs(win).resolves([]);
       styles.makeBodyVisible(doc);
       return new Promise((resolve) => {
         setTimeout(resolve, 0);

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -283,7 +283,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
               ampdoc,
               'viewer',
               'getReferrerUrl'
-            ).returns(Promise.resolve('http://example.org/page.html'));
+            ).resolves('http://example.org/page.html');
             return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
           })
           .then((res) => {
@@ -304,7 +304,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
                 ampdoc,
                 'viewer',
                 'getReferrerUrl'
-              ).returns(Promise.resolve('http://example.org/page.html'));
+              ).resolves('http://example.org/page.html');
               return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
             })
             .then((res) => {
@@ -326,10 +326,8 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
                 ampdoc,
                 'viewer',
                 'getReferrerUrl'
-              ).returns(
-                Promise.resolve(
-                  'https://example-org.cdn.ampproject.org/v/example.org/page.html'
-                )
+              ).resolves(
+                'https://example-org.cdn.ampproject.org/v/example.org/page.html'
               );
               return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
             })
@@ -352,11 +350,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
                 ampdoc,
                 'viewer',
                 'getReferrerUrl'
-              ).returns(
-                Promise.resolve(
-                  'https://cdn.ampproject.org/v/example.org/page.html'
-                )
-              );
+              ).resolves('https://cdn.ampproject.org/v/example.org/page.html');
               return replacements.expandUrlAsync('?ref=EXTERNAL_REFERRER');
             })
             .then((res) => {
@@ -633,9 +627,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
       it('should allow empty CLIENT_ID', () => {
         return getReplacements()
           .then((replacements) => {
-            stubServiceForDoc(env.sandbox, ampdoc, 'cid', 'get').returns(
-              Promise.resolve()
-            );
+            stubServiceForDoc(env.sandbox, ampdoc, 'cid', 'get').resolves();
             return replacements.expandUrlAsync('?a=CLIENT_ID(_ga)');
           })
           .then((res) => {
@@ -692,14 +684,12 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
 
       it('should replace AMP_STATE(key)', () => {
         const win = getFakeWindow();
-        env.sandbox.stub(Services, 'bindForDocOrNull').returns(
-          Promise.resolve({
-            getStateValue(key) {
-              expect(key).to.equal('foo.bar');
-              return Promise.resolve('baz');
-            },
-          })
-        );
+        env.sandbox.stub(Services, 'bindForDocOrNull').resolves({
+          getStateValue(key) {
+            expect(key).to.equal('foo.bar');
+            return Promise.resolve('baz');
+          },
+        });
         return Services.urlReplacementsForDoc(win.document.documentElement)
           .expandUrlAsync('?state=AMP_STATE(foo.bar)')
           .then((res) => {
@@ -1015,7 +1005,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
         return getReplacements().then((replacements) => {
           env.sandbox
             .stub(viewerService, 'getViewerOrigin')
-            .returns(Promise.resolve('https://www.google.com'));
+            .resolves('https://www.google.com');
           return replacements.expandUrlAsync('?sh=VIEWER').then((res) => {
             expect(res).to.equal('?sh=https%3A%2F%2Fwww.google.com');
           });
@@ -1024,9 +1014,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
 
       it('should replace VIEWER with empty string', () => {
         return getReplacements().then((replacements) => {
-          env.sandbox
-            .stub(viewerService, 'getViewerOrigin')
-            .returns(Promise.resolve(''));
+          env.sandbox.stub(viewerService, 'getViewerOrigin').resolves('');
           return replacements.expandUrlAsync('?sh=VIEWER').then((res) => {
             expect(res).to.equal('?sh=');
           });
@@ -1070,15 +1058,13 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
       });
 
       it('should replace AMP_GEO(ISOCountry) and AMP_GEO', () => {
-        env.sandbox.stub(Services, 'geoForDocOrNull').returns(
-          Promise.resolve({
-            'ISOCountry': 'unknown',
-            'ISOCountryGroups': ['nafta', 'waldo'],
-            'nafta': true,
-            'waldo': true,
-            'matchedISOCountryGroups': ['nafta', 'waldo'],
-          })
-        );
+        env.sandbox.stub(Services, 'geoForDocOrNull').resolves({
+          'ISOCountry': 'unknown',
+          'ISOCountryGroups': ['nafta', 'waldo'],
+          'nafta': true,
+          'waldo': true,
+          'matchedISOCountryGroups': ['nafta', 'waldo'],
+        });
         return expandUrlAsync('?geo=AMP_GEO,country=AMP_GEO(ISOCountry)').then(
           (res) => {
             expect(res).to.equal('?geo=nafta%2Cwaldo,country=unknown');
@@ -1596,7 +1582,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
         it('should replace ACCESS_READER_ID', () => {
           accessServiceMock
             .expects('getAccessReaderId')
-            .returns(Promise.resolve('reader1'))
+            .resolves('reader1')
             .once();
           return expandUrlAsync('?a=ACCESS_READER_ID').then((res) => {
             expect(res).to.match(/a=reader1/);
@@ -1608,7 +1594,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
           accessServiceMock
             .expects('getAuthdataField')
             .withExactArgs('field1')
-            .returns(Promise.resolve('value1'))
+            .resolves('value1')
             .once();
           return expandUrlAsync('?a=AUTHDATA(field1)').then((res) => {
             expect(res).to.match(/a=value1/);
@@ -1670,7 +1656,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
         it('should replace ACCESS_READER_ID', () => {
           subscriptionsServiceMock
             .expects('getAccessReaderId')
-            .returns(Promise.resolve('reader1'))
+            .resolves('reader1')
             .once();
           return expandUrlAsync('?a=ACCESS_READER_ID').then((res) => {
             expect(res).to.match(/a=reader1/);
@@ -1682,7 +1668,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
           subscriptionsServiceMock
             .expects('getAuthdataField')
             .withExactArgs('field1')
-            .returns(Promise.resolve('value1'))
+            .resolves('value1')
             .once();
           return expandUrlAsync('?a=AUTHDATA(field1)').then((res) => {
             expect(res).to.match(/a=value1/);
@@ -1717,7 +1703,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
           subscriptionsServiceMock
             .expects('getAuthdataField')
             .withExactArgs('field1')
-            .returns(Promise.resolve('value1'))
+            .resolves('value1')
             .once();
           return expandUrlAsync('?a=AUTHDATA(field1)').then((res) => {
             expect(res).to.match(/a=value1/);

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -47,7 +47,7 @@ describes.fakeWin('validator-integration', {}, (env) => {
 
     it('should load validator script if dev mode', () => {
       modeStub.returns({development: true});
-      loadScriptStub.returns(Promise.resolve());
+      loadScriptStub.resolves();
       maybeValidate(win);
       expect(loadScriptStub).to.have.been.called;
     });
@@ -58,9 +58,7 @@ describes.fakeWin('validator-integration', {}, (env) => {
       const scriptEl = env.win.document.createElement('script');
       scriptEl.setAttribute('nonce', '123');
       win.document.head.append(scriptEl);
-      loadScriptStub = env.sandbox
-        .stub(eventHelper, 'loadPromise')
-        .returns(Promise.resolve());
+      loadScriptStub = env.sandbox.stub(eventHelper, 'loadPromise').resolves();
 
       loadScript(win.document, 'http://example.com');
 

--- a/test/unit/test-viewer-cid-api.js
+++ b/test/unit/test-viewer-cid-api.js
@@ -107,8 +107,8 @@ describes.realWin('viewerCidApi', {amp: true}, (env) => {
     });
 
     it('should reject if Viewer rejects', () => {
-      viewerMock.sendMessageAwaitResponse.returns(
-        Promise.reject('Client API error')
+      viewerMock.sendMessageAwaitResponse.rejects(
+        'Client API error'
       );
       return expect(
         api.getScopedCid('api-key', 'AMP_ECID_GOOGLE')

--- a/test/unit/test-viewer-cid-api.js
+++ b/test/unit/test-viewer-cid-api.js
@@ -107,7 +107,9 @@ describes.realWin('viewerCidApi', {amp: true}, (env) => {
     });
 
     it('should reject if Viewer rejects', () => {
-      viewerMock.sendMessageAwaitResponse.rejects('Client API error');
+      viewerMock.sendMessageAwaitResponse.returns(
+        Promise.reject('Client API error')
+      );
       return expect(
         api.getScopedCid('api-key', 'AMP_ECID_GOOGLE')
       ).to.eventually.be.rejectedWith(/Client API error/);

--- a/test/unit/test-viewer-cid-api.js
+++ b/test/unit/test-viewer-cid-api.js
@@ -36,7 +36,7 @@ describes.realWin('viewerCidApi', {amp: true}, (env) => {
 
   describe('isSupported', () => {
     it('should return true if Viewer is trusted and has CID capability', () => {
-      viewerMock.isTrustedViewer.returns(Promise.resolve(true));
+      viewerMock.isTrustedViewer.resolves(true);
       viewerMock.hasCapability.withArgs('cid').returns(true);
       return expect(api.isSupported()).to.eventually.be.true;
     });
@@ -48,7 +48,7 @@ describes.realWin('viewerCidApi', {amp: true}, (env) => {
     });
 
     it('should return false if Viewer is not trusted', () => {
-      viewerMock.isTrustedViewer.returns(Promise.resolve(false));
+      viewerMock.isTrustedViewer.resolves(false);
       viewerMock.hasCapability.withArgs('cid').returns(true);
       return expect(api.isSupported()).to.eventually.be.false;
     });
@@ -56,9 +56,7 @@ describes.realWin('viewerCidApi', {amp: true}, (env) => {
 
   describe('getScopedCid', () => {
     function verifyClientIdApiInUse(used) {
-      viewerMock.sendMessageAwaitResponse.returns(
-        Promise.resolve('client-id-from-viewer')
-      );
+      viewerMock.sendMessageAwaitResponse.resolves('client-id-from-viewer');
       return api
         .getScopedCid(used ? 'api-key' : undefined, 'AMP_ECID_GOOGLE')
         .then((cid) => {
@@ -96,14 +94,14 @@ describes.realWin('viewerCidApi', {amp: true}, (env) => {
             'canonicalOrigin': 'http://localhost:9876',
           })
         )
-        .returns(Promise.resolve('client-id-from-viewer'));
+        .resolves('client-id-from-viewer');
       return expect(
         api.getScopedCid(undefined, 'NON_ALLOWLISTED_SCOPE')
       ).to.eventually.equal('client-id-from-viewer');
     });
 
     it('should return undefined if Viewer returns undefined', () => {
-      viewerMock.sendMessageAwaitResponse.returns(Promise.resolve());
+      viewerMock.sendMessageAwaitResponse.resolves();
       return expect(api.getScopedCid('api-key', 'AMP_ECID_GOOGLE')).to
         .eventually.be.undefined;
     });

--- a/test/unit/test-viewer-cid-api.js
+++ b/test/unit/test-viewer-cid-api.js
@@ -107,9 +107,7 @@ describes.realWin('viewerCidApi', {amp: true}, (env) => {
     });
 
     it('should reject if Viewer rejects', () => {
-      viewerMock.sendMessageAwaitResponse.rejects(
-        'Client API error'
-      );
+      viewerMock.sendMessageAwaitResponse.rejects('Client API error');
       return expect(
         api.getScopedCid('api-key', 'AMP_ECID_GOOGLE')
       ).to.eventually.be.rejectedWith(/Client API error/);

--- a/test/unit/test-viewer.js
+++ b/test/unit/test-viewer.js
@@ -885,7 +885,7 @@ describes.sandboxed('Viewer', {}, (env) => {
         );
 
         const delivererSpy = env.sandbox.stub();
-        delivererSpy.returns(Promise.resolve());
+        delivererSpy.resolves();
 
         viewer.setMessageDeliverer(delivererSpy, 'https://www.example.com');
         env.sandbox.assert.callOrder(
@@ -915,12 +915,8 @@ describes.sandboxed('Viewer', {}, (env) => {
         );
 
         const delivererSpy = env.sandbox.stub();
-        delivererSpy
-          .withArgs('event-a', {value: 2}, true)
-          .returns(Promise.resolve('result-2'));
-        delivererSpy
-          .withArgs('event-a', {value: 3}, true)
-          .returns(Promise.resolve('result-3'));
+        delivererSpy.withArgs('event-a', {value: 2}, true).resolves('result-2');
+        delivererSpy.withArgs('event-a', {value: 3}, true).resolves('result-3');
         viewer.setMessageDeliverer(delivererSpy, 'https://www.example.com');
 
         const response3 = viewer.sendMessageAwaitResponse(

--- a/test/unit/test-viewport.js
+++ b/test/unit/test-viewport.js
@@ -997,9 +997,7 @@ describes.fakeWin('Viewport', {}, (env) => {
 
   it('should calculate client rect w/o global client rect', () => {
     const bindingMock = env.sandbox.mock(binding);
-    bindingMock
-      .expects('getRootClientRectAsync')
-      .returns(Promise.resolve(null));
+    bindingMock.expects('getRootClientRectAsync').resolves(null);
     const el = document.createElement('div');
     el.getBoundingClientRect = () => layoutRectLtwh(1, 2, 3, 4);
     stubVsyncMeasure();
@@ -1012,7 +1010,7 @@ describes.fakeWin('Viewport', {}, (env) => {
     const bindingMock = env.sandbox.mock(binding);
     bindingMock
       .expects('getRootClientRectAsync')
-      .returns(Promise.resolve(layoutRectLtwh(5, 5, 5, 5)))
+      .resolves(layoutRectLtwh(5, 5, 5, 5))
       .twice();
     const el = document.createElement('div');
     el.getBoundingClientRect = () => layoutRectLtwh(1, 2, 3, 4);

--- a/test/unit/test-xhr-document-fetcher.js
+++ b/test/unit/test-xhr-document-fetcher.js
@@ -169,14 +169,12 @@ describes.realWin('DocumentFetcher', {amp: true}, function (env) {
       };
     }
     it('should return correct document response', () => {
-      sendMessageStub.returns(
-        Promise.resolve({
-          body: '<html><body>Foo</body></html>',
-          init: {
-            headers: [],
-          },
-        })
-      );
+      sendMessageStub.resolves({
+        body: '<html><body>Foo</body></html>',
+        init: {
+          headers: [],
+        },
+      });
       return fetchDocument(
         interceptionEnabledWin,
         'https://www.some-url.org/some-resource/'

--- a/test/unit/test-xhr.js
+++ b/test/unit/test-xhr.js
@@ -749,9 +749,7 @@ describe
       });
 
       it('should not intercept if viewer untrusted and non-dev mode', () => {
-        window.sandbox
-          .stub(viewer, 'isTrustedViewer')
-          .returns(Promise.resolve(false));
+        window.sandbox.stub(viewer, 'isTrustedViewer').resolves(false);
         interceptionEnabledWin.AMP_DEV_MODE = false;
 
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
@@ -778,9 +776,7 @@ describe
       });
 
       it('should intercept if viewer untrusted but in local dev mode', () => {
-        window.sandbox
-          .stub(viewer, 'isTrustedViewer')
-          .returns(Promise.resolve(false));
+        window.sandbox.stub(viewer, 'isTrustedViewer').resolves(false);
         window.sandbox.stub(mode, 'getMode').returns({localDev: true});
 
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
@@ -791,9 +787,7 @@ describe
       });
 
       it('should intercept if untrusted-xhr-interception experiment enabled', () => {
-        window.sandbox
-          .stub(viewer, 'isTrustedViewer')
-          .returns(Promise.resolve(false));
+        window.sandbox.stub(viewer, 'isTrustedViewer').resolves(false);
         window.sandbox.stub(mode, 'getMode').returns({localDev: false});
         window.sandbox
           .stub(viewer, 'hasCapability')
@@ -813,9 +807,7 @@ describe
       });
 
       it('should intercept if non-dev mode but viewer trusted', () => {
-        window.sandbox
-          .stub(viewer, 'isTrustedViewer')
-          .returns(Promise.resolve(true));
+        window.sandbox.stub(viewer, 'isTrustedViewer').resolves(true);
         interceptionEnabledWin.AMP_DEV_MODE = false;
 
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
@@ -936,7 +928,7 @@ describe
 
       it('should be rejected when response undefined', () => {
         expectAsyncConsoleError(/Object expected/);
-        sendMessageStub.returns(Promise.resolve());
+        sendMessageStub.resolves();
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
         return expect(
@@ -946,7 +938,7 @@ describe
 
       it('should be rejected when response null', () => {
         expectAsyncConsoleError(/Object expected/);
-        sendMessageStub.returns(Promise.resolve(null));
+        sendMessageStub.resolves(null);
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
         return expect(
@@ -956,7 +948,7 @@ describe
 
       it('should be rejected when response is string', () => {
         expectAsyncConsoleError(/Object expected/);
-        sendMessageStub.returns(Promise.resolve('response text'));
+        sendMessageStub.resolves('response text');
         const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
         return expect(
@@ -971,19 +963,17 @@ describe
         beforeEach(() => (interceptionEnabledWin.Response = window.Response));
 
         it('should return correct non-document response', () => {
-          sendMessageStub.returns(
-            Promise.resolve({
-              body: '{"content":32}',
-              init: {
-                status: 242,
-                statusText: 'Magic status',
-                headers: [
-                  ['a', 2],
-                  ['b', false],
-                ],
-              },
-            })
-          );
+          sendMessageStub.resolves({
+            body: '{"content":32}',
+            init: {
+              status: 242,
+              statusText: 'Magic status',
+              headers: [
+                ['a', 2],
+                ['b', false],
+              ],
+            },
+          });
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr
@@ -1010,19 +1000,17 @@ describe
         beforeEach(() => (interceptionEnabledWin.Response = undefined));
 
         it('should return correct non-document response', () => {
-          sendMessageStub.returns(
-            Promise.resolve({
-              body: '{"content":32}',
-              init: {
-                status: 242,
-                statusText: 'Magic status',
-                headers: [
-                  ['a', 2],
-                  ['b', false],
-                ],
-              },
-            })
-          );
+          sendMessageStub.resolves({
+            body: '{"content":32}',
+            init: {
+              status: 242,
+              statusText: 'Magic status',
+              headers: [
+                ['a', 2],
+                ['b', false],
+              ],
+            },
+          });
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr
@@ -1039,7 +1027,7 @@ describe
         });
 
         it('should return default response when body/init missing', () => {
-          sendMessageStub.returns(Promise.resolve({}));
+          sendMessageStub.resolves({});
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr
@@ -1054,7 +1042,7 @@ describe
         });
 
         it('should return default response when status/headers missing', () => {
-          sendMessageStub.returns(Promise.resolve({body: '', init: {}}));
+          sendMessageStub.resolves({body: '', init: {}});
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr
@@ -1067,7 +1055,7 @@ describe
         });
 
         it('should convert body to string', () => {
-          sendMessageStub.returns(Promise.resolve({body: 32}));
+          sendMessageStub.resolves({body: 32});
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr
@@ -1078,7 +1066,7 @@ describe
         });
 
         it('should convert status to int', () => {
-          sendMessageStub.returns(Promise.resolve({init: {status: '209.6'}}));
+          sendMessageStub.resolves({init: {status: '209.6'}});
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr
@@ -1091,17 +1079,15 @@ describe
         });
 
         it('should convert headers to string', () => {
-          sendMessageStub.returns(
-            Promise.resolve({
-              init: {
-                headers: [
-                  [1, true],
-                  [false, NaN],
-                  [undefined, null],
-                ],
-              },
-            })
-          );
+          sendMessageStub.resolves({
+            init: {
+              headers: [
+                [1, true],
+                [false, NaN],
+                [undefined, null],
+              ],
+            },
+          });
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr
@@ -1114,17 +1100,15 @@ describe
         });
 
         it('should support case-insensitive header search', () => {
-          sendMessageStub.returns(
-            Promise.resolve({
-              init: {
-                headers: [
-                  ['Content-Type', 'text/plain'],
-                  ['ACCEPT', 'text/plain'],
-                  ['x-amp-custom', 'foo'],
-                ],
-              },
-            })
-          );
+          sendMessageStub.resolves({
+            init: {
+              headers: [
+                ['Content-Type', 'text/plain'],
+                ['ACCEPT', 'text/plain'],
+                ['x-amp-custom', 'foo'],
+              ],
+            },
+          });
           const xhr = xhrServiceForTesting(interceptionEnabledWin);
 
           return xhr

--- a/test/unit/utils/test-xhr-utils.js
+++ b/test/unit/utils/test-xhr-utils.js
@@ -96,7 +96,7 @@ describes.sandboxed('utils/xhr-utils', {}, (env) => {
         getRootNode() {
           return {documentElement: doc};
         },
-        whenFirstVisible: env.sandbox.stub().returns(Promise.resolve()),
+        whenFirstVisible: env.sandbox.stub().resolves(),
       };
       doc = document.createElement('html');
       doc.setAttribute('allow-xhr-interception', 'true');
@@ -105,9 +105,7 @@ describes.sandboxed('utils/xhr-utils', {}, (env) => {
       viewer = {
         hasCapability: (unusedParam) => true,
         isTrustedViewer: () => Promise.resolve(true),
-        sendMessageAwaitResponse: env.sandbox
-          .stub()
-          .returns(Promise.resolve({})),
+        sendMessageAwaitResponse: env.sandbox.stub().resolves({}),
       };
       viewerForDoc = env.sandbox.stub(Services, 'viewerForDoc').returns(viewer);
       win = {


### PR DESCRIPTION
> [**`stub.resolves(value);`**](https://sinonjs.org/releases/latest/stubs/)
>
> Causes the stub to return a Promise which resolves to the provided value.

[Transformer used for this change.](https://astexplorer.net/#/gist/9f5fce239afbaf22448fca30bf5b14b3/1256a39f912be10bc899511376acdf12d893e596)

```diff
- stub.returns(Promise.resolve(x));
+ stub.resolves(x);
```