### PR TITLE
✨ Send extension versions from AMPHTML ads to FIE 

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -329,6 +329,8 @@ exports.rules = [
       // Parsing extension urls.
       'extensions/amp-a4a/0.1/head-validation.js->' +
         'src/service/extension-script.js',
+      'extensions/amp-a4a/0.1/amp-ad-utils.js->' +
+        'src/service/extension-script.js',
       'extensions/amp-live-list/0.1/live-list-manager.js->' +
         'src/service/extension-script.js',
       'extensions/amp-video/0.1/amp-video.js->' +

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -57,13 +57,14 @@ import {
 } from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
 import {getExperimentBranch, isExperimentOn} from '../../../src/experiments';
-import {getMode} from '../../../src/mode';
-import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {
+  getExtensionsFromMetadata,
   installFriendlyIframeEmbed,
   isSrcdocSupported,
-  preloadFriendlyIframeEmbedExtensionIdsDeprecated,
+  preloadFriendlyIframeEmbedExtensions,
 } from '../../../src/friendly-iframe-embed';
+import {getMode} from '../../../src/mode';
+import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {installRealTimeConfigServiceForDoc} from '../../../src/service/real-time-config/real-time-config-impl';
 import {installUrlReplacementsForEmbed} from '../../../src/service/url-replacements-impl';
 import {
@@ -1122,12 +1123,8 @@ export class AmpA4A extends AMP.BaseElement {
 
           // Load any extensions; do not wait on their promises as this
           // is just to prefetch.
-          // TODO(#33020): switch to `preloadFriendlyIframeEmbedExtensions` with
-          // the format of `[{extensionId, extensionVersion}]`.
-          preloadFriendlyIframeEmbedExtensionIdsDeprecated(
-            this.win,
-            creativeMetaDataDef.customElementExtensions
-          );
+          const extensions = getExtensionsFromMetadata(creativeMetaDataDef);
+          preloadFriendlyIframeEmbedExtensions(this.win, extensions);
 
           // Preload any fonts.
           (creativeMetaDataDef.customStylesheets || []).forEach((font) =>
@@ -1825,13 +1822,9 @@ export class AmpA4A extends AMP.BaseElement {
       body
     );
 
-    // TODO(ccordry): FIE does not handle extension versioning, but we have
-    // it accessible here.
-    const extensionIds = extensions.map((extension) => extension.extensionId);
-
     const fieInstallPromise = this.installFriendlyIframeEmbed_(
       secureDoc,
-      extensionIds,
+      extensions,
       fonts,
       true // skipHtmlMerge
     );
@@ -1845,6 +1838,7 @@ export class AmpA4A extends AMP.BaseElement {
       }
     );
 
+    const extensionIds = extensions.map((extension) => extension.extensionId);
     return fieInstallPromise.then((friendlyIframeEmbed) => {
       checkStillCurrent();
       this.makeFieVisible_(
@@ -1906,10 +1900,11 @@ export class AmpA4A extends AMP.BaseElement {
       });
     }
     const checkStillCurrent = this.verifyStillCurrent();
-    const {minifiedCreative, customElementExtensions} = creativeMetaData;
+    const {minifiedCreative} = creativeMetaData;
+    const extensions = getExtensionsFromMetadata(creativeMetaData);
     return this.installFriendlyIframeEmbed_(
       minifiedCreative,
-      customElementExtensions,
+      extensions,
       fontsArray || [],
       false // skipHtmlMerge
     ).then((friendlyIframeEmbed) =>
@@ -1924,12 +1919,12 @@ export class AmpA4A extends AMP.BaseElement {
   /**
    * Convert the iframe to FIE impl and append to DOM.
    * @param {string} html
-   * @param {!Array<string>} extensionIds
+   * @param {!Array<?{extensionId: string, extensionVersion: string}>} extensions
    * @param {!Array<string>} fonts
    * @param {boolean} skipHtmlMerge
    * @return {!Promise<!../../../src/friendly-iframe-embed.FriendlyIframeEmbed>}
    */
-  installFriendlyIframeEmbed_(html, extensionIds, fonts, skipHtmlMerge) {
+  installFriendlyIframeEmbed_(html, extensions, fonts, skipHtmlMerge) {
     return installFriendlyIframeEmbed(
       devAssert(this.iframe),
       this.element,
@@ -1938,9 +1933,7 @@ export class AmpA4A extends AMP.BaseElement {
         // Need to guarantee that this is no longer null
         url: devAssert(this.adUrl_),
         html,
-        // TODO(#33020): provide the `extensions` property instead, in
-        // the format of `[{extensionId, extensionVersion}]`.
-        extensionIds,
+        extensions,
         fonts,
         skipHtmlMerge,
       },

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -57,14 +57,14 @@ import {
 } from '../../../src/consent';
 import {getContextMetadata} from '../../../src/iframe-attributes';
 import {getExperimentBranch, isExperimentOn} from '../../../src/experiments';
+import {getExtensionsFromMetadata} from './amp-ad-utils';
+import {getMode} from '../../../src/mode';
+import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {
-  getExtensionsFromMetadata,
   installFriendlyIframeEmbed,
   isSrcdocSupported,
   preloadFriendlyIframeEmbedExtensions,
 } from '../../../src/friendly-iframe-embed';
-import {getMode} from '../../../src/mode';
-import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {installRealTimeConfigServiceForDoc} from '../../../src/service/real-time-config/real-time-config-impl';
 import {installUrlReplacementsForEmbed} from '../../../src/service/url-replacements-impl';
 import {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1919,7 +1919,7 @@ export class AmpA4A extends AMP.BaseElement {
   /**
    * Convert the iframe to FIE impl and append to DOM.
    * @param {string} html
-   * @param {!Array<?{extensionId: string, extensionVersion: string}>} extensions
+   * @param {!Array<{extensionId: string, extensionVersion: string}>} extensions
    * @param {!Array<string>} fonts
    * @param {boolean} skipHtmlMerge
    * @return {!Promise<!../../../src/friendly-iframe-embed.FriendlyIframeEmbed>}
@@ -2255,6 +2255,9 @@ export class AmpA4A extends AMP.BaseElement {
         }
       } else {
         metaData.customElementExtensions = [];
+      }
+      if (metaDataObj['extensions']) {
+        metaData.extensions = metaDataObj['extensions'];
       }
       if (metaDataObj['customStylesheets']) {
         // Expect array of objects with at least one key being 'href' whose

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -163,7 +163,7 @@ export function getAmpAdMetadata(creative) {
 }
 
 /**
- * Determine if parsed extensions metadata object
+ * Determine if parsed extensions metadata contains given element id.
  * @param {!Array<{custom-element: string, src: string}>} extensions
  * @param {string} id
  * @return {boolean}

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -17,6 +17,7 @@ import {Services} from '../../../src/services';
 import {dev} from '../../../src/log';
 import {isArray, isObject} from '../../../src/types';
 import {isSecureUrlDeprecated} from '../../../src/url';
+import {parseExtensionUrl} from '../../../src/service/extension-script';
 import {parseJson} from '../../../src/json';
 
 const TAG = 'amp-ad-util';
@@ -159,4 +160,36 @@ export function getAmpAdMetadata(creative) {
     );
     return null;
   }
+}
+
+/**
+ * Determine if parsed extensions metadata object
+ * @param {!Array<{custom-element: string, src: string}>} extensions
+ * @param {string} id
+ * @return {boolean}
+ */
+export function extensionsHasElement(extensions, id) {
+  return extensions.some((entry) => entry['custom-element'] === id);
+}
+
+/**
+ * Parses extension urls from given metadata to retrieve name and version.
+ * @param {!./amp-ad-type-defs.CreativeMetaDataDef} creativeMetadata
+ * @return {!Array<?{extensionId: string, extensionVersion: string}>}
+ */
+export function getExtensionsFromMetadata(creativeMetadata) {
+  const parsedExtensions = [];
+  const {extensions} = creativeMetadata;
+  if (!extensions || !isArray(extensions)) {
+    return parsedExtensions;
+  }
+
+  for (let i = 0; i < extensions.length; i++) {
+    const extension = extensions[i];
+    const extensionData = parseExtensionUrl(extension.src);
+    if (extensionData) {
+      parsedExtensions.push(extensionData);
+    }
+  }
+  return parsedExtensions;
 }

--- a/extensions/amp-a4a/0.1/friendly-frame-util.js
+++ b/extensions/amp-a4a/0.1/friendly-frame-util.js
@@ -17,12 +17,15 @@
 import {A4AVariableSource} from '../../amp-a4a/0.1/a4a-variable-source';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
-import {installFriendlyIframeEmbed} from '../../../src/friendly-iframe-embed';
+import {
+  getExtensionsFromMetadata,
+  installFriendlyIframeEmbed,
+} from '../../../src/friendly-iframe-embed';
 import {installUrlReplacementsForEmbed} from '../../../src/service/url-replacements-impl';
 import {setStyle} from '../../../src/style';
 
 /**
- * Renders a creative into a "NameFrame" iframe.
+ * Renders a creative into a friendly iframe.
  *
  * @param {string} adUrl The ad request URL.
  * @param {!./amp-ad-type-defs.LayoutInfoDef} size The size and layout of the
@@ -66,6 +69,7 @@ export function renderCreativeIntoFriendlyFrame(
     });
   }
 
+  const extensions = getExtensionsFromMetadata(creativeMetadata);
   return installFriendlyIframeEmbed(
     iframe,
     element,
@@ -73,9 +77,7 @@ export function renderCreativeIntoFriendlyFrame(
       host: element,
       url: /** @type {string} */ (adUrl),
       html: creativeMetadata.minifiedCreative,
-      // TODO(#33020): provide the `extensions` property instead, in
-      // the format of `[{extensionId, extensionVersion}]`.
-      extensionIds: creativeMetadata.customElementExtensions || [],
+      extensions,
       fonts: fontsArray,
     },
     (embedWin, ampdoc) => {

--- a/extensions/amp-a4a/0.1/friendly-frame-util.js
+++ b/extensions/amp-a4a/0.1/friendly-frame-util.js
@@ -17,10 +17,8 @@
 import {A4AVariableSource} from '../../amp-a4a/0.1/a4a-variable-source';
 import {createElementWithAttributes} from '../../../src/dom';
 import {dict} from '../../../src/utils/object';
-import {
-  getExtensionsFromMetadata,
-  installFriendlyIframeEmbed,
-} from '../../../src/friendly-iframe-embed';
+import {getExtensionsFromMetadata} from './amp-ad-utils';
+import {installFriendlyIframeEmbed} from '../../../src/friendly-iframe-embed';
 import {installUrlReplacementsForEmbed} from '../../../src/service/url-replacements-impl';
 import {setStyle} from '../../../src/style';
 

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -82,7 +82,7 @@ export class TemplateValidator extends Validator {
         if (!extensionsHasElement(extensions, 'amp-mustache')) {
           extensions.push({
             'custom-element': 'amp-mustache',
-            src: 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
+            src: 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
           });
         }
 

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -17,11 +17,11 @@
 import {AdResponseType, Validator, ValidatorResult} from './amp-ad-type-defs';
 import {
   extensionsHasElement,
+  getAmpAdMetadata,
   getExtensionsFromMetadata,
-  preloadFriendlyIframeEmbedExtensions,
-} from '../../../src/friendly-iframe-embed';
-import {getAmpAdMetadata} from './amp-ad-utils';
+} from './amp-ad-utils';
 import {getAmpAdTemplateHelper} from './amp-ad-template-helper';
+import {preloadFriendlyIframeEmbedExtensions} from '../../../src/friendly-iframe-embed';
 import {tryParseJson} from '../../../src/json';
 import {utf8Decode} from '../../../src/utils/bytes';
 

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -16,7 +16,7 @@
 
 import {AdResponseType, Validator, ValidatorResult} from './amp-ad-type-defs';
 import {
-  extensionsHasId,
+  extensionsHasElement,
   getExtensionsFromMetadata,
   preloadFriendlyIframeEmbedExtensions,
 } from '../../../src/friendly-iframe-embed';
@@ -68,24 +68,26 @@ export class TemplateValidator extends Validator {
       .fetch(parsedResponseBody.templateUrl)
       .then((template) => {
         const creativeMetadata = getAmpAdMetadata(template);
-        const extensions = getExtensionsFromMetadata(creativeMetadata);
+        creativeMetadata['extensions'] = creativeMetadata['extensions'] || [];
+        const extensions = creativeMetadata['extensions'];
         if (
           parsedResponseBody.analytics &&
-          extensionsHasId(extensions, 'amp-analytics')
+          !extensionsHasElement(extensions, 'amp-analytics')
         ) {
           extensions.push({
-            extensionId: 'amp-analytics',
-            extensionVersion: 'latest',
+            'custom-element': 'amp-analytics',
+            src: 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
           });
         }
-        if (!extensionsHasId('amp-mustache')) {
+        if (!extensionsHasElement(extensions, 'amp-mustache')) {
           extensions.push({
-            extensionId: 'amp-mustache',
-            extensionVersion: 'latest',
+            'custom-element': 'amp-mustache',
+            src: 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
           });
         }
 
-        preloadFriendlyIframeEmbedExtensions(context.win, extensions);
+        const extensionsInfo = getExtensionsFromMetadata(creativeMetadata);
+        preloadFriendlyIframeEmbedExtensions(context.win, extensionsInfo);
 
         // TODO(levitzky) Add preload logic for fonts / images.
         return Promise.resolve(

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -23,6 +23,7 @@ import {
 import {getAmpAdTemplateHelper} from './amp-ad-template-helper';
 import {preloadFriendlyIframeEmbedExtensions} from '../../../src/friendly-iframe-embed';
 import {tryParseJson} from '../../../src/json';
+import {urls} from '../../../src/config';
 import {utf8Decode} from '../../../src/utils/bytes';
 
 /** @const {string} */
@@ -76,13 +77,13 @@ export class TemplateValidator extends Validator {
         ) {
           extensions.push({
             'custom-element': 'amp-analytics',
-            src: 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+            src: `${urls.cdn}/v0/amp-analytics-0.1.js`,
           });
         }
         if (!extensionsHasElement(extensions, 'amp-mustache')) {
           extensions.push({
             'custom-element': 'amp-mustache',
-            src: 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+            src: `${urls.cdn}/v0/amp-mustache-latest.js`,
           });
         }
 

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -2352,6 +2352,28 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       expect(actual).to.deep.equal(expected);
     });
 
+    it('should copy over any extensions detail', () => {
+      metaData.extensions = [
+        {
+          'custom-element': 'amp-analytics',
+          'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+        },
+        {
+          'custom-element': 'amp-mustache',
+          'src': 'https://cdn.ampproject.org/v0/amp-mustache-1.0.js',
+        },
+      ];
+      const actual = a4a.getAmpAdMetadata(buildCreativeString(metaData));
+      expect(actual.extensions).to.deep.include({
+        'custom-element': 'amp-analytics',
+        'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+      });
+      expect(actual.extensions).to.deep.include({
+        'custom-element': 'amp-mustache',
+        'src': 'https://cdn.ampproject.org/v0/amp-mustache-1.0.js',
+      });
+    });
+
     // TODO(levitzky) remove the following two tests after metadata bug is
     // fixed.
     it('should parse metadata with wrong opening tag', () => {

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
@@ -15,7 +15,11 @@
  */
 
 import {data} from './testdata/valid_css_at_rules_amp.reserialized';
-import {getAmpAdMetadata} from '../amp-ad-utils';
+import {
+  extensionsHasElement,
+  getAmpAdMetadata,
+  getExtensionsFromMetadata,
+} from '../amp-ad-utils';
 
 describe('getAmpAdMetadata', () => {
   it('should parse metadata successfully', () => {
@@ -54,5 +58,64 @@ describe('getAmpAdMetadata', () => {
       data.reserializedMissingScriptTag
     );
     expect(creativeMetadata).to.be.null;
+  });
+});
+
+describe('extensionsHasElement', () => {
+  it('should return true if containing extension', () => {
+    const extensions = [
+      {
+        'custom-element': 'amp-cats',
+        src: 'https://cdn.ampproject.org/v0/amp-cats-0.1.js',
+      },
+    ];
+    expect(extensionsHasElement(extensions, 'amp-cats')).to.be.true;
+  });
+
+  it('should return false if it does not contain extension', () => {
+    const extensions = [
+      {
+        'custom-element': 'amp-cats',
+        src: 'https://cdn.ampproject.org/v0/amp-cats-0.1.js',
+      },
+    ];
+    expect(extensionsHasElement(extensions, 'amp-dogs')).to.be.false;
+  });
+
+  it('should return false if empty array', () => {
+    const extensions = [];
+    expect(extensionsHasElement(extensions, 'amp-dogs')).to.be.false;
+  });
+});
+
+describe('getExtensionsFromMetadata', () => {
+  it('should return extension name and version', () => {
+    const metadata = {
+      extensions: [
+        {
+          'custom-element': 'amp-analytics',
+          'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+        },
+        {
+          'custom-element': 'amp-mustache',
+          'src': 'https://cdn.ampproject.org/v0/amp-mustache-1.0.js',
+        },
+      ],
+    };
+    const extensions = getExtensionsFromMetadata(metadata);
+    expect(extensions).to.deep.include({
+      extensionId: 'amp-analytics',
+      extensionVersion: '0.1',
+    });
+    expect(extensions).to.deep.include({
+      extensionId: 'amp-mustache',
+      extensionVersion: '1.0',
+    });
+  });
+
+  it('should handle no `extensions` key in metadata', () => {
+    const metadata = {};
+    const extensions = getExtensionsFromMetadata(metadata);
+    expect(extensions).to.eql([]);
   });
 });

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -130,12 +130,12 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
       });
     });
 
-    it('should have amp-analytics and mustache in customElementExtensions', () => {
+    it('should have amp-analytics and mustache in extensions', () => {
       return validatorPromise.then((validatorOutput) => {
         expect(validatorOutput).to.be.ok;
         expect(validatorOutput.creativeData).to.be.ok;
         const {creativeMetadata} = validatorOutput.creativeData;
-        expect(creativeMetadata.customElementExtensions).to.deep.equal([
+        expect(creativeMetadata.extensions).to.deep.equal([
           'amp-analytics',
           'amp-mustache',
         ]);

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -135,10 +135,14 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
         expect(validatorOutput).to.be.ok;
         expect(validatorOutput.creativeData).to.be.ok;
         const {creativeMetadata} = validatorOutput.creativeData;
-        expect(creativeMetadata.extensions).to.deep.equal([
-          'amp-analytics',
-          'amp-mustache',
-        ]);
+        expect(creativeMetadata.extensions).to.deep.include({
+          'custom-element': 'amp-analytics',
+          'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+        });
+        expect(creativeMetadata.extensions).to.deep.include({
+          'custom-element': 'amp-mustache',
+          'src': 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
+        });
       });
     });
   });

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -141,7 +141,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
         });
         expect(creativeMetadata.extensions).to.deep.include({
           'custom-element': 'amp-mustache',
-          'src': 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
+          'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
         });
       });
     });

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -246,11 +246,13 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
       });
   });
 
+  // broke
   it('should perform media operations on fie video when active', (done) => {
     const iframe = win.document.createElement('iframe');
     const fiePromise = installFriendlyIframeEmbed(iframe, gridLayerEl, {
       url: 'https://amp.dev',
       html: '<video src="https://example.com/video.mp3"></video>',
+      extensions: [],
     });
     env.sandbox.stub(page, 'loadPromise').returns(Promise.resolve());
 

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -246,7 +246,6 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
       });
   });
 
-  // broke
   it('should perform media operations on fie video when active', (done) => {
     const iframe = win.document.createElement('iframe');
     const fiePromise = installFriendlyIframeEmbed(iframe, gridLayerEl, {

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -153,13 +153,15 @@ export function preloadFriendlyIframeEmbedExtensionIdsDeprecated(
 }
 
 /**
- * Determine if extensions array contains given extension name.
- * @param {!Array<?{extensionId: string, extensionVersion: string}>} extensions
+ * Determine if parsed extensions metadata object
+ * @param {!Array<{custom-element: string, src: string}>} extensions
  * @param {string} id
  * @return {boolean}
  */
-export function extensionsHasId(extensions, id) {
-  return findIndex(extensions, (entry) => entry.extensionId === id) !== -1;
+export function extensionsHasElement(extensions, id) {
+  return (
+    findIndex(extensions, (entry) => entry['custom-element'] === id) !== -1
+  );
 }
 
 /**

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -28,7 +28,6 @@ import {
   setParentWindow,
 } from './service';
 import {escapeHtml} from './dom';
-import {findIndex} from './utils/array';
 import {getMode} from './mode';
 import {install as installAbortController} from './polyfills/abort-controller';
 import {installAmpdocServicesForEmbed} from './service/core-services';
@@ -159,9 +158,7 @@ export function preloadFriendlyIframeEmbedExtensionIdsDeprecated(
  * @return {boolean}
  */
 export function extensionsHasElement(extensions, id) {
-  return (
-    findIndex(extensions, (entry) => entry['custom-element'] === id) !== -1
-  );
+  return extensions.some((entry) => entry['custom-element'] === id);
 }
 
 /**

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -137,8 +137,12 @@ export function preloadFriendlyIframeEmbedExtensions(win, extensions) {
  * @param {!Window} win
  * @param {!Array<string>} extensionIds
  * TODO(#33020): remove this method in favor `preloadFriendlyIframeEmbedExtensions`.
+ * @visibleForTesting
  */
-function preloadFriendlyIframeEmbedExtensionIdsDeprecated(win, extensionIds) {
+export function preloadFriendlyIframeEmbedExtensionIdsDeprecated(
+  win,
+  extensionIds
+) {
   const extensionsService = Services.extensionsFor(win);
 
   // Load any extensions; do not wait on their promises as this
@@ -166,7 +170,7 @@ export function extensionsHasId(extensions, id) {
 export function getExtensionsFromMetadata(creativeMetadata) {
   const parsedExtensions = [];
   const {extensions} = creativeMetadata;
-  if (!extensions || isArray(extensions)) {
+  if (!extensions || !isArray(extensions)) {
     return parsedExtensions;
   }
 

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -38,11 +38,9 @@ import {installForChildWin as installIntersectionObserver} from './polyfills/int
 import {installForChildWin as installResizeObserver} from './polyfills/resize-observer';
 import {installStylesForDoc} from './style-installer';
 import {installTimerInEmbedWindow} from './service/timer-impl';
-import {isArray, toWin} from './types';
 import {isDocumentReady} from './document-ready';
 import {layoutRectLtwh, moveLayoutRect} from './layout-rect';
 import {loadPromise} from './event-helper';
-import {parseExtensionUrl} from './service/extension-script';
 import {
   px,
   resetStyles,
@@ -50,6 +48,7 @@ import {
   setStyle,
   setStyles,
 } from './style';
+import {toWin} from './types';
 import {urls} from './config';
 import {whenContentIniLoad} from './ini-load';
 
@@ -149,38 +148,6 @@ export function preloadFriendlyIframeEmbedExtensionIdsDeprecated(
   extensionIds.forEach((extensionId) =>
     extensionsService.preloadExtension(extensionId)
   );
-}
-
-/**
- * Determine if parsed extensions metadata object
- * @param {!Array<{custom-element: string, src: string}>} extensions
- * @param {string} id
- * @return {boolean}
- */
-export function extensionsHasElement(extensions, id) {
-  return extensions.some((entry) => entry['custom-element'] === id);
-}
-
-/**
- * Parses extension urls from given metadata to retrieve name and version.
- * @param {!./amp-ad-type-defs.CreativeMetaDataDef} creativeMetadata
- * @return {!Array<?{extensionId: string, extensionVersion: string}>}
- */
-export function getExtensionsFromMetadata(creativeMetadata) {
-  const parsedExtensions = [];
-  const {extensions} = creativeMetadata;
-  if (!extensions || !isArray(extensions)) {
-    return parsedExtensions;
-  }
-
-  for (let i = 0; i < extensions.length; i++) {
-    const extension = extensions[i];
-    const extensionData = parseExtensionUrl(extension.src);
-    if (extensionData) {
-      parsedExtensions.push(extensionData);
-    }
-  }
-  return parsedExtensions;
 }
 
 /**

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -22,7 +22,7 @@ import {FakeWindow} from '../../testing/fake-dom';
 import {
   FriendlyIframeEmbed,
   Installers,
-  extensionsHasId,
+  extensionsHasElement,
   getExtensionsFromMetadata,
   installFriendlyIframeEmbed,
   mergeHtmlForTesting,
@@ -1545,20 +1545,30 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
   });
 });
 
-describe('extensionsHasId', () => {
+describe('extensionsHasElement', () => {
   it('should return true if containing extension', () => {
-    const extensions = [{extensionId: 'amp-cats', extensionVersion: '1.0'}];
-    expect(extensionsHasId(extensions, 'amp-cats')).to.be.true;
+    const extensions = [
+      {
+        'custom-element': 'amp-cats',
+        src: 'https://cdn.ampproject.org/v0/amp-cats-0.1.js',
+      },
+    ];
+    expect(extensionsHasElement(extensions, 'amp-cats')).to.be.true;
   });
 
   it('should return false if it does not contain extension', () => {
-    const extensions = [{extensionId: 'amp-cats', extensionVersion: '1.0'}];
-    expect(extensionsHasId(extensions, 'amp-dogs')).to.be.false;
+    const extensions = [
+      {
+        'custom-element': 'amp-cats',
+        src: 'https://cdn.ampproject.org/v0/amp-cats-0.1.js',
+      },
+    ];
+    expect(extensionsHasElement(extensions, 'amp-dogs')).to.be.false;
   });
 
   it('should return false if empty array', () => {
-    const extensions = [{extensionId: 'amp-cats', extensionVersion: '1.0'}];
-    expect(extensionsHasId(extensions, 'amp-dogs')).to.be.false;
+    const extensions = [];
+    expect(extensionsHasElement(extensions, 'amp-dogs')).to.be.false;
   });
 });
 

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -22,8 +22,6 @@ import {FakeWindow} from '../../testing/fake-dom';
 import {
   FriendlyIframeEmbed,
   Installers,
-  extensionsHasElement,
-  getExtensionsFromMetadata,
   installFriendlyIframeEmbed,
   mergeHtmlForTesting,
   preloadFriendlyIframeEmbedExtensionIdsDeprecated,
@@ -1542,64 +1540,5 @@ describes.realWin('installExtensionsInEmbed', {amp: true}, (env) => {
     // Extension elements are stubbed immediately, but registered only
     // after extension is loaded.
     expect(iframeWin.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(AmpTest);
-  });
-});
-
-describe('extensionsHasElement', () => {
-  it('should return true if containing extension', () => {
-    const extensions = [
-      {
-        'custom-element': 'amp-cats',
-        src: 'https://cdn.ampproject.org/v0/amp-cats-0.1.js',
-      },
-    ];
-    expect(extensionsHasElement(extensions, 'amp-cats')).to.be.true;
-  });
-
-  it('should return false if it does not contain extension', () => {
-    const extensions = [
-      {
-        'custom-element': 'amp-cats',
-        src: 'https://cdn.ampproject.org/v0/amp-cats-0.1.js',
-      },
-    ];
-    expect(extensionsHasElement(extensions, 'amp-dogs')).to.be.false;
-  });
-
-  it('should return false if empty array', () => {
-    const extensions = [];
-    expect(extensionsHasElement(extensions, 'amp-dogs')).to.be.false;
-  });
-});
-
-describe('getExtensionsFromMetadata', () => {
-  it('should return extension name and version', () => {
-    const metadata = {
-      extensions: [
-        {
-          'custom-element': 'amp-analytics',
-          'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
-        },
-        {
-          'custom-element': 'amp-mustache',
-          'src': 'https://cdn.ampproject.org/v0/amp-mustache-1.0.js',
-        },
-      ],
-    };
-    const extensions = getExtensionsFromMetadata(metadata);
-    expect(extensions).to.deep.include({
-      extensionId: 'amp-analytics',
-      extensionVersion: '0.1',
-    });
-    expect(extensions).to.deep.include({
-      extensionId: 'amp-mustache',
-      extensionVersion: '1.0',
-    });
-  });
-
-  it('should handle no `extensions` key in metadata', () => {
-    const metadata = {};
-    const extensions = getExtensionsFromMetadata(metadata);
-    expect(extensions).to.eql([]);
   });
 });


### PR DESCRIPTION
- Extracts extension version from ad where previously unavailable.
- Passes extension version info (as `extensions`) from A4A legacy code, no signing, and templates ads. 
- Removes `preloadFriendlyIframeEmbedExtensionIdsDeprecated` from all call sites outside of `friendly-iframe-embed.js`.

Partial #33020 