### PR TITLE
🐛 Disable `dock` on amp-brightcove

### DIFF
--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -135,6 +135,16 @@ class AmpBrightcove extends AMP.BaseElement {
       },
       3000
     ));
+
+    if (this.element.hasAttribute('dock')) {
+      this.mutateElement(() => {
+        user().warn(
+          TAG,
+          '`dock` has been disabled on this element. See https://go.amp.dev/issue/32706 for more information.'
+        );
+        this.element.removeAttribute('dock');
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
`<amp-brightcove>` is autoplaying without `autoplay`. This means that the video can also dock without user interaction, which it should not. See #32706

Brightcove should update their player document so that it can't autoplay without the attribute. Otherwise, it cannot dock.

cc @mister-ben 