### PR TITLE
Multi-version: signal when extensions are known

### DIFF
--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -22,6 +22,7 @@ import {installGlobalSubmitListenerForDoc} from '../../../../../src/document-sub
 import {listenOncePromise} from '../../../../../src/event-helper';
 import {poll} from '../../../../../testing/iframe';
 import {registerExtendedTemplateForDoc} from '../../../../../src/service/template-impl';
+import {stubElementsForDoc} from '../../../../../src/service/custom-element-registry';
 
 /** @const {number} */
 const RENDER_TIMEOUT = 15000;
@@ -58,15 +59,16 @@ describes.realWin(
 
       const mustache = document.createElement('script');
       mustache.setAttribute('custom-template', 'amp-mustache');
+      env.sandbox.stub(mustache, 'src').value('https://cdn.ampproject.org/v0/amp-mustache-0.1.js');
       doc.body.appendChild(mustache);
       registerExtendedTemplateForDoc(env.ampdoc, 'amp-mustache', AmpMustache);
 
       const form = document.createElement('script');
       form.setAttribute('custom-element', 'amp-form');
-      Object.defineProperty(form, 'src', {
-        value: 'https://cdn.ampproject.org/v0/amp-form-0.1.js',
-      });
+      env.sandbox.stub(form, 'src').value('https://cdn.ampproject.org/v0/amp-form-0.1.js');
       doc.head.appendChild(form);
+
+      stubElementsForDoc(env.ampdoc);
 
       new AmpFormService(env.ampdoc);
 

--- a/extensions/amp-form/0.1/test/integration/test-integration-form.js
+++ b/extensions/amp-form/0.1/test/integration/test-integration-form.js
@@ -59,13 +59,17 @@ describes.realWin(
 
       const mustache = document.createElement('script');
       mustache.setAttribute('custom-template', 'amp-mustache');
-      env.sandbox.stub(mustache, 'src').value('https://cdn.ampproject.org/v0/amp-mustache-0.1.js');
+      env.sandbox
+        .stub(mustache, 'src')
+        .value('https://cdn.ampproject.org/v0/amp-mustache-0.1.js');
       doc.body.appendChild(mustache);
       registerExtendedTemplateForDoc(env.ampdoc, 'amp-mustache', AmpMustache);
 
       const form = document.createElement('script');
       form.setAttribute('custom-element', 'amp-form');
-      env.sandbox.stub(form, 'src').value('https://cdn.ampproject.org/v0/amp-form-0.1.js');
+      env.sandbox
+        .stub(form, 'src')
+        .value('https://cdn.ampproject.org/v0/amp-form-0.1.js');
       doc.head.appendChild(form);
 
       stubElementsForDoc(env.ampdoc);

--- a/src/document-submit.js
+++ b/src/document-submit.js
@@ -23,7 +23,6 @@ import {
 } from './url';
 import {Services} from './services';
 import {dev, user, userAssert} from './log';
-import {isExtensionScriptInNode} from './element-service';
 
 /**
  * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
@@ -32,15 +31,13 @@ import {isExtensionScriptInNode} from './element-service';
 export function installGlobalSubmitListenerForDoc(ampdoc) {
   // Register global submit event listener only if the amp-form
   // extension is used. Allowing the usage of native forms, otherwise.
-  return isExtensionScriptInNode(ampdoc, 'amp-form').then(
-    (ampFormInstalled) => {
-      if (ampFormInstalled) {
-        ampdoc
-          .getRootNode()
-          .addEventListener('submit', onDocumentFormSubmit_, true);
-      }
+  return ampdoc.whenExtensionsKnown().then(() => {
+    if (ampdoc.declaresExtension('amp-form')) {
+      ampdoc
+        .getRootNode()
+        .addEventListener('submit', onDocumentFormSubmit_, true);
     }
-  );
+  });
 }
 
 /**

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -837,6 +837,7 @@ export class Installers {
           ampdoc,
           extensionIds
         );
+        ampdoc.setExtensionsKnown();
         if (opt_installComplete) {
           opt_installComplete(promise);
         }

--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -463,6 +463,7 @@ export class MultidocManager {
         }
       }
     }
+    ampdoc.setExtensionsKnown();
   }
 
   /**

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -55,6 +55,8 @@ export let AmpDocOptions;
  * @enum {string}
  */
 const AmpDocSignals = {
+  // A complete preinstalled list of extensions is known.
+  EXTENSIONS_KNOWN: '-ampdoc-ext-known',
   // Signals the document has become visible for the first time.
   FIRST_VISIBLE: '-ampdoc-first-visible',
   // Signals when the document becomes visible the next time.
@@ -448,6 +450,22 @@ export class AmpDoc {
       extensionId
     );
     this.declaredExtensions_[extensionId] = version;
+  }
+
+  /**
+   * Signal that the initial document set of extensions is known.
+   * @restricted
+   */
+  setExtensionsKnown() {
+    this.signals_.signal(AmpDocSignals.EXTENSIONS_KNOWN);
+  }
+
+  /**
+   * Resolved when the initial document set of extension is known.
+   * @return {!Promise}
+   */
+  whenExtensionsKnown() {
+    return this.signals_.whenSignal(AmpDocSignals.EXTENSIONS_KNOWN);
   }
 
   /**

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -135,6 +135,9 @@ export function stubElementsForDoc(ampdoc) {
     ampdoc.declareExtension(extensionId, extensionVersion);
     stubElementIfNotKnown(ampdoc.win, extensionId);
   });
+  if (ampdoc.isBodyAvailable()) {
+    ampdoc.setExtensionsKnown();
+  }
 }
 
 /**

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -128,6 +128,32 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
     expect(getImplSyncForTesting(element2)).to.be.instanceOf(ConcreteElement);
   });
 
+  it('should only set extensionsKnown when body is available', () => {
+    const head = document.createElement('fake-head');
+    const script = document.createElement('script');
+    script.setAttribute('custom-element', 'amp-element2');
+    Object.defineProperty(script, 'src', {
+      value: 'https://cdn.ampproject.org/v0/amp-element2-0.2.js',
+    });
+    head.appendChild(script);
+    env.sandbox.stub(ampdoc, 'getHeadNode').returns(head);
+    env.sandbox.stub(ampdoc, 'setExtensionsKnown');
+    const isBodyAvailableStub = env.sandbox.stub(ampdoc, 'isBodyAvailable');
+
+    // Body is not available.
+    isBodyAvailableStub.returns(false);
+    stubElementsForDoc(ampdoc);
+    expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
+    expect(ampdoc.declaresExtension('amp-element2', '0.2')).to.be.true;
+    expect(ampdoc.setExtensionsKnown).to.not.be.called;
+
+    // Body is not available.
+    isBodyAvailableStub.returns(true);
+    stubElementsForDoc(ampdoc);
+    expect(ampdoc.declaresExtension('amp-element2')).to.be.true;
+    expect(ampdoc.setExtensionsKnown).to.be.calledOnce;
+  });
+
   it('should mark stubbed element as declared', () => {
     expect(ampdoc.declaresExtension('amp-element2')).to.be.false;
 

--- a/test/unit/test-document-submit.js
+++ b/test/unit/test-document-submit.js
@@ -31,25 +31,16 @@ describes.sandboxed('test-document-submit', {}, (env) => {
       ampdoc = {
         getHeadNode: () => headNode,
         getRootNode: () => rootNode,
-        waitForBodyOpen: () => Promise.resolve({}),
+        whenExtensionsKnown: () => Promise.resolve(),
+        declaresExtension: () => false,
       };
     });
 
-    /**
-     * @param {string} extension
-     */
-    const createScript = (extension) => {
-      const script = document.createElement('script');
-      script.setAttribute(
-        'src',
-        'https://cdn.ampproject.org/v0/' + extension + '-0.1.js'
-      );
-      script.setAttribute('custom-element', extension);
-      return script;
-    };
-
     it('should not register submit listener if amp-form is not registered.', () => {
-      ampdoc.getHeadNode().appendChild(createScript('amp-list'));
+      env.sandbox
+        .stub(ampdoc, 'declaresExtension')
+        .withArgs('amp-form')
+        .returns(false);
       env.sandbox.spy(rootNode, 'addEventListener');
       return installGlobalSubmitListenerForDoc(ampdoc).then(() => {
         expect(rootNode.addEventListener).not.to.have.been.called;
@@ -57,7 +48,10 @@ describes.sandboxed('test-document-submit', {}, (env) => {
     });
 
     it('should register submit listener if amp-form extension is registered.', () => {
-      ampdoc.getHeadNode().appendChild(createScript('amp-form'));
+      env.sandbox
+        .stub(ampdoc, 'declaresExtension')
+        .withArgs('amp-form')
+        .returns(true);
       env.sandbox.spy(rootNode, 'addEventListener');
       return installGlobalSubmitListenerForDoc(ampdoc).then(() => {
         expect(rootNode.addEventListener).called;

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -150,8 +150,10 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
           'https://acme.org/url2'
         );
 
-        return loadPromise(iframe);
+        // Check that extensions-known has been set.
+        return embed.ampdoc.whenExtensionsKnown();
       })
+      .then(() => loadPromise(iframe))
       .then(() => {
         // Iframe is marked as complete.
         expect(iframe.readyState).to.equal('complete');
@@ -191,6 +193,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
       getHeadNode: () => childWinForAmpDoc.document.head,
+      setExtensionsKnown: env.sandbox.stub(),
     };
     ampdocServiceMock
       .expects('installFieDoc')
@@ -250,6 +253,11 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         expect(ampdoc).to.equal(embed.ampdoc);
         expect(installServicesStub).to.be.calledOnce.calledWith(ampdoc);
         expect(ampdoc.setReady).to.not.be.called;
+
+        // Check that extensions-known has been set.
+        expect(embed.ampdoc.setExtensionsKnown).to.be.calledOnce;
+
+        // Complete rendering.
         renderCompleteResolver();
         return renderCompletePromise;
       })
@@ -272,6 +280,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
       getHeadNode: () => childWinForAmpDoc.document.head,
+      setExtensionsKnown: env.sandbox.stub(),
     };
     ampdocServiceMock
       .expects('installFieDoc')
@@ -357,6 +366,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
       getHeadNode: () => childWinForAmpDoc.document.head,
+      setExtensionsKnown: env.sandbox.stub(),
     };
     let childWinForAmpDoc;
     ampdocServiceMock
@@ -490,6 +500,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
       getHeadNode: () => childWinForAmpDoc.document.head,
+      setExtensionsKnown: env.sandbox.stub(),
       overrideVisibilityState: env.sandbox.spy(),
       dispose: env.sandbox.spy(),
     };
@@ -578,6 +589,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       setReady: env.sandbox.spy(),
       signals: () => ampdocSignals,
       getHeadNode: () => childWinForAmpDoc.document.head,
+      setExtensionsKnown: env.sandbox.stub(),
       dispose: env.sandbox.spy(),
     };
     ampdocServiceMock

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -1027,7 +1027,7 @@ describes.realWin(
         expect(ret.viewer).to.not.exist;
       });
 
-      it('should install doc services', () => {
+      it('should install doc services', async () => {
         class Service1 {}
         win.AMP.push({
           n: 'amp-ext',
@@ -1049,12 +1049,12 @@ describes.realWin(
 
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
 
-        return extensions.waitForExtension(win, 'amp-ext').then(() => {
-          // Factories have been applied.
-          expect(getServiceForDoc(ampdoc, 'service1')).to.be.instanceOf(
-            Service1
-          );
-        });
+        // Extensions-known has been set.
+        await ampdoc.whenExtensionsKnown();
+
+        // Factories have been applied.
+        await extensions.waitForExtension(win, 'amp-ext');
+        expect(getServiceForDoc(ampdoc, 'service1')).to.be.instanceOf(Service1);
       });
 
       it('should pass init parameters to viewer', () => {
@@ -1211,7 +1211,7 @@ describes.realWin(
           .exist;
       });
 
-      it('should import extension element', () => {
+      it('should import extension element', async () => {
         extensionsMock
           .expects('preloadExtension')
           .withExactArgs('amp-ext1', '0.1')
@@ -1234,6 +1234,9 @@ describes.realWin(
         win.AMP.attachShadowDoc(hostElement, importDoc, docUrl);
         expect(win.document.querySelector('script[custom-element="amp-ext1"]'))
           .to.not.exist;
+
+        // Extensions-known has been set.
+        await ampdoc.whenExtensionsKnown();
       });
 
       it('should import module/nomodule extension element', () => {
@@ -1452,7 +1455,7 @@ describes.realWin(
           expect(shadowDoc.viewer).to.not.exist;
         });
 
-        it('should install doc services', () => {
+        it('should install doc services', async () => {
           shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
           writer = shadowDoc.writer;
 
@@ -1472,14 +1475,16 @@ describes.realWin(
           );
           writer.write('<body>');
 
-          return ampdoc.waitForBodyOpen().then(() => {
-            return extensions.waitForExtension(win, 'amp-ext').then(() => {
-              // Factories have been applied.
-              expect(getServiceForDoc(ampdoc, 'service1')).to.be.instanceOf(
-                Service1
-              );
-            });
-          });
+          await ampdoc.waitForBodyOpen();
+
+          // Extensions-known has been set.
+          await ampdoc.whenExtensionsKnown();
+
+          // Factories have been applied.
+          await extensions.waitForExtension(win, 'amp-ext');
+          expect(getServiceForDoc(ampdoc, 'service1')).to.be.instanceOf(
+            Service1
+          );
         });
 
         it('should pass init parameters to viewer', () => {
@@ -1628,7 +1633,7 @@ describes.realWin(
           });
         });
 
-        it('should ignore runtime extension', () => {
+        it('should ignore runtime extension', async () => {
           shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
           writer = shadowDoc.writer;
           extensionsMock.expects('preloadExtension').never();
@@ -1636,7 +1641,10 @@ describes.realWin(
             '<script src="https://cdn.ampproject.org/v0.js"></script>'
           );
           writer.write('<body>');
-          return ampdoc.waitForBodyOpen();
+          await ampdoc.waitForBodyOpen();
+
+          // Extensions-known has been set.
+          await ampdoc.whenExtensionsKnown();
         });
 
         it('should ignore unknown script', () => {
@@ -1659,7 +1667,7 @@ describes.realWin(
           });
         });
 
-        it('should import extension element', () => {
+        it('should import extension element', async () => {
           shadowDoc = win.AMP.attachShadowDocAsStream(hostElement, docUrl);
           writer = shadowDoc.writer;
           extensionsMock
@@ -1677,11 +1685,14 @@ describes.realWin(
             '<script custom-element="amp-ext1" src="https://cdn.ampproject.org/v0/amp-ext1-0.1.js"></script>'
           );
           writer.write('<body>');
-          return ampdoc.waitForBodyOpen().then(() => {
-            expect(
-              win.document.querySelector('script[custom-element="amp-ext1"]')
-            ).to.not.exist;
-          });
+          await ampdoc.waitForBodyOpen();
+
+          // Extensions-known has been set.
+          await ampdoc.whenExtensionsKnown();
+
+          expect(
+            win.document.querySelector('script[custom-element="amp-ext1"]')
+          ).to.not.exist;
         });
 
         it('should import extension template', () => {

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -886,6 +886,7 @@ class AmpFixture {
         env.extensions.installExtensionsInDoc(ampdoc, extensionIds),
         ampdoc.whenReady(),
       ]);
+      ampdoc.setExtensionsKnown();
       completePromise = completePromise
         ? completePromise.then(() => promise)
         : promise;


### PR DESCRIPTION
Partial for #33020.

The document will get a signal when extensions are known. This will remove the need from polling and/or rescanning scripts in the `<head>` to know whether an extension and its version are in a document. See `src/document-submit.js` for an example of how this is used.


TODO:

- [ ] Tests
