### PR TITLE
🐛 Change ESbuild 3p vendor target to ES5

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -72,14 +72,13 @@ function getMinifiedConfig() {
     {
       bugfixes: true,
       modules: false,
-      targets: {esmodules: true},
+      targets: argv.esm ? {esmodules: true} : {ie: 11, chrome: 41},
     },
   ];
-  const presets = argv.esm ? [presetEnv] : [];
   return {
     compact: false,
     plugins,
-    presets,
+    presets: [presetEnv],
     retainLines: true,
   };
 }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -562,6 +562,7 @@ async function compileJsWithEsbuild(srcDir, srcFilename, destDir, options) {
       outfile: destFile,
       plugins: [plugin],
       minify: options.minify,
+      target: argv.esm ? 'es6' : 'es5',
       incremental: !!options.watch,
       logLevel: 'silent',
     })

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -25,6 +25,7 @@ const magicstring = require('magic-string');
 const open = require('open');
 const path = require('path');
 const Remapping = require('@ampproject/remapping');
+const terser = require('terser');
 const wrappers = require('../compile/compile-wrappers');
 const {
   VERSION: internalRuntimeVersion,
@@ -554,8 +555,12 @@ async function compileJsWithEsbuild(srcDir, srcFilename, destDir, options) {
     options.minify ? 'minified' : 'unminified',
     /* enableCache */ true
   );
-  const buildResult = await esbuild
-    .build({
+
+  /**
+   * @param {number} time
+   */
+  async function build(time) {
+    await esbuild.build({
       entryPoints: [entryPoint],
       bundle: true,
       sourcemap: true,
@@ -565,30 +570,67 @@ async function compileJsWithEsbuild(srcDir, srcFilename, destDir, options) {
       target: argv.esm ? 'es6' : 'es5',
       incremental: !!options.watch,
       logLevel: 'silent',
-    })
-    .then((result) => {
-      finishBundle(srcFilename, destDir, destFilename, options, startTime);
-      return result;
-    })
-    .catch((err) => handleBundleError(err, !!options.watch, destFilename));
+    });
+    await minifyWithTerser(destDir, destFilename, options);
+    await finishBundle(srcFilename, destDir, destFilename, options, time);
+  }
+
+  await build(startTime).catch((err) =>
+    handleBundleError(err, !!options.watch, destFilename)
+  );
 
   if (options.watch) {
     watchedTargets.set(entryPoint, {
       rebuild: async () => {
         const time = Date.now();
-        const buildPromise = buildResult
-          .rebuild()
-          .then(() =>
-            finishBundle(srcFilename, destDir, destFilename, options, time)
-          )
-          .catch((err) =>
-            handleBundleError(err, /* continueOnError */ true, destFilename)
-          );
-        options?.onWatchBuild(buildPromise);
+        const buildPromise = build(time).catch((err) =>
+          handleBundleError(err, !!options.watch, destFilename)
+        );
+        if (options.onWatchBuild) {
+          options.onWatchBuild(buildPromise);
+        }
         await buildPromise;
       },
     });
   }
+}
+
+/**
+ * Minify the code with Terser. Only used by the ESBuild.
+ *
+ * @param {string} destDir
+ * @param {string} destFilename
+ * @param {?Object} options
+ * @return {!Promise}
+ */
+function minifyWithTerser(destDir, destFilename, options) {
+  if (!options.minify) {
+    return Promise.resolve();
+  }
+
+  const filename = destDir + destFilename;
+  const terserOptions = {
+    mangle: false,
+    compress: true,
+    output: {
+      beautify: !!argv.pretty_print,
+      comments: /\/*/,
+      // eslint-disable-next-line google-camelcase/google-camelcase
+      keep_quoted_props: true,
+    },
+    sourceMap: true,
+  };
+  return terser
+    .minify(fs.readFileSync(filename, 'utf8'), terserOptions)
+    .then((minified) => {
+      const remapped = remapping(
+        [minified.map, fs.readFileSync(`${filename}.map`, 'utf8')],
+        () => null,
+        !argv.full_sourcemaps
+      );
+      fs.writeFileSync(filename, minified.code);
+      fs.writeFileSync(`${filename}.map`, remapped.toString());
+    });
 }
 
 /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -603,14 +603,14 @@ async function compileJsWithEsbuild(srcDir, srcFilename, destDir, options) {
  * @param {?Object} options
  * @return {!Promise}
  */
-function minifyWithTerser(destDir, destFilename, options) {
+async function minifyWithTerser(destDir, destFilename, options) {
   if (!options.minify) {
     return Promise.resolve();
   }
 
   const filename = destDir + destFilename;
   const terserOptions = {
-    mangle: false,
+    mangle: true,
     compress: true,
     output: {
       beautify: !!argv.pretty_print,


### PR DESCRIPTION
3p vendors' compilation process uses `compileJsWithEsbuild` without a target attribute, which causes esbuild to output some arrow functions after babel transpiler. This PR specifies target to es5 on esbuild to prevent that. For ESM builds, the babel transpiler will transform them back to ESM.

This PR only affects 3p vendor compilation, not anything else (e.g. runtime or extensions).