### PR TITLE
V1: allow lightbox to add its own intersection observer to the scheduler

### DIFF
--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -41,6 +41,7 @@ import {htmlFor} from '../../../src/static-template';
 import {isInFie} from '../../../src/iframe-helper';
 import {toArray} from '../../../src/types';
 import {tryFocus} from '../../../src/dom';
+import {unmountAll} from '../../../src/utils/resource-container-helper';
 
 /** @const {string} */
 const TAG = 'amp-lightbox';
@@ -391,6 +392,8 @@ class AmpLightbox extends AMP.BaseElement {
     element.addEventListener('transitionend', onAnimationEnd);
     element.addEventListener('animationend', onAnimationEnd);
 
+    this.setAsContainer();
+
     // TODO: instead of laying out children all at once, layout children based
     // on visibility.
     const owners = Services.ownersForDoc(this.element);
@@ -615,6 +618,12 @@ class AmpLightbox extends AMP.BaseElement {
     this.boundFocusin_ = null;
 
     this.untieCloseButton_();
+
+    this.removeAsContainer();
+
+    // Unmount all children when the lightbox is closed. They will automatically
+    // remount when the lightbox is opened again.
+    unmountAll(this.element);
 
     Services.ownersForDoc(this.element).schedulePause(
       this.element,

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -468,7 +468,7 @@ export class BaseElement {
    * inside a non-document scroller and this method instructs the scheduler
    * to also use the `IntersectionObserver` corresponding to the container.
    *
-   * @param {!Element} opt_scroller A child of the container that should be
+   * @param {!Element=} opt_scroller A child of the container that should be
    * monitored. Typically a scrollable element.
    */
   setAsContainer(opt_scroller) {

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -461,6 +461,28 @@ export class BaseElement {
   }
 
   /**
+   * Set itself as a container element that can be monitored by the scheduler
+   * for auto-mounting. Scheduler is used for V1 elements. A container is
+   * usually a top-level scrollable overlay such as a lightbox or a sidebar.
+   * The main scheduler (`IntersectionObserver`) cannot properly handle elements
+   * inside a non-document scroller and this method instructs the scheduler
+   * to also use the `IntersectionObserver` corresponding to the container.
+   *
+   * @param {!Element} opt_scroller A child of the container that should be
+   * monitored. Typically a scrollable element.
+   */
+  setAsContainer(opt_scroller) {
+    this.element.setAsContainerInternal(opt_scroller);
+  }
+
+  /**
+   * Removes itself as a container. See `setAsContainer`.
+   */
+  removeAsContainer() {
+    this.element.removeAsContainerInternal();
+  }
+
+  /**
    * Subclasses can override this method to indicate that it is has
    * render-blocking service.
    *

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -810,6 +810,30 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     }
 
     /**
+     * See `BaseElement.setAsContainer`.
+     *
+     * @param {!Element} opt_scroller A child of the container that should be
+     * monitored. Typically a scrollable element.
+     * @restricted
+     * @final
+     */
+    setAsContainerInternal(opt_scroller) {
+      devAssert(!opt_scroller || this.contains(opt_scroller));
+      const builder = getSchedulerForDoc(this.getAmpDoc());
+      builder.setContainer(this, opt_scroller);
+    }
+
+    /**
+     * See `BaseElement.removeAsContainer`.
+     * @restricted
+     * @final
+     */
+    removeAsContainerInternal() {
+      const builder = getSchedulerForDoc(this.getAmpDoc());
+      builder.removeContainer(this);
+    }
+
+    /**
      * Update the internal ready state.
      *
      * @param {!ReadyState} state

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -812,13 +812,12 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     /**
      * See `BaseElement.setAsContainer`.
      *
-     * @param {!Element} opt_scroller A child of the container that should be
+     * @param {!Element=} opt_scroller A child of the container that should be
      * monitored. Typically a scrollable element.
      * @restricted
      * @final
      */
     setAsContainerInternal(opt_scroller) {
-      devAssert(!opt_scroller || this.contains(opt_scroller));
       const builder = getSchedulerForDoc(this.getAmpDoc());
       builder.setContainer(this, opt_scroller);
     }

--- a/src/dom.js
+++ b/src/dom.js
@@ -980,3 +980,14 @@ export function dispatchCustomEvent(node, name, opt_data, opt_options) {
   event.initEvent(name, bubbles, cancelable);
   node.dispatchEvent(event);
 }
+
+/**
+ * Ensures the child is contained by the parent, but not the parent itself.
+ *
+ * @param {!Node} parent
+ * @param {!Node} child
+ * @return {boolean}
+ */
+export function containsNotSelf(parent, child) {
+  return child !== parent && parent.contains(child);
+}

--- a/src/service/scheduler.js
+++ b/src/service/scheduler.js
@@ -18,6 +18,7 @@ import {LayoutPriority} from '../layout';
 import {READY_SCAN_SIGNAL} from './resources-interface';
 import {VisibilityState} from '../visibility-state';
 import {containsNotSelf, hasNextNodeInDocumentOrder, isIframed} from '../dom';
+import {devAssert} from '../log';
 import {getServiceForDoc, registerServiceBuilderForDoc} from '../service';
 import {removeItem} from '../utils/array';
 
@@ -134,6 +135,7 @@ export class Scheduler {
    * @param {!Element=} opt_scroller
    */
   setContainer(container, opt_scroller) {
+    devAssert(!opt_scroller || container.contains(opt_scroller));
     if (this.containerMap_.has(container)) {
       return;
     }

--- a/src/service/scheduler.js
+++ b/src/service/scheduler.js
@@ -17,11 +17,13 @@
 import {LayoutPriority} from '../layout';
 import {READY_SCAN_SIGNAL} from './resources-interface';
 import {VisibilityState} from '../visibility-state';
+import {containsNotSelf, hasNextNodeInDocumentOrder, isIframed} from '../dom';
 import {getServiceForDoc, registerServiceBuilderForDoc} from '../service';
-import {hasNextNodeInDocumentOrder, isIframed} from '../dom';
 import {removeItem} from '../utils/array';
 
 const ID = 'scheduler';
+
+const ROOT_MARGIN = '250% 31.25%';
 
 /** @implements {../service.Disposable} */
 export class Scheduler {
@@ -37,9 +39,11 @@ export class Scheduler {
       // Root bounds are not important, so we can use the `root:null` for a
       // top-level window.
       root: isIframed(win) ? win.document : null,
-      rootMargin: '250% 31.25%',
-      threshold: 0.001,
+      rootMargin: ROOT_MARGIN,
     });
+
+    /** @private @const {!Map<!Element, !IntersectionObserver>} */
+    this.containerMap_ = new Map();
 
     /** @private @const {!Map<!AmpElement, {asap: boolean, isIntersecting: boolean}>} */
     this.targets_ = new Map();
@@ -85,6 +89,13 @@ export class Scheduler {
     if (target.deferredBuild()) {
       this.targets_.set(target, {asap: false, isIntersecting: false});
       this.observer_.observe(target);
+      if (this.containerMap_.size > 0) {
+        this.containerMap_.forEach((observer, container) => {
+          if (containsNotSelf(container, target)) {
+            observer.observe(target);
+          }
+        });
+      }
     } else {
       this.targets_.set(target, {asap: false, isIntersecting: true});
     }
@@ -103,11 +114,62 @@ export class Scheduler {
     this.targets_.delete(target);
 
     this.observer_.unobserve(target);
+    if (this.containerMap_.size > 0) {
+      this.containerMap_.forEach((observer) => {
+        observer.unobserve(target);
+      });
+    }
 
     if (this.parsingTargets_) {
       removeItem(this.parsingTargets_, target);
       this.checkParsing_();
     }
+  }
+
+  /**
+   * Adds the observer for the specified container. The first observer to
+   * find an intersection will trigger the element's mount.
+   *
+   * @param {!Element} container
+   * @param {!Element=} opt_scroller
+   */
+  setContainer(container, opt_scroller) {
+    if (this.containerMap_.has(container)) {
+      return;
+    }
+
+    // Create observer.
+    const {win} = this.ampdoc_;
+    const observer = new win.IntersectionObserver((e) => this.observed_(e), {
+      root: opt_scroller || container,
+      rootMargin: ROOT_MARGIN,
+    });
+    this.containerMap_.set(container, observer);
+
+    // Subscribe all pending children. Ignore `asap` targets since they
+    // will be scheduled immediately and do not need an intersection
+    // observer input.
+    this.targets_.forEach(({asap}, target) => {
+      if (!asap && containsNotSelf(container, target)) {
+        observer.observe(target);
+      }
+    });
+  }
+
+  /**
+   * Removes the container and its observer that were set by the `setContainer`.
+   *
+   * @param {!Element} container
+   */
+  removeContainer(container) {
+    const observer = this.containerMap_.get(container);
+    if (!observer) {
+      return;
+    }
+
+    // Disconnect. All children will be unobserved automatically.
+    observer.disconnect();
+    this.containerMap_.delete(container);
   }
 
   /** @private*/
@@ -180,14 +242,17 @@ export class Scheduler {
    */
   observed_(entries) {
     for (let i = 0; i < entries.length; i++) {
-      const {target, isIntersecting} = entries[i];
+      const {target, isIntersecting: isThisIntersecting} = entries[i];
 
       const current = this.targets_.get(target);
       if (!current) {
         continue;
       }
 
-      this.targets_.set(target, {asap: current.asap, isIntersecting});
+      const isIntersecting = isThisIntersecting || current.isIntersecting;
+      if (isIntersecting !== current.isIntersecting) {
+        this.targets_.set(target, {asap: current.asap, isIntersecting});
+      }
       if (isIntersecting) {
         this.maybeBuild_(target);
       }

--- a/src/utils/display-observer.js
+++ b/src/utils/display-observer.js
@@ -15,6 +15,7 @@
  */
 
 import {VisibilityState} from '../visibility-state';
+import {containsNotSelf} from '../dom';
 import {getServiceForDoc, registerServiceBuilderForDoc} from '../service';
 import {pushIfNotExist, removeItem} from './array';
 import {rethrowAsync} from '../log';
@@ -491,15 +492,6 @@ function findObserverByContainer(observers, container) {
     }
   }
   return -1;
-}
-
-/**
- * @param {!Element} container
- * @param {!Element} child
- * @return {boolean}
- */
-function containsNotSelf(container, child) {
-  return child !== container && container.contains(child);
 }
 
 /**

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -934,6 +934,42 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
     });
   });
 
+  describe('setAsContainerInternal', () => {
+    let element, scroller, impl;
+
+    beforeEach(async () => {
+      builderMock.expects('schedule').atLeast(0);
+
+      element = new ElementClass();
+      doc.body.appendChild(element);
+      impl = await element.getImpl();
+
+      scroller = doc.createElement('div');
+      element.appendChild(scroller);
+    });
+
+    it('should propagate setAsContainerInternal without scroller', () => {
+      builderMock
+        .expects('setContainer')
+        .withExactArgs(element, undefined)
+        .once();
+      impl.setAsContainer();
+    });
+
+    it('should propagate setAsContainerInternal with scroller', () => {
+      builderMock
+        .expects('setContainer')
+        .withExactArgs(element, scroller)
+        .once();
+      impl.setAsContainer(scroller);
+    });
+
+    it('should propagate removeAsContainerInternal', () => {
+      builderMock.expects('removeContainer').withExactArgs(element).once();
+      impl.removeAsContainer();
+    });
+  });
+
   describe('setReadyStateInternal', () => {
     let element;
 

--- a/test/unit/test-dom.js
+++ b/test/unit/test-dom.js
@@ -1197,6 +1197,26 @@ describes.sandboxed('DOM', {}, (env) => {
     }
   );
 
+  it('should implement containsNotSelf', () => {
+    const parent = document.createElement('div');
+    const child = document.createElement('div');
+    const uncle = document.createElement('div');
+    const grandparent = document.createElement('div');
+    grandparent.appendChild(parent);
+    grandparent.appendChild(uncle);
+    parent.appendChild(child);
+
+    expect(dom.containsNotSelf(grandparent, grandparent)).to.be.false;
+    expect(dom.containsNotSelf(grandparent, parent)).to.be.true;
+    expect(dom.containsNotSelf(grandparent, uncle)).to.be.true;
+    expect(dom.containsNotSelf(grandparent, child)).to.be.true;
+
+    expect(dom.containsNotSelf(parent, parent)).to.be.false;
+    expect(dom.containsNotSelf(parent, uncle)).to.be.false;
+    expect(dom.containsNotSelf(parent, grandparent)).to.be.false;
+    expect(dom.containsNotSelf(parent, child)).to.be.true;
+  });
+
   describe('domOrderComparator', () => {
     it('should sort elements by dom order', () => {
       //

--- a/testing/intersection-observer-stub.js
+++ b/testing/intersection-observer-stub.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {areEqualOrdered} from '../src/utils/array';
+
 /**
  * @param {!Object} sandbox
  * @param {!Window} window
@@ -32,33 +34,51 @@ class IntersectionObservers {
     const observers = new Set();
     this.observers = observers;
 
-    sandbox.stub(win, 'IntersectionObserver').value(function (callback) {
-      const observer = new IntersectionObserverStub(callback, () => {
-        observers.delete(observer);
+    sandbox
+      .stub(win, 'IntersectionObserver')
+      .value(function (callback, options) {
+        const observer = new IntersectionObserverStub(callback, options, () => {
+          observers.delete(observer);
+        });
+        observers.add(observer);
+        return observer;
       });
-      observers.add(observer);
-      return observer;
-    });
   }
 
   /**
    * @param {!Element} target
+   * @param {{
+   *   root: (!Document|!Element|undefined),
+   *   rootMargin: (string|undefined),
+   *   thresholds: (number|!Array<number>|undefined),
+   * }=} options
    * @return {boolean}
    */
-  isObserved(target) {
-    return Array.from(this.observers).some((observer) =>
-      observer.elements.has(target)
-    );
+  isObserved(target, options = {}) {
+    return Array.from(this.observers).some((observer) => {
+      if (!observer.elements.has(target)) {
+        return false;
+      }
+      return matchesObserver(observer, options);
+    });
   }
 
   /**
    * @param {!IntersectionObserverEntry|!Array<IntersectionObserverEntry>} entryOrEntries
+   * @param {{
+   *   root: (!Document|!Element|undefined),
+   *   rootMargin: (string|undefined),
+   *   thresholds: (number|!Array<number>|undefined),
+   * }=} options
    */
-  notifySync(entryOrEntries) {
+  notifySync(entryOrEntries, options = {}) {
     const entries = Array.isArray(entryOrEntries)
       ? entryOrEntries
       : [entryOrEntries];
     this.observers.forEach((observer) => {
+      if (!matchesObserver(observer, options)) {
+        return;
+      }
       const subEntries = entries.filter(({target}) =>
         observer.elements.has(target)
       );
@@ -70,10 +90,16 @@ class IntersectionObservers {
 }
 
 class IntersectionObserverStub {
-  constructor(callback, onDisconnect) {
+  constructor(callback, options, onDisconnect) {
     this.onDisconnect_ = onDisconnect;
     this.callback = callback;
     this.elements = new Set();
+
+    options = options || {};
+    this.root = options.root || null;
+    this.rootMargin = options.rootMargin || '0px';
+    this.thresholds =
+      options.threshold != null ? [].concat(options.threshold) : [0];
   }
 
   disconnect() {
@@ -94,4 +120,22 @@ class IntersectionObserverStub {
   unobserve(element) {
     this.elements.delete(element);
   }
+}
+
+/**
+ * @param {!IntersectionObserverStub} observer
+ * @param {{
+ *   root: (!Document|!Element|undefined),
+ *   rootMargin: (string|undefined),
+ *   thresholds: (number|!Array<number>|undefined),
+ * }} options
+ */
+function matchesObserver(observer, options) {
+  const {root, rootMargin, thresholds} = options;
+  return (
+    (root === undefined || root == observer.root) &&
+    (rootMargin === undefined || rootMargin == observer.rootMargin) &&
+    (thresholds === undefined ||
+      areEqualOrdered(thresholds, observer.thresholds))
+  );
 }


### PR DESCRIPTION
Partial for #31915.
Partial for #31540.

Key changes:
* A container element, such as `amp-lightbox` can contribute its own intersection observer to the scheduler.
* `unmountAll` is used from the new `resources-container-helper.js`.

TODO:
- [x] Rebase on https://github.com/ampproject/amphtml/pull/33272
- [x] Rebase on https://github.com/ampproject/amphtml/pull/33450 (new `resource-container-helper.js`)
- [x] Tests
