### PR TITLE
🐛Fix mediapool location logic for elements inside iframe.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2466,8 +2466,15 @@ export class AmpStory extends AMP.BaseElement {
    *     specified element, if any.
    */
   getPageContainingElement_(element) {
+    let startingElement = element;
+    // If the element is inside an iframe (most likely an ad), start from the
+    // containing iframe element.
+    if (element.ownerDocument !== this.win.document) {
+      startingElement = element.ownerDocument.defaultView.frameElement;
+    }
+
     const pageIndex = findIndex(this.pages_, (page) => {
-      const pageEl = closest(element, (el) => {
+      const pageEl = closest(startingElement, (el) => {
         return el === page.element;
       });
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -67,7 +67,7 @@ describes.realWin(
     async function createStoryWithPages(count, ids = [], autoAdvance = false) {
       element = win.document.createElement('amp-story');
 
-      Array(count)
+      const pageArray = Array(count)
         .fill(undefined)
         .map((unused, i) => {
           const page = win.document.createElement('amp-story-page');
@@ -81,6 +81,8 @@ describes.realWin(
 
       win.document.body.appendChild(element);
       story = await element.getImpl();
+
+      return pageArray;
     }
 
     /**
@@ -1141,6 +1143,40 @@ describes.realWin(
             [MediaType.VIDEO]: 8,
           };
           expect(story.getMaxMediaElementCounts()).to.deep.equal(expected);
+        });
+      });
+
+      describe('#getElementDistance', () => {
+        it('should return -1 for elements without a page', async () => {
+          await createStoryWithPages(3);
+          await story.layoutCallback();
+          const elToFind = win.document.createElement('video');
+          const distance = story.getElementDistance(elToFind);
+          expect(distance).to.equal(-1);
+        });
+
+        it('should find elements inside organic pages', async () => {
+          const pageArray = await createStoryWithPages(3);
+          await story.layoutCallback();
+          const elToFind = win.document.createElement('video');
+          const hostPage = pageArray[1];
+          hostPage.setAttribute('distance', '4');
+          hostPage.appendChild(elToFind);
+          const distance = story.getElementDistance(elToFind);
+          expect(distance).to.equal(4);
+        });
+
+        it('should find elements inside ad pages / FIE', async () => {
+          const pageArray = await createStoryWithPages(3);
+          await story.layoutCallback();
+          const elToFind = win.document.createElement('video');
+          const hostPage = pageArray[1];
+          hostPage.setAttribute('distance', '4');
+          const iframe = win.document.createElement('iframe');
+          iframe.appendChild(elToFind);
+          hostPage.appendChild(iframe);
+          const distance = story.getElementDistance(elToFind);
+          expect(distance).to.equal(4);
         });
       });
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1173,8 +1173,8 @@ describes.realWin(
           const hostPage = pageArray[1];
           hostPage.setAttribute('distance', '4');
           const iframe = win.document.createElement('iframe');
-          iframe.appendChild(elToFind);
           hostPage.appendChild(iframe);
+          iframe.contentDocument.body.appendChild(elToFind);
           const distance = story.getElementDistance(elToFind);
           expect(distance).to.equal(4);
         });


### PR DESCRIPTION
Reported as bug where stories with > 2 video ads and no organic videos would often show broken ads after the second video ad. 

When mediapool goes to evict an element, it will try to locate the element with the largest distance from the current page. It does this by starting at the element and walking up the tree until it finds an amp story page. When the element is inside an iframe it will always stop at the iframe boundary and never find the correct page nor distance. This leads to cases where the video element on the page that is about to show with be chosen to be evicted, swapped, and re-sourced all in a race condition with undesirable results. 

This may also be responsible for hard to reproduce "black screen" bugs reported in past.

This fix is to always return the right distance even when the video element is inside an iframe.