### PR TITLE
Ensure that pre-stubbing always happens before the first element is upgraded

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -966,7 +966,6 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         const ampdocService = Services.ampdocServiceFor(win);
         const ampdoc = ampdocService.getAmpDoc(this);
         this.ampdoc_ = ampdoc;
-
         elementConnectedCallback(ampdoc, this, this.implClass_);
       }
       if (!this.resources_) {
@@ -1982,11 +1981,19 @@ function isInternalOrServiceNode(node) {
  *
  * @param {!Window} win The window in which to register the custom element.
  * @param {(typeof ./base-element.BaseElement)=} opt_implementationClass For testing only.
+ * @param {function(!./service/ampdoc-impl.AmpDoc, !AmpElement element, ?(typeof BaseElement))=} opt_elementConnectedCallback
  * @return {!Object} Prototype of element.
  * @visibleForTesting
  */
-export function createAmpElementForTesting(win, opt_implementationClass) {
-  const Element = createCustomElementClass(win, () => {});
+export function createAmpElementForTesting(
+  win,
+  opt_implementationClass,
+  opt_elementConnectedCallback
+) {
+  const Element = createCustomElementClass(
+    win,
+    opt_elementConnectedCallback || (() => {})
+  );
   if (getMode().test && opt_implementationClass) {
     Element.prototype.implementationClassForTesting = opt_implementationClass;
   }

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -21,6 +21,9 @@ import {extensionScriptsInNode} from './extension-script';
 import {reportError} from '../error';
 import {pureUserAssert as userAssert} from '../core/assert';
 
+/** @type {!WeakMap<!./service/ampdoc-impl.AmpDoc, boolean>} */
+const docInitializedMap = new WeakMap();
+
 /**
  * @param {!Window} win
  * @return {!Object<string, typeof ../base-element.BaseElement>}
@@ -174,8 +177,33 @@ export function copyElementToChildWindow(parentWin, childWin, name) {
 export function registerElement(win, name, implementationClass) {
   const knownElements = getExtendedElements(win);
   knownElements[name] = implementationClass;
-  const klass = createCustomElementClass(win, stubElementsForDoc);
+  const klass = createCustomElementClass(win, elementConnectedCallback);
   win['customElements'].define(name, klass);
+}
+
+/**
+ * @param {!./ampdoc-impl.AmpDoc} ampdoc
+ * @param {!AmpElement} element
+ * @param {?(typeof BaseElement)} implementationClass
+ * @visibleForTesting
+ */
+export function elementConnectedCallback(ampdoc, element, implementationClass) {
+  // Make sure that the ampdoc has already been stubbed.
+  if (!docInitializedMap.has(ampdoc)) {
+    docInitializedMap.set(ampdoc, true);
+    stubElementsForDoc(ampdoc);
+  }
+
+  // Load the pre-stubbed legacy extension if needed.
+  const extensionId = element.localName;
+  if (!implementationClass && !ampdoc.declaresExtension(extensionId)) {
+    Services.extensionsFor(ampdoc.win).installExtensionForDoc(
+      ampdoc,
+      extensionId,
+      // The legacy auto-extensions are always 0.1.
+      '0.1'
+    );
+  }
 }
 
 /**

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -174,7 +174,7 @@ export function copyElementToChildWindow(parentWin, childWin, name) {
 export function registerElement(win, name, implementationClass) {
   const knownElements = getExtendedElements(win);
   knownElements[name] = implementationClass;
-  const klass = createCustomElementClass(win);
+  const klass = createCustomElementClass(win, stubElementsForDoc);
   win['customElements'].define(name, klass);
 }
 

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -27,6 +27,7 @@ import {
   createAmpElementForTesting,
   getImplSyncForTesting,
 } from '../../src/custom-element';
+import {elementConnectedCallback} from '../../src/service/custom-element-registry';
 import {toggleExperiment} from '../../src/experiments';
 
 describes.realWin('CustomElement', {amp: true}, (env) => {
@@ -121,6 +122,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         clock = fakeTimers.withGlobal(win).install();
         delete win.requestIdleCallback;
         delete win.cancelIdleCallback;
+        delete win.__AMP_BASE_CE_CLASS;
         resources = Services.resourcesForDoc(doc);
         resources.isBuildOn_ = true;
         resourcesMock = env.sandbox.mock(resources);
@@ -244,7 +246,12 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       });
 
       it('StubElement - should try to install an unregistered legacy extensions', () => {
-        const LegacyElementClass = createAmpElementForTesting(win, ElementStub);
+        delete win.__AMP_BASE_CE_CLASS;
+        const LegacyElementClass = createAmpElementForTesting(
+          win,
+          ElementStub,
+          elementConnectedCallback
+        );
         win.customElements.define('amp-legacy', LegacyElementClass);
         win.__AMP_EXTENDED_ELEMENTS['amp-legacy'] = ElementStub;
 
@@ -264,7 +271,12 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       });
 
       it('StubElement - should not try to install a pre-registered legacy extensions', () => {
-        const LegacyElementClass = createAmpElementForTesting(win, ElementStub);
+        delete win.__AMP_BASE_CE_CLASS;
+        const LegacyElementClass = createAmpElementForTesting(
+          win,
+          ElementStub,
+          elementConnectedCallback
+        );
         win.customElements.define('amp-legacy', LegacyElementClass);
         win.__AMP_EXTENDED_ELEMENTS['amp-legacy'] = ElementStub;
         ampdoc.declareExtension('amp-legacy', '0.1');


### PR DESCRIPTION
Currently, the first `stubElementsForDoc` can be called after the first element is upgraded. This could create race conditions where an element would request its implementation before it knows whether the implementation has already been requested.