### PR TITLE
🏗 Lazy-require babel configs

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -25,33 +25,27 @@
 
 'use strict';
 
-const {
-  getDepCheckConfig,
-  getPostClosureConfig,
-  getPreClosureConfig,
-  getTestConfig,
-  getUnminifiedConfig,
-  getEslintConfig,
-} = require('./build-system/babel-config');
+const log = require('fancy-log');
 const {cyan, yellow} = require('kleur/colors');
-const {log} = require('./build-system/common/logging');
 
 /**
- * Mapping of babel transform callers to their corresponding babel configs.
+ * Mapping of each babel transform caller to the name of the function that
+ * returns its config.
  */
 const babelTransforms = new Map([
-  ['babel-jest', {}],
-  ['dep-check', getDepCheckConfig()],
-  ['post-closure', getPostClosureConfig()],
-  ['pre-closure', getPreClosureConfig()],
-  ['test', getTestConfig()],
-  ['unminified', getUnminifiedConfig()],
-  ['@babel/eslint-parser', getEslintConfig()],
+  ['babel-jest', 'getEmptyConfig'],
+  ['dep-check', 'getDepCheckConfig'],
+  ['post-closure', 'getPostClosureConfig'],
+  ['pre-closure', 'getPreClosureConfig'],
+  ['test', 'getTestConfig'],
+  ['unminified', 'getUnminifiedConfig'],
+  ['@babel/eslint-parser', 'getEslintConfig'],
 ]);
 
 /**
- * Main entry point. Returns babel config corresponding to the caller, or a
- * blank config if the caller is unrecognized.
+ * Main entry point. Returns babel config corresponding to the caller, or an
+ * empty object if the caller is unrecognized. Configs are lazy-required when
+ * requested so we don't unnecessarily compute the entire set for all callers.
  *
  * @param {!Object} api
  * @return {!Object}
@@ -61,7 +55,8 @@ module.exports = function (api) {
     return callerObj ? callerObj.name : '<unnamed>';
   });
   if (callerName && babelTransforms.has(callerName)) {
-    return babelTransforms.get(callerName);
+    const configFunctionName = babelTransforms.get(callerName);
+    return require('./build-system/babel-config')[configFunctionName]();
   } else {
     log(
       yellow('WARNING:'),

--- a/build-system/babel-config/empty-config.js
+++ b/build-system/babel-config/empty-config.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Helper that creates an empty babel config object.
+ *
+ * @return {!Object}
+ */
+const getEmptyConfig = () => ({});
+
+module.exports = {
+  getEmptyConfig,
+};

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -1245,6 +1245,7 @@ const forbiddenTermsSrcInclusive = {
     message:
       'Instead of fancy-log, use the logging functions in build-system/common/logging.js.',
     allowlist: [
+      'babel.config.js',
       'build-system/common/logging.js',
       'build-system/tasks/visual-diff/helpers.js',
       'validator/js/gulpjs/index.js',


### PR DESCRIPTION
**Two changes:**

- When a `babel` caller loads `babel.config.js`, lazy-require and return only the config requested.
- Remove `build-system/` deps from `babel.config.js` to eliminate side-effects when an empty config is returned.
