### PR TITLE
✅  Fix e2e test for collapsed amp-accordion

### DIFF
--- a/extensions/amp-accordion/1.0/test-e2e/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test-e2e/test-amp-accordion.js
@@ -65,7 +65,7 @@ describes.endtoend(
       // section 1 is collapsed
       await expect(
         controller.getElementProperty(content1, 'clientHeight')
-      ).to.equal(25);
+      ).to.equal(0);
     });
 
     it('renders section in expanded state when expanded attribute provided', async () => {


### PR DESCRIPTION
Appears to be flaky in [master](https://app.circleci.com/pipelines/github/ampproject/amphtml/3624/workflows/a9c3b54b-7a9c-4dee-a089-241d6c8c3d14/jobs/45085) due to async expect of the incorrect value (which is sometimes met during size transition).
