### PR TITLE
🐛[no-signing] Transfer attributes on body element

### DIFF
--- a/src/utils/dom-tranform-stream.js
+++ b/src/utils/dom-tranform-stream.js
@@ -130,6 +130,14 @@ export class DomTransformStream {
     this.shouldTransfer_ = true;
     this.targetBodyResolver_(targetBody);
 
+    this.headPromise_.then(() => {
+      const attrs = this.detachedBody_.attributes;
+      for (let i = 0; i < attrs.length; i++) {
+        const {name, value} = attrs[i];
+        targetBody.setAttribute(name, value);
+      }
+    });
+
     this.transferBodyChunk_();
 
     return this.bodyTransferPromise_;

--- a/test/unit/utils/test-dom-transform-stream.js
+++ b/test/unit/utils/test-dom-transform-stream.js
@@ -119,6 +119,28 @@ describes.fakeWin('DomTransformStream', {amp: true}, (env) => {
       expect(body.querySelector('child-two')).to.exist;
     });
 
+    it('should transfer <body> attributes to target body element', async () => {
+      const {body} = win.document;
+      detachedDoc.write(`
+        <!doctype html>
+          <html ⚡>
+          <head>
+            <script async src="https://cdn.ampproject.org/v0.js"></script>
+          </head>
+          <body marginwidth="0" marginheight="0" class="amp-cats" style="opacity: 1;">
+            <child-one></child-one>
+            <child-two></child-two>
+     `);
+      transformer.onChunk(detachedDoc);
+      transformer.transferBody(body /* targetBody */);
+      await flush();
+
+      expect(body.getAttribute('marginwidth')).to.equal('0');
+      expect(body.getAttribute('marginheight')).to.equal('0');
+      expect(body.getAttribute('style')).to.equal('opacity: 1;');
+      expect(body).to.have.class('amp-cats');
+    });
+
     it('should keep transferring new chunks after call', async () => {
       const {body} = win.document;
       detachedDoc.write(`


### PR DESCRIPTION
Transfer any attributes that may exist on `<body>` in the in-memory dom to live DOM.

Closes #33274