### PR TITLE
🏗 Move 3p iframe vendor builds to use esbuild

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -39,6 +39,7 @@ const babelTransforms = new Map([
   ['pre-closure', 'getPreClosureConfig'],
   ['test', 'getTestConfig'],
   ['unminified', 'getUnminifiedConfig'],
+  ['minified', 'getMinifiedConfig'],
   ['@babel/eslint-parser', 'getEslintConfig'],
 ]);
 

--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS-IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const argv = require('minimist')(process.argv.slice(2));
+const {getReplacePlugin} = require('./helpers');
+
+/**
+ * Gets the config for minified babel transforms run, used by 3p vendors.
+ *
+ * @return {!Object}
+ */
+function getMinifiedConfig() {
+  const replacePlugin = getReplacePlugin();
+  const plugins = [
+    'optimize-objstr',
+    './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
+    './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
+    '@babel/plugin-transform-react-constant-elements',
+    argv.esm
+      ? './build-system/babel-plugins/babel-plugin-transform-dev-methods'
+      : null,
+    [
+      './build-system/babel-plugins/babel-plugin-transform-log-methods',
+      {replaceCallArguments: false},
+    ],
+    './build-system/babel-plugins/babel-plugin-transform-parenthesize-expression',
+    [
+      './build-system/babel-plugins/babel-plugin-transform-json-import',
+      {freeze: false},
+    ],
+    './build-system/babel-plugins/babel-plugin-is_minified-constant-transformer',
+    './build-system/babel-plugins/babel-plugin-transform-html-template',
+    './build-system/babel-plugins/babel-plugin-transform-jss',
+    './build-system/babel-plugins/babel-plugin-transform-version-call',
+    './build-system/babel-plugins/babel-plugin-transform-simple-array-destructure',
+    './build-system/babel-plugins/babel-plugin-transform-default-assignment',
+    replacePlugin,
+    './build-system/babel-plugins/babel-plugin-transform-amp-asserts',
+    // TODO(erwinm, #28698): fix this in fixit week
+    // argv.esm
+    //? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
+    //: null,
+    argv.fortesting
+      ? null
+      : './build-system/babel-plugins/babel-plugin-transform-json-configuration',
+    argv.fortesting
+      ? null
+      : [
+          './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
+          {isEsmBuild: !!argv.esm},
+        ],
+    argv.fortesting
+      ? null
+      : './build-system/babel-plugins/babel-plugin-is_dev-constant-transformer',
+  ].filter(Boolean);
+  const presetEnv = [
+    '@babel/preset-env',
+    {
+      bugfixes: true,
+      modules: false,
+      targets: {esmodules: true},
+    },
+  ];
+  const presets = argv.esm ? [presetEnv] : [];
+  return {
+    compact: false,
+    plugins,
+    presets,
+    retainLines: true,
+  };
+}
+
+module.exports = {
+  getMinifiedConfig,
+};

--- a/build-system/tasks/3p-vendor-helpers.js
+++ b/build-system/tasks/3p-vendor-helpers.js
@@ -16,7 +16,7 @@
 
 const debounce = require('debounce');
 const globby = require('globby');
-const {compileJs} = require('./helpers');
+const {compileJsWithEsbuild} = require('./helpers');
 const {endBuildStep} = require('./helpers');
 const {VERSION} = require('../compile/internal-version');
 const {watchDebounceDelay} = require('./helpers');
@@ -84,7 +84,7 @@ async function buildVendorConfigs(options) {
  * @return {!Promise}
  */
 async function buildVendor(name, options) {
-  await compileJs(
+  await compileJsWithEsbuild(
     './3p/vendors/',
     name + '.js',
     './dist.3p/',

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -75,9 +75,12 @@ async function doBuild(extraArgs = {}) {
     await compileCoreRuntime(options);
   } else {
     await compileAllJs(options);
-    await buildVendorConfigs(options);
   }
   await buildExtensions(options);
+
+  if (!argv.core_runtime_only) {
+    await buildVendorConfigs(options);
+  }
   if (!argv.watch) {
     exitCtrlcHandler(handlerProcess);
   }

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -26,6 +26,7 @@ const {
   exitCtrlcHandler,
 } = require('../common/ctrlcHandler');
 const {buildExtensions} = require('./extension-helpers');
+const {buildVendorConfigs} = require('./3p-vendor-helpers');
 const {compileCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {maybeUpdatePackages} = require('./update-packages');
@@ -74,6 +75,7 @@ async function doBuild(extraArgs = {}) {
     await compileCoreRuntime(options);
   } else {
     await compileAllJs(options);
+    await buildVendorConfigs(options);
   }
   await buildExtensions(options);
   if (!argv.watch) {

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -40,6 +40,7 @@ const {
   displayLifecycleDebugging,
 } = require('../compile/debug-compilation-lifecycle');
 const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
+const {buildVendorConfigs} = require('./3p-vendor-helpers');
 const {compileCss, copyCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {formatExtractedMessages} = require('../compile/log-messages');
@@ -148,6 +149,7 @@ async function doDist(extraArgs = {}) {
   await buildExtensions(options);
 
   if (!argv.core_runtime_only) {
+    await buildVendorConfigs(options);
     await formatExtractedMessages();
   }
   if (!argv.watch) {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -406,7 +406,8 @@ function handleBundleError(err, continueOnError, destFilename) {
 }
 
 /**
- * Performs the final steps after a JS file is bundled with esbuild and babel
+ * Performs the final steps after a JS file is bundled and optionally minified
+ * with esbuild and babel.
  * @param {string} srcFilename
  * @param {string} destDir
  * @param {string} destFilename

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -426,21 +426,24 @@ async function finishBundle(
     options
   );
 
-  if (options.latestName) {
-    // "amp-foo-latest.js" -> "amp-foo-latest.max.js"
-    const latestMaxName = options.latestName.replace(/\.js$/, '.max.js');
-    // Copy amp-foo-0.1.js to amp-foo-latest.max.js.
+  const logPrefix = options.minify ? 'Minified' : 'Compiled';
+  let {latestName} = options;
+  if (latestName) {
+    if (!options.minify) {
+      latestName = latestName.replace(/\.js$/, '.max.js');
+    }
     fs.copySync(
       path.join(destDir, options.toName),
-      path.join(destDir, latestMaxName)
+      path.join(destDir, latestName)
     );
-    endBuildStep('Compiled', `${destFilename} → ${latestMaxName}`, startTime);
+    endBuildStep(logPrefix, `${destFilename} → ${latestName}`, startTime);
   } else {
-    endBuildStep('Compiled', destFilename, startTime);
+    endBuildStep(logPrefix, destFilename, startTime);
   }
 
+  const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;
   const target = path.basename(destFilename, path.extname(destFilename));
-  if (UNMINIFIED_TARGETS.includes(target)) {
+  if (targets.includes(target)) {
     await applyAmpConfig(
       path.join(destDir, destFilename),
       /* localDev */ true,
@@ -494,6 +497,68 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
       plugins: [plugin],
       banner,
       footer,
+      incremental: !!options.watch,
+      logLevel: 'silent',
+    })
+    .then((result) => {
+      finishBundle(srcFilename, destDir, destFilename, options, startTime);
+      return result;
+    })
+    .catch((err) => handleBundleError(err, !!options.watch, destFilename));
+
+  if (options.watch) {
+    watchedTargets.set(entryPoint, {
+      rebuild: async () => {
+        const time = Date.now();
+        const buildPromise = buildResult
+          .rebuild()
+          .then(() =>
+            finishBundle(srcFilename, destDir, destFilename, options, time)
+          )
+          .catch((err) =>
+            handleBundleError(err, /* continueOnError */ true, destFilename)
+          );
+        options?.onWatchBuild(buildPromise);
+        await buildPromise;
+      },
+    });
+  }
+}
+
+/**
+ * Transforms a given JavaScript file entry point with esbuild and babel, and
+ * watches it for changes (if required).
+ * Used by 3p iframe vendors.
+ * @param {string} srcDir
+ * @param {string} srcFilename
+ * @param {string} destDir
+ * @param {?Object} options
+ * @return {!Promise}
+ */
+async function compileJsWithEsbuild(srcDir, srcFilename, destDir, options) {
+  const startTime = Date.now();
+  const entryPoint = path.join(srcDir, srcFilename);
+  const destFilename = maybeToEsmName(
+    options.minify ? options.minifiedName : options.toName
+  );
+  const destFile = path.join(destDir, destFilename);
+
+  if (watchedTargets.has(entryPoint)) {
+    return watchedTargets.get(entryPoint).rebuild();
+  }
+
+  const plugin = getEsbuildBabelPlugin(
+    options.minify ? 'minified' : 'unminified',
+    /* enableCache */ true
+  );
+  const buildResult = await esbuild
+    .build({
+      entryPoints: [entryPoint],
+      bundle: true,
+      sourcemap: true,
+      outfile: destFile,
+      plugins: [plugin],
+      minify: options.minify,
       incremental: !!options.watch,
       logLevel: 'silent',
     })
@@ -725,6 +790,7 @@ module.exports = {
   compileAllJs,
   compileCoreRuntime,
   compileJs,
+  compileJsWithEsbuild,
   compileTs,
   doBuildJs,
   endBuildStep,


### PR DESCRIPTION
To improve the performance during circleci testing and dist.

Added 8s build time for all 274 vendors.