### PR TITLE
🏗 Guard access to `BASH_ENV` during CircleCI push builds

### DIFF
--- a/.circleci/compute_merge_commit.sh
+++ b/.circleci/compute_merge_commit.sh
@@ -24,7 +24,9 @@ GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
 
 # Try to determine the PR number.
 curl -sS https://raw.githubusercontent.com/ampproject/amphtml/master/.circleci/get_pr_number.sh | bash
-source $BASH_ENV
+if [[ -f "$BASH_ENV" ]]; then
+  source $BASH_ENV
+fi
 
 # If PR_NUMBER doesn't exist, there is nothing more to do.
 if [[ -z "$PR_NUMBER" ]]; then

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -25,7 +25,9 @@ RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 
 # Try to determine the PR number.
 ./.circleci/get_pr_number.sh
-source $BASH_ENV
+if [[ -f "$BASH_ENV" ]]; then
+  source $BASH_ENV
+fi
 
 # If PR_NUMBER doesn't exist, there is nothing more to do.
 if [[ -z "$PR_NUMBER" ]]; then


### PR DESCRIPTION
Follow up to #33215 to make it work on push builds

