### PR TITLE
performance-impl: use fcp and ofv entryTime when summing for cls-fcp and cls-ofv

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -529,19 +529,16 @@ export class Performance {
     }, 0);
 
     if (this.shiftScoresTicked_ === 0) {
-      this.tickDelta(TickLabel.CUMULATIVE_LAYOUT_SHIFT, cls);
+      this.tick(TickLabel.CUMULATIVE_LAYOUT_SHIFT_BEFORE_VISIBLE, clsBeforeOFV);
       this.tickDelta(
         TickLabel.CUMULATIVE_LAYOUT_SHIFT_BEFORE_FCP,
         clsBeforeFCP
       );
-      this.tick(TickLabel.CUMULATIVE_LAYOUT_SHIFT_BEFORE_VISIBLE, clsBeforeOFV);
+      this.tickDelta(TickLabel.CUMULATIVE_LAYOUT_SHIFT, cls);
       this.flush();
       this.shiftScoresTicked_ = 1;
     } else if (this.shiftScoresTicked_ === 1) {
-      this.tickDelta(
-        TickLabel.CUMULATIVE_LAYOUT_SHIFT_2,
-        this.aggregateShiftScore_
-      );
+      this.tickDelta(TickLabel.CUMULATIVE_LAYOUT_SHIFT_2, cls);
       this.flush();
       this.shiftScoresTicked_ = 2;
 

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -511,8 +511,8 @@ export class Performance {
    */
   tickLayoutShiftScore_() {
     const cls = this.layoutShifts_.reduce((sum, entry) => sum + entry.value, 0);
-    const fcp = this.metrics_.get(TickLabel.FIRST_CONTENTFUL_PAINT) ?? Infinity;
-    const ofv = this.metrics_.get(TickLabel.ON_FIRST_VISIBLE) ?? Infinity;
+    const fcp = this.metrics_.get(TickLabel.FIRST_CONTENTFUL_PAINT) ?? 0; // fallback to 0, so that we never overcount.
+    const ofv = this.metrics_.get(TickLabel.ON_FIRST_VISIBLE) ?? 0;
 
     // TODO(#33207): Remove after data collection
     const clsBeforeFCP = this.layoutShifts_.reduce((sum, entry) => {

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -114,6 +114,18 @@ export class Performance {
      */
     this.aggregateShiftScore_ = 0;
 
+    /**
+     * TODO(#33207): Remove after data collection
+     * @private {number}
+     */
+    this.clsBeforeFCP_ = 0;
+
+    /**
+     * TODO(#33207): Remove after data collection
+     * @private {number}
+     */
+    this.clsBeforeOFV_ = 0;
+
     const supportedEntryTypes =
       (this.win.PerformanceObserver &&
         this.win.PerformanceObserver.supportedEntryTypes) ||
@@ -241,11 +253,7 @@ export class Performance {
 
     this.ampdoc_.whenFirstVisible().then(() => {
       this.tick(TickLabel.ON_FIRST_VISIBLE);
-      // TODO(#33207): Remove after data collection
-      this.tick(
-        TickLabel.CUMULATIVE_LAYOUT_SHIFT_BEFORE_VISIBLE,
-        this.aggregateShiftScore_
-      );
+      this.clsBeforeOFV_ = this.aggregateShiftScore_;
       this.flush();
     });
 
@@ -357,11 +365,7 @@ export class Performance {
         recordedFirstContentfulPaint = true;
 
         // TODO(#33207): remove after data collection
-        // On the first contentful paint, report cumulative CLS score
-        this.tickDelta(
-          TickLabel.CUMULATIVE_LAYOUT_SHIFT_BEFORE_FCP,
-          this.aggregateShiftScore_
-        );
+        this.clsBeforeFCP_ = this.aggregateShiftScore_;
       } else if (
         entry.entryType === 'first-input' &&
         !recordedFirstInputDelay
@@ -528,6 +532,14 @@ export class Performance {
       this.tickDelta(
         TickLabel.CUMULATIVE_LAYOUT_SHIFT,
         this.aggregateShiftScore_
+      );
+      this.tickDelta(
+        TickLabel.CUMULATIVE_LAYOUT_SHIFT_BEFORE_FCP,
+        this.clsBeforeFCP_
+      );
+      this.tick(
+        TickLabel.CUMULATIVE_LAYOUT_SHIFT_BEFORE_VISIBLE,
+        this.clsBeforeOFV_
       );
       this.flush();
       this.shiftScoresTicked_ = 1;

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -358,7 +358,8 @@ export class Performance {
       } else if (entry.entryType === 'layout-shift') {
         // Ignore layout shift that occurs within 500ms of user input, as it is
         // likely in response to the user's action.
-        if (!entry.hadRecentInput) {
+        // 1000 here is a magic number to prevent unbounded growth. We don't expect it to be reached.
+        if (!entry.hadRecentInput && this.layoutShifts_.length < 1000) {
           this.layoutShifts_.push(entry);
         }
       } else if (entry.entryType === 'largest-contentful-paint') {


### PR DESCRIPTION
**summary**
- All CLS-related events are emitted within the same `flush()`, at the time when CLS would normally be emitted.
- `cls-fcp` and `cls-ofv` now use the corresponding entryTime for knowing which layout-shifts to include, as opposed to assuming they were invoked synchronously after the corresponding event.
- In order to accomplish both items above, we now collect all the layout shift events into an array instead of summing as we go. I've added a limit of 1000 entries so that it can't have unbounded growth.