### PR TITLE
V1: mount/unmount concept and automatic scheduling

### DIFF
--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -150,14 +150,21 @@ const forbiddenTerms = {
   '\\.buildInternal': {
     message: 'can only be called by the framework',
     allowlist: [
-      'src/service/builder.js',
+      'src/custom-element.js',
       'src/service/resource.js',
       'testing/iframe.js',
     ],
   },
-  'getBuilderForDoc': {
+  '\\.mountInternal': {
+    message: 'can only be called by the framework',
+    allowlist: [
+      'src/service/scheduler.js',
+      'testing/iframe.js',
+    ],
+  },
+  'getSchedulerForDoc': {
     message: 'can only be used by the runtime',
-    allowlist: ['src/custom-element.js', 'src/service/builder.js'],
+    allowlist: ['src/custom-element.js', 'src/service/scheduler.js'],
   },
   // Service factories that should only be installed once.
   'installActionServiceForDoc': {
@@ -322,7 +329,7 @@ const forbiddenTerms = {
       'src/chunk.js',
       'src/element-service.js',
       'src/service.js',
-      'src/service/builder.js',
+      'src/service/scheduler.js',
       'src/service/cid-impl.js',
       'src/service/origin-experiments-impl.js',
       'src/service/template-impl.js',

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -157,10 +157,7 @@ const forbiddenTerms = {
   },
   '\\.mountInternal': {
     message: 'can only be called by the framework',
-    allowlist: [
-      'src/service/scheduler.js',
-      'testing/iframe.js',
-    ],
+    allowlist: ['src/service/scheduler.js', 'testing/iframe.js'],
   },
   'getSchedulerForDoc': {
     message: 'can only be used by the runtime',

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -57,7 +57,7 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override @nocollapse */
-  static load() {
+  static usesLoading() {
     return true;
   }
 
@@ -336,8 +336,6 @@ export class AmpImg extends BaseElement {
       removeElement(img);
       this.img_ = null;
     }
-
-    return true;
   }
 
   /** @override */

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -57,6 +57,11 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override @nocollapse */
+  static load() {
+    return true;
+  }
+
+  /** @override @nocollapse */
   static getPreconnects(element) {
     const src = element.getAttribute('src');
     if (src) {
@@ -176,10 +181,11 @@ export class AmpImg extends BaseElement {
   /**
    * Create the actual image element and set up instance variables.
    * Called lazily in the first `#layoutCallback`.
+   * @return {!Image}
    */
   initialize_() {
     if (this.img_) {
-      return;
+      return this.img_;
     }
     // If this amp-img IS the fallback then don't allow it to have its own
     // fallback to stop from nested fallback abuse.
@@ -219,6 +225,7 @@ export class AmpImg extends BaseElement {
     propagateObjectFitStyles(this.element, this.img_);
 
     this.element.appendChild(this.img_);
+    return this.img_;
   }
 
   /**
@@ -294,29 +301,43 @@ export class AmpImg extends BaseElement {
   }
 
   /** @override */
-  buildCallback() {
-    if (!AmpImg.V1()) {
-      return;
+  mountCallback() {
+    const initialized = !!this.img_;
+    const img = this.initialize_();
+    if (!initialized) {
+      listen(img, 'load', () => {
+        this.setReadyState(ReadyState.COMPLETE);
+        this.firstLayoutCompleted();
+        this.hideFallbackImg_();
+      });
+      listen(img, 'error', (reason) => {
+        this.setReadyState(ReadyState.ERROR, reason);
+        this.onImgLoadingError_();
+      });
     }
-
-    // A V1 amp-img loads and reloads automatically.
-    this.setReadyState(ReadyState.LOADING);
-    this.initialize_();
-    const img = dev().assertElement(this.img_);
     if (img.complete) {
       this.setReadyState(ReadyState.COMPLETE);
       this.firstLayoutCompleted();
       this.hideFallbackImg_();
+    } else {
+      this.setReadyState(ReadyState.LOADING);
     }
-    listen(img, 'load', () => {
-      this.setReadyState(ReadyState.COMPLETE);
-      this.firstLayoutCompleted();
-      this.hideFallbackImg_();
-    });
-    listen(img, 'error', (reason) => {
-      this.setReadyState(ReadyState.ERROR, reason);
-      this.onImgLoadingError_();
-    });
+  }
+
+  /** @override */
+  unmountCallback() {
+    // Interrupt retrieval of incomplete images to free network resources when
+    // navigating pages in a PWA. Opt for tiny dataURI image instead of empty
+    // src to prevent the viewer from detecting a load error.
+    const img = this.img_;
+    if (img && !img.complete) {
+      img.src =
+        'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
+      removeElement(img);
+      this.img_ = null;
+    }
+
+    return true;
   }
 
   /** @override */

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -1069,10 +1069,10 @@ describes.realWin(
         width: 100,
         height: 100,
       });
-      await ampIframe.getImpl(false);
+      const impl = await ampIframe.getImpl(false);
       await waitForAmpIframeLayoutPromise(doc, ampIframe);
       expect(ampIframe.querySelector('iframe')).to.exist;
-      expect(ampIframe.unlayoutOnPause()).to.be.true;
+      expect(impl.unlayoutOnPause()).to.be.true;
     });
 
     describe('throwIfCannotNavigate()', () => {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -533,6 +533,9 @@ export class BaseElement {
    * times for resource management. The unmount should reverse the changes
    * made by the mount. See `unmountCallback` for more info.
    *
+   * If this callback returns a promise, the `readyState` becomes "complete"
+   * after the promise is resolved.
+   *
    * @param {!AbortSignal=} opt_abortSignal
    * @return {?Promise|undefined}
    */

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -540,13 +540,8 @@ export class BaseElement {
 
   /**
    * Unload heavy elements, remove global listeners, etc.
-   *
-   * @return {boolean} Return `true` if the element should be remounted
-   * the next time it's displayed.
    */
-  unmountCallback() {
-    return false;
-  }
+  unmountCallback() {}
 
   /**
    * Subclasses can override this method to opt-in into receiving additional

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -154,6 +154,20 @@ export class BaseElement {
   }
 
   /**
+   * Subclasses can override this method to indicate that an element can load
+   * network resources.
+   *
+   * Such elements can have their `ensureLoaded` method called.
+   *
+   * @param {!AmpElement} unusedElement
+   * @return {boolean}
+   * @nocollapse
+   */
+  static load(unusedElement) {
+    return false;
+  }
+
+  /**
    * Subclasses can override this method to provide a svg logo that will be
    * displayed as the loader.
    *
@@ -511,6 +525,24 @@ export class BaseElement {
    */
   setReadyState(state, opt_failure) {
     this.element.setReadyStateInternal(state, opt_failure);
+  }
+
+  /**
+   * Load heavy elements, perform expensive operations, add global
+   * listeners/observers, etc.
+   *
+   * @param {!AbortSignal=} opt_abortSignal
+   * @return {?Promise|undefined}
+   */
+  mountCallback(opt_abortSignal) {}
+
+  /**
+   * Unload heavy elements, remove global listeners, etc.
+   *
+   * @return {boolean}
+   */
+  unmountCallback() {
+    return false;
   }
 
   /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -163,7 +163,7 @@ export class BaseElement {
    * @return {boolean}
    * @nocollapse
    */
-  static load(unusedElement) {
+  static usesLoading(unusedElement) {
     return false;
   }
 
@@ -529,7 +529,9 @@ export class BaseElement {
 
   /**
    * Load heavy elements, perform expensive operations, add global
-   * listeners/observers, etc.
+   * listeners/observers, etc. The mount and unmount can be called multiple
+   * times for resource management. The unmount should reverse the changes
+   * made by the mount. See `unmountCallback` for more info.
    *
    * @param {!AbortSignal=} opt_abortSignal
    * @return {?Promise|undefined}
@@ -539,7 +541,8 @@ export class BaseElement {
   /**
    * Unload heavy elements, remove global listeners, etc.
    *
-   * @return {boolean}
+   * @return {boolean} Return `true` if the element should be remounted
+   * the next time it's displayed.
    */
   unmountCallback() {
     return false;

--- a/src/common-signals.js
+++ b/src/common-signals.js
@@ -35,6 +35,11 @@ export const CommonSignals = {
   BUILT: 'built',
 
   /**
+   * The element has been mounted.
+   */
+  MOUNTED: 'mounted',
+
+  /**
    * The element has started loading.
    * LOAD_START triggers at the start of the layoutCallback.
    */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -684,8 +684,13 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         this.pause();
       }
 
+      if (!this.V1()) {
+        this.getResource_().unlayout();
+        return;
+      }
+
       // Hasn't been mounted yet and hasn't started mounting.
-      if (!this.V1() || !this.mountPromise_) {
+      if (!this.mountPromise_) {
         return;
       }
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -833,7 +833,11 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           this.dispatchCustomEventForTesting(AmpEvents.LOAD_START);
           return;
         case ReadyState.COMPLETE:
+          // LOAD_START is set just in case. It won't be overwritten if
+          // it had been set before.
+          this.signals_.signal(CommonSignals.LOAD_START);
           this.signals_.signal(CommonSignals.LOAD_END);
+          this.signals_.reset(CommonSignals.UNLOAD);
           this.classList.add('i-amphtml-layout');
           this.toggleLoading(false);
           dom.dispatchCustomEvent(this, 'load', null, NO_BUBBLES);

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -623,7 +623,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
             return;
           }
           this.setReadyStateInternal(
-            this.implClass_.load(this)
+            this.implClass_.usesLoading(this)
               ? ReadyState.LOADING
               : ReadyState.MOUNTING
           );
@@ -636,7 +636,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           }
           this.signals_.signal(CommonSignals.MOUNTED);
           if (
-            this.implClass_.load(this) &&
+            this.implClass_.usesLoading(this) &&
             this.readyState_ !== ReadyState.COMPLETE
           ) {
             this.setReadyStateInternal(ReadyState.LOADING);
@@ -682,7 +682,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * @final
      */
     unmount() {
-      // Hasn't been mounted yet.
+      // Hasn't been mounted yet and hasn't started mounting.
       if (!this.mountPromise_) {
         return;
       }
@@ -713,7 +713,9 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       if (this.isConnected_) {
         // Update the ready state.
         this.setReadyStateInternal(
-          this.implClass_.load(this) ? ReadyState.LOADING : ReadyState.MOUNTING
+          this.implClass_.usesLoading(this)
+            ? ReadyState.LOADING
+            : ReadyState.MOUNTING
         );
 
         // Schedule to mount again when the mounting conditions trigger.
@@ -749,7 +751,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     ensureLoaded(opt_parentPriority) {
       return this.build().then(() => {
         if (this.V1()) {
-          if (this.implClass_.load(this)) {
+          if (this.implClass_.usesLoading(this)) {
             this.impl_.ensureLoaded();
           }
           return this.whenLoaded();

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -714,12 +714,9 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       const scheduler = getSchedulerForDoc(this.getAmpDoc());
       scheduler.unschedule(this);
 
-      // Try to unmount. Not every element has been mounted, can be unmounted
-      // or has anything to unmount.
-      const reMount =
-        !this.mountPromise_ || !this.impl_ || this.impl_.unmountCallback();
-      if (!reMount) {
-        return;
+      // Try to unmount if the element has been built already.
+      if (this.isBuilt()) {
+        this.impl_.unmountCallback();
       }
 
       // Complete unmount and reset the state.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -543,7 +543,11 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           this.signals_.signal(CommonSignals.BUILT);
 
           if (this.V1()) {
-            this.setReadyStateInternal(ReadyState.MOUNTING);
+            this.setReadyStateInternal(
+              this.readyState_ != ReadyState.BUILDING
+                ? this.readyState_
+                : ReadyState.MOUNTING
+            );
           } else {
             this.setReadyStateInternal(ReadyState.LOADING);
             this.preconnect(/* onLayout */ false);
@@ -631,7 +635,9 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
             return;
           }
           this.setReadyStateInternal(
-            this.implClass_.usesLoading(this)
+            this.readyState_ != ReadyState.MOUNTING
+              ? this.readyState_
+              : this.implClass_.usesLoading(this)
               ? ReadyState.LOADING
               : ReadyState.MOUNTING
           );

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -147,6 +147,13 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       /** @private {?Promise} */
       this.buildingPromise_ = null;
 
+      /**
+       * Indicates that the `mountCallback()` has been called and it hasn't
+       * been reversed with an `unmountCallback()` call.
+       * @private {boolean}
+       */
+      this.mounted_ = false;
+
       /** @private {?Promise} */
       this.mountPromise_ = null;
 
@@ -625,6 +632,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
               ? ReadyState.LOADING
               : ReadyState.MOUNTING
           );
+          this.mounted_ = true;
           return this.impl_.mountCallback(signal);
         })
         .then(() => {
@@ -715,11 +723,12 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       scheduler.unschedule(this);
 
       // Try to unmount if the element has been built already.
-      if (this.isBuilt()) {
+      if (this.mounted_) {
         this.impl_.unmountCallback();
       }
 
       // Complete unmount and reset the state.
+      this.mounted_ = false;
       this.mountPromise_ = null;
       this.signals_.reset(CommonSignals.MOUNTED);
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -203,7 +203,7 @@ export class PreactBaseElement extends AMP.BaseElement {
   }
 
   /** @override @nocollapse */
-  static load() {
+  static usesLoading() {
     // eslint-disable-next-line local/no-static-this
     const Ctor = this;
     return Ctor['loadable'];
@@ -213,7 +213,7 @@ export class PreactBaseElement extends AMP.BaseElement {
   static prerenderAllowed() {
     // eslint-disable-next-line local/no-static-this
     const Ctor = this;
-    return !Ctor.load();
+    return !Ctor.usesLoading();
   }
 
   /** @param {!AmpElement} element */

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -203,10 +203,17 @@ export class PreactBaseElement extends AMP.BaseElement {
   }
 
   /** @override @nocollapse */
+  static load() {
+    // eslint-disable-next-line local/no-static-this
+    const Ctor = this;
+    return Ctor['loadable'];
+  }
+
+  /** @override @nocollapse */
   static prerenderAllowed() {
     // eslint-disable-next-line local/no-static-this
     const Ctor = this;
-    return !Ctor['loadable'];
+    return !Ctor.load();
   }
 
   /** @param {!AmpElement} element */

--- a/src/ready-state.js
+++ b/src/ready-state.js
@@ -31,6 +31,11 @@ export const ReadyState = {
   BUILDING: 'building',
 
   /**
+   * The element has been built and waiting to be mounted.
+   */
+  MOUNTING: 'mounting',
+
+  /**
    * The element has been built and waiting to be loaded.
    */
   LOADING: 'loading',

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -1093,6 +1093,9 @@ export class Resource {
     if (this.element.unlayoutOnPause()) {
       this.unlayout();
     }
+    if (this.element.V1()) {
+      this.element.pause();
+    }
   }
 
   /**
@@ -1115,6 +1118,9 @@ export class Resource {
   unload() {
     this.pause();
     this.unlayout();
+    if (this.element.V1()) {
+      this.element.unmount();
+    }
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -1103,7 +1103,7 @@ export class Resource {
    * Calls element's resumeCallback callback.
    */
   resume() {
-    this.element.resumeCallback();
+    this.element.resume();
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -1089,20 +1089,14 @@ export class Resource {
    * Calls element's pauseCallback callback.
    */
   pause() {
-    this.element.pauseCallback();
-    if (this.element.unlayoutOnPause()) {
-      this.unlayout();
-    }
-    if (this.element.V1()) {
-      this.element.pause();
-    }
+    this.element.pause();
   }
 
   /**
    * Calls element's pauseCallback callback.
    */
   pauseOnRemove() {
-    this.element.pauseCallback();
+    this.element.pause();
   }
 
   /**
@@ -1116,11 +1110,8 @@ export class Resource {
    * Called when a previously visible element is no longer displayed.
    */
   unload() {
-    this.pause();
+    this.element.unmount();
     this.unlayout();
-    if (this.element.V1()) {
-      this.element.unmount();
-    }
   }
 
   /**

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -1111,7 +1111,6 @@ export class Resource {
    */
   unload() {
     this.element.unmount();
-    this.unlayout();
   }
 
   /**

--- a/src/service/scheduler.js
+++ b/src/service/scheduler.js
@@ -21,10 +21,10 @@ import {getServiceForDoc, registerServiceBuilderForDoc} from '../service';
 import {hasNextNodeInDocumentOrder, isIframed} from '../dom';
 import {removeItem} from '../utils/array';
 
-const ID = 'builder';
+const ID = 'scheduler';
 
 /** @implements {../service.Disposable} */
-export class Builder {
+export class Scheduler {
   /** @param {!./ampdoc-impl.AmpDoc} ampdoc  */
   constructor(ampdoc) {
     /** @private @const */
@@ -227,15 +227,15 @@ export class Builder {
       asap || target.getBuildPriority() <= LayoutPriority.CONTENT
         ? win.setTimeout
         : win.requestIdleCallback || win.setTimeout;
-    scheduler(() => target.buildInternal());
+    scheduler(() => target.mountInternal());
   }
 }
 
 /**
  * @param {!./ampdoc-impl.AmpDoc} ampdoc
- * @return {!Builder}
+ * @return {!Scheduler}
  */
-export function getBuilderForDoc(ampdoc) {
-  registerServiceBuilderForDoc(ampdoc, ID, Builder);
-  return /** @type {!Builder} */ (getServiceForDoc(ampdoc, ID));
+export function getSchedulerForDoc(ampdoc) {
+  registerServiceBuilderForDoc(ampdoc, ID, Scheduler);
+  return /** @type {!Scheduler} */ (getServiceForDoc(ampdoc, ID));
 }

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -520,7 +520,7 @@ t.run('Viewer Visibility State', () => {
           return waitForNextPass().then(() => {
             expect(layoutCallback).not.to.have.been.called;
             expect(unlayoutCallback).to.have.been.called;
-            expect(pauseCallback).not.to.have.been.called;
+            expect(pauseCallback).to.have.been.called;
             expect(resumeCallback).not.to.have.been.called;
           });
         });

--- a/test/unit/inabox/test-inabox-resources.js
+++ b/test/unit/inabox/test-inabox-resources.js
@@ -119,18 +119,18 @@ describes.realWin('inabox-resources', {amp: true}, (env) => {
     resources.add(element1);
     resources.add(element2);
 
-    env.sandbox.stub(element1, 'pauseCallback');
-    env.sandbox.stub(element1, 'resumeCallback');
-    env.sandbox.stub(element2, 'pauseCallback');
-    env.sandbox.stub(element2, 'resumeCallback');
+    env.sandbox.stub(element1, 'pause');
+    env.sandbox.stub(element1, 'resume');
+    env.sandbox.stub(element2, 'pause');
+    env.sandbox.stub(element2, 'resume');
 
     env.ampdoc.overrideVisibilityState('paused');
-    expect(element1.pauseCallback).to.be.calledOnce;
-    expect(element2.pauseCallback).to.be.calledOnce;
+    expect(element1.pause).to.be.calledOnce;
+    expect(element2.pause).to.be.calledOnce;
 
     env.ampdoc.overrideVisibilityState('visible');
-    expect(element1.resumeCallback).to.be.calledOnce;
-    expect(element2.resumeCallback).to.be.calledOnce;
+    expect(element1.resume).to.be.calledOnce;
+    expect(element2.resume).to.be.calledOnce;
   });
 
   it('should unload all resources on dispose', async () => {

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -140,7 +140,7 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       element.addEventListener('error', errorEventSpy);
 
       // Build.
-      await element.buildInternal();
+      await element.mountInternal();
       expect(element.readyState).to.equal('loading');
       expect(loader).to.be.calledWith('auto');
       expect(lastLoading).to.equal('auto');
@@ -161,7 +161,7 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       element.addEventListener('error', errorEventSpy);
 
       // Build.
-      await element.buildInternal();
+      await element.mountInternal();
       expect(element.readyState).to.equal('loading');
       expect(loader).to.be.calledWith('auto');
       expect(lastLoading).to.equal('auto');
@@ -184,7 +184,7 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       api = {readyState: 'complete'};
 
       // Build.
-      await element.buildInternal();
+      await element.mountInternal();
       expect(element.readyState).to.equal('complete');
       expect(loadEventSpy).to.be.calledOnce;
       expect(loadEventSpy.firstCall.firstArg).to.contain({bubbles: false});
@@ -200,7 +200,7 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       api = {readyState: 'error'};
 
       // Build.
-      await element.buildInternal();
+      await element.mountInternal();
       expect(element.readyState).to.equal('error');
       expect(errorEventSpy).to.be.calledOnce;
       expect(errorEventSpy.firstCall.firstArg).to.contain({bubbles: false});
@@ -216,19 +216,19 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       api = {};
 
       // Build.
-      await element.buildInternal();
+      await element.mountInternal();
       expect(element.readyState).to.equal('loading');
       expect(loadEventSpy).to.not.be.called;
       expect(errorEventSpy).to.not.be.called;
     });
 
     it('should load with loading=auto by default', async () => {
-      await element.buildInternal();
+      await element.mountInternal();
       expect(lastLoading).to.equal('auto');
     });
 
     it('should load with loading=eager on ensureLoaded', async () => {
-      await element.buildInternal();
+      await element.mountInternal();
       expect(lastLoading).to.equal('auto');
 
       // Should set loading=eager.
@@ -267,7 +267,7 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
 
       await element.buildInternal();
 
-      element.pauseCallback();
+      element.pause();
       expect(pauseStub).to.be.calledOnce;
     });
 
@@ -277,7 +277,7 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
       await element.buildInternal();
       await waitFor(() => component.callCount > 0, 'component rendered');
 
-      element.pauseCallback();
+      element.pause();
 
       component.resetHistory();
       await waitFor(() => component.callCount > 0, 'component rendered');

--- a/test/unit/test-amp-img-v1.js
+++ b/test/unit/test-amp-img-v1.js
@@ -111,6 +111,42 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
     expect(togglePlaceholderSpy).to.be.calledOnce.calledWith(false);
   });
 
+  it('should unload the img on unmount before loaded', async () => {
+    const ampImg = await getImg({
+      src: '/examples/img/sample.jpg',
+      width: 300,
+      height: 200,
+      alt: 'An image',
+      title: 'Image title',
+      referrerpolicy: 'origin',
+    });
+    const iniImg = ampImg.querySelector('img');
+    expect(iniImg).to.exist;
+
+    ampImg.unmount();
+    expect(ampImg.querySelector('img')).to.not.exist;
+    expect(iniImg.src).to.contain('data:image/gif;');
+  });
+
+  it('should NOT unload the img on unmount after loaded', async () => {
+    const ampImg = await getImg({
+      src: '/examples/img/sample.jpg',
+      width: 300,
+      height: 200,
+      alt: 'An image',
+      title: 'Image title',
+      referrerpolicy: 'origin',
+    });
+    const iniImg = ampImg.querySelector('img');
+    expect(iniImg).to.exist;
+
+    Object.defineProperty(iniImg, 'complete', {value: true});
+
+    ampImg.unmount();
+    expect(ampImg.querySelector('img')).to.equal(iniImg);
+    expect(iniImg.src).to.not.contain('data:image/gif;');
+  });
+
   it('should set eager loading on ensureLoaded', async () => {
     const ampImg = await getImg({
       src: '/examples/img/sample.jpg',

--- a/test/unit/test-amp-img-v1.js
+++ b/test/unit/test-amp-img-v1.js
@@ -61,13 +61,18 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
     img.onerror = sandbox.spy();
 
     doc.body.appendChild(img);
-    await img.build();
+    await img.mount();
     return img;
   }
 
   it('testElementV1', () => {
     testElementV1(AmpImg, {
-      exceptions: ['Must not use getLayoutSize'],
+      exceptions: [
+        'Must not have preconnectCallback',
+        'Must not have layoutCallback',
+        'Must not have unlayoutCallback',
+        'Must not use getLayoutSize',
+      ],
     });
   });
 
@@ -104,6 +109,27 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
     expect(ampImg.onerror).to.not.be.called;
     expect(toggleFallbackSpy).to.not.be.called;
     expect(togglePlaceholderSpy).to.be.calledOnce.calledWith(false);
+  });
+
+  it('should set eager loading on ensureLoaded', async () => {
+    const ampImg = await getImg({
+      src: '/examples/img/sample.jpg',
+      width: 300,
+      height: 200,
+      alt: 'An image',
+      title: 'Image title',
+      referrerpolicy: 'origin',
+    });
+
+    const img = ampImg.querySelector('img');
+    expect(img.loading == 'auto' || !img.loading).to.be.true;
+
+    const promise = ampImg.ensureLoaded();
+    await new Promise(setTimeout);
+    expect(img.loading).to.equal('eager');
+
+    dispatchCustomEvent(img, 'load', null, {bubbles: false});
+    await promise;
   });
 
   it('should fail when img fails', async () => {

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -867,6 +867,8 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(element.readyState).equal('complete');
       expect(element.toggleLoading).to.be.calledOnce.calledWith(false);
       expect(element.signals().get(CommonSignals.LOAD_END)).to.exist;
+      expect(element.signals().get(CommonSignals.LOAD_START)).to.exist;
+      expect(element.signals().get(CommonSignals.UNLOAD)).to.not.exist;
       expect(element).to.have.class('i-amphtml-layout');
       expect(loadEventSpy).to.be.calledOnce;
       expect(loadEventSpy.firstCall.firstArg.bubbles).to.be.false;
@@ -906,9 +908,11 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(element.readyState).equal('complete');
       expect(element.signals().get(CommonSignals.LOAD_END)).to.exist;
 
+      element.signals().reset(CommonSignals.LOAD_START);
       element.setReadyStateInternal('loading');
       expect(element.readyState).equal('loading');
       expect(element.signals().get(CommonSignals.LOAD_END)).to.be.null;
+      expect(element.signals().get(CommonSignals.LOAD_START)).to.exist;
     });
   });
 

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -26,7 +26,7 @@ import {
   getImplClassSyncForTesting,
   getImplSyncForTesting,
 } from '../../src/custom-element';
-import {getBuilderForDoc} from '../../src/service/builder';
+import {getSchedulerForDoc} from '../../src/service/scheduler';
 
 describes.realWin('CustomElement V1', {amp: true}, (env) => {
   let win, doc, ampdoc;
@@ -59,7 +59,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
     resourcesMock = env.sandbox.mock(resources);
     resourcesMock.expects('upgraded').never();
 
-    builder = getBuilderForDoc(ampdoc);
+    builder = getSchedulerForDoc(ampdoc);
     builderMock = env.sandbox.mock(builder);
   });
 
@@ -229,6 +229,40 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(buildCallbackStub).to.be.calledOnce;
       expect(element.isUpgraded()).to.be.true;
       expect(element.isBuilt()).to.be.true;
+      expect(element.readyState).to.equal('mounting');
+      expect(element).to.not.have.class('i-amphtml-notbuilt');
+      expect(element).to.not.have.class('amp-notbuilt');
+      expect(element).to.have.class('i-amphtml-built');
+      expect(element.signals().get(CommonSignals.BUILT)).to.exist;
+      expect(attachedCallbackStub).to.be.calledOnce;
+    });
+
+    it('should mount a pre-upgraded element', async () => {
+      const attachedCallbackStub = env.sandbox.stub(
+        TestElement.prototype,
+        'attachedCallback'
+      );
+
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      const promise = element.mountInternal();
+      expect(element.isBuilding()).to.be.true;
+      expect(getImplSyncForTesting(element)).to.be.null;
+      expect(element.isUpgraded()).to.be.false;
+      expect(element.isBuilt()).to.be.false;
+      expect(element.readyState).to.equal('building');
+      expect(element).to.have.class('i-amphtml-notbuilt');
+      expect(element).to.have.class('amp-notbuilt');
+      expect(element).to.not.have.class('i-amphtml-built');
+      expect(element.signals().get(CommonSignals.BUILT)).to.be.null;
+      expect(attachedCallbackStub).to.not.be.called;
+
+      await promise;
+      expect(getImplSyncForTesting(element)).to.be.instanceOf(TestElement);
+      expect(buildCallbackStub).to.be.calledOnce;
+      expect(element.isUpgraded()).to.be.true;
+      expect(element.isBuilt()).to.be.true;
       expect(element.readyState).to.equal('complete');
       expect(element).to.not.have.class('i-amphtml-notbuilt');
       expect(element).to.not.have.class('amp-notbuilt');
@@ -260,6 +294,37 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(buildCallbackStub).to.be.calledOnce;
       expect(element.isUpgraded()).to.be.true;
       expect(element.isBuilt()).to.be.true;
+      expect(element.readyState).to.equal('mounting');
+      expect(element).to.not.have.class('i-amphtml-notbuilt');
+      expect(element).to.not.have.class('amp-notbuilt');
+      expect(element).to.have.class('i-amphtml-built');
+      expect(element.signals().get(CommonSignals.BUILT)).to.exist;
+      expect(attachedCallbackStub).to.be.calledOnce;
+    });
+
+    it('should mount an element after upgrade', async () => {
+      const attachedCallbackStub = env.sandbox.stub(
+        TestElement.prototype,
+        'attachedCallback'
+      );
+
+      const element = new StubElementClass();
+      doc.body.appendChild(element);
+      element.upgrade(TestElement);
+
+      const promise = element.mountInternal();
+      expect(element.isBuilding()).to.be.true;
+      expect(getImplSyncForTesting(element)).to.be.null;
+      expect(element.isUpgraded()).to.be.false;
+      expect(element.isBuilt()).to.be.false;
+      expect(element.readyState).to.equal('building');
+      expect(attachedCallbackStub).to.not.be.called;
+
+      await promise;
+      expect(getImplSyncForTesting(element)).to.be.instanceOf(TestElement);
+      expect(buildCallbackStub).to.be.calledOnce;
+      expect(element.isUpgraded()).to.be.true;
+      expect(element.isBuilt()).to.be.true;
       expect(element.readyState).to.equal('complete');
       expect(element).to.not.have.class('i-amphtml-notbuilt');
       expect(element).to.not.have.class('amp-notbuilt');
@@ -268,15 +333,13 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(attachedCallbackStub).to.be.calledOnce;
     });
 
-    it('should continue in loading state if buildCallback requests it', async () => {
-      buildCallbackStub.callsFake(function () {
-        this.setReadyState('loading');
-      });
+    it('should continue in loading state for usesLoading', async () => {
+      env.sandbox.stub(TestElement, 'usesLoading').returns(true);
 
       const element = new ElementClass();
       doc.body.appendChild(element);
 
-      await element.buildInternal();
+      await element.mountInternal();
       expect(buildCallbackStub).to.be.calledOnce;
       expect(element.readyState).to.equal('loading');
     });
@@ -340,7 +403,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
 
       await element.buildInternal();
       expect(buildCallbackStub).to.be.calledOnce;
-      expect(element.readyState).to.equal('complete');
+      expect(element.readyState).to.equal('mounting');
     });
 
     describe('consent', () => {
@@ -362,7 +425,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
 
         await element.buildInternal();
         expect(buildCallbackStub).to.be.calledOnce;
-        expect(element.readyState).to.equal('complete');
+        expect(element.readyState).to.equal('mounting');
       });
 
       it('should not build on consent insufficient', async () => {
@@ -452,17 +515,274 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
     });
   });
 
+  describe('mount/unmount', () => {
+    let mountCallbackStub, unmountCallbackStub;
+
+    beforeEach(() => {
+      mountCallbackStub = env.sandbox.stub(
+        TestElement.prototype,
+        'mountCallback'
+      );
+      unmountCallbackStub = env.sandbox.stub(
+        TestElement.prototype,
+        'unmountCallback'
+      );
+    });
+
+    it('should only execute mount once', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      builderMock.expects('scheduleAsap').never();
+      builderMock.expects('schedule').never();
+
+      const promise = element.mountInternal();
+      const promise2 = element.mount();
+      expect(promise2).to.equal(promise);
+
+      await promise;
+      await promise2;
+      const promise3 = element.mount();
+      expect(promise3).to.equal(promise);
+
+      await element.whenMounted();
+    });
+
+    it('should wait until the element is upgraded', async () => {
+      const element = new StubElementClass();
+
+      builderMock.expects('scheduleAsap').withExactArgs(element).once();
+
+      const promise = element.mount();
+
+      doc.body.appendChild(element);
+      element.upgrade(TestElement);
+
+      await element.mountInternal();
+      await promise;
+      expect(mountCallbackStub).to.be.calledOnce;
+
+      await element.whenMounted();
+    });
+
+    it('should consider element loading if mountCallback has no result', async () => {
+      env.sandbox.stub(TestElement, 'usesLoading').returns(true);
+
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledOnce;
+      expect(element.readyState).to.equal('loading');
+    });
+
+    it('should consider element completed if mountCallback returns promise', async () => {
+      env.sandbox.stub(TestElement, 'usesLoading').returns(true);
+      mountCallbackStub.resolves();
+
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledOnce;
+      expect(element.readyState).to.equal('complete');
+    });
+
+    it('should mount -> unmount -> mount when connected', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      builderMock.expects('scheduleAsap').never();
+
+      const scheduleStub = env.sandbox.stub(builder, 'schedule');
+      const unscheduleStub = env.sandbox.stub(builder, 'unschedule');
+
+      // Mount.
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledOnce;
+      expect(element.signals().get('mounted')).to.exist;
+      expect(element.readyState).to.equal('complete');
+
+      // Unmount.
+      element.unmount();
+      expect(unmountCallbackStub).to.be.calledOnce;
+      expect(unscheduleStub).to.be.calledOnce;
+      expect(scheduleStub).to.be.calledOnce;
+      expect(element.signals().get('mounted')).to.not.exist;
+      expect(element.readyState).to.equal('mounting');
+
+      // Remount.
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledTwice;
+      expect(element.signals().get('mounted')).to.exist;
+      expect(element.readyState).to.equal('complete');
+
+      await element.whenMounted();
+    });
+
+    it('should mount -> unmount -> mount with usesLoading', async () => {
+      env.sandbox.stub(TestElement, 'usesLoading').returns(true);
+      mountCallbackStub.resolves();
+
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      builderMock.expects('scheduleAsap').never();
+
+      const scheduleStub = env.sandbox.stub(builder, 'schedule');
+      const unscheduleStub = env.sandbox.stub(builder, 'unschedule');
+
+      // Mount.
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledOnce;
+      expect(element.signals().get('mounted')).to.exist;
+      expect(element.readyState).to.equal('complete');
+
+      // Unmount.
+      element.unmount();
+      expect(unmountCallbackStub).to.be.calledOnce;
+      expect(unscheduleStub).to.be.calledOnce;
+      expect(scheduleStub).to.be.calledOnce;
+      expect(element.signals().get('mounted')).to.not.exist;
+      expect(element.readyState).to.equal('loading');
+
+      // Remount.
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledTwice;
+      expect(element.signals().get('mounted')).to.exist;
+      expect(element.readyState).to.equal('complete');
+
+      await element.whenMounted();
+    });
+
+    it('should unmount on disconnect', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      builderMock.expects('scheduleAsap').never();
+
+      const scheduleStub = env.sandbox.stub(builder, 'schedule');
+      const unscheduleStub = env.sandbox.stub(builder, 'unschedule');
+
+      // Mount.
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledOnce;
+      expect(element.signals().get('mounted')).to.exist;
+
+      // Disconnect
+      element.remove();
+      expect(unmountCallbackStub).to.be.calledOnce;
+      expect(unscheduleStub).to.be.calledOnce;
+
+      // Not rescheduled.
+      expect(scheduleStub).to.not.be.called;
+      expect(element.signals().get('mounted')).to.not.exist;
+    });
+
+    it('should NOT call unmountCallback if was not mounted before', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      builderMock.expects('scheduleAsap').never();
+
+      const scheduleStub = env.sandbox.stub(builder, 'schedule');
+      const unscheduleStub = env.sandbox.stub(builder, 'unschedule');
+
+      // Unmount.
+      element.unmount();
+      expect(unmountCallbackStub).to.not.be.called;
+      expect(unscheduleStub).to.be.calledOnce;
+      expect(scheduleStub).to.be.calledOnce;
+      expect(element.signals().get('mounted')).to.not.exist;
+    });
+
+    it('should cancel mount', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      builderMock.expects('scheduleAsap').never();
+
+      const scheduleStub = env.sandbox.stub(builder, 'schedule');
+      const unscheduleStub = env.sandbox.stub(builder, 'unschedule');
+
+      // Mount and unmount in the same task.
+      const promise = element.mountInternal();
+      element.unmount();
+      expect(unscheduleStub).to.be.calledOnce;
+      expect(scheduleStub).to.be.calledOnce;
+
+      await new Promise(setTimeout);
+      expect(mountCallbackStub).to.not.be.called;
+
+      try {
+        await promise;
+      } catch (e) {
+        expect(() => {
+          throw e;
+        }).to.throw(/CANCELLED/);
+      }
+
+      // Mount again.
+      await element.mountInternal();
+      expect(mountCallbackStub).to.be.calledOnce;
+    });
+
+    it('should pause on unmount when connected', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      const pauseStub = env.sandbox.stub(element, 'pause');
+      element.unmount();
+      expect(pauseStub).to.be.calledOnce;
+    });
+
+    it('should NOT pause on disconnect', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      const pauseStub = env.sandbox.stub(element, 'pause');
+      element.remove();
+      expect(pauseStub).to.not.be.called;
+    });
+  });
+
+  describe('pause', () => {
+    let pauseCallbackStub;
+
+    beforeEach(() => {
+      pauseCallbackStub = env.sandbox.stub(
+        TestElement.prototype,
+        'pauseCallback'
+      );
+    });
+
+    it('should NOT pause an unbuilt element', () => {
+      const element = new StubElementClass();
+      doc.body.appendChild(element);
+
+      element.pause();
+      expect(pauseCallbackStub).to.not.be.called;
+    });
+
+    it('should pause a built element', async () => {
+      const element = new ElementClass();
+      doc.body.appendChild(element);
+
+      await element.buildInternal();
+      element.pause();
+      expect(pauseCallbackStub).to.be.calledOnce;
+    });
+  });
+
   describe('ensureLoaded', () => {
     let element;
-    let buildCallbackStub;
+    let usesLoadingStub;
     let ensureLoadedStub;
 
     beforeEach(() => {
       element = new StubElementClass();
-      buildCallbackStub = env.sandbox.stub(
-        TestElement.prototype,
-        'buildCallback'
-      );
+      usesLoadingStub = env.sandbox.stub(TestElement, 'usesLoading');
+      usesLoadingStub.returns(true);
       ensureLoadedStub = env.sandbox.stub(
         TestElement.prototype,
         'ensureLoaded'
@@ -472,22 +792,20 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
     });
 
     it('should force build and wait for whenLoaded even if not marked as loading', async () => {
+      usesLoadingStub.returns(false);
       const promise = element.ensureLoaded();
 
       doc.body.appendChild(element);
       element.upgrade(TestElement);
 
-      await element.buildInternal();
+      await element.mountInternal();
       await promise;
-      expect(ensureLoadedStub).to.be.calledOnce;
+      expect(ensureLoadedStub).to.not.be.called;
 
       await element.whenLoaded();
     });
 
     it('should force build and ensureLoaded if loading', async () => {
-      buildCallbackStub.callsFake(function () {
-        this.setReadyState('loading');
-      });
       ensureLoadedStub.callsFake(function () {
         this.setReadyState('complete');
       });
@@ -497,7 +815,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       doc.body.appendChild(element);
       element.upgrade(TestElement);
 
-      await element.buildInternal();
+      await element.mountInternal();
       await promise;
       expect(ensureLoadedStub).to.be.calledOnce;
 

--- a/test/unit/test-mutator.js
+++ b/test/unit/test-mutator.js
@@ -98,8 +98,8 @@ describes.realWin('mutator changeSize', {amp: true}, (env) => {
       prerenderAllowed: () => true,
       renderOutsideViewport: () => false,
       unlayoutCallback: () => true,
-      pauseCallback: () => {},
-      unlayoutOnPause: () => true,
+      pause: () => {},
+      unmount: () => {},
       isRelayoutNeeded: () => true,
       /* eslint-disable google-camelcase/google-camelcase */
       contains: (unused_otherElement) => false,
@@ -197,7 +197,7 @@ describes.realWin('mutator changeSize', {amp: true}, (env) => {
     );
     expect(resources.requestsChangeSize_.length).to.equal(2);
     resource1.state_ = ResourceState.LAYOUT_SCHEDULED;
-    resource1.unload();
+    resource1.unlayout();
     resources.cleanupTasks_(resource1);
     expect(resources.requestsChangeSize_.length).to.equal(1);
     expect(resources.requestsChangeSize_[0].resource).to.equal(resource2);
@@ -1404,9 +1404,9 @@ describes.realWin('mutator mutateElement and collapse', {amp: true}, (env) => {
     element.prerenderAllowed = () => true;
     element.renderOutsideViewport = () => true;
     element.isRelayoutNeeded = () => true;
-    element.pauseCallback = () => {};
+    element.pause = () => {};
+    element.unmount = () => {};
     element.unlayoutCallback = () => true;
-    element.unlayoutOnPause = () => true;
     element.togglePlaceholder = () => env.sandbox.spy();
 
     env.win.document.body.appendChild(element);

--- a/test/unit/test-owners.js
+++ b/test/unit/test-owners.js
@@ -113,23 +113,13 @@ describes.realWin(
         }).to.not.throw();
       });
 
-      it('should call pauseCallback on custom element', () => {
-        const stub1 = env.sandbox.stub(children[1], 'pauseCallback');
-        const stub2 = env.sandbox.stub(children[2], 'pauseCallback');
+      it('should call pause on custom element', () => {
+        const stub1 = env.sandbox.stub(children[1], 'pause');
+        const stub2 = env.sandbox.stub(children[2], 'pause');
 
         owners.schedulePause(parent, children);
         expect(stub1.calledOnce).to.be.true;
         expect(stub2.calledOnce).to.be.true;
-      });
-
-      it('should call unlayoutCallback when unlayoutOnPause', () => {
-        const stub1 = env.sandbox.stub(children[1], 'unlayoutCallback');
-        const stub2 = env.sandbox.stub(children[2], 'unlayoutCallback');
-        env.sandbox.stub(children[1], 'unlayoutOnPause').returns(true);
-
-        owners.schedulePause(parent, children);
-        expect(stub1.calledOnce).to.be.true;
-        expect(stub2.calledOnce).to.be.false;
       });
     });
 
@@ -158,15 +148,15 @@ describes.realWin(
         }).to.not.throw();
       });
 
-      it('should call resumeCallback on paused custom elements', () => {
-        const stub1 = env.sandbox.stub(children[1], 'resumeCallback');
+      it('should call resume on paused custom elements', () => {
+        const stub1 = env.sandbox.stub(children[1], 'resume');
 
         owners.scheduleResume(parent, children);
         expect(stub1.calledOnce).to.be.true;
       });
 
-      it('should call resumeCallback on non-paused custom elements', () => {
-        const stub2 = env.sandbox.stub(children[2], 'resumeCallback');
+      it('should call resume on non-paused custom elements', () => {
+        const stub2 = env.sandbox.stub(children[2], 'resume');
 
         owners.scheduleResume(parent, children);
         expect(stub2.calledOnce).to.be.true;

--- a/test/unit/test-resource.js
+++ b/test/unit/test-resource.js
@@ -50,6 +50,7 @@ describes.realWin('Resource', {amp: true}, (env) => {
       .callsFake(() => {});
     resources = new ResourcesImpl(env.ampdoc);
     resource = new Resource(1, element, resources);
+    element.resources_ = resources;
 
     const vsync = Services.vsyncFor(win);
     env.sandbox.stub(vsync, 'mutate').callsFake((mutator) => {
@@ -941,58 +942,36 @@ describes.realWin('Resource', {amp: true}, (env) => {
     });
   });
 
-  describe('pauseCallback', () => {
-    it('should call pauseCallback on unbuilt element', () => {
+  describe('pause', () => {
+    it('should call pause on unbuilt element', () => {
       resource.state_ = ResourceState.NOT_BUILT;
-      elementMock.expects('pauseCallback').once();
+      elementMock.expects('pause').once();
       resource.pause();
     });
 
-    it('should call pauseCallback on built element', () => {
+    it('should call pause on built element', () => {
       resource.state_ = ResourceState.LAYOUT_COMPLETE;
-      elementMock.expects('pauseCallback').once();
+      elementMock.expects('pause').once();
       resource.pause();
     });
 
     it('should NOT call unlayoutCallback', () => {
       resource.state_ = ResourceState.LAYOUT_COMPLETE;
-      elementMock.expects('pauseCallback').once();
+      elementMock.expects('pause').once();
       elementMock.expects('unlayoutCallback').never();
       resource.pause();
     });
 
-    describe('when unlayoutOnPause', () => {
-      beforeEach(() => {
-        elementMock.expects('unlayoutOnPause').returns(true).once();
-      });
-
-      it('should call unlayoutCallback and update state', () => {
-        resource.state_ = ResourceState.LAYOUT_COMPLETE;
-        elementMock.expects('pauseCallback').once();
-        elementMock.expects('unlayoutCallback').returns(true).once();
-        resource.pause();
-        expect(resource.getState()).to.equal(ResourceState.NOT_LAID_OUT);
-      });
-
-      it('should call unlayoutCallback but NOT update state', () => {
-        resource.state_ = ResourceState.LAYOUT_COMPLETE;
-        elementMock.expects('pauseCallback').once();
-        elementMock.expects('unlayoutCallback').returns(false).once();
-        resource.pause();
-        expect(resource.getState()).to.equal(ResourceState.LAYOUT_COMPLETE);
-      });
-    });
-
     describe('when remove from DOM', () => {
-      it('should call pauseCallback on remove for unbuilt ele', () => {
+      it('should call pause on remove for unbuilt ele', () => {
         resource.state_ = ResourceState.NOT_BUILT;
-        elementMock.expects('pauseCallback').once();
+        elementMock.expects('pause').once();
         resource.pauseOnRemove();
       });
 
-      it('should call pauseCallback on remove for built ele', () => {
+      it('should call pause on remove for built ele', () => {
         resource.state_ = ResourceState.LAYOUT_COMPLETE;
-        elementMock.expects('pauseCallback').once();
+        elementMock.expects('pause').once();
         resource.pauseOnRemove();
       });
     });
@@ -1024,16 +1003,16 @@ describes.realWin('Resource', {amp: true}, (env) => {
     });
   });
 
-  describe('resumeCallback', () => {
-    it('should call resumeCallback on unbuilt element', () => {
+  describe('resume', () => {
+    it('should call resume on unbuilt element', () => {
       resource.state_ = ResourceState.NOT_BUILT;
-      elementMock.expects('resumeCallback').once();
+      elementMock.expects('resume').once();
       resource.resume();
     });
 
-    it('should call resumeCallback on un-paused element', () => {
+    it('should call resume on un-paused element', () => {
       resource.state_ = ResourceState.LAYOUT_COMPLETE;
-      elementMock.expects('resumeCallback').once();
+      elementMock.expects('resume').once();
       resource.resume();
     });
   });
@@ -1066,8 +1045,8 @@ describe('Resource idleRenderOutsideViewport', () => {
       applySize: () => {},
       unlayoutOnPause: () => false,
       unlayoutCallback: () => true,
-      pauseCallback: () => false,
-      resumeCallback: () => false,
+      pause: () => false,
+      resume: () => false,
       getLayoutPriority: () => LayoutPriority.CONTENT,
     };
     resources = new ResourcesImpl(new AmpDocSingle(window));

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -79,6 +79,8 @@ describes.realWin('Resources', {amp: true}, (env) => {
     element.V1 = () => false;
     element.isBuilt = () => isBuilt;
     element.isBuilding = () => isBuilding;
+    element.pause = () => {};
+    element.unmount = () => {};
 
     const resource = new Resource(id, element, resources);
     env.sandbox.stub(resource, 'getState').returns(state);
@@ -638,9 +640,9 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
     element.prerenderAllowed = () => true;
     element.renderOutsideViewport = () => true;
     element.isRelayoutNeeded = () => true;
-    element.pauseCallback = () => {};
+    element.pause = () => {};
+    element.unmount = () => {};
     element.unlayoutCallback = () => true;
-    element.unlayoutOnPause = () => true;
     element.togglePlaceholder = () => sandbox.spy();
     element.fakeComputedStyle = {
       marginTop: '0px',
@@ -906,7 +908,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
 
     // Remove unloaded resources from exec queue.
     resource2.abortController_ = null;
-    resource2.unload();
+    resource2.unlayout();
     resources.cleanupTasks_(resource2);
     expect(resources.exec_.getSize()).to.equal(1);
 
@@ -921,7 +923,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
 
     // Removes them even from scheduling queue.
     resource2.abortController_ = null;
-    resource2.unload();
+    resource2.unlayout();
     resources.cleanupTasks_(resource2, /* opt_removePending */ true);
     expect(resources.queue_.getSize()).to.equal(0);
     expect(resources.pendingBuildResources_.length).to.equal(1);
@@ -1381,8 +1383,9 @@ describes.fakeWin('Resources.add/upgrade/remove', {amp: true}, (env) => {
       reconstructWhenReparented() {
         return true;
       },
-      pauseCallback() {},
-      resumeCallback() {},
+      pause() {},
+      resume() {},
+      unmount() {},
       updateLayoutBox() {},
       getBoundingClientRect() {
         return layoutRectLtwh(0, 0, 0, 0);

--- a/test/unit/test-scheduler.js
+++ b/test/unit/test-scheduler.js
@@ -15,9 +15,9 @@
  */
 
 import * as fakeTimers from '@sinonjs/fake-timers';
-import {Scheduler} from '../../src/service/scheduler';
 import {LayoutPriority} from '../../src/layout';
 import {READY_SCAN_SIGNAL} from '../../src/service/resources-interface';
+import {Scheduler} from '../../src/service/scheduler';
 import {createElementWithAttributes} from '../../src/dom';
 import {installIntersectionObserverStub} from '../../testing/intersection-observer-stub';
 

--- a/test/unit/test-scheduler.js
+++ b/test/unit/test-scheduler.js
@@ -15,18 +15,18 @@
  */
 
 import * as fakeTimers from '@sinonjs/fake-timers';
-import {Builder} from '../../src/service/builder';
+import {Scheduler} from '../../src/service/scheduler';
 import {LayoutPriority} from '../../src/layout';
 import {READY_SCAN_SIGNAL} from '../../src/service/resources-interface';
 import {createElementWithAttributes} from '../../src/dom';
 import {installIntersectionObserverStub} from '../../testing/intersection-observer-stub';
 
-describes.realWin('Builder', {amp: true}, (env) => {
+describes.realWin('Scheduler', {amp: true}, (env) => {
   let win, doc, ampdoc;
   let setAmpdocReady;
   let clock;
   let intersectionObserverStub;
-  let builder;
+  let scheduler;
 
   beforeEach(() => {
     win = env.win;
@@ -57,7 +57,7 @@ describes.realWin('Builder', {amp: true}, (env) => {
       win
     );
 
-    builder = new Builder(ampdoc);
+    scheduler = new Scheduler(ampdoc);
   });
 
   afterEach(() => {
@@ -70,29 +70,29 @@ describes.realWin('Builder', {amp: true}, (env) => {
     element.prerenderAllowed = () => options.prerenderAllowed || false;
     element.getBuildPriority = () =>
       options.buildPriority || LayoutPriority.CONTENT;
-    element.buildInternal = env.sandbox.stub();
+    element.mountInternal = env.sandbox.stub();
     return element;
   }
 
   describe('schedule', () => {
     it('should schedule a deferredBuild element', () => {
       const element = createAmpElement({deferredBuild: true});
-      builder.schedule(element);
+      scheduler.schedule(element);
       expect(intersectionObserverStub.isObserved(element)).to.be.true;
 
-      builder.unschedule(element);
+      scheduler.unschedule(element);
       expect(intersectionObserverStub.isObserved(element)).to.be.false;
     });
 
     it('should schedule a non-deferredBuild element', () => {
       const element = createAmpElement({deferredBuild: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       expect(intersectionObserverStub.isObserved(element)).to.be.false;
     });
 
     it('should unschedule when built', async () => {
       const element = createAmpElement({deferredBuild: true});
-      builder.schedule(element);
+      scheduler.schedule(element);
       expect(intersectionObserverStub.isObserved(element)).to.be.true;
 
       await setAmpdocReady();
@@ -106,7 +106,7 @@ describes.realWin('Builder', {amp: true}, (env) => {
     it('should NOT signal READY_SCAN_SIGNAL until document is ready', async () => {
       ampdoc.signals().reset(READY_SCAN_SIGNAL);
       const element = createAmpElement({deferredBuild: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       expect(ampdoc.signals().get(READY_SCAN_SIGNAL)).to.be.null;
 
       clock.tick(50);
@@ -125,78 +125,78 @@ describes.realWin('Builder', {amp: true}, (env) => {
     it('should build when document ready', async () => {
       await setAmpdocReady();
       const element = createAmpElement({deferredBuild: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should build when document becomes ready', async () => {
       const element = createAmpElement({deferredBuild: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.not.called;
+      expect(element.mountInternal).to.be.not.called;
 
       await setAmpdocReady();
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should build asap when document ready', async () => {
       await setAmpdocReady();
       const element = createAmpElement({deferredBuild: true});
-      builder.scheduleAsap(element);
+      scheduler.scheduleAsap(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should build asap when document becomes ready', async () => {
       const element = createAmpElement({deferredBuild: true});
-      builder.scheduleAsap(element);
+      scheduler.scheduleAsap(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.not.called;
+      expect(element.mountInternal).to.be.not.called;
 
       await setAmpdocReady();
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should build when has next siblings', async () => {
       const element = createAmpElement({deferredBuild: false});
       doc.body.appendChild(element);
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       const element2 = createAmpElement({deferredBuild: false});
       doc.body.appendChild(element2);
-      builder.schedule(element2);
+      scheduler.schedule(element2);
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
-      expect(element2.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.be.calledOnce;
+      expect(element2.mountInternal).to.not.be.called;
     });
 
     it('should build asap when has next siblings', async () => {
       const element = createAmpElement({deferredBuild: false});
       doc.body.appendChild(element);
-      builder.scheduleAsap(element);
+      scheduler.scheduleAsap(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       const element2 = createAmpElement({deferredBuild: false});
       doc.body.appendChild(element2);
-      builder.scheduleAsap(element2);
+      scheduler.scheduleAsap(element2);
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
-      expect(element2.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.be.calledOnce;
+      expect(element2.mountInternal).to.not.be.called;
     });
 
     it('should wait the deferred even when parsed', async () => {
       await setAmpdocReady();
       const element = createAmpElement({deferredBuild: true});
       doc.body.appendChild(element);
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
     });
   });
 
@@ -211,9 +211,9 @@ describes.realWin('Builder', {amp: true}, (env) => {
         deferredBuild: false,
         prerenderAllowed: true,
       });
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should build asap if prerenderAllowed', () => {
@@ -221,9 +221,9 @@ describes.realWin('Builder', {amp: true}, (env) => {
         deferredBuild: true,
         prerenderAllowed: true,
       });
-      builder.scheduleAsap(element);
+      scheduler.scheduleAsap(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should NOT build if not prerenderAllowed', () => {
@@ -231,9 +231,9 @@ describes.realWin('Builder', {amp: true}, (env) => {
         deferredBuild: false,
         prerenderAllowed: false,
       });
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.not.called;
+      expect(element.mountInternal).to.be.not.called;
     });
 
     it('should NOT build asap if not prerenderAllowed', () => {
@@ -241,72 +241,72 @@ describes.realWin('Builder', {amp: true}, (env) => {
         deferredBuild: true,
         prerenderAllowed: false,
       });
-      builder.scheduleAsap(element);
+      scheduler.scheduleAsap(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.not.called;
+      expect(element.mountInternal).to.be.not.called;
     });
 
     it('should build when becomes visible', () => {
       const element = createAmpElement({prerenderAllowed: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       ampdoc.overrideVisibilityState('visible');
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should build when becomes hidden', () => {
       const element = createAmpElement({prerenderAllowed: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       ampdoc.overrideVisibilityState('hidden');
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should NOT build when becomes paused or inactive', () => {
       const element = createAmpElement({prerenderAllowed: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       ampdoc.overrideVisibilityState('paused');
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       ampdoc.overrideVisibilityState('inactive');
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
     });
 
     it('should NOT build when scheduled in paused', () => {
       ampdoc.overrideVisibilityState('paused');
 
       const element = createAmpElement({prerenderAllowed: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       ampdoc.overrideVisibilityState('visible');
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should NOT build when scheduled in inactive', () => {
       ampdoc.overrideVisibilityState('inactive');
 
       const element = createAmpElement({prerenderAllowed: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       ampdoc.overrideVisibilityState('visible');
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
   });
 
@@ -317,40 +317,40 @@ describes.realWin('Builder', {amp: true}, (env) => {
 
     it('should wait for intersection when deferred', () => {
       const element = createAmpElement({deferredBuild: true});
-      builder.schedule(element);
+      scheduler.schedule(element);
       expect(intersectionObserverStub.isObserved(element)).to.be.true;
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       intersectionObserverStub.notifySync({
         target: element,
         isIntersecting: false,
       });
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       intersectionObserverStub.notifySync({
         target: element,
         isIntersecting: true,
       });
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should not wait for intersection when not deferred', () => {
       const element = createAmpElement({deferredBuild: false});
-      builder.schedule(element);
+      scheduler.schedule(element);
       expect(intersectionObserverStub.isObserved(element)).to.be.false;
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should not wait for intersection when asap', () => {
       const element = createAmpElement({deferredBuild: true});
-      builder.scheduleAsap(element);
+      scheduler.scheduleAsap(element);
       expect(intersectionObserverStub.isObserved(element)).to.be.false;
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
   });
 
@@ -361,13 +361,13 @@ describes.realWin('Builder', {amp: true}, (env) => {
 
     it('should run deferred CONTENT at high priority', () => {
       const element = createAmpElement({deferredBuild: true});
-      builder.schedule(element);
+      scheduler.schedule(element);
       intersectionObserverStub.notifySync({
         target: element,
         isIntersecting: true,
       });
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should run deferred METADATA at low priority', () => {
@@ -375,16 +375,16 @@ describes.realWin('Builder', {amp: true}, (env) => {
         deferredBuild: true,
         buildPriority: LayoutPriority.METADATA,
       });
-      builder.schedule(element);
+      scheduler.schedule(element);
       intersectionObserverStub.notifySync({
         target: element,
         isIntersecting: true,
       });
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       clock.tick(100);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should run non-deferred METADATA at low priority', () => {
@@ -392,12 +392,12 @@ describes.realWin('Builder', {amp: true}, (env) => {
         deferredBuild: false,
         buildPriority: LayoutPriority.METADATA,
       });
-      builder.schedule(element);
+      scheduler.schedule(element);
       clock.tick(1);
-      expect(element.buildInternal).to.not.be.called;
+      expect(element.mountInternal).to.not.be.called;
 
       clock.tick(100);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
 
     it('should run asap METADATA at high priority', () => {
@@ -405,9 +405,9 @@ describes.realWin('Builder', {amp: true}, (env) => {
         deferredBuild: false,
         buildPriority: LayoutPriority.METADATA,
       });
-      builder.scheduleAsap(element);
+      scheduler.scheduleAsap(element);
       clock.tick(1);
-      expect(element.buildInternal).to.be.calledOnce;
+      expect(element.mountInternal).to.be.calledOnce;
     });
   });
 });

--- a/testing/element-v1.js
+++ b/testing/element-v1.js
@@ -70,6 +70,15 @@ const RULES = [
       return !hasCallback;
     },
   },
+  {
+    name: 'Must not have resumeCallback',
+    test: (implClass) => {
+      const hasCallback =
+        implClass.prototype.resumeCallback !==
+        BaseElement.prototype.resumeCallback;
+      return !hasCallback;
+    },
+  },
 
   {
     name: 'If load==true, must also have ensureLoaded',

--- a/testing/element-v1.js
+++ b/testing/element-v1.js
@@ -29,7 +29,8 @@ const RULES = [
   },
 
   {
-    name: 'If has getLayoutPriority, must also have getBuildPriority',
+    name: 'Must not have getLayoutPriority',
+    notes: 'Can be replaced with getBuildPriority',
     test: (implClass) => {
       const hasLayoutPriority =
         implClass.prototype.getLayoutPriority !==
@@ -39,28 +40,44 @@ const RULES = [
       return !hasLayoutPriority || hasBuildPriority;
     },
   },
-
   {
-    name: 'If has preconnectCallback, must also have getPreconnects',
+    name: 'Must not have preconnectCallback',
+    notes: 'Can be replaced with getPreconnects',
     test: (implClass) => {
-      const hasPreconnectCallback =
+      const hasCallback =
         implClass.prototype.preconnectCallback !==
         BaseElement.prototype.preconnectCallback;
-      const hasGetPreconnects =
-        implClass.getPreconnects !== BaseElement.getPreconnects;
-      return !hasPreconnectCallback || hasGetPreconnects;
+      return !hasCallback;
+    },
+  },
+  {
+    name: 'Must not have layoutCallback',
+    notes: 'Can be replaced with mountCallback',
+    test: (implClass) => {
+      const hasCallback =
+        implClass.prototype.layoutCallback !==
+        BaseElement.prototype.layoutCallback;
+      return !hasCallback;
+    },
+  },
+  {
+    name: 'Must not have unlayoutCallback',
+    notes: 'Can be replaced with unmountCallback',
+    test: (implClass) => {
+      const hasCallback =
+        implClass.prototype.unlayoutCallback !==
+        BaseElement.prototype.unlayoutCallback;
+      return !hasCallback;
     },
   },
 
   {
-    name: 'If has layoutCallback, must also have ensureLoaded',
+    name: 'If load==true, must also have ensureLoaded',
     test: (implClass) => {
-      const hasLayoutCallback =
-        implClass.prototype.layoutCallback !==
-        BaseElement.prototype.layoutCallback;
+      const load = implClass.load();
       const hasEnsureLoaded =
         implClass.prototype.ensureLoaded !== BaseElement.prototype.ensureLoaded;
-      return !hasLayoutCallback || hasEnsureLoaded;
+      return !load || hasEnsureLoaded;
     },
   },
 
@@ -114,11 +131,11 @@ const RULES = [
  */
 export function testElementV1(implClass, options = {}) {
   const exceptions = options.exceptions || [];
-  RULES.forEach(({name, test}) => {
+  RULES.forEach(({name, notes, test}) => {
     if (exceptions.includes(name)) {
       expect(test(implClass), 'unused exception: ' + name).to.be.false;
     } else {
-      expect(test(implClass), name).to.be.true;
+      expect(test(implClass), name + (notes ? `. ${notes}` : '')).to.be.true;
     }
   });
 }

--- a/testing/element-v1.js
+++ b/testing/element-v1.js
@@ -74,7 +74,7 @@ const RULES = [
   {
     name: 'If load==true, must also have ensureLoaded',
     test: (implClass) => {
-      const load = implClass.load();
+      const load = implClass.usesLoading();
       const hasEnsureLoaded =
         implClass.prototype.ensureLoaded !== BaseElement.prototype.ensureLoaded;
       return !load || hasEnsureLoaded;


### PR DESCRIPTION
Partial for #31915.
Partial for #31540.

Key changes:
* The `mount/unmount` callbacks are added to a V1 element API. They are called automatically on first build, attach/detach from DOM, manual unmount, etc. They are similar to `layout/unlayout` callbacks, but meant to be executed with build and more "like build, but reversible".
* Builder now calls `mountInternal()` on an element. Consequently it's renamed to `Scheduler`.
* `BaseElement.load()` is added to make build->load states a little less fragile.
* The `layoutCallback`, `unlayoutCallback`, `pauseCallback`, and `resumeCallback` in the `CustomElement` have been deprecated.

TODO:
- [ ] Complete the remaining tests
