### PR TITLE
build-system: use esbuild for compiling AMP Server (new server).

### DIFF
--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -63,10 +63,7 @@ function typecheckNewServer() {
   const result = exec(cmd, {'stdio': ['inherit', 'inherit', 'pipe']});
 
   if (result.status != 0) {
-    const err = new Error('Could not build AMP Server');
-    // @ts-ignore
-    err.showStack = false;
-    throw err;
+    throw new Error(`Typechecking AMP Server failed.`);
   }
 }
 

--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -21,13 +21,8 @@ const {endBuildStep} = require('../tasks/helpers');
 const {exec} = require('../common/exec');
 const {log} = require('../common/logging');
 
-const SERVER_TRANSFORM_PATH = path.join(
-  'build-system',
-  'server',
-  'new-server',
-  'transforms'
-);
-const CONFIG_PATH = path.join(SERVER_TRANSFORM_PATH, 'tsconfig.json');
+const SERVER_TRANSFORM_PATH = 'build-system/server/new-server/transforms';
+const CONFIG_PATH = `${SERVER_TRANSFORM_PATH}/tsconfig.json`;
 
 /**
  * Builds the new server by converting typescript transforms to JS
@@ -40,10 +35,7 @@ async function buildNewServer() {
     green('at'),
     cyan(`${SERVER_TRANSFORM_PATH}/dist`) + green('...')
   );
-  const entryPoints = globby.sync(
-    path.join(SERVER_TRANSFORM_PATH, '**', '*.ts')
-  );
-
+  const entryPoints = globby.sync(`${SERVER_TRANSFORM_PATH}/**/*.ts`);
   const startTime = Date.now();
   return esbuild
     .build({

--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -31,7 +31,7 @@ const CONFIG_PATH = path.join(SERVER_TRANSFORM_PATH, 'tsconfig.json');
 
 /**
  * Builds the new server by converting typescript transforms to JS
- * @return {Promise}
+ * @return {Promise<void>}
  */
 async function buildNewServer() {
   log(

--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -27,6 +27,7 @@ const SERVER_TRANSFORM_PATH = path.join(
   'new-server',
   'transforms'
 );
+const CONFIG_PATH = path.join(SERVER_TRANSFORM_PATH, 'tsconfig.json');
 
 /**
  * Builds the new server by converting typescript transforms to JS
@@ -49,7 +50,7 @@ async function buildNewServer() {
       entryPoints,
       outdir: path.join(SERVER_TRANSFORM_PATH, 'dist'),
       bundle: false,
-      tsconfig: path.join(SERVER_TRANSFORM_PATH, 'tsconfig.json'),
+      tsconfig: CONFIG_PATH,
       format: 'cjs',
     })
     .then(() => {
@@ -58,10 +59,9 @@ async function buildNewServer() {
 }
 
 function typecheckNewServer() {
-  const configPath = path.join(SERVER_TRANSFORM_PATH, 'tsconfig.json');
-  const cmd = `npx -p typescript tsc --noEmit -p ${configPath}`;
-
+  const cmd = `npx -p typescript tsc --noEmit -p ${CONFIG_PATH}`;
   const result = exec(cmd, {'stdio': ['inherit', 'inherit', 'pipe']});
+
   if (result.status != 0) {
     const err = new Error('Could not build AMP Server');
     // @ts-ignore

--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -37,17 +37,14 @@ async function buildNewServer() {
   );
   const entryPoints = globby.sync(`${SERVER_TRANSFORM_PATH}/**/*.ts`);
   const startTime = Date.now();
-  return esbuild
-    .build({
-      entryPoints,
-      outdir: path.join(SERVER_TRANSFORM_PATH, 'dist'),
-      bundle: false,
-      tsconfig: CONFIG_PATH,
-      format: 'cjs',
-    })
-    .then(() => {
-      endBuildStep('Built', 'AMP Server', startTime);
-    });
+  await esbuild.build({
+    entryPoints,
+    outdir: path.join(SERVER_TRANSFORM_PATH, 'dist'),
+    bundle: false,
+    tsconfig: CONFIG_PATH,
+    format: 'cjs',
+  });
+  endBuildStep('Built', 'AMP Server', startTime);
 }
 
 function typecheckNewServer() {

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -26,6 +26,7 @@ const {compileCss} = require('./css');
 const {extensions, maybeInitializeExtensions} = require('./extension-helpers');
 const {log} = require('../common/logging');
 const {maybeUpdatePackages} = require('./update-packages');
+const {typecheckNewServer} = require('../server/typescript-compile');
 
 /**
  * Dedicated type check path.
@@ -37,6 +38,9 @@ async function checkTypes() {
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();
   maybeInitializeExtensions();
+
+  typecheckNewServer();
+
   const compileSrcs = [
     'src/amp.js',
     'src/amp-shadow.js',

--- a/build-system/tasks/coverage-map/index.js
+++ b/build-system/tasks/coverage-map/index.js
@@ -144,7 +144,7 @@ async function generateMap() {
  */
 async function coverageMap() {
   installPackages(__dirname);
-  buildNewServer();
+  await buildNewServer();
 
   if (!argv.nobuild) {
     await dist();

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -90,7 +90,7 @@ async function startServer(
   serverOptions = {},
   modeOptions = {}
 ) {
-  buildNewServer();
+  await buildNewServer();
   if (serverOptions.lazyBuild) {
     lazyBuild = serverOptions.lazyBuild;
   }
@@ -170,7 +170,7 @@ async function stopServer() {
 async function restartServer() {
   stopServer();
   try {
-    buildNewServer();
+    await buildNewServer();
   } catch {
     log(red('ERROR:'), 'Could not rebuild', cyan('AMP Server'));
     return;

--- a/build-system/tasks/server-tests.js
+++ b/build-system/tasks/server-tests.js
@@ -198,7 +198,7 @@ async function runTest(inputFile) {
  * Tests for AMP server custom transforms. Entry point for `gulp server-tests`.
  */
 async function serverTests() {
-  buildNewServer();
+  await buildNewServer();
   const inputFiles = globby.sync(inputPaths);
   for (const inputFile of inputFiles) {
     await runTest(inputFile);


### PR DESCRIPTION
**summary**
- Use esbuild instead of tsc for compilation. 
- Task duration goes from **~1.3s --> ~30ms**.

![Screen Shot 2021-03-12 at 5 50 36 PM](https://user-images.githubusercontent.com/4656974/111006815-7c8fe600-835b-11eb-8a6c-18f2b0b99251.png)

It is important to note that **esbuild does not perform typeschecking**. Therefore we still need to use `tsc`, but I've moved this usage to the `gulp check-types` command.