### PR TITLE
🏗 Add support for minified lazy build + watch

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -431,6 +431,9 @@ async function compile(
       .sync(srcs)
       .map((src) => preClosureBabel(src, outputFilename, options))
   );
+  if (options.errored && options.continueOnError) {
+    return; // Watch build. Bail on transform errors.
+  }
   const flags = generateFlags(
     options,
     compilerOptions,
@@ -439,6 +442,9 @@ async function compile(
     sourcemapFile
   );
   await runClosure(outputFilename, options, flags, transformedSrcFiles);
+  if (options.errored && options.continueOnError) {
+    return; // Watch build. Bail on compilation errors.
+  }
   if (!options.typeCheckOnly) {
     if (!argv.pseudo_names && !options.skipUnknownDepsCheck) {
       await checkForUnknownDeps(destFile);

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -48,6 +48,18 @@ function getBabelCacheDir() {
 }
 
 /**
+ * Removes the transformed output of a file or a directory from the babel cache
+ * so it can be retransformed during a watch build.
+ * @param {string} fileOrDir
+ */
+function removeFromBabelCache(fileOrDir) {
+  const cachedPath = path.join(cacheDir, fileOrDir);
+  if (fs.existsSync(cachedPath)) {
+    fs.removeSync(cachedPath);
+  }
+}
+
+/**
  * Computes the set of files on which to run pre-closure babel transforms.
  *
  * @return {!Array<string>}
@@ -126,5 +138,6 @@ function handlePreClosureError(err, outputFilename, options) {
 
 module.exports = {
   getBabelCacheDir,
+  removeFromBabelCache,
   preClosureBabel,
 };

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const colors = require('kleur/colors');
+const argv = require('minimist')(process.argv.slice(2));
 const debounce = require('debounce');
 const fs = require('fs-extra');
 const path = require('path');
@@ -28,14 +28,13 @@ const {
 const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
 const {compileJison} = require('./compile-jison');
 const {endBuildStep, watchDebounceDelay, doBuildJs} = require('./helpers');
+const {green, red, cyan} = require('kleur/colors');
 const {isCiBuild} = require('../common/ci');
 const {jsifyCssAsync} = require('./css/jsify-css');
 const {log} = require('../common/logging');
 const {maybeToEsmName, compileJs, mkdirSync} = require('./helpers');
+const {removeFromBabelCache} = require('../compile/pre-closure-babel');
 const {watch} = require('chokidar');
-
-const {green, red, cyan} = colors;
-const argv = require('minimist')(process.argv.slice(2));
 
 /**
  * Extensions to build when `--extensions=inabox`.
@@ -377,15 +376,16 @@ async function doBuildExtension(extensions, extension, options) {
  * Watches the contents of an extension directory. When a file in the given path
  * changes, the extension is rebuilt.
  *
- * @param {string} path
+ * @param {string} extDir
  * @param {string} name
  * @param {string} version
  * @param {string} latestVersion
  * @param {boolean} hasCss
  * @param {?Object} options
  */
-function watchExtension(path, name, version, latestVersion, hasCss, options) {
+function watchExtension(extDir, name, version, latestVersion, hasCss, options) {
   const watchFunc = function () {
+    removeFromBabelCache(extDir);
     const bundleComplete = buildExtension(
       name,
       version,
@@ -397,7 +397,7 @@ function watchExtension(path, name, version, latestVersion, hasCss, options) {
       options.onWatchBuild(bundleComplete);
     }
   };
-  watch(`${path}/**/*`).on('change', debounce(watchFunc, watchDebounceDelay));
+  watch(`${extDir}/**/*`).on('change', debounce(watchFunc, watchDebounceDelay));
 }
 
 /**
@@ -467,13 +467,13 @@ async function buildExtension(
 }
 
 /**
- * @param {string} path
+ * @param {string} extDir
  * @param {string} name
  * @param {string} version
  * @param {!Object} options
  * @return {!Promise}
  */
-function buildExtensionCss(path, name, version, options) {
+function buildExtensionCss(extDir, name, version, options) {
   /**
    * Writes CSS binaries
    *
@@ -491,7 +491,7 @@ function buildExtensionCss(path, name, version, options) {
   const isAliased = aliasBundle && aliasBundle.version == version;
 
   const promises = [];
-  const mainCssBinary = jsifyCssAsync(path + '/' + name + '.css').then(
+  const mainCssBinary = jsifyCssAsync(extDir + '/' + name + '.css').then(
     (mainCss) => {
       writeCssBinaries(`${name}-${version}.css`, mainCss);
       if (isAliased) {
@@ -504,7 +504,7 @@ function buildExtensionCss(path, name, version, options) {
     promises.push.apply(
       promises,
       options.cssBinaries.map(function (name) {
-        return jsifyCssAsync(`${path}/${name}.css`).then((css) => {
+        return jsifyCssAsync(`${extDir}/${name}.css`).then((css) => {
           writeCssBinaries(`${name}-${version}.css`, css);
           if (isAliased) {
             writeCssBinaries(`${name}-${aliasBundle.aliasedVersion}.css`, css);
@@ -520,7 +520,7 @@ function buildExtensionCss(path, name, version, options) {
 /**
  * Build the JavaScript for the extension specified
  *
- * @param {string} path Path to the extensions directory
+ * @param {string} extDir Path to the extension's directory
  * @param {string} name Name of the extension. Must be the sub directory in
  *     the extensions directory and the name of the JS and optional CSS file.
  * @param {string} version Version of the extension. Must be identical to
@@ -529,11 +529,11 @@ function buildExtensionCss(path, name, version, options) {
  * @param {!Object} options
  * @return {!Promise}
  */
-async function buildExtensionJs(path, name, version, latestVersion, options) {
+async function buildExtensionJs(extDir, name, version, latestVersion, options) {
   const filename = options.filename || name + '.js';
   const latest = version === latestVersion;
   await compileJs(
-    path + '/',
+    extDir + '/',
     filename,
     './dist/v0',
     Object.assign(options, {


### PR DESCRIPTION
Now that our closure compilation code has been refactored, it's time to make sure incremental minified watch builds work.

**PR Highlights:**
- Add `removeFromBabelCache()` to delete files / dirs from the local pre-closure babel cache directory
- Call it wherever minified watch builds are triggered so babel transforms are re-run on modified files
- Add missing `continueOnError: true` to `watchFunc()` in `compileCoreRuntime()`
- If transformation / compilation fails during a watch build, early-exit from `compile()`
- Bonus cleanup: Rename extension directory variable in `extension-helpers.js` from `path` to `extDir`

**Usage:**
1. Run `gulp --compiled`
2. Go to `http://localhost:8000` and load a test page
3. When a JS file / extension is edited, old results are removed from the babel cache and code is retransformed + recompiled

**Screenshot:**

![image](https://user-images.githubusercontent.com/26553114/111376705-2fbb5080-8676-11eb-97df-0e2b03fb5260.png)
