### PR TITLE
performance-impl: exclusively use ampdoc visibility state

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -460,7 +460,10 @@ export class Performance {
    */
   onAmpDocVisibilityChange_() {
     const state = this.ampdoc_.getVisibilityState();
-    if (state === VisibilityState.INACTIVE || VisibilityState.HIDDEN) {
+    if (
+      state === VisibilityState.INACTIVE ||
+      state === VisibilityState.HIDDEN
+    ) {
       this.tickCumulativeMetrics_();
     }
   }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -36,9 +36,6 @@ import {whenDocumentComplete, whenDocumentReady} from '../document-ready';
  */
 const QUEUE_LIMIT = 50;
 
-/** @const {string} */
-const VISIBILITY_CHANGE_EVENT = 'visibilitychange';
-
 const TAG = 'Performance';
 
 /**
@@ -194,7 +191,6 @@ export class Performance {
      */
     this.largestContentfulPaintRenderTime_ = null;
 
-    this.boundOnVisibilityChange_ = this.onVisibilityChange_.bind(this);
     this.onAmpDocVisibilityChange_ = this.onAmpDocVisibilityChange_.bind(this);
 
     // Add RTV version as experiment ID, so we can slice the data by version.
@@ -247,12 +243,6 @@ export class Performance {
     // Register a handler to record metrics when the page enters the hidden
     // lifecycle state.
     if (registerVisibilityChangeListener) {
-      this.win.addEventListener(
-        VISIBILITY_CHANGE_EVENT,
-        this.boundOnVisibilityChange_,
-        {capture: true}
-      );
-
       this.ampdoc_.onVisibilityChanged(this.onAmpDocVisibilityChange_);
     }
 
@@ -464,23 +454,13 @@ export class Performance {
   }
 
   /**
-   * When the visibility state of the document changes to hidden,
-   * send the layout scores.
-   * @private
-   */
-  onVisibilityChange_() {
-    if (this.win.document.visibilityState === 'hidden') {
-      this.tickCumulativeMetrics_();
-    }
-  }
-
-  /**
-   * When the viewer visibility state of the document changes to inactive,
+   * When the viewer visibility state of the document changes to inactive or hidden,
    * send the layout score.
    * @private
    */
   onAmpDocVisibilityChange_() {
-    if (this.ampdoc_.getVisibilityState() === VisibilityState.INACTIVE) {
+    const state = this.ampdoc_.getVisibilityState();
+    if (state === VisibilityState.INACTIVE || VisibilityState.HIDDEN) {
       this.tickCumulativeMetrics_();
     }
   }
@@ -542,13 +522,6 @@ export class Performance {
       this.tickDelta(TickLabel.CUMULATIVE_LAYOUT_SHIFT_2, cls);
       this.flush();
       this.shiftScoresTicked_ = 2;
-
-      // No more work to do, so clean up event listeners.
-      this.win.removeEventListener(
-        VISIBILITY_CHANGE_EVENT,
-        this.boundOnVisibilityChange_,
-        {capture: true}
-      );
     }
   }
 


### PR DESCRIPTION
**summary**
Use `AmpDoc#onVisibilityChange` for both `inactive` and `hidden` states, instead of a mix of visibilitychange API and ampdoc.

- Removes the need for a `fakeWin` in tests.
- I removed the test "For chromium 77", although I couldn't understand why it existed in the first place. Should I put it back? It seemed like a regular CLS test (of which we have others)

---

Note: this is relatively low priority. When reading through the code again I was just confused as to why we are doing this.