### PR TITLE
🏗 In integration test, window.karma should be window.__karma__

### DIFF
--- a/test/_init_tests.js
+++ b/test/_init_tests.js
@@ -81,7 +81,9 @@ global.AMP.extension = function (name, version, installer) {
 };
 
 // Make amp section in karma config readable by tests.
-window.ampTestRuntimeConfig = parent.karma ? parent.karma.config.amp : {};
+window.ampTestRuntimeConfig = parent.__karma__
+  ? parent.__karma__.config.amp
+  : {};
 
 /**
  * Helper class to skip or retry tests under specific environment.


### PR DESCRIPTION
I am always getting `{}` for `window.ampTestRuntimeConfig`. Upon looking, it appears that the property now appears as `window.__karma__`.