### PR TITLE
📖 Document that amp-story-cta-layer may not appear on the first story page

### DIFF
--- a/extensions/amp-story/amp-story-cta-layer.md
+++ b/extensions/amp-story/amp-story-cta-layer.md
@@ -28,7 +28,9 @@ limitations under the License.
 
 The `<amp-story-cta-layer>` component allows the usage of `<a>` and `<button>` elements inside an `<amp-story-page>`.
 
--   If specified, the `<amp-story-cta-layer>` element must be the last layer within an `<amp-story-page>`. As a result, effectively every `<amp-story-page>` can have exactly one or exactly zero of the `<amp-story-cta-layer>` element.
+-   The `<amp-story-cta-layer>` element may not appear on the first story page.
+-   If specified, the `<amp-story-cta-layer>` element must be the last layer within an `<amp-story-page>`.
+-   Every `<amp-story-page>` (except the first) can have exactly one or exactly zero of the `<amp-story-cta-layer>` element.
 -   Positioning and sizing of this layer cannot be controlled. It is always 100% width of the page, 20% height of the page, and aligned to the bottom of the page.
 
 [tip type="important"]


### PR DESCRIPTION
Update [amp-story-cta-layer docs page](https://amp.dev/documentation/components/amp-story-cta-layer/) to specify that `<amp-story-cta-layer>` may not be used on the first story page.

/cc @gmajoulet 

Resolves #24978