### PR TITLE
🐛  [Story interactives] Fixed text align of buttons

### DIFF
--- a/examples/amp-story/interactives.html
+++ b/examples/amp-story/interactives.html
@@ -67,7 +67,7 @@
                 prompt-text="Is this an international quiz?"
                 option-1-text="你好，这是马蒂亚斯"
                 option-2-text="مرحبا هذا ماتياس"
-                option-3-text="Yes it is" option-3-correct
+                option-3-text="Yes it is, this is indeed an international quiz" option-3-correct
                 option-3-confetti="🌎"
                 option-4-text="ब्राज़ील यहाँ होना चाहिए">
             </amp-story-interactive-quiz>
@@ -429,7 +429,7 @@
               theme="light"
               prompt-text="What is your favorite food?"
               option-1-text="Tacos"
-              option-2-text="Bacon"
+              option-2-text="Bacon is my favourite food in the world and I eat it everyday"
               option-3-text="Broccoli"
               option-4-text="Ice cream"
               option-1-confetti="🌮"

--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-poll.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-poll.css
@@ -41,6 +41,7 @@
   color: inherit !important;
   width: 100% !important;
   outline: none !important;
+  text-align: start !important;
 }
 
 .i-amphtml-story-interactive-option:not(:first-child) {

--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
@@ -58,6 +58,7 @@
   z-index: 0 !important;
   border: none !important;
   outline: none !important;
+  text-align: start !important;
 }
 
 [dir='rtl'] .i-amphtml-story-interactive-quiz-option {


### PR DESCRIPTION
Fixes #33206

We recently changed the options to use <button> tags for accessibility, and buttons by default have text centered instead of the initial alignment. This causes quizzes or polls options that have 2 lines to have text-align: center.

Tested fix locally on ltr and rtl stories

Eg (before/after):
<img src="https://user-images.githubusercontent.com/22420856/110849275-0b7a0100-827d-11eb-9913-04e922e862e2.png" width="600">

<img src="https://user-images.githubusercontent.com/22420856/110849260-074de380-827d-11eb-9e06-99169b10cdf8.png" width="300">
<img src="https://user-images.githubusercontent.com/22420856/110849321-19c81d00-827d-11eb-9365-324b0b8a3082.png" width="300">

