### PR TITLE
🐛  [Story video] Fix video downgrading on load

### DIFF
--- a/extensions/amp-video/0.1/flexible-bitrate.js
+++ b/extensions/amp-video/0.1/flexible-bitrate.js
@@ -261,6 +261,10 @@ export class BitrateManager {
  */
 function onNontrivialWait(video, callback) {
   listen(video, 'waiting', () => {
+    // Do not trigger downgrade if not loaded metadata yet.
+    if (video.readyState < 1) {
+      return;
+    }
     let timer = null;
     const unlisten = listenOnce(video, 'playing', () => {
       clearTimeout(timer);

--- a/extensions/amp-video/0.1/test/test-flexible-bitrate.js
+++ b/extensions/amp-video/0.1/test/test-flexible-bitrate.js
@@ -93,6 +93,18 @@ describes.fakeWin('amp-video flexible-bitrate', {}, (env) => {
 
       expect(currentBitrates(v0)[0]).to.equal(4000);
     });
+
+    it('should not lower bitrate on waiting before metadata loaded', () => {
+      const m = getManager('4g');
+      const v0 = getVideo([4000, 1000, 3000, 2000]);
+      v0.id = 'v0';
+      m.sortSources_(v0);
+      m.manage(v0);
+      // Video should not downgrade on wait since it has not started loading (we never called `load`).
+      expect(currentBitrates(v0)[0]).to.equal(2000);
+      causeWait(v0);
+      expect(currentBitrates(v0)[0]).to.equal(2000);
+    });
   });
 
   describe('sorting', () => {
@@ -251,6 +263,7 @@ describes.fakeWin('amp-video flexible-bitrate', {}, (env) => {
         video.appendChild(s);
       });
     });
+    video.readyStateOverride = 0;
 
     Object.defineProperty(video, 'currentSrc', {
       get: () => {
@@ -265,9 +278,15 @@ describes.fakeWin('amp-video flexible-bitrate', {}, (env) => {
         video.currentTimeOverride = val;
       },
     });
+    Object.defineProperty(video, 'readyState', {
+      get: () => {
+        return video.readyStateOverride;
+      },
+    });
     video.load = function () {
       video.currentTime = 0;
       video.currentSrcOverride = video.firstElementChild.src;
+      video.readyStateOverride = 1;
     };
     video.play = env.sandbox.spy();
     env.win.document.body.appendChild(video);


### PR DESCRIPTION
When a cached video loads, it has a chance of sending a `waiting` event before loading and a `playing` event when it starts playing. If these events take more than 100ms, it would trigger a downgrade on the videos even though the video is not loaded yet, and the `nonTrivialWait` is not a buffering problem