### PR TITLE
Multi-version: always specify version when waiting for an extension

### DIFF
--- a/src/element-service.js
+++ b/src/element-service.js
@@ -34,29 +34,29 @@ import {pureUserAssert as userAssert} from './core/assert';
  * @param {string} id of the service.
  * @param {string} extension Name of the custom extension that provides the
  *     implementation of this service.
+ * @param {string} version The extension version.
  * @param {boolean=} opt_element Whether this service is provided by an
  *     element, not the extension.
  * @return {!Promise<?Object>}
  */
-export function getElementServiceIfAvailable(win, id, extension, opt_element) {
+export function getElementServiceIfAvailable(
+  win,
+  id,
+  extension,
+  version,
+  opt_element
+) {
   const s = getServicePromiseOrNull(win, id);
   if (s) {
     return /** @type {!Promise<?Object>} */ (s);
   }
-  return getElementServicePromiseOrNull(win, id, extension, opt_element);
-}
-
-/**
- * @param {!Window} win
- * @param {string} elementName Name of an extended custom element.
- * @return {boolean} Whether this element is scheduled to be loaded.
- */
-function isElementScheduled(win, elementName) {
-  // Set in custom-element.js
-  if (!win.__AMP_EXTENDED_ELEMENTS) {
-    return false;
-  }
-  return !!win.__AMP_EXTENDED_ELEMENTS[elementName];
+  return getElementServicePromiseOrNull(
+    win,
+    id,
+    extension,
+    version,
+    opt_element
+  );
 }
 
 /**
@@ -105,19 +105,25 @@ export function getElementServiceIfAvailableForDoc(
   }
   const ampdoc = getAmpdoc(element);
   return ampdoc
-    .waitForBodyOpen()
-    .then(() =>
-      waitForExtensionIfPresent(ampdoc.win, extension, ampdoc.win.document.head)
-    )
+    .whenExtensionsKnown()
     .then(() => {
+      const version = ampdoc.getExtensionVersion(extension);
+      if (!version) {
+        return null;
+      }
+      const extensions = getService(ampdoc.win, 'extensions');
+      return extensions.waitForExtension(extension, version);
+    })
+    .then((ext) => {
+      if (!ext) {
+        return null;
+      }
       // If this service is provided by an element, then we can't depend on
       // the service (they may not use the element).
       if (opt_element) {
         return getServicePromiseOrNullForDoc(element, id);
-      } else if (isElementScheduled(ampdoc.win, extension)) {
-        return getServicePromiseForDoc(element, id);
       }
-      return null;
+      return getServicePromiseForDoc(element, id);
     });
 }
 
@@ -167,60 +173,19 @@ function assertService(service, id, extension) {
 }
 
 /**
- * Waits for body to be present then verifies that an extension script is
- * present in head for installation.
- * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
- * @param {string} extensionId
- * @return {!Promise<boolean>}
- */
-export function isExtensionScriptInNode(ampdoc, extensionId) {
-  return ampdoc.waitForBodyOpen().then(() => {
-    return extensionScriptInNode(ampdoc.getHeadNode(), extensionId);
-  });
-}
-
-/**
  * Verifies that an extension script is present in head for
  * installation.
- * @param {HTMLHeadElement|Element|ShadowRoot} head
+ * @param {!Window} win
  * @param {string} id
+ * @param {string} version
  * @return {boolean}
  * @private
  */
-function extensionScriptInNode(head, id) {
-  return extensionScriptsInNode(head).some(
-    ({extensionId}) => id == extensionId
+function extensionScriptInNode(win, id, version) {
+  return extensionScriptsInNode(win.document.head).some(
+    ({extensionId, extensionVersion}) =>
+      id == extensionId && version == extensionVersion
   );
-}
-
-/**
- * Waits for an extension if its script is present
- * @param {!Window} win
- * @param {string} extension
- * @param {HTMLHeadElement|Element|ShadowRoot} head
- * @return {!Promise}
- * @private
- */
-function waitForExtensionIfPresent(win, extension, head) {
-  /**
-   * If there is an extension script wait for it to load before trying
-   * to get the service. Prevents a race condition when everything but
-   * the extensions is in cache. If there is no script then it's either
-   * not present, or the service was defined by a test. In those cases
-   * we don't wait around for an extension that does not exist.
-   */
-
-  // TODO(jpettitt) investigate registerExtension to short circuit
-  // the dom call in extensionScriptsInNode()
-  if (!extensionScriptInNode(head, extension)) {
-    return Promise.resolve();
-  }
-
-  const extensions = getService(win, 'extensions');
-  return /** @type {!Promise<?Object>} */ (extensions.waitForExtension(
-    win,
-    extension
-  ));
 }
 
 /**
@@ -229,22 +194,44 @@ function waitForExtensionIfPresent(win, extension, head) {
  * @param {!Window} win
  * @param {string} id
  * @param {string} extension
+ * @param {string} version
  * @param {boolean=} opt_element
  * @return {!Promise<Object>}
  * @private
  */
-function getElementServicePromiseOrNull(win, id, extension, opt_element) {
+function getElementServicePromiseOrNull(
+  win,
+  id,
+  extension,
+  version,
+  opt_element
+) {
   return dom
     .waitForBodyOpenPromise(win.document)
-    .then(() => waitForExtensionIfPresent(win, extension, win.document.head))
     .then(() => {
+      // If there is an extension script wait for it to load before trying
+      // to get the service. Prevents a race condition when everything but
+      // the extensions is in cache. If there is no script then it's either
+      // not present, or the service was defined by a test. In those cases
+      // we don't wait around for an extension that does not exist.
+      const extensions = getService(win, 'extensions');
+
+      // TODO(jpettitt) investigate registerExtension to short circuit
+      // the dom call in extensionScriptsInNode()
+      if (!extensionScriptInNode(extensions.win, extension, version)) {
+        return null;
+      }
+      return extensions.waitForExtension(extension, version);
+    })
+    .then((ext) => {
+      if (!ext) {
+        return null;
+      }
       // If this service is provided by an element, then we can't depend on
       // the service (they may not use the element).
       if (opt_element) {
         return getServicePromiseOrNull(win, id);
-      } else if (isElementScheduled(win, extension)) {
-        return getServicePromise(win, id);
       }
-      return null;
+      return getServicePromise(win, id);
     });
 }

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -442,7 +442,6 @@ export class AmpDoc {
    * @restricted
    */
   declareExtension(extensionId, version) {
-    devAssert(version); // QQQ: remove/debugging.
     devAssert(
       !this.declaredExtensions_[extensionId] ||
         this.declaredExtensions_[extensionId] === version,
@@ -450,6 +449,14 @@ export class AmpDoc {
       extensionId
     );
     this.declaredExtensions_[extensionId] = version;
+  }
+
+  /**
+   * @param {string} extensionId
+   * @return {?string}
+   */
+  getExtensionVersion(extensionId) {
+    return this.declaredExtensions_[extensionId] || null;
   }
 
   /**

--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -179,14 +179,15 @@ export class Extensions {
   /**
    * Waits for the previously included extension to complete
    * loading/registration.
-   * @param {!Window} win
    * @param {string} extensionId
+   * @param {string} version
    * @param {number=} opt_timeout
    * @return {!Promise<?ExtensionDef>}
    */
-  waitForExtension(win, extensionId, opt_timeout) {
+  waitForExtension(extensionId, version, opt_timeout) {
+    // TODO(#33020): Wait for the specified version.
     return /** @type {!Promise<?ExtensionDef>} */ (Services.timerFor(
-      win
+      this.win
     ).timeoutPromise(
       opt_timeout || LOAD_TIMEOUT,
       this.waitFor_(this.getExtensionHolder_(extensionId, /* auto */ false)),

--- a/src/services.js
+++ b/src/services.js
@@ -481,7 +481,7 @@ export class Services {
   static storyVariableServiceForOrNull(win) {
     return (
       /** @type {!Promise<?../extensions/amp-story/1.0/variable-service.AmpStoryVariableService>} */
-      (getElementServiceIfAvailable(win, 'story-variable', 'amp-story'))
+      (getElementServiceIfAvailable(win, 'story-variable', 'amp-story', '1.0'))
     );
   }
 
@@ -505,7 +505,7 @@ export class Services {
   static storyStoreServiceForOrNull(win) {
     return (
       /** @type {!Promise<?../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService>} */
-      (getElementServiceIfAvailable(win, 'story-store', 'amp-story'))
+      (getElementServiceIfAvailable(win, 'story-store', 'amp-story', '1.0'))
     );
   }
 
@@ -539,7 +539,7 @@ export class Services {
   static storyRequestServiceForOrNull(win) {
     return (
       /** @type {!Promise<?../extensions/amp-story/1.0/amp-story-request-service.AmpStoryRequestService>} */
-      (getElementServiceIfAvailable(win, 'story-request', 'amp-story'))
+      (getElementServiceIfAvailable(win, 'story-request', 'amp-story', '1.0'))
     );
   }
 
@@ -595,7 +595,13 @@ export class Services {
   static storyAnalyticsServiceForOrNull(win) {
     return (
       /** @type {!Promise<?../extensions/amp-story/1.0/story-analytics.StoryAnalyticsService>} */
-      (getElementServiceIfAvailable(win, 'story-analytics', 'amp-story', true))
+      (getElementServiceIfAvailable(
+        win,
+        'story-analytics',
+        'amp-story',
+        '1.0',
+        true
+      ))
     );
   }
 

--- a/test/unit/test-element-service.js
+++ b/test/unit/test-element-service.js
@@ -14,139 +14,125 @@
  * limitations under the License.
  */
 
+import * as fakeTimers from '@sinonjs/fake-timers';
 import {FakeWindow} from '../../testing/fake-dom';
+import {Services} from '../../src/services';
+import {createElementWithAttributes} from '../../src/dom';
 import {
   getElementServiceForDoc,
   getElementServiceIfAvailable,
   getElementServiceIfAvailableForDoc,
   getElementServiceIfAvailableForDocInEmbedScope,
-  isExtensionScriptInNode,
 } from '../../src/element-service';
 import {
   installServiceInEmbedDoc,
   registerServiceBuilder,
   registerServiceBuilderForDoc,
-  resetServiceForTesting,
   setParentWindow,
 } from '../../src/service';
-import {
-  markElementScheduledForTesting,
-  resetScheduledElementForTesting,
-} from '../../src/service/custom-element-registry';
 
-describe('getElementServiceIfAvailable()', () => {
-  let doc;
-  let win;
-  let setIntervalCallback;
+describes.realWin('getElementServiceIfAvailable()', {amp: true}, (env) => {
+  let win, doc;
+  let extensionsMock;
+  let clock;
 
   beforeEach(() => {
-    doc = {
-      head: {},
-      body: {},
-    };
-    doc.documentElement = {ownerDocument: doc};
-    doc.getHeadNode = () => doc.head;
-    doc.head.querySelectorAll = () => [];
+    win = env.win;
+    doc = env.win.document;
+    clock = fakeTimers.withGlobal(win).install();
 
-    win = {
-      document: doc,
-      setInterval: (callback) => {
-        setIntervalCallback = callback;
-      },
-      clearInterval: () => {},
-    };
-    doc.defaultView = win;
-
-    resetServiceForTesting(win, 'e1');
-    resetScheduledElementForTesting(win, 'element-1');
+    extensionsMock = env.sandbox.mock(Services.extensionsFor(win));
   });
 
   afterEach(() => {
-    setIntervalCallback = undefined;
+    clock.uninstall();
+    extensionsMock.verify();
   });
 
-  it('should wait for doc ready when not available', () => {
-    doc.body = null; // Body not available
+  it('should wait for body', async () => {
+    const {body} = doc;
+    doc.documentElement.removeChild(body);
     let resolvedService;
-    const p1 = getElementServiceIfAvailable(win, 'e1', 'element-1').then(
+    const p1 = getElementServiceIfAvailable(win, 'e1', 'element1', '0.1').then(
       (service) => {
         resolvedService = service;
         return service;
       }
     );
-    return Promise.resolve()
-      .then(() => {
-        expect(setIntervalCallback).to.exist;
-        expect(resolvedService).to.be.undefined;
 
-        // Resolve body.
-        doc.body = {};
-        setIntervalCallback();
-        return p1;
-      })
-      .then((service) => {
-        expect(resolvedService).to.be.null;
-        expect(service).to.be.null;
-      });
+    await Promise.resolve();
+    expect(resolvedService).to.be.undefined;
+
+    // Resolve body.
+    doc.documentElement.appendChild(body);
+    expect(doc.body).to.exist;
+    clock.tick(1000);
+
+    const service = await p1;
+    expect(resolvedService).to.be.null;
+    expect(service).to.be.null;
   });
 
-  it('should resolve with body when not available', () => {
-    doc.body = {}; // Body is available
-    const p1 = getElementServiceIfAvailable(win, 'e1', 'element-1');
-    return Promise.resolve()
-      .then(() => {
-        expect(setIntervalCallback).to.be.undefined;
-        return p1;
-      })
-      .then((service) => {
-        expect(service).to.be.null;
-      });
-  });
-
-  it('should wait for body when available', () => {
-    doc.body = null; // Body not available
-    let resolvedService;
-    const p1 = getElementServiceIfAvailable(win, 'e1', 'element-1').then(
-      (service) => {
-        resolvedService = service;
-        return service;
-      }
+  it('should resolve with body when not available', async () => {
+    const service = await getElementServiceIfAvailable(
+      win,
+      'e1',
+      'element1',
+      '0.1'
     );
-    return Promise.resolve()
-      .then(() => {
-        expect(setIntervalCallback).to.exist;
-        expect(resolvedService).to.be.undefined;
-
-        // Resolve body.
-        markElementScheduledForTesting(win, 'element-1');
-        registerServiceBuilder(win, 'e1', function () {
-          return {str: 'fake1'};
-        });
-        doc.body = {};
-        setIntervalCallback();
-        return p1;
-      })
-      .then((service) => {
-        expect(resolvedService).to.deep.equal({str: 'fake1'});
-        expect(service).to.deep.equal({str: 'fake1'});
-      });
+    expect(service).to.be.null;
   });
 
-  it('should resolve with body when available', () => {
-    doc.body = {}; // Body is available
-    markElementScheduledForTesting(win, 'element-1');
-    const p1 = getElementServiceIfAvailable(win, 'e1', 'element-1');
-    return Promise.resolve()
-      .then(() => {
-        expect(setIntervalCallback).to.be.undefined;
-        registerServiceBuilder(win, 'e1', function () {
-          return {str: 'fake1'};
-        });
-        return p1;
-      })
-      .then((service) => {
-        expect(service).to.deep.equal({str: 'fake1'});
-      });
+  it('should resolve when available', async () => {
+    const script = createElementWithAttributes(doc, 'script', {
+      'custom-element': 'element1',
+    });
+    env.sandbox
+      .stub(script, 'src')
+      .value('https://cdn.ampproject.org/v0/element1-0.1.js');
+    doc.head.appendChild(script);
+
+    extensionsMock
+      .expects('waitForExtension')
+      .withExactArgs('element1', '0.1')
+      .returns(Promise.resolve({}))
+      .once();
+
+    const promise = getElementServiceIfAvailable(win, 'e1', 'element1', '0.1');
+
+    registerServiceBuilder(win, 'e1', function () {
+      return {str: 'fake1'};
+    });
+
+    const service = await promise;
+    expect(service).to.deep.equal({str: 'fake1'});
+  });
+
+  it('should not wait for the element-service', async () => {
+    const script = createElementWithAttributes(doc, 'script', {
+      'custom-element': 'element1',
+    });
+    env.sandbox
+      .stub(script, 'src')
+      .value('https://cdn.ampproject.org/v0/element1-0.1.js');
+    doc.head.appendChild(script);
+
+    extensionsMock
+      .expects('waitForExtension')
+      .withExactArgs('element1', '0.1')
+      .returns(Promise.resolve({}))
+      .once();
+
+    const promise = getElementServiceIfAvailable(
+      win,
+      'e1',
+      'element1',
+      '0.1',
+      true
+    );
+
+    const service = await promise;
+    expect(service).to.deep.be.null;
   });
 });
 
@@ -158,56 +144,91 @@ describes.realWin(
     },
   },
   (env) => {
-    let ampdoc;
+    let win, doc, ampdoc;
+    let extensionsMock;
 
     beforeEach(() => {
+      win = env.win;
+      doc = win.document;
       ampdoc = env.ampdoc;
+      extensionsMock = env.sandbox.mock(Services.extensionsFor(win));
+    });
 
-      resetServiceForTesting(env.win, 'e1');
-      resetScheduledElementForTesting(env.win, 'element-1');
-      resetScheduledElementForTesting(env.win, 'element-foo');
+    afterEach(() => {
+      extensionsMock.verify();
     });
 
     describe('getElementServiceIfAvailable()', () => {
-      it('should be provided by element if available', () => {
-        markElementScheduledForTesting(env.win, 'element-1');
-        const p1 = getElementServiceIfAvailable(env.win, 'e1', 'element-1');
-        const p2 = getElementServiceIfAvailable(env.win, 'e2', 'not-available');
+      it('should be provided by element if available', async () => {
+        const script = createElementWithAttributes(doc, 'script', {
+          'custom-element': 'element1',
+        });
+        env.sandbox
+          .stub(script, 'src')
+          .value('https://cdn.ampproject.org/v0/element1-0.1.js');
+        doc.head.appendChild(script);
+
+        extensionsMock
+          .expects('waitForExtension')
+          .withExactArgs('element1', '0.1')
+          .returns(Promise.resolve({}))
+          .once();
+
+        const p1 = getElementServiceIfAvailable(
+          env.win,
+          'e1',
+          'element1',
+          '0.1'
+        );
+        const p2 = getElementServiceIfAvailable(
+          env.win,
+          'e2',
+          'not-available',
+          '0.1'
+        );
         registerServiceBuilder(env.win, 'e1', function () {
           return {str: 'from e1'};
         });
-        return p1.then((s1) => {
-          expect(s1).to.deep.equal({str: 'from e1'});
-          return p2.then((s2) => {
-            expect(s2).to.be.null;
-          });
-        });
+
+        const s1 = await p1;
+        expect(s1).to.deep.equal({str: 'from e1'});
+
+        const s2 = await p2;
+        expect(s2).to.be.null;
       });
     });
 
     describe('getElementServiceForDoc()', () => {
-      it('should be provided by element', () => {
-        markElementScheduledForTesting(env.win, 'element-1');
-        const p1 = getElementServiceForDoc(ampdoc, 'e1', 'element-1');
-        const p2 = getElementServiceForDoc(ampdoc, 'e1', 'element-1');
+      it('should be provided by element', async () => {
+        // Make sure that `whenExtensionsKnown` is observerd.
+        ampdoc.signals().reset('-ampdoc-ext-known');
+        extensionsMock
+          .expects('waitForExtension')
+          .withExactArgs('element1', '0.2')
+          .returns(Promise.resolve({}))
+          .twice();
+
+        const p1 = getElementServiceForDoc(ampdoc, 'e1', 'element1');
+        const p2 = getElementServiceForDoc(ampdoc, 'e1', 'element1');
+
+        ampdoc.declareExtension('element1', '0.2');
+        ampdoc.setExtensionsKnown();
 
         registerServiceBuilder(env.win, 'e1', function () {
           return {str: 'from e1'};
         });
 
-        return p1.then((s1) => {
-          expect(s1).to.deep.equal({str: 'from e1'});
-          return p2.then((s2) => {
-            expect(s1).to.equal(s2);
-          });
-        });
+        const s1 = await p1;
+        expect(s1).to.deep.equal({str: 'from e1'});
+
+        const s2 = await p2;
+        expect(s2).to.equal(s1);
       });
 
       it('should fail if element is not in page.', () => {
         expectAsyncConsoleError(
           /e1 was requested to be provided through element-bar/
         );
-        markElementScheduledForTesting(env.win, 'element-foo');
 
         return getElementServiceForDoc(ampdoc, 'e1', 'element-bar')
           .then(
@@ -227,136 +248,65 @@ describes.realWin(
     });
 
     describe('getElementServiceIfAvailableForDoc()', () => {
-      it('should be provided by element if available', () => {
-        markElementScheduledForTesting(env.win, 'element-1');
-        const p1 = getElementServiceIfAvailableForDoc(
-          ampdoc,
-          'e1',
-          'element-1'
-        );
+      it('should be provided by element if available', async () => {
+        // Make sure that `whenExtensionsKnown` is observerd.
+        ampdoc.signals().reset('-ampdoc-ext-known');
+        extensionsMock
+          .expects('waitForExtension')
+          .withExactArgs('element1', '0.2')
+          .returns(Promise.resolve({}))
+          .once();
+
+        const p1 = getElementServiceIfAvailableForDoc(ampdoc, 'e1', 'element1');
         const p2 = getElementServiceIfAvailableForDoc(
           ampdoc,
           'e2',
           'not-available'
         );
+
+        ampdoc.declareExtension('element1', '0.2');
+        ampdoc.setExtensionsKnown();
+
         registerServiceBuilder(env.win, 'e1', function () {
           return {str: 'from e1'};
         });
-        return p1.then((s1) => {
-          expect(s1).to.deep.equal({str: 'from e1'});
-          return p2.then((s2) => {
-            expect(s2).to.be.null;
-          });
-        });
+
+        const s1 = await p1;
+        expect(s1).to.deep.equal({str: 'from e1'});
+
+        const s2 = await p2;
+        expect(s2).to.be.null;
       });
 
-      it('should wait for body when not available', () => {
-        let bodyResolver;
-        ampdoc.bodyPromise_ = new Promise((resolve) => {
-          bodyResolver = resolve;
-        });
-        let resolvedService;
-        const p1 = getElementServiceIfAvailableForDoc(
+      it('resolve w/ body when not available', async () => {
+        const service = await getElementServiceIfAvailableForDoc(
           ampdoc,
           'e1',
-          'element-1'
-        ).then((service) => {
-          resolvedService = service;
-          return service;
+          'element1'
+        );
+        expect(service).to.be.null;
+      });
+
+      it('should resolve with body when available', async () => {
+        // Make sure that `whenExtensionsKnown` is observerd.
+        ampdoc.signals().reset('-ampdoc-ext-known');
+        extensionsMock
+          .expects('waitForExtension')
+          .withExactArgs('element1', '0.2')
+          .returns(Promise.resolve({}))
+          .once();
+
+        const p1 = getElementServiceIfAvailableForDoc(ampdoc, 'e1', 'element1');
+
+        ampdoc.declareExtension('element1', '0.2');
+        ampdoc.setExtensionsKnown();
+
+        registerServiceBuilder(env.win, 'e1', function () {
+          return {str: 'fake1'};
         });
-        return Promise.resolve()
-          .then(() => {
-            expect(resolvedService).to.be.undefined;
 
-            // Resolve body.
-            bodyResolver();
-            return p1;
-          })
-          .then((service) => {
-            expect(resolvedService).to.be.null;
-            expect(service).to.be.null;
-          });
-      });
-
-      it('resolve w/ body when not available', () => {
-        const p1 = getElementServiceIfAvailableForDoc(
-          ampdoc,
-          'e1',
-          'element-1'
-        );
-        return Promise.resolve()
-          .then(() => {
-            return p1;
-          })
-          .then((service) => {
-            expect(service).to.be.null;
-          });
-      });
-
-      it('should wait for body when available', () => {
-        let bodyResolver;
-        ampdoc.bodyPromise_ = new Promise((resolve) => {
-          bodyResolver = resolve;
-        });
-        let resolvedService;
-        const p1 = getElementServiceIfAvailableForDoc(
-          ampdoc,
-          'e1',
-          'element-1'
-        ).then((service) => {
-          resolvedService = service;
-          return service;
-        });
-        return Promise.resolve()
-          .then(() => {
-            expect(resolvedService).to.be.undefined;
-
-            // Resolve body.
-            markElementScheduledForTesting(env.win, 'element-1');
-            registerServiceBuilder(env.win, 'e1', function () {
-              return {str: 'fake1'};
-            });
-            bodyResolver();
-            return p1;
-          })
-          .then((service) => {
-            expect(resolvedService).to.deep.equal({str: 'fake1'});
-            expect(service).to.deep.equal({str: 'fake1'});
-          });
-      });
-
-      it('should resolve with body when available', () => {
-        markElementScheduledForTesting(env.win, 'element-1');
-        const p1 = getElementServiceIfAvailableForDoc(
-          ampdoc,
-          'e1',
-          'element-1'
-        );
-        return Promise.resolve()
-          .then(() => {
-            registerServiceBuilder(env.win, 'e1', function () {
-              return {str: 'fake1'};
-            });
-            return p1;
-          })
-          .then((service) => {
-            expect(service).to.deep.equal({str: 'fake1'});
-          });
-      });
-
-      it('isExtensionScriptInNode', () => {
-        const extension = document.createElement('script');
-        extension.setAttribute('custom-element', 'amp-form');
-        extension.setAttribute(
-          'src',
-          'https://cdn.ampproject.org/v0/amp-form-0.1.js'
-        );
-        ampdoc.getHeadNode().appendChild(extension);
-        return isExtensionScriptInNode(ampdoc, 'amp-form').then(
-          (ampFormInstalled) => {
-            expect(ampFormInstalled).to.equal(true);
-          }
-        );
+        const service = await p1;
+        expect(service).to.deep.equal({str: 'fake1'});
       });
     });
   }
@@ -370,9 +320,11 @@ describes.fakeWin('in embed scope', {amp: true}, (env) => {
   let frameElement;
   let service;
   let embedAmpDoc;
+  let extensionsMock;
 
   beforeEach(() => {
     win = env.win;
+    extensionsMock = env.sandbox.mock(Services.extensionsFor(win));
 
     frameElement = win.document.createElement('div');
     win.document.body.appendChild(frameElement);
@@ -400,6 +352,10 @@ describes.fakeWin('in embed scope', {amp: true}, (env) => {
     service = {name: 'fake-service-object'};
   });
 
+  afterEach(() => {
+    extensionsMock.verify();
+  });
+
   it('should return existing service', () => {
     installServiceInEmbedDoc(embedAmpDoc, 'foo', service);
     return getElementServiceIfAvailableForDocInEmbedScope(
@@ -411,21 +367,31 @@ describes.fakeWin('in embed scope', {amp: true}, (env) => {
     });
   });
 
-  it('should return service for scheduled element', () => {
-    markElementScheduledForTesting(embedWin, 'amp-foo');
+  it('should return service for scheduled element', async () => {
+    // Make sure that `whenExtensionsKnown` is observerd.
+    embedAmpDoc.signals().reset('-ampdoc-ext-known');
+    extensionsMock
+      .expects('waitForExtension')
+      .withExactArgs('amp-foo', '0.2')
+      .returns(Promise.resolve({}))
+      .once();
+
     const promise = getElementServiceIfAvailableForDocInEmbedScope(
       nodeInEmbedWin,
       'foo',
       'amp-foo'
     );
+
+    embedAmpDoc.declareExtension('amp-foo', '0.2');
+    embedAmpDoc.setExtensionsKnown();
+
     installServiceInEmbedDoc(embedAmpDoc, 'foo', service);
-    return promise.then((returned) => {
-      expect(returned).to.equal(service);
-    });
+
+    const returned = await promise;
+    expect(returned).to.equal(service);
   });
 
-  it('should return ampdoc-scope service if node in top window', () => {
-    markElementScheduledForTesting(win, 'amp-foo');
+  it('should return ampdoc-scope service if node in top window', async () => {
     registerServiceBuilderForDoc(
       nodeInTopWin,
       'foo',
@@ -434,17 +400,16 @@ describes.fakeWin('in embed scope', {amp: true}, (env) => {
       },
       /* opt_instantiate */ true
     );
-    return getElementServiceIfAvailableForDocInEmbedScope(
+
+    const returned = await getElementServiceIfAvailableForDocInEmbedScope(
       nodeInTopWin,
       'foo',
       'amp-foo'
-    ).then((returned) => {
-      expect(returned).to.equal(service);
-    });
+    );
+    expect(returned).to.equal(service);
   });
 
-  it('should NOT return ampdoc-scope service if node in embed window', () => {
-    markElementScheduledForTesting(win, 'amp-foo');
+  it('should NOT return ampdoc-scope service if node in embed window', async () => {
     registerServiceBuilderForDoc(
       nodeInTopWin,
       'foo',
@@ -453,12 +418,14 @@ describes.fakeWin('in embed scope', {amp: true}, (env) => {
       },
       /* opt_instantiate */ true
     );
-    return getElementServiceIfAvailableForDocInEmbedScope(
+
+    embedAmpDoc.setExtensionsKnown();
+
+    const returned = await getElementServiceIfAvailableForDocInEmbedScope(
       nodeInEmbedWin,
       'foo',
       'amp-foo'
-    ).then((returned) => {
-      expect(returned).to.be.null;
-    });
+    );
+    expect(returned).to.be.null;
   });
 });

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -86,7 +86,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(holder.scriptPresent).to.be.undefined;
 
       // However, the promise is created lazily.
-      return extensions.waitForExtension(win, 'amp-ext').then((extension) => {
+      return extensions.waitForExtension('amp-ext', '0.1').then((extension) => {
         expect(extension).to.exist;
         expect(extension.elements).to.exist;
       });
@@ -108,7 +108,7 @@ describes.sandboxed('Extensions', {}, () => {
     });
 
     it('should register successfully with promise', () => {
-      const promise = extensions.waitForExtension(win, 'amp-ext');
+      const promise = extensions.waitForExtension('amp-ext', '0.1');
       extensions.registerExtension('amp-ext', '0.1', true, () => {}, {});
       expect(extensions.currentExtensionId_).to.be.null;
 
@@ -149,7 +149,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(holder.promise).to.be.undefined;
 
       // However, the promise is created lazily.
-      return extensions.waitForExtension(win, 'amp-ext').then(
+      return extensions.waitForExtension('amp-ext', '0.1').then(
         () => {
           throw new Error('must have been rejected');
         },
@@ -160,7 +160,7 @@ describes.sandboxed('Extensions', {}, () => {
     });
 
     it('should fail registration with promise', () => {
-      const promise = extensions.waitForExtension(win, 'amp-ext');
+      const promise = extensions.waitForExtension('amp-ext', '0.1');
       expect(() => {
         extensions.registerExtension(
           'amp-ext',
@@ -183,7 +183,7 @@ describes.sandboxed('Extensions', {}, () => {
       expect(holder.promise).to.exist;
       expect(promise).to.eventually.equal(holder.promise);
 
-      return extensions.waitForExtension(win, 'amp-ext').then(
+      return extensions.waitForExtension('amp-ext', '0.1').then(
         () => {
           throw new Error('must have been rejected');
         },
@@ -195,7 +195,7 @@ describes.sandboxed('Extensions', {}, () => {
 
     it('should fail on timeout', () => {
       timeoutCallback = null;
-      const promise = extensions.waitForExtension(win, 'amp-ext');
+      const promise = extensions.waitForExtension('amp-ext', '0.1');
       expect(timeoutCallback).to.be.a('function');
       timeoutCallback();
 
@@ -221,7 +221,7 @@ describes.sandboxed('Extensions', {}, () => {
         },
         {}
       );
-      return extensions.waitForExtension(win, 'amp-ext').then((extension) => {
+      return extensions.waitForExtension('amp-ext', '0.1').then((extension) => {
         expect(extension.elements['e1']).to.exist;
         expect(extension.elements['e1'].implementationClass).to.equal(ctor);
       });
@@ -253,7 +253,7 @@ describes.sandboxed('Extensions', {}, () => {
         },
         {}
       );
-      await extensions.waitForExtension(win, 'amp-ext');
+      await extensions.waitForExtension('amp-ext', '0.1');
 
       const holder = extensions.getExtensionHolder_('amp-ext');
       expect(holder.docFactories).to.have.length(1);
@@ -1396,8 +1396,6 @@ describes.sandboxed('Extensions', {}, () => {
           expect(win.__AMP_EXTENDED_ELEMENTS['amp-test-sub']).to.equal(
             AmpTestSub
           );
-          // Extension is now declared.
-          expect(ampdoc.declaresExtension('amp-test')).to.be.true;
         });
       });
 

--- a/test/unit/test-runtime.js
+++ b/test/unit/test-runtime.js
@@ -609,7 +609,7 @@ describes.fakeWin(
         });
         runChunks(win.document);
 
-        await extensions.waitForExtension(win, 'amp-ext');
+        await extensions.waitForExtension('amp-ext', '0.1');
 
         // Extension is added immediately. Can't find for micro-tasks here.
         const extHolder = extensions.extensions_['amp-ext'];
@@ -651,7 +651,7 @@ describes.fakeWin(
         });
         runChunks(win.document);
 
-        yield extensions.waitForExtension(win, 'amp-ext');
+        yield extensions.waitForExtension('amp-ext', '0.1');
 
         // Extension is added immediately. Can't find for micro-tasks here.
         const ext = extensions.extensions_['amp-ext'].extension;
@@ -670,7 +670,7 @@ describes.fakeWin(
 
         // Service and extensions are resolved.
         yield Promise.all([
-          extensions.waitForExtension(win, 'amp-ext'),
+          extensions.waitForExtension('amp-ext', '0.1'),
           servicePromise,
         ]);
       });
@@ -698,7 +698,7 @@ describes.fakeWin(
         runChunks(win.document);
 
         // Extension is added immediately. Can't find for micro-tasks here.
-        yield extensions.waitForExtension(win, 'amp-ext');
+        yield extensions.waitForExtension('amp-ext', '0.1');
         const ext = extensions.extensions_['amp-ext'].extension;
         expect(ext.elements['amp-ext']).exist;
         expect(ext.elements['amp-ext'].implementationClass).to.equal(
@@ -724,7 +724,7 @@ describes.fakeWin(
 
         // Service and extensions are resolved.
         yield Promise.all([
-          extensions.waitForExtension(win, 'amp-ext'),
+          extensions.waitForExtension('amp-ext', '0.1'),
           servicePromise,
         ]);
       });
@@ -746,7 +746,7 @@ describes.fakeWin(
         runChunks(win.document);
 
         // No factories
-        yield extensions.waitForExtension(win, 'amp-ext');
+        yield extensions.waitForExtension('amp-ext', '0.1');
         const extHolder = extensions.extensions_['amp-ext'];
         expect(extHolder.docFactories).to.have.length(1);
 
@@ -778,7 +778,7 @@ describes.fakeWin(
         runChunks(win.document);
 
         // No factories
-        yield extensions.waitForExtension(win, 'amp-ext');
+        yield extensions.waitForExtension('amp-ext', '0.1');
         const extHolder = extensions.extensions_['amp-ext'];
         expect(extHolder.docFactories).to.have.length(1);
 
@@ -831,7 +831,7 @@ describes.fakeWin(
         runChunks(win.document);
 
         // Extension is added immediately. Can't find for micro-tasks here.
-        yield extensions.waitForExtension(win, 'amp-ext');
+        yield extensions.waitForExtension('amp-ext', '0.1');
         const extHolder = extensions.extensions_['amp-ext'];
         const ext = extHolder.extension;
         expect(ext.elements['amp-ext']).exist;
@@ -855,7 +855,7 @@ describes.fakeWin(
 
         // Service and extensions are resolved.
         yield Promise.all([
-          extensions.waitForExtension(win, 'amp-ext'),
+          extensions.waitForExtension('amp-ext', '0.1'),
           servicePromise,
         ]);
       });
@@ -881,7 +881,7 @@ describes.fakeWin(
         runChunks(win.document);
 
         // Extension is added immediately. Can't find for micro-tasks here.
-        yield extensions.waitForExtension(win, 'amp-ext');
+        yield extensions.waitForExtension('amp-ext', '0.1');
         const extHolder = extensions.extensions_['amp-ext'];
         const ext = extHolder.extension;
         expect(ext.elements['amp-ext']).exist;
@@ -915,7 +915,7 @@ describes.fakeWin(
 
         // Service and extensions are resolved.
         yield Promise.all([
-          extensions.waitForExtension(win, 'amp-ext'),
+          extensions.waitForExtension('amp-ext', '0.1'),
           servicePromise,
         ]);
       });
@@ -934,7 +934,7 @@ describes.fakeWin(
         runChunks(win.document);
 
         // Factory recorded.
-        yield extensions.waitForExtension(win, 'amp-ext');
+        yield extensions.waitForExtension('amp-ext', '0.1');
         const extHolder = extensions.extensions_['amp-ext'];
         expect(extHolder.docFactories).to.have.length(1);
 
@@ -1053,7 +1053,7 @@ describes.realWin(
         await ampdoc.whenExtensionsKnown();
 
         // Factories have been applied.
-        await extensions.waitForExtension(win, 'amp-ext');
+        await extensions.waitForExtension('amp-ext', '0.1');
         expect(getServiceForDoc(ampdoc, 'service1')).to.be.instanceOf(Service1);
       });
 
@@ -1481,7 +1481,7 @@ describes.realWin(
           await ampdoc.whenExtensionsKnown();
 
           // Factories have been applied.
-          await extensions.waitForExtension(win, 'amp-ext');
+          await extensions.waitForExtension('amp-ext', '0.1');
           expect(getServiceForDoc(ampdoc, 'service1')).to.be.instanceOf(
             Service1
           );

--- a/test/unit/test-url-replacements.js
+++ b/test/unit/test-url-replacements.js
@@ -1586,6 +1586,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
             link.setAttribute('rel', 'canonical');
             iframe.doc.head.appendChild(link);
             const {documentElement} = iframe.doc;
+            Services.ampdoc(documentElement).setExtensionsKnown();
             const replacements = Services.urlReplacementsForDoc(
               documentElement
             );
@@ -1660,6 +1661,7 @@ describes.sandboxed('UrlReplacements', {}, (env) => {
             link.setAttribute('rel', 'canonical');
             iframe.doc.head.appendChild(link);
             const {documentElement} = iframe.doc;
+            Services.ampdoc(documentElement).setExtensionsKnown();
             const replacements = Services.urlReplacementsForDoc(
               documentElement
             );


### PR DESCRIPTION
Partial for #33020.

With ampdoc services the version is declared on the document itself. With global services the version has to be provided explicitly.

TODO:
- [x] Blocked by https://github.com/ampproject/amphtml/pull/33282
- [x] Tests
