### PR TITLE
Multiversion: declare extensions with version

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -328,6 +328,8 @@ exports.rules = [
       // Parsing extension urls.
       'extensions/amp-a4a/0.1/head-validation.js->' +
         'src/service/extension-script.js',
+      'extensions/amp-live-list/0.1/live-list-manager.js->' +
+        'src/service/extension-script.js',
       'extensions/amp-video/0.1/amp-video.js->' +
         'src/service/video-manager-impl.js',
       'extensions/amp-video-iframe/0.1/amp-video-iframe.js->' +

--- a/extensions/amp-ad/0.1/test/test-amp-ad.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad.js
@@ -248,6 +248,8 @@ describes.realWin('Ad loader', {amp: true}, (env) => {
             const extensions = Services.extensionsFor(win);
             extensions.registerExtension(
               'amp-ad-network-zort-impl',
+              '0.1',
+              true,
               () => {
                 extensions.addElement(
                   'amp-ad-network-zort-impl',

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -37,7 +37,7 @@ describes.realWin(
   },
   (env) => {
     const {testServerPort} = window.ampTestRuntimeConfig;
-    const baseUrl = `http://localhost:${testServerPort}`;
+    const baseUrl = `http://localhost:${testServerPort || '9876'}`;
     let doc;
 
     const realSetTimeout = window.setTimeout;
@@ -52,11 +52,9 @@ describes.realWin(
     beforeEach(() => {
       doc = env.win.document;
 
-      env.sandbox.stub(Services, 'formSubmitForDoc').returns(
-        Promise.resolve(() => {
-          fire: () => {};
-        })
-      );
+      env.sandbox.stub(Services, 'formSubmitForDoc').resolves({
+        fire: () => {},
+      });
 
       const mustache = document.createElement('script');
       mustache.setAttribute('custom-template', 'amp-mustache');
@@ -65,6 +63,9 @@ describes.realWin(
 
       const form = document.createElement('script');
       form.setAttribute('custom-element', 'amp-form');
+      Object.defineProperty(form, 'src', {
+        value: 'https://cdn.ampproject.org/v0/amp-form-0.1.js',
+      });
       doc.head.appendChild(form);
 
       new AmpFormService(env.ampdoc);

--- a/extensions/amp-live-list/0.1/live-list-manager.js
+++ b/extensions/amp-live-list/0.1/live-list-manager.js
@@ -17,10 +17,10 @@
 import {Poller} from './poller';
 import {Services} from '../../../src/services';
 import {addParamToUrl} from '../../../src/url';
+import {extensionScriptsInNode} from '../../../src/service/extension-script';
 import {fetchDocument} from '../../../src/document-fetcher';
 import {getMode} from '../../../src/mode';
 import {getServicePromiseForDoc} from '../../../src/service';
-import {toArray} from '../../../src/types';
 import {pureUserAssert as userAssert} from '../../../src/core/assert';
 
 /** @const {string} */
@@ -312,16 +312,15 @@ export class LiveListManager {
    * @param {!Document} doc
    */
   installExtensionsForDoc_(doc) {
-    const extensions = toArray(
-      doc.querySelectorAll('script[custom-element], script[custom-template]')
-    );
-    extensions.forEach((script) => {
-      const extensionName =
-        script.getAttribute('custom-element') ||
-        script.getAttribute('custom-template');
+    const extensions = extensionScriptsInNode(doc);
+    extensions.forEach(({extensionId, extensionVersion}) => {
       // This is a cheap operation if extension is already installed so no need
       // to over optimize checks.
-      this.extensions_.installExtensionForDoc(this.ampdoc, extensionName);
+      this.extensions_.installExtensionForDoc(
+        this.ampdoc,
+        extensionId,
+        extensionVersion
+      );
     });
   }
 

--- a/extensions/amp-live-list/0.1/test/test-live-list-manager.js
+++ b/extensions/amp-live-list/0.1/test/test-live-list-manager.js
@@ -742,7 +742,7 @@ describes.fakeWin('LiveListManager', {amp: true}, (env) => {
   );
 
   it('should find highest "update time" from amp-live-list elements', () => {
-    const doc = [];
+    const doc = {};
     const list1 = getLiveList(undefined, 'id1');
     const list2 = getLiveList(undefined, 'id2');
     env.sandbox.stub(list1, 'update').returns(1000);
@@ -750,7 +750,7 @@ describes.fakeWin('LiveListManager', {amp: true}, (env) => {
     doc.getElementsByTagName = () => {
       return [list1.element, list2.element];
     };
-    doc.querySelectorAll = function () {};
+    doc.querySelectorAll = () => [];
     list1.buildCallback();
     list2.buildCallback();
     expect(manager.latestUpdateTime_).to.equal(0);
@@ -824,7 +824,13 @@ describes.realWin(
       const script1 = document.createElement('script');
       const script2 = document.createElement('script');
       script1.setAttribute('custom-element', 'amp-test');
+      env.sandbox
+        .stub(script1, 'src')
+        .value('https://cdn.ampproject.org/v0/amp-test-0.2.js');
       script2.setAttribute('custom-template', 'amp-template');
+      env.sandbox
+        .stub(script2, 'src')
+        .value('https://cdn.ampproject.org/v0/amp-template-0.2.js');
       div.appendChild(script1);
       div.appendChild(script2);
 
@@ -841,12 +847,14 @@ describes.realWin(
       manager.installExtensionsForDoc_(div);
 
       expect(
-        doc.head.querySelectorAll('[custom-element="amp-test"]')
+        doc.head.querySelectorAll('[custom-element="amp-test"][src*="-0.2"]')
       ).to.have.length(1);
       expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
 
       expect(
-        doc.head.querySelectorAll('[custom-element="amp-template"]')
+        doc.head.querySelectorAll(
+          '[custom-element="amp-template"][src*="-0.2"]'
+        )
       ).to.have.length(1);
       expect(extensions.extensions_['amp-template'].scriptPresent).to.be.true;
     });

--- a/src/element-service.js
+++ b/src/element-service.js
@@ -183,12 +183,14 @@ export function isExtensionScriptInNode(ampdoc, extensionId) {
  * Verifies that an extension script is present in head for
  * installation.
  * @param {HTMLHeadElement|Element|ShadowRoot} head
- * @param {string} extensionId
+ * @param {string} id
  * @return {boolean}
  * @private
  */
-function extensionScriptInNode(head, extensionId) {
-  return extensionScriptsInNode(head).includes(extensionId);
+function extensionScriptInNode(head, id) {
+  return extensionScriptsInNode(head).some(
+    ({extensionId}) => id == extensionId
+  );
 }
 
 /**

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -183,7 +183,13 @@ function adoptShared(global, callback) {
         if (typeof fnOrStruct == 'function') {
           fnOrStruct(global.AMP, global.AMP._);
         } else {
-          extensions.registerExtension(fnOrStruct.n, fnOrStruct.f, global.AMP);
+          extensions.registerExtension(
+            fnOrStruct.n,
+            fnOrStruct.ev,
+            fnOrStruct.l,
+            fnOrStruct.f,
+            global.AMP
+          );
         }
       });
     };

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -440,8 +440,10 @@ export class AmpDoc {
    * @restricted
    */
   declareExtension(extensionId, version) {
+    devAssert(version); // QQQ: remove/debugging.
     devAssert(
-      (this.declaredExtensions_[extensionId] || version) === version,
+      !this.declaredExtensions_[extensionId] ||
+        this.declaredExtensions_[extensionId] === version,
       'extension already declared %s',
       extensionId
     );

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -263,8 +263,8 @@ export class AmpDoc {
     /** @protected {?Object<string, string>} */
     this.meta_ = null;
 
-    /** @private @const {!Array<string>} */
-    this.declaredExtensions_ = [];
+    /** @private @const {!Object<string, string>} */
+    this.declaredExtensions_ = {};
 
     /** @private {?VisibilityState} */
     this.visibilityStateOverride_ =
@@ -422,21 +422,31 @@ export class AmpDoc {
   /**
    * Returns whether the specified extension has been declared on this ampdoc.
    * @param {string} extensionId
+   * @param {string=} opt_version
    * @return {boolean}
    */
-  declaresExtension(extensionId) {
-    return this.declaredExtensions_.indexOf(extensionId) != -1;
+  declaresExtension(extensionId, opt_version) {
+    const declared = this.declaredExtensions_[extensionId];
+    if (!declared) {
+      return false;
+    }
+    return !opt_version || declared === opt_version;
   }
 
   /**
    * Adds a declared extension to an ampdoc.
    * @param {string} extensionId
+   * @param {string} version
    * @restricted
    */
-  declareExtension(extensionId) {
-    if (!this.declaresExtension(extensionId)) {
-      this.declaredExtensions_.push(extensionId);
-    }
+  declareExtension(extensionId, version) {
+    devAssert(version); // QQQ: remove/debugging.
+    devAssert(
+      (this.declaredExtensions_[extensionId] || version) === version,
+      'extension already declared %s',
+      extensionId
+    );
+    this.declaredExtensions_[extensionId] = version;
   }
 
   /**

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -440,7 +440,6 @@ export class AmpDoc {
    * @restricted
    */
   declareExtension(extensionId, version) {
-    devAssert(version); // QQQ: remove/debugging.
     devAssert(
       (this.declaredExtensions_[extensionId] || version) === version,
       'extension already declared %s',

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -131,9 +131,9 @@ function waitReadyForUpgrade(win, elementClass) {
  */
 export function stubElementsForDoc(ampdoc) {
   const extensions = extensionScriptsInNode(ampdoc.getHeadNode());
-  extensions.forEach((name) => {
-    ampdoc.declareExtension(name);
-    stubElementIfNotKnown(ampdoc.win, name);
+  extensions.forEach(({extensionId, extensionVersion}) => {
+    ampdoc.declareExtension(extensionId, extensionVersion);
+    stubElementIfNotKnown(ampdoc.win, extensionId);
   });
 }
 

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -94,6 +94,9 @@ export function calculateEntryPointScriptUrl(
  * @return {?{extensionId: string, extensionVersion: string}}
  */
 export function parseExtensionUrl(scriptUrl) {
+  if (!scriptUrl) {
+    return null;
+  }
   // Note that the "(\.max)?" group only applies to local dev.
   const matches = scriptUrl.match(
     /^(.*)\/(.*)-([0-9.]+|latest)(\.max)?\.(?:js|mjs)$/i
@@ -210,7 +213,7 @@ export function getExtensionScripts(
  * @param {HTMLHeadElement|Element|ShadowRoot|Document} head
  * @return {!Array<{extensionId: string, extensionVersion: string}>}
  */
-export function extensionScriptsInNode(head) {//QQQQ:calls
+export function extensionScriptsInNode(head) {
   // ampdoc.getHeadNode() can return null.
   if (!head) {
     return [];
@@ -229,8 +232,10 @@ export function extensionScriptsInNode(head) {//QQQQ:calls
     const extensionId =
       script.getAttribute('custom-element') ||
       script.getAttribute('custom-template');
-    const {extensionVersion} = parseExtensionUrl(script.src);
-    scripts.push({extensionId, extensionVersion});
+    const urlParts = parseExtensionUrl(script.src);
+    if (extensionId && urlParts) {
+      scripts.push({extensionId, extensionVersion: urlParts.extensionVersion});
+    }
   }
   return scripts;
 }

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -207,28 +207,32 @@ export function getExtensionScripts(
 
 /**
  * Get list of all the extension JS files.
- * @param {HTMLHeadElement|Element|ShadowRoot} head
- * @return {!Array<string>}
+ * @param {HTMLHeadElement|Element|ShadowRoot|Document} head
+ * @return {!Array<{extensionId: string, extensionVersion: string}>}
  */
-export function extensionScriptsInNode(head) {
+export function extensionScriptsInNode(head) {//QQQQ:calls
   // ampdoc.getHeadNode() can return null.
   if (!head) {
     return [];
   }
-  const scripts = {};
   // Note: Some extensions don't have [custom-element] or [custom-template]
   // e.g. amp-viewer-integration.
   const list = head.querySelectorAll(
     'script[custom-element],script[custom-template]'
   );
+  const scripts = [];
   for (let i = 0; i < list.length; i++) {
     const script = list[i];
-    const name =
+    if (script.hasAttribute('i-amphtml-inserted')) {
+      continue;
+    }
+    const extensionId =
       script.getAttribute('custom-element') ||
       script.getAttribute('custom-template');
-    scripts[name] = true;
+    const {extensionVersion} = parseExtensionUrl(script.src);
+    scripts.push({extensionId, extensionVersion});
   }
-  return Object.keys(scripts);
+  return scripts;
 }
 
 /**

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -226,9 +226,6 @@ export function extensionScriptsInNode(head) {
   const scripts = [];
   for (let i = 0; i < list.length; i++) {
     const script = list[i];
-    if (script.hasAttribute('i-amphtml-inserted')) {
-      continue;
-    }
     const extensionId =
       script.getAttribute('custom-element') ||
       script.getAttribute('custom-template');

--- a/test/fixtures/overflow.html
+++ b/test/fixtures/overflow.html
@@ -6,7 +6,7 @@
   <link rel="canonical" href="amps.html" >
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async src="https://cdn.ampproject.org/v0.js"></script>
-  <script async custom-element="amp-iframe" src="intentionally_wrong"></script>
+  <script async custom-element="amp-iframe" src="intentionally_wrong-0.1.js"></script>
   <style amp-custom>
     div[overflow] {
       height: 33px;

--- a/test/unit/test-ampdoc.js
+++ b/test/unit/test-ampdoc.js
@@ -910,26 +910,34 @@ describes.realWin('AmpDocSingle', {}, (env) => {
 
   it('should declare extension', () => {
     expect(ampdoc.declaresExtension('ext1')).to.be.false;
+    expect(ampdoc.declaresExtension('ext1', '0.2')).to.be.false;
     expect(ampdoc.declaresExtension('ext2')).to.be.false;
-    ampdoc.declareExtension('ext1');
+    ampdoc.declareExtension('ext1', '0.2');
     expect(ampdoc.declaresExtension('ext1')).to.be.true;
+    expect(ampdoc.declaresExtension('ext1', '0.2')).to.be.true;
+    expect(ampdoc.declaresExtension('ext1', '0.1')).to.be.false;
     expect(ampdoc.declaresExtension('ext2')).to.be.false;
 
-    ampdoc.declareExtension('ext2');
+    ampdoc.declareExtension('ext2', '0.3');
     expect(ampdoc.declaresExtension('ext1')).to.be.true;
     expect(ampdoc.declaresExtension('ext2')).to.be.true;
+    expect(ampdoc.declaresExtension('ext2', '0.3')).to.be.true;
+    expect(ampdoc.declaresExtension('ext2', '0.1')).to.be.false;
   });
 
   it('should ignore duplicate extensions', () => {
     expect(ampdoc.declaresExtension('ext1')).to.be.false;
-    ampdoc.declareExtension('ext1');
+    ampdoc.declareExtension('ext1', '0.2');
     expect(ampdoc.declaresExtension('ext1')).to.be.true;
-    expect(ampdoc.declaredExtensions_).to.have.length(1);
+    expect(ampdoc.declaresExtension('ext1', '0.2')).to.be.true;
 
     // Repeat.
-    ampdoc.declareExtension('ext1');
-    expect(ampdoc.declaredExtensions_).to.have.length(1);
+    ampdoc.declareExtension('ext1', '0.2');
     expect(ampdoc.declaresExtension('ext1')).to.be.true;
+    expect(ampdoc.declaresExtension('ext1', '0.2')).to.be.true;
+
+    // A different version is not allowed.
+    expect(() => ampdoc.declareExtension('ext1', '0.1')).to.throw();
   });
 });
 

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -46,7 +46,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
     doc = win.document;
     ampdoc = env.ampdoc;
     extensions = env.extensions;
-    ampdoc.declareExtension('amp-element1');
+    ampdoc.declareExtension('amp-element1', '0.2');
   });
 
   function insertElement(name) {
@@ -134,11 +134,15 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
     const head = document.createElement('fake-head');
     const script = document.createElement('script');
     script.setAttribute('custom-element', 'amp-element2');
+    Object.defineProperty(script, 'src', {
+      value: 'https://cdn.ampproject.org/v0/amp-element2-0.2.js',
+    });
     head.appendChild(script);
     env.sandbox.stub(ampdoc, 'getHeadNode').callsFake(() => head);
 
     stubElementsForDoc(ampdoc);
     expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
+    expect(ampdoc.declaresExtension('amp-element2', '0.2')).to.be.true;
     expect(win.__AMP_EXTENDED_ELEMENTS['amp-element2']).to.equal(ElementStub);
   });
 
@@ -157,7 +161,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
   });
 
   it('should not install declared pre-stubbed element extension', () => {
-    ampdoc.declareExtension('amp-element2');
+    ampdoc.declareExtension('amp-element2', '0.2');
     const stub = env.sandbox.stub(extensions, 'installExtensionForDoc');
 
     stubElementIfNotKnown(win, 'amp-element2');
@@ -238,11 +242,15 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
       };
 
       elem1 = {
-        getAttribute: (name) => {
+        getAttribute(name) {
           if (name == 'custom-element') {
             return 'amp-test1';
           }
         },
+        hasAttribute(name) {
+          return name == 'custom-element' || name == 'src';
+        },
+        src: 'https://cdn.ampproject.org/v0/amp-test1-0.2.js',
         ownerDocument: doc,
       };
       elements.push(elem1);
@@ -276,6 +284,10 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
       expect(win.__AMP_EXTENDED_ELEMENTS['amp-test2']).to.be.undefined;
       expect(win.customElements.define).to.be.calledOnce;
       expect(win.customElements.define.firstCall.args[0]).to.equal('amp-test1');
+
+      expect(ampdoc.declaresExtension('amp-test1')).to.be.true;
+      expect(ampdoc.declaresExtension('amp-test1', '0.2')).to.be.true;
+      expect(ampdoc.declaresExtension('amp-test2')).to.be.false;
     });
 
     it('should repeat stubbing when body is not available', () => {
@@ -288,14 +300,21 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
       expect(win.__AMP_EXTENDED_ELEMENTS['amp-test2']).to.be.undefined;
       expect(win.customElements.define).to.be.calledOnce;
       expect(win.customElements.define.firstCall.args[0]).to.equal('amp-test1');
+      expect(ampdoc.declaresExtension('amp-test1')).to.be.true;
+      expect(ampdoc.declaresExtension('amp-test1', '0.2')).to.be.true;
+      expect(ampdoc.declaresExtension('amp-test2')).to.be.false;
 
       // Add more elements
       const elem2 = {
-        getAttribute: (name) => {
+        getAttribute(name) {
           if (name == 'custom-element') {
             return 'amp-test2';
           }
         },
+        hasAttribute(name) {
+          return name == 'custom-element' || name == 'src';
+        },
+        src: 'https://cdn.ampproject.org/v0/amp-test2-0.3.js',
         ownerDocument: doc,
       };
       elements.push(elem2);
@@ -309,6 +328,8 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
       expect(win.customElements.define.getCall(1).args[0]).to.equal(
         'amp-test2'
       );
+      expect(ampdoc.declaresExtension('amp-test2')).to.be.true;
+      expect(ampdoc.declaresExtension('amp-test2', '0.3')).to.be.true;
     });
 
     it('should stub element when not stubbed yet', () => {

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -47,7 +47,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
     win.customElements.define('amp-stub', StubElementClass);
     win.__AMP_EXTENDED_ELEMENTS['amp-test'] = TestElement;
     win.__AMP_EXTENDED_ELEMENTS['amp-stub'] = ElementStub;
-    ampdoc.declareExtension('amp-stub');
+    ampdoc.declareExtension('amp-stub', '0.1');
     ElementClass.prototype.inspect = function () {
       return this.tagName;
     };

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -147,7 +147,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         win.__AMP_EXTENDED_ELEMENTS[
           'amp-test-with-re-upgrade'
         ] = TestElementWithReUpgrade;
-        ampdoc.declareExtension('amp-stub');
+        ampdoc.declareExtension('amp-stub', '0.1');
 
         testElementPreconnectCallback = env.sandbox.spy();
         testElementBuildCallback = env.sandbox.spy();
@@ -267,7 +267,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         const LegacyElementClass = createAmpElementForTesting(win, ElementStub);
         win.customElements.define('amp-legacy', LegacyElementClass);
         win.__AMP_EXTENDED_ELEMENTS['amp-legacy'] = ElementStub;
-        ampdoc.declareExtension('amp-legacy');
+        ampdoc.declareExtension('amp-legacy', '0.1');
 
         const extensions = Services.extensionsFor(win);
         env.sandbox.stub(extensions, 'installExtensionForDoc');
@@ -1869,7 +1869,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, (env) => {
     doc = win.document;
     StubElementClass = createAmpElementForTesting(win, ElementStub);
     win.customElements.define('amp-stub2', StubElementClass);
-    env.ampdoc.declareExtension('amp-stub2');
+    env.ampdoc.declareExtension('amp-stub2', '0.1');
     element = new StubElementClass();
   });
 

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -61,6 +61,8 @@ describes.sandboxed('Extensions', {}, () => {
       let currentHolder;
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         (arg) => {
           expect(factoryExecuted).to.be.false;
           expect(arg).to.equal(amp);
@@ -107,7 +109,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should register successfully with promise', () => {
       const promise = extensions.waitForExtension(win, 'amp-ext');
-      extensions.registerExtension('amp-ext', () => {}, {});
+      extensions.registerExtension('amp-ext', '0.1', true, () => {}, {});
       expect(extensions.currentExtensionId_).to.be.null;
 
       const holder = extensions.extensions_['amp-ext'];
@@ -127,6 +129,8 @@ describes.sandboxed('Extensions', {}, () => {
       expect(() => {
         extensions.registerExtension(
           'amp-ext',
+          '0.1',
+          true,
           () => {
             throw new Error('intentional');
           },
@@ -160,6 +164,8 @@ describes.sandboxed('Extensions', {}, () => {
       expect(() => {
         extensions.registerExtension(
           'amp-ext',
+          '0.1',
+          true,
           () => {
             throw new Error('intentional');
           },
@@ -208,6 +214,8 @@ describes.sandboxed('Extensions', {}, () => {
       ctor.requiresShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         () => {
           extensions.addElement('e1', ctor);
         },
@@ -238,6 +246,8 @@ describes.sandboxed('Extensions', {}, () => {
       const ctor = function () {};
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         () => {
           extensions.addTemplate('e1', ctor);
         },
@@ -270,6 +280,8 @@ describes.sandboxed('Extensions', {}, () => {
       const ctor = function () {};
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addTemplate('amp-test', ctor);
         },
@@ -304,6 +316,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addElement('amp-test', AmpTest);
           extensions.addElement('amp-test-sub', AmpTestSub);
@@ -333,6 +347,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addElement('amp-test', AmpTest);
           extensions.addElement('amp-test-sub', AmpTestSub);
@@ -366,6 +382,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addElement('amp-test', AmpTest);
           extensions.addElement('amp-test-sub', AmpTestSub);
@@ -396,6 +414,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addElement('amp-test', AmpTest);
           extensions.addElement('amp-test-sub', AmpTestSub);
@@ -424,6 +444,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addElement('amp-test', AmpTest);
           extensions.addElement('amp-test-sub', AmpTestSub);
@@ -459,6 +481,8 @@ describes.sandboxed('Extensions', {}, () => {
       const factory = function () {};
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         () => {
           extensions.addDocFactory(factory);
         },
@@ -493,6 +517,8 @@ describes.sandboxed('Extensions', {}, () => {
       const factory3 = env.sandbox.spy();
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         () => {
           extensions.addDocFactory(factory1);
           extensions.addDocFactory(factory2);
@@ -517,6 +543,8 @@ describes.sandboxed('Extensions', {}, () => {
       const factory = function () {};
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         () => {
           extensions.addService('service1', factory);
         },
@@ -561,6 +589,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addService('service1', factory1);
           extensions.addService('service2', factory2);
@@ -585,6 +615,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addService('service1', factory1);
           extensions.addService('service2', factory2);
@@ -622,6 +654,8 @@ describes.sandboxed('Extensions', {}, () => {
       // Resolve the promise.
       extensions.registerExtension(
         'amp-test',
+        '0.1',
+        true,
         () => {
           extensions.addService('service1', factory1);
           extensions.addService('service2', factory2);
@@ -648,6 +682,8 @@ describes.sandboxed('Extensions', {}, () => {
       const factory3 = env.sandbox.spy();
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         () => {
           extensions.addService('service1', factory1);
           extensions.addService('service2', factory2);
@@ -675,6 +711,8 @@ describes.sandboxed('Extensions', {}, () => {
       ctor.requiresShadowDom = () => false;
       extensions.registerExtension(
         'amp-ext',
+        '0.1',
+        true,
         () => {
           extensions.addElement('amp-ext', ctor);
         },
@@ -701,7 +739,7 @@ describes.sandboxed('Extensions', {}, () => {
       const reloadPromise = extensions.reloadExtension('amp-ext', '0.1', true);
 
       // Register extension.
-      extensions.registerExtension('amp-ext', () => {}, {});
+      extensions.registerExtension('amp-ext', '0.1', true, () => {}, {});
 
       return reloadPromise.then((reloadedExtension) => {
         expect(reloadedExtension).to.exist;
@@ -1268,7 +1306,23 @@ describes.sandboxed('Extensions', {}, () => {
         expect(loadSpy).to.be.calledOnce;
         expect(loadSpy).to.be.calledWithExactly('amp-test', '0.1');
         expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"][src*="-0.1"]')
+        ).to.have.length(1);
+        expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
+        expect(win.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
+      });
+
+      it('should insert extension script correctly for non-default version', () => {
+        const loadSpy = env.sandbox.spy(extensions, 'preloadExtension');
+        expect(
           doc.head.querySelectorAll('[custom-element="amp-test"]')
+        ).to.have.length(0);
+        expect(extensions.extensions_['amp-test']).to.be.undefined;
+        extensions.installExtensionForDoc(ampdoc, 'amp-test', '0.2');
+        expect(loadSpy).to.be.calledOnce;
+        expect(loadSpy).to.be.calledWithExactly('amp-test', '0.2');
+        expect(
+          doc.head.querySelectorAll('[custom-element="amp-test"][src*="-0.2"]')
         ).to.have.length(1);
         expect(
           doc.head
@@ -1315,6 +1369,8 @@ describes.sandboxed('Extensions', {}, () => {
         // Resolve the promise.
         extensions.registerExtension(
           'amp-test',
+          '0.1',
+          true,
           (AMP) => {
             // Main extension with CSS.
             AMP.registerElement('amp-test', AmpTest, 'a{}');
@@ -1344,7 +1400,7 @@ describes.sandboxed('Extensions', {}, () => {
         expect(loadSpy).to.be.calledOnce;
 
         // Resolve.
-        extensions.registerExtension('amp-test', () => {}, {});
+        extensions.registerExtension('amp-test', '0.1', true, () => {}, {});
         return promise1.then(() => {
           const promise3 = extensions.installExtensionForDoc(
             ampdoc,
@@ -1389,6 +1445,8 @@ describes.sandboxed('Extensions', {}, () => {
         // Resolve the promise.
         extensions.registerExtension(
           'amp-test',
+          '0.1',
+          true,
           (AMP) => {
             AMP.registerServiceForDoc('service1', factory1);
             AMP.registerServiceForDoc('service2', factory2);
@@ -1429,6 +1487,8 @@ describes.sandboxed('Extensions', {}, () => {
         const promise = extensions.installExtensionForDoc(ampdoc, 'amp-test');
         extensions.registerExtension(
           'amp-test',
+          '0.1',
+          true,
           (AMP) => {
             AMP.registerServiceForDoc('service1', factory1);
             AMP.registerServiceForDoc('service2', factory2);

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -95,13 +95,13 @@ describes.sandboxed('Extensions', {}, () => {
     it('should register only once', () => {
       const amp = {};
       const factoryStub = env.sandbox.stub();
-      extensions.registerExtension('amp-ext', factoryStub, amp);
+      extensions.registerExtension('amp-ext', '0.1', true, factoryStub, amp);
       expect(factoryStub).to.be.calledOnce;
       const holder1 = extensions.extensions_['amp-ext'];
       expect(extensions.getExtensionHolder_('amp-ext')).to.equal(holder1);
 
       // Try register again.
-      extensions.registerExtension('amp-ext', factoryStub, amp);
+      extensions.registerExtension('amp-ext', '0.1', true, factoryStub, amp);
       expect(factoryStub).to.be.calledOnce; // no change.
       const holder2 = extensions.extensions_['amp-ext'];
       expect(holder2).to.equal(holder1);
@@ -1308,6 +1308,11 @@ describes.sandboxed('Extensions', {}, () => {
         expect(
           doc.head.querySelectorAll('[custom-element="amp-test"][src*="-0.1"]')
         ).to.have.length(1);
+        expect(
+          doc.head
+            .querySelector('[custom-element="amp-test"]')
+            .getAttribute('src')
+        ).to.contain('-0.1');
         expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
         expect(win.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
       });
@@ -1328,7 +1333,7 @@ describes.sandboxed('Extensions', {}, () => {
           doc.head
             .querySelector('[custom-element="amp-test"]')
             .getAttribute('src')
-        ).to.contain('-0.1');
+        ).to.contain('-0.2');
         expect(extensions.extensions_['amp-test'].scriptPresent).to.be.true;
         expect(win.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
       });

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -352,7 +352,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should install declared elements for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-      ampdoc.declareExtension('amp-test');
+      ampdoc.declareExtension('amp-test', '0.1');
       expect(
         win.__AMP_EXTENDED_ELEMENTS && win.__AMP_EXTENDED_ELEMENTS['amp-test']
       ).to.be.undefined;
@@ -380,7 +380,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should install non-auto declared elements for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-      ampdoc.declareExtension('amp-test');
+      ampdoc.declareExtension('amp-test', '0.1');
       expect(
         win.__AMP_EXTENDED_ELEMENTS && win.__AMP_EXTENDED_ELEMENTS['amp-test']
       ).to.be.undefined;
@@ -606,7 +606,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should install declared services for single-doc', () => {
       const ampdoc = Services.ampdocServiceFor(win).getSingleDoc();
-      ampdoc.declareExtension('amp-test');
+      ampdoc.declareExtension('amp-test', '0.1');
 
       const factory1Spy = env.sandbox.spy();
       const factory2Spy = env.sandbox.spy();

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -1458,6 +1458,8 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
     // Resolve the promise.
     extensions.registerExtension(
       'amp-test',
+      '0.1',
+      true,
       (AMP) => {
         // Main extension with CSS.
         AMP.registerElement('amp-test', AmpTest, 'a{}');
@@ -1535,6 +1537,8 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
     // Resolve the promise `install`.
     extensions.registerExtension(
       'amp-test',
+      '0.1',
+      true,
       (AMP) => {
         AMP.registerServiceForDoc('fake-service-foo', FooService);
       },
@@ -1586,6 +1590,8 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
     // Resolve the promise.
     extensions.registerExtension(
       'amp-test',
+      '0.1',
+      true,
       (AMP) => {
         AMP.registerElement('amp-test', AmpTest);
       },

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -320,6 +320,8 @@ describes.fakeWin(
       });
       win.AMP.push({
         n: 'ext2',
+        ev: '0.1',
+        l: true,
         p: 'high',
         f: (amp) => {
           expect(amp).to.equal(win.AMP);
@@ -347,6 +349,8 @@ describes.fakeWin(
           expect(progress).to.equal('1HIGH');
           win.AMP.push({
             n: 'ext1',
+            ev: '0.1',
+            l: true,
             f: (amp) => {
               expect(amp).to.equal(win.AMP);
               progress += 'A';
@@ -596,6 +600,8 @@ describes.fakeWin(
         ampdoc.declareExtension('amp-ext', '0.1');
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerTemplate('amp-ext', TemplateType);
           },
@@ -636,6 +642,8 @@ describes.fakeWin(
         ampdoc.declareExtension('amp-ext', '0.1');
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement);
           },
@@ -680,6 +688,8 @@ describes.fakeWin(
         ampdoc.declareExtension('amp-ext', '0.1');
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement, 'a{}');
           },
@@ -726,6 +736,8 @@ describes.fakeWin(
         ampdocServiceMock.expects('getAmpDoc').returns(ampdoc).atLeast(1);
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerServiceForDoc('service1', Service1);
           },
@@ -756,6 +768,8 @@ describes.fakeWin(
         ampdocServiceMock.expects('getAmpDoc').returns(ampdoc).atLeast(1);
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerServiceForDoc('service1', factory);
           },
@@ -807,6 +821,8 @@ describes.fakeWin(
 
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement);
           },
@@ -855,6 +871,8 @@ describes.fakeWin(
 
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerElement('amp-ext', win.AMP.BaseElement, 'a{}');
           },
@@ -906,6 +924,8 @@ describes.fakeWin(
         class Service1 {}
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerServiceForDoc('service1', Service1);
           },
@@ -1011,6 +1031,8 @@ describes.realWin(
         class Service1 {}
         win.AMP.push({
           n: 'amp-ext',
+          ev: '0.1',
+          l: true,
           f: (amp) => {
             amp.registerServiceForDoc('service1', Service1);
           },
@@ -1437,6 +1459,8 @@ describes.realWin(
           class Service1 {}
           win.AMP.push({
             n: 'amp-ext',
+            ev: '0.1',
+            l: true,
             f: (amp) => {
               amp.registerServiceForDoc('service1', Service1);
             },

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -593,7 +593,7 @@ describes.fakeWin(
 
         class TemplateType {}
 
-        ampdoc.declareExtension('amp-ext');
+        ampdoc.declareExtension('amp-ext', '0.1');
         win.AMP.push({
           n: 'amp-ext',
           f: (amp) => {
@@ -633,7 +633,7 @@ describes.fakeWin(
           'installStylesForDoc'
         );
 
-        ampdoc.declareExtension('amp-ext');
+        ampdoc.declareExtension('amp-ext', '0.1');
         win.AMP.push({
           n: 'amp-ext',
           f: (amp) => {
@@ -677,7 +677,7 @@ describes.fakeWin(
             installStylesCallback = cb;
           });
 
-        ampdoc.declareExtension('amp-ext');
+        ampdoc.declareExtension('amp-ext', '0.1');
         win.AMP.push({
           n: 'amp-ext',
           f: (amp) => {
@@ -722,7 +722,7 @@ describes.fakeWin(
       it('should register doc-service as ctor and install imm', function* () {
         class Service1 {}
         const ampdoc = new AmpDocSingle(win);
-        ampdoc.declareExtension('amp-ext');
+        ampdoc.declareExtension('amp-ext', '0.1');
         ampdocServiceMock.expects('getAmpDoc').returns(ampdoc).atLeast(1);
         win.AMP.push({
           n: 'amp-ext',
@@ -752,7 +752,7 @@ describes.fakeWin(
           return {str: 'A'};
         }
         const ampdoc = new AmpDocSingle(win);
-        ampdoc.declareExtension('amp-ext');
+        ampdoc.declareExtension('amp-ext', '0.1');
         ampdocServiceMock.expects('getAmpDoc').returns(ampdoc).atLeast(1);
         win.AMP.push({
           n: 'amp-ext',

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -769,7 +769,13 @@ class AmpFixture {
           if (env.ampdoc) {
             env.ampdoc.declareExtension(extensionId, extensionVersion);
           }
-          env.extensions.registerExtension(extensionId, installer, win.AMP);
+          env.extensions.registerExtension(
+            extensionId,
+            extensionVersion,
+            /* latest */ false,
+            installer,
+            win.AMP
+          );
         }
       });
     }
@@ -802,7 +808,13 @@ class AmpFixture {
       if (env.ampdoc) {
         env.ampdoc.declareExtension(extensionId, version);
       }
-      env.extensions.registerExtension(extensionId, installer, win.AMP);
+      env.extensions.registerExtension(
+        extensionId,
+        version,
+        /* latest */ false,
+        installer,
+        win.AMP
+      );
     };
 
     /**


### PR DESCRIPTION
Partial for #33001.

The main change is `AmpDoc.declareExtension(extensionId, version)`. Starting from this PR an ampdoc will not only track which extensions are installed for this doc, but also which version exactly. All other changes, essentially, are only there to propagate version as far as needed.