### PR TITLE
🏗 Remove `Compute Merge Commit` as a direct CircleCI job dependency where it's already a transitive dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,7 +277,6 @@ workflows:
       - 'Bundle Size':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
             - 'Nomodule Build'
             - 'Module Build'
       - 'Validator Tests':
@@ -287,7 +286,6 @@ workflows:
       - 'Visual Diff Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
             - 'Nomodule Build'
       - 'Unit Tests':
           <<: *push_and_pr_builds
@@ -296,7 +294,6 @@ workflows:
       - 'Unminified Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
             - 'Unminified Build'
       - 'Nomodule Tests':
           name: 'Nomodule Tests (<< matrix.config >>)'
@@ -305,7 +302,6 @@ workflows:
               config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
             - 'Nomodule Build'
       - 'Module Tests':
           name: 'Module Tests (<< matrix.config >>)'
@@ -314,13 +310,11 @@ workflows:
               config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
             - 'Nomodule Build'
             - 'Module Build'
       - 'End-to-End Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
             - 'Nomodule Build'
       - 'Experiment Build':
           name: 'Experiment << matrix.exp >> Build'
@@ -337,7 +331,6 @@ workflows:
               exp: ['A', 'B', 'C']
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
             - 'Experiment << matrix.exp >> Build'
       # TODO(wg-performance, #12128): This takes 30 mins and fails regularly.
       # - 'Performance Tests':

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,5 +336,4 @@ workflows:
       # - 'Performance Tests':
       #     <<: *push_builds_only
       #     requires:
-      #       - 'Compute Merge Commit'
       #       - 'Nomodule Build'


### PR DESCRIPTION
I just think it makes the graph look better 😅

![image](https://user-images.githubusercontent.com/1839738/111197923-6b321e00-8595-11eb-945e-53bf95491a10.png) | ![image](https://user-images.githubusercontent.com/1839738/111198000-7dac5780-8595-11eb-9ffd-8e1dd60f01f0.png)
------ | ------
Before | After
