### PR TITLE
Multi-version: declare the installed extension as soon as possible

### DIFF
--- a/src/service/extensions-impl.js
+++ b/src/service/extensions-impl.js
@@ -227,6 +227,7 @@ export class Extensions {
     if (extLoaders[extensionId]) {
       return extLoaders[extensionId];
     }
+    ampdoc.declareExtension(extensionId, version);
     stubElementIfNotKnown(ampdoc.win, extensionId);
     return (extLoaders[extensionId] = this.preloadExtension(
       extensionId,

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -1324,6 +1324,10 @@ describes.sandboxed('Extensions', {}, () => {
         ).to.have.length(0);
         expect(extensions.extensions_['amp-test']).to.be.undefined;
         extensions.installExtensionForDoc(ampdoc, 'amp-test', '0.2');
+
+        // Extension is declared immediately.
+        expect(ampdoc.declaresExtension('amp-test', '0.2')).to.be.true;
+
         expect(loadSpy).to.be.calledOnce;
         expect(loadSpy).to.be.calledWithExactly('amp-test', '0.2');
         expect(
@@ -1366,7 +1370,7 @@ describes.sandboxed('Extensions', {}, () => {
         const promise = extensions.installExtensionForDoc(ampdoc, 'amp-test');
 
         // Extension is declared immediately.
-        expect(ampdoc.declaresExtension('amp-test')).to.be.true;
+        expect(ampdoc.declaresExtension('amp-test', '0.1')).to.be.true;
 
         // Stubbed immediately.
         expect(win.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
@@ -1437,7 +1441,7 @@ describes.sandboxed('Extensions', {}, () => {
         const promise = extensions.installExtensionForDoc(ampdoc, 'amp-test');
 
         // Extension is declared immediately.
-        expect(ampdoc.declaresExtension('amp-test')).to.be.true;
+        expect(ampdoc.declaresExtension('amp-test', '0.1')).to.be.true;
 
         // Services do not exist yet.
         allowConsoleError(() => {

--- a/test/unit/test-extensions.js
+++ b/test/unit/test-extensions.js
@@ -1364,7 +1364,9 @@ describes.sandboxed('Extensions', {}, () => {
         extHolder.scriptPresent = true;
         expect(ampdoc.declaresExtension('amp-test')).to.be.false;
         const promise = extensions.installExtensionForDoc(ampdoc, 'amp-test');
-        expect(ampdoc.declaresExtension('amp-test')).to.be.false;
+
+        // Extension is declared immediately.
+        expect(ampdoc.declaresExtension('amp-test')).to.be.true;
 
         // Stubbed immediately.
         expect(win.__AMP_EXTENDED_ELEMENTS['amp-test']).to.equal(ElementStub);
@@ -1433,7 +1435,9 @@ describes.sandboxed('Extensions', {}, () => {
         extHolder.scriptPresent = true;
         expect(ampdoc.declaresExtension('amp-test')).to.be.false;
         const promise = extensions.installExtensionForDoc(ampdoc, 'amp-test');
-        expect(ampdoc.declaresExtension('amp-test')).to.be.false;
+
+        // Extension is declared immediately.
+        expect(ampdoc.declaresExtension('amp-test')).to.be.true;
 
         // Services do not exist yet.
         allowConsoleError(() => {


### PR DESCRIPTION
Partial for #33020.

This is a subtle change, but it's important for consistency. I couldn't find any good argument why we need to wait until the extension is loaded before declaring it. All other codepaths declare an extension before it's loaded.
