### PR TITLE
Bento Lightbox: Support providing custom close button

### DIFF
--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -59,16 +59,6 @@ class AmpLightbox extends BaseElement {
   }
 
   /** @override */
-  mutationObserverCallback() {
-    const open = this.element.hasAttribute('open');
-    if (open === this.open_) {
-      return;
-    }
-    this.open_ = open;
-    open ? this.api().open() : this.api().close();
-  }
-
-  /** @override */
   isLayoutSupported(layout) {
     userAssert(
       isExperimentOn(this.win, 'bento') ||

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -47,6 +47,16 @@ export class BaseElement extends PreactBaseElement {
     toggle(this.element, this.open_);
     this.triggerEvent(this.element, this.open_ ? 'open' : 'close');
   }
+
+  /** @override */
+  mutationObserverCallback() {
+    const open = this.element.hasAttribute('open');
+    if (open === this.open_) {
+      return;
+    }
+    this.open_ = open;
+    open ? this.api().open() : this.api().close();
+  }
 }
 
 /** @override */

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -65,6 +65,7 @@ BaseElement['Component'] = Lightbox;
 /** @override */
 BaseElement['props'] = {
   'animation': {attr: 'animation'},
+  'closeButton': {selector: '[slot="close-button"]', single: true},
   'children': {passthrough: true},
   'id': {attr: 'id'},
   'scrollable': {attr: 'scrollable', type: 'boolean'},

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -38,6 +38,11 @@ export class BaseElement extends PreactBaseElement {
     });
   }
 
+  /** @override */
+  updatePropsForRendering(props) {
+    props['closeButtonAs'] = () => props['closeButton'];
+  }
+
   /**
    * Toggle open/closed attributes.
    * @param {boolean} opt_state

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -16,8 +16,10 @@
 
 import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
+import {Keys} from '../../../src/utils/key-codes';
 import {forwardRef} from '../../../src/preact/compat';
 import {setStyle} from '../../../src/style';
+import {tryFocus} from '../../../src/dom';
 import {
   useImperativeHandle,
   useLayoutEffect,
@@ -86,9 +88,7 @@ function LightboxWithRef(
         setMounted(true);
         setVisible(true);
       },
-      close: () => {
-        setVisible(false);
-      },
+      close: () => setVisible(false),
     }),
     [onBeforeOpenRef]
   );
@@ -107,7 +107,7 @@ function LightboxWithRef(
       const postVisibleAnim = () => {
         setStyle(element, 'opacity', 1);
         setStyle(element, 'visibility', 'visible');
-        element./*REVIEW*/ focus();
+        tryFocus(element);
       };
       if (!element.animate) {
         postVisibleAnim();
@@ -152,9 +152,7 @@ function LightboxWithRef(
   return (
     mounted && (
       <ContainWrapper
-        ref={(r) => {
-          lightboxRef.current = r;
-        }}
+        ref={lightboxRef}
         size={true}
         layout={true}
         paint={true}
@@ -172,7 +170,7 @@ function LightboxWithRef(
         role="dialog"
         tabindex="0"
         onKeyDown={(event) => {
-          if (event.key === 'Escape') {
+          if (event.key === Keys.ESCAPE) {
             setVisible(false);
           }
         }}
@@ -183,9 +181,7 @@ function LightboxWithRef(
           ariaLabel={DEFAULT_CLOSE_LABEL}
           tabIndex={-1}
           className={classes.closeButton}
-          onClick={() => {
-            setVisible(false);
-          }}
+          onClick={() => setVisible(false)}
         />
       </ContainWrapper>
     )

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -55,6 +55,7 @@ function LightboxWithRef(
   {
     animation = 'fade-in',
     children,
+    closeButton,
     onBeforeOpen,
     onAfterClose,
     scrollable = false,
@@ -176,13 +177,11 @@ function LightboxWithRef(
         }}
         {...rest}
       >
-        {children}
-        <button
-          ariaLabel={DEFAULT_CLOSE_LABEL}
-          tabIndex={-1}
-          className={classes.closeButton}
-          onClick={() => setVisible(false)}
+        <CloseButton
+          customCloseButton={closeButton}
+          close={() => setVisible(false)}
         />
+        {children}
       </ContainWrapper>
     )
   );
@@ -191,3 +190,43 @@ function LightboxWithRef(
 const Lightbox = forwardRef(LightboxWithRef);
 Lightbox.displayName = 'Lightbox';
 export {Lightbox};
+
+/**
+ *
+ * @param {!LightboxDef.CloseButtonProps} props
+ * @return {PreactDef.Renderable}
+ */
+function CloseButton({close, customCloseButton = <ScreenReaderCloseButton />}) {
+  const {'onClick': onCustomClick} = customCloseButton.props;
+  const onClick = (e) => {
+    if (onCustomClick) {
+      onCustomClick(e);
+    }
+    close();
+  };
+  return Preact.cloneElement(customCloseButton, {
+    'onClick': onClick,
+  });
+}
+
+/**
+ * This is for screen-readers only, should not get a tab stop. Note that
+ * screen readers can still swipe / navigate to this element, it just will
+ * not be reachable via the tab button. Note that for desktop, hitting esc
+ * to close is also an option.
+ *
+ * We do not want this in the tab order since it is not really "visible"
+ * and would be confusing to tab to if not using a screen reader.
+ *
+ * @return {PreactDef.Renderable}
+ */
+function ScreenReaderCloseButton() {
+  const classes = useStyles();
+  return (
+    <button
+      ariaLabel={DEFAULT_CLOSE_LABEL}
+      tabIndex={-1}
+      className={classes.closeButton}
+    />
+  );
+}

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -55,7 +55,7 @@ function LightboxWithRef(
   {
     animation = 'fade-in',
     children,
-    closeButton,
+    closeButtonAs,
     onBeforeOpen,
     onAfterClose,
     scrollable = false,
@@ -177,10 +177,7 @@ function LightboxWithRef(
         }}
         {...rest}
       >
-        <CloseButton
-          customCloseButton={closeButton}
-          close={() => setVisible(false)}
-        />
+        <CloseButton as={closeButtonAs} onClick={() => setVisible(false)} />
         {children}
       </ContainWrapper>
     )
@@ -196,17 +193,8 @@ export {Lightbox};
  * @param {!LightboxDef.CloseButtonProps} props
  * @return {PreactDef.Renderable}
  */
-function CloseButton({close, customCloseButton = <ScreenReaderCloseButton />}) {
-  const {'onClick': onCustomClick} = customCloseButton.props;
-  const onClick = (e) => {
-    if (onCustomClick) {
-      onCustomClick(e);
-    }
-    close();
-  };
-  return Preact.cloneElement(customCloseButton, {
-    'onClick': onClick,
-  });
+function CloseButton({onClick, as: Comp = ScreenReaderCloseButton}) {
+  return <Comp aria-label={DEFAULT_CLOSE_LABEL} onClick={onClick} />;
 }
 
 /**
@@ -218,15 +206,10 @@ function CloseButton({close, customCloseButton = <ScreenReaderCloseButton />}) {
  * We do not want this in the tab order since it is not really "visible"
  * and would be confusing to tab to if not using a screen reader.
  *
+ * @param {!LightboxDef.CloseButtonProps} props
  * @return {PreactDef.Renderable}
  */
-function ScreenReaderCloseButton() {
+function ScreenReaderCloseButton(props) {
   const classes = useStyles();
-  return (
-    <button
-      ariaLabel={DEFAULT_CLOSE_LABEL}
-      tabIndex={-1}
-      className={classes.closeButton}
-    />
-  );
+  return <button {...props} tabIndex={-1} className={classes.closeButton} />;
 }

--- a/extensions/amp-lightbox/1.0/component.type.js
+++ b/extensions/amp-lightbox/1.0/component.type.js
@@ -34,8 +34,9 @@ LightboxDef.Props;
 
 /**
  * @typedef {{
- *   close: function,
- *   closeButton: (?PreactDef.Renderable|undefined),
+ *   aria-label: (string),
+ *   as: (function:PreactDef.Renderable|undefined),
+ *   onClick: function,
  * }}
  */
 LightboxDef.CloseButtonProps;

--- a/extensions/amp-lightbox/1.0/component.type.js
+++ b/extensions/amp-lightbox/1.0/component.type.js
@@ -23,7 +23,7 @@ var LightboxDef = {};
  *   id: (string),
  *   animation: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
- *   closeButton: (?PreactDef.Renderable|undefined),
+ *   closeButtonAs: (function:PreactDef.Renderable|undefined),
  *   scrollable: (boolean),
  *   initialOpen: (boolean),
  *   onBeforeOpen: (function|undefined),

--- a/extensions/amp-lightbox/1.0/component.type.js
+++ b/extensions/amp-lightbox/1.0/component.type.js
@@ -22,7 +22,8 @@ var LightboxDef = {};
  * @typedef {{
  *   id: (string),
  *   animation: (string|undefined),
- *   closeButtonAriaLabel: (string|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ *   closeButton: (?PreactDef.Renderable|undefined),
  *   scrollable: (boolean),
  *   initialOpen: (boolean),
  *   onBeforeOpen: (function|undefined),
@@ -30,6 +31,14 @@ var LightboxDef = {};
  * }}
  */
 LightboxDef.Props;
+
+/**
+ * @typedef {{
+ *   close: function,
+ *   closeButton: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+LightboxDef.CloseButtonProps;
 
 /** @interface */
 Lightbox.LightboxApi = class {

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -47,7 +47,7 @@ export const Default = () => {
       <div style="height: 300px;">
         <amp-lightbox id="lightbox" layout="nodisplay" animation={animation}>
           <p>Test</p>
-          <button on="tap:lightbox.close">Close</button>
+          <button slot="close-button">Close</button>
         </amp-lightbox>
         <div class="buttons">
           <button on="tap:lightbox">Open</button>
@@ -212,7 +212,7 @@ export const scrollable = () => {
               </p>
             </>
           )}
-          <button on="tap:lightbox.close">Close</button>
+          <button slot="close-button">Close</button>
         </amp-lightbox>
         <div class="buttons">
           <button on="tap:lightbox">Open</button>

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -214,7 +214,7 @@ export const scrollable = () => {
               </p>
             </>
           )}
-          <button slot="close-button">Close</button>
+          <button slot="close-button" on="tap:lightbox.close">Close</button>
         </amp-lightbox>
         <div class="buttons">
           <button on="tap:lightbox">Open</button>

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -214,7 +214,9 @@ export const scrollable = () => {
               </p>
             </>
           )}
-          <button slot="close-button" on="tap:lightbox.close">Close</button>
+          <button slot="close-button" on="tap:lightbox.close">
+            Close
+          </button>
         </amp-lightbox>
         <div class="buttons">
           <button on="tap:lightbox">Open</button>

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -47,7 +47,9 @@ export const Default = () => {
       <div style="height: 300px;">
         <amp-lightbox id="lightbox" layout="nodisplay" animation={animation}>
           <p>Test</p>
-          <button slot="close-button">Close</button>
+          <button slot="close-button" on="tap:lightbox.close">
+            Close
+          </button>
         </amp-lightbox>
         <div class="buttons">
           <button on="tap:lightbox">Open</button>

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -35,7 +35,11 @@ function LightboxWithActions({children, ...rest}) {
   return (
     <section>
       <Lightbox
-        closeButton={<button aria-label="My custom close button">close</button>}
+        closeButtonAs={(props) => (
+          <button {...props} aria-label="My custom close button">
+            close
+          </button>
+        )}
         ref={ref}
         {...rest}
       >

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -34,9 +34,12 @@ function LightboxWithActions({children, ...rest}) {
   const ref = useRef();
   return (
     <section>
-      <Lightbox ref={ref} {...rest}>
+      <Lightbox
+        closeButton={<button aria-label="My custom close button">close</button>}
+        ref={ref}
+        {...rest}
+      >
         {children}
-        <button onClick={() => ref.current.close()}>close</button>
       </Lightbox>
       <div style={{marginTop: 8}}>
         <button onClick={() => ref.current.open()}>open</button>

--- a/extensions/amp-lightbox/1.0/test-e2e/test-custom-close-button.js
+++ b/extensions/amp-lightbox/1.0/test-e2e/test-custom-close-button.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describes.endtoend(
+  'amp-lightbox custom close button',
+  {
+    fixture: 'amp-lightbox/custom-close-button.amp.html',
+
+    versions: {
+      '1.0': {
+        environments: ['single', 'viewer-demo'],
+        experiments: ['bento'],
+        initialRect: {width: 800, height: 800},
+      },
+    },
+  },
+  async (env) => {
+    let controller;
+
+    beforeEach(() => {
+      controller = env.controller;
+    });
+
+    it('should render correctly', async () => {
+      const lightbox = await controller.findElement('#lightbox');
+      await expect(controller.getElementProperty(lightbox, 'hidden')).to.be
+        .true;
+
+      const image = await controller.findElement('#image');
+      await expect(
+        controller.getElementProperty(image, 'clientWidth')
+      ).to.equal(0);
+    });
+
+    it('should open the lightbox', async () => {
+      const open = await controller.findElement('#open');
+      await controller.click(open);
+
+      const lightbox = await controller.findElement('#lightbox');
+      await expect(controller.getElementProperty(lightbox, 'hidden')).to.be
+        .false;
+
+      const documentElement = await controller.getDocumentElement();
+      const width = await controller.getElementProperty(
+        documentElement,
+        'clientWidth'
+      );
+      await expect(
+        controller.getElementProperty(lightbox, 'clientWidth')
+      ).to.equal(width);
+
+      const backingImageOrLoader = await controller.findElement(
+        '#image img, #image .i-amphtml-loader-background'
+      );
+      await expect(
+        controller.getElementProperty(backingImageOrLoader, 'clientWidth')
+      ).to.equal(641);
+    });
+
+    it('should close the lightbox', async () => {
+      const open = await controller.findElement('#open');
+      await controller.click(open);
+
+      const lightbox = await controller.findElement('#lightbox');
+      await expect(controller.getElementProperty(lightbox, 'hidden')).to.be
+        .false;
+
+      const close = await controller.findElement('#close');
+      await controller.click(close);
+
+      await expect(controller.getElementProperty(lightbox, 'hidden')).to.be
+        .true;
+    });
+  }
+);

--- a/extensions/amp-lightbox/1.0/test/test-component.js
+++ b/extensions/amp-lightbox/1.0/test/test-component.js
@@ -90,9 +90,11 @@ describes.sandboxed('Lightbox preact component v1.0', {}, () => {
       <Lightbox
         id="lightbox"
         ref={ref}
-        closeButton={
-          <button aria-label="close my fancy lightbox">Close!</button>
-        }
+        closeButtonAs={(props) => (
+          <button {...props} aria-label="close my fancy lightbox">
+            Close!
+          </button>
+        )}
       >
         <p>Hello World</p>
       </Lightbox>

--- a/extensions/amp-lightbox/1.0/test/test-component.js
+++ b/extensions/amp-lightbox/1.0/test/test-component.js
@@ -19,7 +19,7 @@ import {Lightbox} from '../component';
 import {mount} from 'enzyme';
 
 describes.sandboxed('Lightbox preact component v1.0', {}, () => {
-  it('Normal lightbox render', () => {
+  it('renders', () => {
     const ref = Preact.createRef();
     const wrapper = mount(
       <Lightbox id="lightbox" ref={ref}>
@@ -45,9 +45,16 @@ describes.sandboxed('Lightbox preact component v1.0', {}, () => {
       wrapper.find('div[part="lightbox"] > div').getDOMNode().style.overflow
     ).to.equal('hidden');
     expect(wrapper.find('p').text()).to.equal('Hello World');
+
+    // Default SR button is present
+    const buttons = wrapper.find('button');
+    expect(buttons).to.have.lengthOf(1);
+    const closeButton = buttons.first().getDOMNode();
+    expect(closeButton.getAttribute('aria-label')).to.equal('Close the modal');
+    expect(closeButton.textContent).to.equal('');
   });
 
-  it('Scrollable lightbox', () => {
+  it('renders scrollable', () => {
     const ref = Preact.createRef();
     const wrapper = mount(
       <Lightbox id="lightbox" ref={ref} scrollable>
@@ -68,5 +75,46 @@ describes.sandboxed('Lightbox preact component v1.0', {}, () => {
     expect(
       wrapper.find('div[part="lightbox"] > div').getDOMNode().style.overflow
     ).to.equal('scroll');
+
+    // Default SR button is present
+    const buttons = wrapper.find('button');
+    expect(buttons).to.have.lengthOf(1);
+    const closeButton = buttons.first().getDOMNode();
+    expect(closeButton.getAttribute('aria-label')).to.equal('Close the modal');
+    expect(closeButton.textContent).to.equal('');
+  });
+
+  it('renders custom close button', () => {
+    const ref = Preact.createRef();
+    const wrapper = mount(
+      <Lightbox
+        id="lightbox"
+        ref={ref}
+        closeButton={
+          <button aria-label="close my fancy lightbox">Close!</button>
+        }
+      >
+        <p>Hello World</p>
+      </Lightbox>
+    );
+
+    // Nothing is rendered at first.
+    expect(wrapper.children()).to.have.lengthOf(0);
+
+    ref.current.open();
+    wrapper.update();
+
+    // Render provided children
+    expect(wrapper.children()).to.have.lengthOf(1);
+    expect(wrapper.find('p').text()).to.equal('Hello World');
+
+    // Default SR button is present
+    const buttons = wrapper.find('button');
+    expect(buttons).to.have.lengthOf(1);
+    const closeButton = buttons.first().getDOMNode();
+    expect(closeButton.getAttribute('aria-label')).to.equal(
+      'close my fancy lightbox'
+    );
+    expect(closeButton.textContent).to.equal('Close!');
   });
 });

--- a/test/fixtures/e2e/amp-lightbox/custom-close-button.amp.html
+++ b/test/fixtures/e2e/amp-lightbox/custom-close-button.amp.html
@@ -17,7 +17,7 @@
 
 <body>
   <amp-lightbox id="lightbox" layout="nodisplay">
-    <button id="close" slot="close-button">
+    <button id="close" slot="close-button" on="tap:lightbox.close">
       Close Lightbox
     </button>
     <amp-img

--- a/test/fixtures/e2e/amp-lightbox/custom-close-button.amp.html
+++ b/test/fixtures/e2e/amp-lightbox/custom-close-button.amp.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html ⚡>
+<head>
+    <meta charset="utf-8">
+    <title>amp-lightbox</title>
+    <link rel="canonical" href="//example.com" >
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-latest.js"></script>
+    <style amp-custom>
+    amp-lightbox {
+      background-color: rgba(0, 0, 0, 0.9);
+    }
+    </style>
+</head>
+
+<body>
+  <amp-lightbox id="lightbox" layout="nodisplay">
+    <button id="close" slot="close-button">
+      Close Lightbox
+    </button>
+    <amp-img
+        id="image"
+        src="/examples/img/sample.jpg"
+        width="641" height="481"
+    ></amp-img>
+  </amp-lightbox>
+
+  <button id="open" on="tap:lightbox.open">
+    Open Lightbox
+  </button>
+</body>
+</html>


### PR DESCRIPTION
If one is not provided, the 2x2 screen reader-only close button will be provided with a generic label "Close the modal". Customizing the label itself is recommended to be done by providing a custom close button.

Related to #31052 cc @dvoytenko 