### PR TITLE
🏗 Read merge commit only if file was created

### DIFF
--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -34,6 +34,12 @@ if [[ -z "$PR_NUMBER" ]]; then
   exit 0
 fi
 
+# If PR_NUMBER exists, but the merge commit file doesn't exist, the PR was
+# created after the first stage of CI was run. There is nothing more to do.
+if [[ ! -f .CIRCLECI_MERGE_COMMIT ]]; then
+  exit 0
+fi
+
 # Extract the merge commit for this workflow and make it visible to other steps.
 CIRCLECI_MERGE_COMMIT="$(cat .CIRCLECI_MERGE_COMMIT)"
 echo "export CIRCLECI_MERGE_COMMIT=$CIRCLECI_MERGE_COMMIT" >> $BASH_ENV


### PR DESCRIPTION
This PR prevents a race that occurs as follows:

- A file is directly changed on `ampproject/amphtml` and a branch is created
- CI build starts on that branch
- A PR is created after the first stage of CI has begun, but before the second stage
- Second stage tries to read the merge commit file

Now, we don't read the merge commit file if it doesn't exist.

**[Example race:](https://app.circleci.com/pipelines/github/ampproject/amphtml/4503/workflows/3886a337-e39e-45a2-96e6-c3a73510b082)**

**First stage:**

![image](https://user-images.githubusercontent.com/26553114/111198055-8d2ba080-8595-11eb-862e-800e44e71721.png)


**Second stage:**

![image](https://user-images.githubusercontent.com/26553114/111198116-99aff900-8595-11eb-8ad0-dfc7847d0f5d.png)
