### PR TITLE
🏗 Expand instructions for dealing with stale PR branches

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -22,6 +22,8 @@ err=0
 
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
 RED() { echo -e "\n\033[0;31m$1\033[0m"; }
+YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
+CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
 # Push builds are only run against master and amp-release branches.
 if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
@@ -34,8 +36,35 @@ CONFIG_REV=`git rev-list master -1 -- .circleci/config.yml`
 (set -x && git merge-base --is-ancestor $CONFIG_REV $CIRCLE_SHA1) || err=$?
 
 if [[ "$err" -ne "0" ]]; then
-  echo $(RED "$CIRCLE_BRANCH is missing the latest CircleCI config revision $CONFIG_REV.")
-  echo $(RED "Please rebase / merge $CIRCLE_BRANCH with master.")
+  echo "$(RED "ERROR:") $(CYAN $CIRCLE_BRANCH) is missing the latest CircleCI config revision $(CYAN $CONFIG_REV)."
+  echo -e "\n"
+
+  echo $(YELLOW "This can be fixed in three ways:")
+  echo -e "\n"
+
+  echo "1. Click the $(CYAN "\"Update branch\"") button on GitHub and follow instructions."
+  echo "   ⤷ It can be found towards the bottom of the PR, after the list of checks."
+  echo -e "\n"
+
+  echo "2. Pull the latest commits from $(CYAN "master") and re-push the PR branch."
+  echo "   ⤷ Follow these steps:"
+  echo ""
+  echo "      $(CYAN "git checkout master")"
+  echo "      $(CYAN "git pull")"
+  echo "      $(CYAN "git checkout <PR branch>")"
+  echo "      $(CYAN "git merge master")"
+  echo "      $(CYAN "git push origin")"
+  echo -e "\n"
+
+  echo "3. Rebase on $(CYAN "master") and re-push the PR branch."
+  echo "   ⤷ Follow these steps:"
+  echo ""
+  echo "      $(CYAN "git checkout master")"
+  echo "      $(CYAN "git pull")"
+  echo "      $(CYAN "git checkout <PR branch>")"
+  echo "      $(CYAN "git rebase master")"
+  echo "      $(CYAN "git push origin --force")"
+  echo -e "\n"
   exit 1
 fi
 


### PR DESCRIPTION
This PR adds clear instructions for what to do when a PR branch is outdated and the CircleCI config has changed. The easiest fix involves clicking a button on GitHub, and can be done by internal and external contributors with no trouble.

**Example:** See [these](https://app.circleci.com/pipelines/github/ampproject/amphtml/3792/workflows/34a32c83-7b80-406e-a941-687c41100927/jobs/47915/parallel-runs/0/steps/0-103) logs.

![image](https://user-images.githubusercontent.com/26553114/110172581-58685e00-7dcb-11eb-91ee-6ae647a630c6.png)

