### PR TITLE
FirstImpression.io amp-auto-ads: more debug parameters values options

### DIFF
--- a/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
+++ b/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
@@ -86,10 +86,10 @@ export class FirstImpressionIoConfig {
     if (targeting) {
       queryParams['targeting'] = targeting;
     }
-    if (fiReveal) {
+    if (fiReveal !== undefined) {
       queryParams['fi_reveal'] = fiReveal;
     }
-    if (fiDemand) {
+    if (fiDemand !== undefined) {
       queryParams['fi_demand'] = fiDemand;
     }
     if (fiGeo) {


### PR DESCRIPTION
Tweaks for FirstImpression.io amp-auto-ads network config to allow more debugging options (empty values, specifically)