### PR TITLE
build-system: Introduce CSS Cache 🚀

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,6 +8,7 @@ firebase/**
 out/**
 test/coverage/**
 .babel-cache/**
+.css-cache/**
 
 # Code directories
 build-system/tasks/visual-diff/snippets/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .amp-dep-check
 extensions/**/dist/**
 c
+.css-cache/
 /dist
 dist.3p
 dist.tools

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .babel-cache/**
+.css-cache/**
 .github/ISSUE_TEMPLATE/**
 **/package*.json
 **/node_modules/**

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -27,7 +27,7 @@ const CACHE_DIR = path.resolve(__dirname, '..', '..', '.babel-cache');
  * Used to cache babel transforms done by esbuild.
  * @const {!TransformCache}
  */
-const transformCache = new TransformCache(CACHE_DIR);
+const transformCache = new TransformCache(CACHE_DIR, '.js');
 
 /**
  * Creates a babel plugin for esbuild for the given caller. Optionally enables

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -15,9 +15,8 @@
  */
 
 const babel = require('@babel/core');
-const crypto = require('crypto');
-const fs = require('fs-extra');
 const path = require('path');
+const {TransformCache, batchedRead, md5} = require('./transform-cache');
 
 /**
  * Directory where the babel filecache lives.
@@ -25,67 +24,10 @@ const path = require('path');
 const CACHE_DIR = path.resolve(__dirname, '..', '..', '.babel-cache');
 
 /**
- * Cache for storing transformed files on both memory and on disk.
- */
-class BabelTransformCache {
-  constructor() {
-    fs.ensureDirSync(CACHE_DIR);
-
-    /** @type {Map<string, Promise<Buffer|string>>} */
-    this.map = new Map();
-
-    /** @type {Set<string>} */
-    this.fsCache = new Set(fs.readdirSync(CACHE_DIR));
-  }
-
-  /**
-   * @param {string} hash
-   * @return {null|Promise<Buffer|string>}
-   */
-  get(hash) {
-    const cached = this.map.get(hash);
-    if (cached) {
-      return cached;
-    }
-    if (this.fsCache.has(hash)) {
-      const transformedPromise = fs.readFile(path.join(CACHE_DIR, hash));
-      this.map.set(hash, transformedPromise);
-      return transformedPromise;
-    }
-    return null;
-  }
-
-  /**
-   * @param {string} hash
-   * @param {Promise<string>} transformPromise
-   */
-  set(hash, transformPromise) {
-    if (this.map.has(hash)) {
-      throw new Error(
-        `Read race occured. Attempting to transform a file twice.`
-      );
-    }
-
-    this.map.set(hash, transformPromise);
-    transformPromise.then((contents) => {
-      fs.outputFile(path.join(CACHE_DIR, hash), contents);
-    });
-  }
-}
-
-/**
  * Used to cache babel transforms done by esbuild.
- * @const {!BabelTransformCache}
+ * @const {!TransformCache}
  */
-const transformCache = new BabelTransformCache();
-
-/**
- * Used to cache file reads done by esbuild, since it can issue multiple
- * "loads" per file. This batches consecutive reads into a single, and then
- * clears its cache item for the next load.
- * @private @const {!Map<string, Promise<{hash: string, contents: string}>>}
- */
-const readCache = new Map();
+const transformCache = new TransformCache(CACHE_DIR);
 
 /**
  * Creates a babel plugin for esbuild for the given caller. Optionally enables
@@ -102,40 +44,6 @@ function getEsbuildBabelPlugin(
   preSetup = () => {},
   postLoad = () => {}
 ) {
-  function md5(...args) {
-    if (!enableCache) {
-      return '';
-    }
-    const hash = crypto.createHash('md5');
-    for (const a of args) {
-      hash.update(a);
-    }
-    return hash.digest('hex');
-  }
-
-  /**
-   * @param {string} path
-   * @param {string} optionsHash
-   * @return {{contents: string, hash: string}}
-   */
-  function batchedRead(path, optionsHash) {
-    let read = readCache.get(path);
-    if (!read) {
-      read = fs.promises
-        .readFile(path)
-        .then((contents) => ({
-          contents,
-          hash: md5(contents, optionsHash),
-        }))
-        .finally(() => {
-          readCache.delete(path);
-        });
-      readCache.set(path, read);
-    }
-
-    return read;
-  }
-
   function transformContents(contents, hash, babelOptions) {
     if (enableCache) {
       const cached = transformCache.get(hash);

--- a/build-system/common/transform-cache.js
+++ b/build-system/common/transform-cache.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const crypto = require('crypto');
+const fs = require('fs-extra');
+const path = require('path');
+
+/**
+ * Cache for storing transformed files on both memory and on disk.
+ */
+class TransformCache {
+  constructor(cacheDir) {
+    /** @type {string} */
+    this.cacheDir = cacheDir;
+    fs.ensureDirSync(cacheDir);
+
+    /** @type {Map<string, Promise<Buffer|string>>} */
+    this.transformMap = new Map();
+
+    /** @type {Set<string>} */
+    this.fsCache = new Set(fs.readdirSync(cacheDir));
+  }
+
+  /**
+   * @param {string} hash
+   * @return {null|Promise<Buffer|string>}
+   */
+  get(hash) {
+    const cached = this.transformMap.get(hash);
+    if (cached) {
+      return cached;
+    }
+    if (this.fsCache.has(hash)) {
+      const transformedPromise = fs.readFile(path.join(this.cacheDir, hash));
+      this.transformMap.set(hash, transformedPromise);
+      return transformedPromise;
+    }
+    return null;
+  }
+
+  /**
+   * @param {string} hash
+   * @param {Promise<string>} transformPromise
+   */
+  set(hash, transformPromise) {
+    if (this.transformMap.has(hash)) {
+      throw new Error(
+        `Read race occured. Attempting to transform a file twice.`
+      );
+    }
+
+    this.transformMap.set(hash, transformPromise);
+    transformPromise.then((contents) => {
+      fs.outputFile(path.join(this.cacheDir, hash), contents);
+    });
+  }
+}
+
+/**
+ * Returns the md5 hash of provided args.
+ *
+ * @param {...(string|Buffer)} args
+ * @return {string}
+ */
+function md5(...args) {
+  const hash = crypto.createHash('md5');
+  for (const a of args) {
+    hash.update(a);
+  }
+  return hash.digest('hex');
+}
+
+/**
+ * Used to cache file reads, since some (esbuild) will have multiple
+ * "loads" per file. This batches consecutive reads into a single, and then
+ * clears its cache item for the next load.
+ * @private @const {!Map<string, Promise<{hash: string, contents: string}>>}
+ */
+const readCache = new Map();
+
+/**
+ * Returns the string contents and hash of the file at the specified path.
+ * If multiple reads are requested for the same file before the first read has completed,
+ * the result will be reused.
+ *
+ * @param {string} path
+ * @param {string=} optionsHash
+ * @return {{contents: string, hash: string}}
+ */
+function batchedRead(path, optionsHash) {
+  let read = readCache.get(path);
+  if (!read) {
+    read = fs.promises
+      .readFile(path)
+      .then((contents) => ({
+        contents,
+        hash: md5(contents, optionsHash ?? ''),
+      }))
+      .finally(() => {
+        readCache.delete(path);
+      });
+    readCache.set(path, read);
+  }
+
+  return read;
+}
+
+module.exports = {TransformCache, batchedRead, md5};

--- a/build-system/common/transform-cache.js
+++ b/build-system/common/transform-cache.js
@@ -22,7 +22,10 @@ const path = require('path');
  * Cache for storing transformed files on both memory and on disk.
  */
 class TransformCache {
-  constructor(cacheDir) {
+  constructor(cacheDir, fileExtension) {
+    /** @type {string} */
+    this.fileExtension = fileExtension;
+
     /** @type {string} */
     this.cacheDir = cacheDir;
     fs.ensureDirSync(cacheDir);
@@ -43,8 +46,11 @@ class TransformCache {
     if (cached) {
       return cached;
     }
-    if (this.fsCache.has(hash)) {
-      const transformedPromise = fs.readFile(path.join(this.cacheDir, hash));
+    const filename = hash + this.fileExtension;
+    if (this.fsCache.has(filename)) {
+      const transformedPromise = fs.readFile(
+        path.join(this.cacheDir, filename)
+      );
       this.transformMap.set(hash, transformedPromise);
       return transformedPromise;
     }
@@ -63,8 +69,9 @@ class TransformCache {
     }
 
     this.transformMap.set(hash, transformPromise);
+    const filepath = path.join(this.cacheDir, hash) + this.fileExtension;
     transformPromise.then((contents) => {
-      fs.outputFile(path.join(this.cacheDir, hash), contents);
+      fs.outputFile(filepath, contents);
     });
   }
 }

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -30,6 +30,7 @@ async function clean() {
   const pathsToDelete = [
     '.amp-dep-check',
     '.babel-cache',
+    '.css-cache',
     'build',
     'extensions/**/dist',
     'build-system/server/new-server/transforms/dist',

--- a/build-system/tasks/css/init-sync.js
+++ b/build-system/tasks/css/init-sync.js
@@ -15,17 +15,17 @@
  */
 'use strict';
 
-const {transformCss} = require('./jsify-css');
+const {transformCssString} = require('./jsify-css');
 
 /**
- * Wrapper for the asynchronous transformCss that is used by transformCssSync()
+ * Wrapper for the asynchronous transformCssString that is used by transformCssSync()
  * in build-system/tasks/css/jsify-css-sync.js.
-
- * @return {function(string, !Object=, !Object=): ReturnType<transformCss>}
+ *
+ * @return {function(string, !Object=, !Object=): ReturnType<transformCssString>}
  */
 function init() {
-  return function (cssStr, opt_cssnano, opt_filename) {
-    return Promise.resolve(transformCss(cssStr, opt_cssnano, opt_filename));
+  return function (cssStr, opt_filename) {
+    return Promise.resolve(transformCssString(cssStr, opt_filename));
   };
 }
 module.exports = init;

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -16,9 +16,15 @@
 'use strict';
 
 const cssnano = require('cssnano');
-const fs = require('fs-extra');
+const fs = require('fs');
+const path = require('path');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
+const {
+  TransformCache,
+  batchedRead,
+  md5,
+} = require('../../common/transform-cache');
 const {log} = require('../../common/logging');
 const {red} = require('kleur/colors');
 
@@ -35,6 +41,8 @@ const browsersList = {
   ],
 };
 
+// See http://cssnano.co/optimisations/ for full list.
+// We try and turn off any optimization that is marked unsafe.
 const cssNanoDefaultOptions = {
   autoprefixer: false,
   convertValues: false,
@@ -51,47 +59,50 @@ const cssNanoDefaultOptions = {
   },
 };
 
+const packageJsonPath = path.join(__dirname, '..', '..', '..', 'package.json');
+
+let environmentHash = null;
+
+/** @return {Promise<string>} */
+function getEnvironmentHash() {
+  if (environmentHash) {
+    return environmentHash;
+  }
+
+  // We want to set environmentHash to a promise synchronously s.t.
+  // we never end up with multiple calculations at the same time.
+  environmentHash = Promise.resolve().then(async () => {
+    const packageJsonHash = md5(await fs.promises.readFile(packageJsonPath));
+    const cssOptions = JSON.stringify({cssNanoDefaultOptions, browsersList});
+    return md5(packageJsonHash, cssOptions);
+  });
+  return environmentHash;
+}
+
+const CACHE_DIR = path.join(__dirname, '..', '..', '..', '.css-cache');
+
+/**
+ * Used to cache css transforms done by postcss.
+ * @const {!TransformCache}
+ */
+const transformCache = new TransformCache(CACHE_DIR);
+
+/**
+ * @typedef {{css: string, warnings: string[]}}:
+ */
+let CssTransformResultDef;
+
 /**
  * Transform a css string using postcss.
 
- * @param {string} cssStr the css text to transform
- * @param {!Object=} opt_cssnano cssnano options
+ * @param {string} contents the css text to transform
  * @param {!Object=} opt_filename the filename of the file being transformed. Used for sourcemaps generation.
- * @return {!Promise<postcss.Result>} that resolves with the css content after
+ * @return {!Promise<CssTransformResultDef>} that resolves with the css content after
  *    processing
  */
-async function transformCss(cssStr, opt_cssnano, opt_filename) {
-  opt_cssnano = opt_cssnano || Object.create(null);
-  // See http://cssnano.co/optimisations/ for full list.
-  // We try and turn off any optimization that is marked unsafe.
-  const cssnanoOptions = Object.assign(
-    Object.create(null),
-    cssNanoDefaultOptions,
-    opt_cssnano
-  );
-  const cssnanoTransformer = cssnano({preset: ['default', cssnanoOptions]});
-  const {default: autoprefixer} = await import('autoprefixer'); // Lazy-imported to speed up task loading.
-  const cssprefixer = autoprefixer(browsersList);
-  const transformers = [postcssImport, cssprefixer, cssnanoTransformer];
-  return postcss.default(transformers).process(cssStr, {
-    'from': opt_filename,
-  });
-}
-
-/**
- * Transform a css file using postcss.
-
- * @param {string} filename css file
- * @param {!Object=} opt_cssnano cssnano options
- * @return {!Promise<postcss.Result>} that resolves with the css content after
- *    processing
- */
-function transformCssFile(filename, opt_cssnano) {
-  return transformCss(
-    fs.readFileSync(filename, {encoding: 'utf8'}),
-    opt_cssnano,
-    filename
-  );
+async function transformCssString(contents, opt_filename) {
+  const hash = md5(contents);
+  return transformCss(contents, hash, opt_filename);
 }
 
 /**
@@ -103,17 +114,57 @@ function transformCssFile(filename, opt_cssnano) {
  * @return {!Promise<string>} that resolves with the css content after
  *    processing
  */
-function jsifyCssAsync(filename) {
-  return transformCssFile(filename).then(function (result) {
-    result.warnings().forEach(function (warn) {
-      log(red(warn.toString()));
-    });
-    const {css} = result;
-    return css + '\n/*# sourceURL=/' + filename + '*/';
+async function jsifyCssAsync(filename) {
+  const {contents, hash: filehash} = await batchedRead(filename);
+  const hash = md5(filehash, await getEnvironmentHash());
+  const result = await transformCss(contents, hash, filename);
+
+  result.warnings.forEach((warn) => log(red(warn)));
+  return result.css + '\n/*# sourceURL=/' + filename + '*/';
+}
+
+/**
+ * @param {string} contents
+ * @param {string} hash
+ * @param {string=} opt_filename
+ * @return {Promise<CssTransformResultDef>}
+ */
+async function transformCss(contents, hash, opt_filename) {
+  const cached = transformCache.get(hash);
+  if (cached) {
+    return JSON.parse((await cached).toString());
+  }
+
+  const transformed = transform(contents, opt_filename);
+  transformCache.set(
+    hash,
+    transformed.then((r) => JSON.stringify(r))
+  );
+  return transformed;
+}
+
+/**
+ * @param {string} contents
+ * @param {string=} opt_filename
+ * @return {Promise<CssTransformResultDef>}
+ */
+async function transform(contents, opt_filename) {
+  const cssnanoTransformer = cssnano({
+    preset: ['default', cssNanoDefaultOptions],
   });
+  const {default: autoprefixer} = await import('autoprefixer'); // Lazy-imported to speed up task loading.
+  const cssprefixer = autoprefixer(browsersList);
+  const transformers = [postcssImport, cssprefixer, cssnanoTransformer];
+  return postcss
+    .default(transformers)
+    .process(contents, {'from': opt_filename})
+    .then((result) => ({
+      css: result.css,
+      warnings: result.warnings().map((warning) => warning.toString()),
+    }));
 }
 
 module.exports = {
   jsifyCssAsync,
-  transformCss,
+  transformCssString,
 };

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -41,7 +41,7 @@ const browsersList = {
   ],
 };
 
-// See http://cssnano.co/optimisations/ for full list.
+// See https://cssnano.co/docs/what-are-optimisations for full list.
 // We try and turn off any optimization that is marked unsafe.
 const cssNanoDefaultOptions = {
   autoprefixer: false,

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -85,7 +85,7 @@ const CACHE_DIR = path.join(__dirname, '..', '..', '..', '.css-cache');
  * Used to cache css transforms done by postcss.
  * @const {!TransformCache}
  */
-const transformCache = new TransformCache(CACHE_DIR);
+const transformCache = new TransformCache(CACHE_DIR, '.css');
 
 /**
  * @typedef {{css: string, warnings: string[]}}:


### PR DESCRIPTION
**summary**
Final step for [#33011](https://github.com/ampproject/amphtml/issues/33011)

The slowest part of AMP's dev server startup is transforming CSS via `postcss`. This PR takes the infrastructure we built for [caching babel transforms](https://github.com/ampproject/amphtml/pull/33314) which was surprisingly generic, and reuses it for caching our css transforms.

_results_:
- warm cache css build reduced from 2.7s --> 100ms.
- total lazy server startup time for a warm cache is now 1s.
- extension building should be sped up as well, although these were already pretty fast so much less interesting.

**implementation notes**

- Renamed `BabelTransformCache` to `TransformCache`, and moved it from  `esbuild-babel.js` to its own file.
- Specified cache location as `.css-cache` (corollary to `.babel-cache`) as well as added it to the `gulp clean` command and the `.gitignore` file.
- A combination of `package.json`, `postcss` options, and each individual `filehash` are used for the cache key.