### PR TITLE
Skip flaky amp-base-carousel 1.0 tests

### DIFF
--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -49,7 +49,8 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should render correctly', async function () {
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
+    it.skip('should render correctly', async function () {
       this.timeout(testTimeout);
       const el = await getScrollingElement(controller);
 
@@ -61,7 +62,8 @@ describes.endtoend(
       await waitForCarouselImg(controller, 0);
     });
 
-    it('should layout the two adjacent slides', async function () {
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
+    it.skip('should layout the two adjacent slides', async function () {
       this.timeout(testTimeout);
       // TODO(sparhami) Verify this is on the right of the 0th slide
       await waitForCarouselImg(controller, 1);
@@ -69,7 +71,8 @@ describes.endtoend(
       await waitForCarouselImg(controller, SLIDE_COUNT - 1);
     });
 
-    it('should snap when scrolling', async function () {
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
+    it.skip('should snap when scrolling', async function () {
       this.timeout(testTimeout);
       const el = await getScrollingElement(controller);
       const firstSlide = await getSlide(controller, 0);
@@ -89,7 +92,8 @@ describes.endtoend(
       await expect(prop(el, 'scrollLeft')).to.equal(snappedScrollLeft);
     });
 
-    it('should reset the window after scroll', async function () {
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
+    it.skip('should reset the window after scroll', async function () {
       this.timeout(testTimeout);
       const el = await getScrollingElement(controller);
       const firstSlide = await getSlide(controller, 0);

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -43,7 +43,7 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
-    // TODO(wg-components, #24195): Make this less flaky during CI.
+    // TODO(wg-bento, #24195): getSlides does not always find elements in time.
     it.skip('should move forwards', async () => {
       const slides = await getSlides(styles, controller);
 
@@ -52,7 +52,7 @@ describes.endtoend(
       await expect(rect(slides[0])).to.include({x: 0});
     });
 
-    // TODO(wg-components, #24195): Make this less flaky during CI.
+    // TODO(wg-bento, #24195): getSlides does not always find elements in time.
     it.skip('should go to start and complete two full iterations only', async () => {
       const slides = await getSlides(styles, controller);
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -43,6 +43,7 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
+    // TODO(wg-components, #24195): Make this less flaky during CI.
     it.skip('should move forwards', async () => {
       const slides = await getSlides(styles, controller);
 
@@ -51,6 +52,7 @@ describes.endtoend(
       await expect(rect(slides[0])).to.include({x: 0});
     });
 
+    // TODO(wg-components, #24195): Make this less flaky during CI.
     it.skip('should go to start and complete two full iterations only', async () => {
       const slides = await getSlides(styles, controller);
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -43,7 +43,7 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
-    it('should move forwards', async () => {
+    it.skip('should move forwards', async () => {
       const slides = await getSlides(styles, controller);
 
       await expect(rect(slides[1])).to.include({x: 0});
@@ -51,7 +51,7 @@ describes.endtoend(
       await expect(rect(slides[0])).to.include({x: 0});
     });
 
-    it('should go to start and complete two full iterations only', async () => {
+    it.skip('should go to start and complete two full iterations only', async () => {
       const slides = await getSlides(styles, controller);
 
       // first iteration

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
@@ -93,9 +93,9 @@ describes.endtoend(
       await expect(prop(el, 'scrollLeft')).to.equal(scrollLeft);
     });
 
-    describe('looping', function () {
-      // TODO(wg-components, #24195): Make this less flaky during CI.
-      it.skip('should show the last slide when looping', async function () {
+    // TODO(wg-components, #24195): Make this less flaky during CI.
+    describe.skip('looping', function () {
+      it('should show the last slide when looping', async function () {
         this.timeout(testTimeout);
         const el = await getScrollingElement(styles, controller);
         const lastSlide = await getSlide(styles, controller, SLIDE_COUNT - 1);

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-carousel.js
@@ -93,7 +93,7 @@ describes.endtoend(
       await expect(prop(el, 'scrollLeft')).to.equal(scrollLeft);
     });
 
-    // TODO(wg-components, #24195): Make this less flaky during CI.
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
     describe.skip('looping', function () {
       it('should show the last slide when looping', async function () {
         this.timeout(testTimeout);

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -44,7 +44,7 @@ describes.endtoend(
     });
 
     // Test mixed lengths with snapping.
-    // TODO(wg-components, #24195): Make this less flaky during CI.
+    // TODO(wg-bento, #24195): getSlide/getScrollingElement do not always find element in time.
     describe.skip('snap', () => {
       const slideWidth = pageWidth * 0.75;
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -44,7 +44,8 @@ describes.endtoend(
     });
 
     // Test mixed lengths with snapping.
-    describe('snap', () => {
+    // TODO(wg-components, #24195): Make this less flaky during CI.
+    describe.skip('snap', () => {
       const slideWidth = pageWidth * 0.75;
 
       it('should have the correct initial slide positions', async function () {
@@ -62,8 +63,7 @@ describes.endtoend(
         });
       });
 
-      // TODO(wg-bento): getScrollingElement does not always find element in time.
-      it.skip('should snap on the center point', async function () {
+      it('should snap on the center point', async function () {
         const el = await getScrollingElement(styles, controller);
         const slideTwo = await getSlide(styles, controller, 1);
         const scrollAmount = 1;

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
@@ -51,7 +51,7 @@ describes.endtoend(
       await expect(prop(el, 'scrollWidth')).to.equal(pageWidth * SLIDE_COUNT);
     });
 
-    // TODO(wg-components, #24195): Make this less flaky during CI.
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
     it.skip('should snap when scrolling', async () => {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
@@ -51,7 +51,8 @@ describes.endtoend(
       await expect(prop(el, 'scrollWidth')).to.equal(pageWidth * SLIDE_COUNT);
     });
 
-    it('should snap when scrolling', async () => {
+    // TODO(wg-components, #24195): Make this less flaky during CI.
+    it.skip('should snap when scrolling', async () => {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
@@ -20,7 +20,7 @@ import {useStyles} from '../base-carousel.jss';
 const pageWidth = 800;
 const pageHeight = 600;
 
-// TODO(wg-components, #24195): Make this less flaky during CI.
+// TODO(wg-bento, #24195): getSlide/getArrow does not always find element in time.
 describes.endtoend(
   'amp-base-carousel - rtl',
   {

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
@@ -42,21 +42,21 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
-    it('should place the second slide to the left', async () => {
+    it.skip('should place the second slide to the left', async () => {
       const secondSlide = await getSlide(styles, controller, 1);
       await expect(controller.getElementRect(secondSlide)).to.include({
         left: -pageWidth,
       });
     });
 
-    it('should place the last slide to the right', async () => {
+    it.skip('should place the last slide to the right', async () => {
       const lastSlide = await getSlide(styles, controller, SLIDE_COUNT - 1);
       await expect(controller.getElementRect(lastSlide)).to.include({
         left: pageWidth,
       });
     });
 
-    it('should place the arrows correctly', async () => {
+    it.skip('should place the arrows correctly', async () => {
       const prevArrow = await getPrevArrow(styles, controller);
       const nextArrow = await getNextArrow(styles, controller);
       await expect(controller.getElementRect(prevArrow)).to.include({

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
@@ -20,6 +20,7 @@ import {useStyles} from '../base-carousel.jss';
 const pageWidth = 800;
 const pageHeight = 600;
 
+// TODO(wg-components, #24195): Make this less flaky during CI.
 describes.endtoend(
   'amp-base-carousel - rtl',
   {

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
@@ -46,7 +46,8 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
-    it('should render correctly', async () => {
+    // TODO(wg-bento): getScrollingElement does not always find element in time.
+    it.skip('should render correctly', async () => {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);
 
@@ -57,7 +58,7 @@ describes.endtoend(
       );
     });
 
-    it('should snap when scrolling', async () => {
+    it.skip('should snap when scrolling', async () => {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);
 
@@ -72,7 +73,7 @@ describes.endtoend(
       await expect(prop(el, 'scrollTop')).to.equal(snappedScrollTop);
     });
 
-    it('should reset the window after scroll', async function () {
+    it.skip('should reset the window after scroll', async function () {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
@@ -46,7 +46,7 @@ describes.endtoend(
       await controller.switchToShadowRoot(carousel);
     });
 
-    // TODO(wg-bento): getScrollingElement does not always find element in time.
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
     it.skip('should render correctly', async () => {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);
@@ -58,6 +58,7 @@ describes.endtoend(
       );
     });
 
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
     it.skip('should snap when scrolling', async () => {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);
@@ -73,6 +74,7 @@ describes.endtoend(
       await expect(prop(el, 'scrollTop')).to.equal(snappedScrollTop);
     });
 
+    // TODO(wg-bento, #24195): getScrollingElement does not always find element in time.
     it.skip('should reset the window after scroll', async function () {
       const el = await getScrollingElement(styles, controller);
       const firstSlide = await getSlide(styles, controller, 0);


### PR DESCRIPTION
Related to #24195

Skips all offenders below:
![image](https://user-images.githubusercontent.com/10456171/111199487-0d063a80-8597-11eb-9a51-5a503a3304c5.png)

cc @samouri