### PR TITLE
🏗 Ensure up-to-date and clean `package-lock.json` before running any CI job

### DIFF
--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -30,7 +30,6 @@ const jobName = 'checks.js';
  * @return {void}
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('gulp update-packages');
   timedExecOrDie('gulp presubmit');
   timedExecOrDie('gulp lint');
   timedExecOrDie('gulp prettify');
@@ -56,7 +55,6 @@ function pushBuildWorkflow() {
  */
 async function prBuildWorkflow() {
   await reportAllExpectedTests();
-  timedExecOrDie('gulp update-packages');
 
   if (buildTargetsInclude(Targets.PRESUBMIT)) {
     timedExecOrDie('gulp presubmit');

--- a/build-system/pr-check/ci-job.js
+++ b/build-system/pr-check/ci-job.js
@@ -25,6 +25,7 @@ const {determineBuildTargets} = require('./build-targets');
 const {isPullRequestBuild} = require('../common/ci');
 const {runNpmChecks} = require('./npm-checks');
 const {setLoggingPrefix} = require('../common/logging');
+const {updatePackages} = require('../tasks/update-packages');
 
 /**
  * Helper used by all CI job scripts. Runs the PR / push build workflow.
@@ -35,6 +36,7 @@ const {setLoggingPrefix} = require('../common/logging');
 async function runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow) {
   setLoggingPrefix(jobName);
   const startTime = startTimer(jobName);
+  updatePackages();
   if (!runNpmChecks()) {
     abortTimedJob(jobName, startTime);
     return;

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -103,7 +103,6 @@ function runUnitTestsForPlatform() {
  * @return {void}
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('gulp update-packages');
   runUnitTestsForPlatform();
   timedExecOrDie('gulp dist --fortesting');
   runIntegrationTestsForPlatform();
@@ -130,7 +129,6 @@ async function prBuildWorkflow() {
     );
     return;
   }
-  timedExecOrDie('gulp update-packages');
   if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
     runUnitTestsForPlatform();
   }

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -35,7 +35,6 @@ const jobName = 'e2e-tests.js';
  */
 function pushBuildWorkflow() {
   downloadNomoduleOutput();
-  timedExecOrDie('gulp update-packages');
   try {
     timedExecOrThrow(
       'gulp e2e --nobuild --headless --compiled --report',
@@ -56,7 +55,6 @@ function pushBuildWorkflow() {
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.E2E_TEST)) {
     downloadNomoduleOutput();
-    timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp e2e --nobuild --headless --compiled');
   } else {
     printSkipMessage(

--- a/build-system/pr-check/experiment-build.js
+++ b/build-system/pr-check/experiment-build.js
@@ -38,7 +38,6 @@ function pushBuildWorkflow() {
   const config = getExperimentConfig(experiment);
   if (config) {
     const defineFlag = `--define_experiment_constant ${config.define_experiment_constant}`;
-    timedExecOrDie('gulp update-packages');
     timedExecOrDie(`gulp dist --fortesting ${defineFlag}`);
     uploadExperimentOutput(experiment);
   } else {

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -33,7 +33,6 @@ const jobName = 'module-build.js';
  * @return {void}
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('gulp update-packages');
   timedExecOrDie('gulp dist --esm --fortesting');
   uploadModuleOutput();
 }
@@ -46,7 +45,6 @@ function prBuildWorkflow() {
   // found in pr-check/nomodule-build.js as we turn on the systems that
   // run against the module build. (ex. visual diffs, e2e, etc.)
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
-    timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp dist --esm --fortesting');
     uploadModuleOutput();
   } else {

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -51,7 +51,6 @@ function prependConfig() {
 function pushBuildWorkflow() {
   downloadNomoduleOutput();
   downloadModuleOutput();
-  timedExecOrDie('gulp update-packages');
   prependConfig();
   timedExecOrDie('gulp integration --nobuild --compiled --headless --esm');
 }
@@ -63,7 +62,6 @@ function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     downloadNomoduleOutput();
     downloadModuleOutput();
-    timedExecOrDie('gulp update-packages');
     prependConfig();
     timedExecOrDie(
       `gulp integration --nobuild --compiled --headless --esm --config=${argv.config}`

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -40,7 +40,6 @@ const jobName = 'nomodule-build.js';
  * @return {void}
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('gulp update-packages');
   timedExecOrDie('gulp dist --fortesting');
   uploadNomoduleOutput();
 }
@@ -58,7 +57,6 @@ async function prBuildWorkflow() {
       Targets.VISUAL_DIFF
     )
   ) {
-    timedExecOrDie('gulp update-packages');
     const process = timedExecWithError('gulp dist --fortesting');
     if (process.status !== 0) {
       const message = process?.error

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -49,7 +49,6 @@ function prependConfig() {
  */
 function pushBuildWorkflow() {
   downloadNomoduleOutput();
-  timedExecOrDie('gulp update-packages');
   prependConfig();
   try {
     timedExecOrThrow(
@@ -71,7 +70,6 @@ function pushBuildWorkflow() {
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     downloadNomoduleOutput();
-    timedExecOrDie('gulp update-packages');
     prependConfig();
     timedExecOrDie(
       `gulp integration --nobuild --compiled --headless --config=${argv.config}`

--- a/build-system/pr-check/npm-checks.js
+++ b/build-system/pr-check/npm-checks.js
@@ -23,6 +23,7 @@
 
 const checkDependencies = require('check-dependencies');
 const {cyan, red, yellow} = require('kleur/colors');
+const {exec} = require('../common/exec');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {gitDiffColor, gitDiffNameOnly} = require('../common/git');
 
@@ -65,10 +66,13 @@ function isPackageLockFileInSync() {
 }
 
 /**
- * Makes sure that package-lock.json was properly updated.
+ * Makes sure that package-lock.json was properly updated after running `npm i`,
+ * which will reveal any missing changes. (We do this in a separate step because
+ * the clean-install command `npm ci` doesn't update the lockfile.)
  * @return {boolean}
  */
 function isPackageLockFileProperlyUpdated() {
+  exec('npm install', {'stdio': 'ignore'});
   const filesChanged = gitDiffNameOnly();
   const loggingPrefix = getLoggingPrefix();
 
@@ -81,9 +85,17 @@ function isPackageLockFileProperlyUpdated() {
     );
     logWithoutTimestamp(
       loggingPrefix,
-      yellow('NOTE:'),
+      yellow('NOTE 1:'),
+      'Make sure you are using the version of',
+      cyan('npm'),
+      'that came pre-installed with the latest LTS version of',
+      cyan('node') + '.'
+    );
+    logWithoutTimestamp(
+      loggingPrefix,
+      yellow('NOTE 2:'),
       'To fix this, sync your branch to',
-      cyan('upstream/master') + ', run',
+      cyan('ampproject/amphtml:master') + ', run',
       cyan('gulp update-packages') +
         ', and push a new commit containing the changes.'
     );

--- a/build-system/pr-check/npm-checks.js
+++ b/build-system/pr-check/npm-checks.js
@@ -22,7 +22,8 @@
  */
 
 const checkDependencies = require('check-dependencies');
-const {cyan, red, yellow} = require('kleur/colors');
+const fs = require('fs-extra');
+const {cyan, red} = require('kleur/colors');
 const {exec} = require('../common/exec');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {gitDiffColor, gitDiffNameOnly} = require('../common/git');
@@ -49,8 +50,7 @@ function isPackageLockFileInSync() {
     );
     logWithoutTimestamp(
       loggingPrefix,
-      yellow('NOTE:'),
-      'To update',
+      '⤷ To update',
       cyan('package-lock.json'),
       'after changing',
       cyan('package.json') + ',',
@@ -66,16 +66,33 @@ function isPackageLockFileInSync() {
 }
 
 /**
- * Makes sure that package-lock.json was properly updated after running `npm i`,
- * which will reveal any missing changes. (We do this in a separate step because
- * the clean-install command `npm ci` doesn't update the lockfile.)
+ * Makes sure that package-lock.json was properly updated in two steps:
+ * 1. First make sure it was generated with a compatible version of npm.
+ * 2. Then run `npm i` and check for missing changes (required because `npm ci`
+ *    doesn't update the lockfile).
  * @return {boolean}
  */
 function isPackageLockFileProperlyUpdated() {
+  const loggingPrefix = getLoggingPrefix();
+  if (fs.readJsonSync('package-lock.json').lockfileVersion != 1) {
+    logWithoutTimestamp(
+      loggingPrefix,
+      red('ERROR:'),
+      cyan('package-lock.json'),
+      'was generated with an incorrect version of',
+      cyan('npm') + '.'
+    );
+    logWithoutTimestamp(
+      loggingPrefix,
+      '⤷ To fix this, make sure you are using the version of',
+      cyan('npm'),
+      'that came pre-installed with the latest LTS version of',
+      cyan('node') + '.'
+    );
+  }
+
   exec('npm install', {'stdio': 'ignore'});
   const filesChanged = gitDiffNameOnly();
-  const loggingPrefix = getLoggingPrefix();
-
   if (filesChanged.includes('package-lock.json')) {
     logWithoutTimestamp(
       loggingPrefix,
@@ -85,19 +102,9 @@ function isPackageLockFileProperlyUpdated() {
     );
     logWithoutTimestamp(
       loggingPrefix,
-      yellow('NOTE 1:'),
-      'Make sure you are using the version of',
-      cyan('npm'),
-      'that came pre-installed with the latest LTS version of',
-      cyan('node') + '.'
-    );
-    logWithoutTimestamp(
-      loggingPrefix,
-      yellow('NOTE 2:'),
-      'To fix this, sync your branch to',
+      '⤷ To fix this, sync your branch to',
       cyan('ampproject/amphtml:master') + ', run',
-      cyan('gulp update-packages') +
-        ', and push a new commit containing the changes.'
+      cyan('npm install') + ', and push a new commit containing the changes.'
     );
     logWithoutTimestamp(loggingPrefix, 'Expected changes:');
     logWithoutTimestamp(gitDiffColor());
@@ -108,14 +115,12 @@ function isPackageLockFileProperlyUpdated() {
 
 /**
  * Runs both npm checks, and returns false if either one fails.
- * @param {string} filename
  * @return {boolean}
  */
-function runNpmChecks(filename) {
-  return (
-    isPackageLockFileInSync(filename) &&
-    isPackageLockFileProperlyUpdated(filename)
-  );
+function runNpmChecks() {
+  const loggingPrefix = getLoggingPrefix();
+  logWithoutTimestamp(loggingPrefix, 'Running', cyan('npm'), 'checks...');
+  return isPackageLockFileInSync() && isPackageLockFileProperlyUpdated();
 }
 
 module.exports = {

--- a/build-system/pr-check/performance-tests.js
+++ b/build-system/pr-check/performance-tests.js
@@ -29,7 +29,6 @@ const jobName = 'performance-tests.js';
  */
 function pushBuildWorkflow() {
   downloadNomoduleOutput(jobName);
-  timedExecOrDie('gulp update-packages');
   timedExecOrDie('gulp performance --nobuild --quiet --headless');
 }
 

--- a/build-system/pr-check/unit-tests.js
+++ b/build-system/pr-check/unit-tests.js
@@ -29,7 +29,6 @@ const jobName = 'unit-tests.js';
  * @return {void}
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('gulp update-packages');
   try {
     timedExecOrThrow(
       'gulp unit --headless --coverage --report',
@@ -53,7 +52,6 @@ function pushBuildWorkflow() {
  */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
-    timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp unit --headless --local_changes');
     timedExecOrDie('gulp unit --headless --coverage');
     timedExecOrDie('gulp codecov-upload');

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -33,7 +33,6 @@ const jobName = 'unminified-build.js';
  * @return {void}
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('gulp update-packages');
   timedExecOrDie('gulp build --fortesting');
   uploadUnminifiedOutput();
 }
@@ -43,7 +42,6 @@ function pushBuildWorkflow() {
  */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
-    timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp build --fortesting');
     uploadUnminifiedOutput();
   } else {

--- a/build-system/pr-check/unminified-tests.js
+++ b/build-system/pr-check/unminified-tests.js
@@ -35,7 +35,6 @@ const jobName = 'unminified-tests.js';
  */
 function pushBuildWorkflow() {
   downloadUnminifiedOutput();
-  timedExecOrDie('gulp update-packages');
 
   try {
     timedExecOrThrow(
@@ -61,7 +60,6 @@ function pushBuildWorkflow() {
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     downloadUnminifiedOutput();
-    timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp integration --nobuild --headless --coverage');
     timedExecOrDie('gulp codecov-upload');
   } else {

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -35,7 +35,6 @@ const jobName = 'visual-diff-tests.js';
  */
 function pushBuildWorkflow() {
   downloadNomoduleOutput();
-  timedExecOrDie('gulp update-packages');
   process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
   timedExecOrDie('gulp visual-diff --nobuild --master');
 }
@@ -47,7 +46,6 @@ function prBuildWorkflow() {
   process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
   if (buildTargetsInclude(Targets.RUNTIME, Targets.VISUAL_DIFF)) {
     downloadNomoduleOutput();
-    timedExecOrDie('gulp update-packages');
     timedExecOrDie('gulp visual-diff --nobuild');
   } else {
     timedExecOrDie('gulp visual-diff --empty');


### PR DESCRIPTION
**Two changes:**
- Add a check to `pr-check/npm-checks.js` to ensure `package-lock.json` was properly updated
- Instead of having every CI job independently update packages, make it a step in `pr-check/ci-job.js`

**[Example failure:](https://app.circleci.com/pipelines/github/ampproject/amphtml/4306/workflows/34f185d4-c949-4502-82df-cc6876bb73c4/jobs/55915/parallel-runs/0/steps/0-108)**

![image](https://user-images.githubusercontent.com/26553114/110872327-94089980-829d-11eb-89b9-696076490617.png)

