### PR TITLE
🚀 🚀 🚀  build-system: use fs for babel-cache 🚀 🚀 🚀 

### DIFF
--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -19,27 +19,6 @@ const crypto = require('crypto');
 const fs = require('fs-extra');
 const path = require('path');
 
-let totalTimeHashing = 0;
-let totalTimeTransforming = 0;
-let totalTimeReadingFromFsCache = 0;
-let totalTimeReadingFromRAMCache = 0;
-let filesRead = 0;
-let filesReadFromMem = 0;
-let filesReadFromFsCache = 0;
-let timeReading = 0;
-
-function printStats() {
-  console.log(`Hashing: ${totalTimeHashing}ms`);
-  console.log(`Transforming: ${totalTimeTransforming}ms`);
-  console.log(`BatchRead ${filesRead} files in ${timeReading}ms.`);
-  console.log(
-    `Read ${filesReadFromFsCache} files from fs cache: ${totalTimeReadingFromFsCache}ms`
-  );
-  console.log(
-    `Read ${filesReadFromMem} files from mem cache: ${totalTimeReadingFromRAMCache}ms.`
-  );
-}
-
 /**
  * Directory where the babel filecache lives.
  */
@@ -68,23 +47,14 @@ class BabelTransformCache {
    * @return {null|Promise<{contents: string}>}
    */
   get(hash) {
-    const start = Date.now();
     const key = this.getKey_(hash);
     const cached = this.map.get(key);
     if (cached) {
-      filesReadFromMem++;
-      cached.finally(() => {
-        totalTimeReadingFromRAMCache += Date.now() - start;
-      });
       return cached;
     }
     if (this.fsCache.has(key)) {
-      filesReadFromFsCache++;
       const transformedPromise = fs.readJson(path.join(CACHE_DIR, key));
       this.map.set(key, transformedPromise);
-      transformedPromise.finally(() => {
-        totalTimeReadingFromFsCache += Date.now() - start;
-      });
       return transformedPromise;
     }
     return null;
@@ -142,22 +112,17 @@ function getEsbuildBabelPlugin(
     if (!enableCache) {
       return '';
     }
-    const startTime = Date.now();
-    let h = crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex');
-    totalTimeHashing += Date.now() - startTime;
-    return h;
+    return crypto.createHash('md5').update(JSON.stringify(obj)).digest('hex');
   }
 
   /**
    * @param {string} path
    * @param {string} optionsHash
-   * @returns {{contents: string, hash: string}}
+   * @return {{contents: string, hash: string}}
    */
   function batchedRead(path, optionsHash) {
-    const start = Date.now();
     let read = readCache.get(path);
     if (!read) {
-      filesRead++;
       read = fs.promises
         .readFile(path, 'utf8')
         .then((contents) => ({
@@ -169,14 +134,11 @@ function getEsbuildBabelPlugin(
         });
       readCache.set(path, read);
     }
-    read.finally(() => {
-      timeReading += Date.now() - start;
-    });
+
     return read;
   }
 
   function transformContents(contents, hash, babelOptions) {
-    let start = Date.now();
     if (enableCache) {
       const cached = transformCache.get(hash);
       if (cached) {
@@ -193,9 +155,6 @@ function getEsbuildBabelPlugin(
     if (enableCache) {
       transformCache.set(hash, promise);
     }
-    promise.finally(() => {
-      totalTimeTransforming += Date.now() - start;
-    });
 
     return promise.finally(postLoad);
   }
@@ -204,7 +163,6 @@ function getEsbuildBabelPlugin(
     name: 'babel',
 
     async setup(build) {
-      const start = Date.now();
       preSetup();
 
       const babelOptions =
@@ -220,13 +178,10 @@ function getEsbuildBabelPlugin(
           filenameRelative: path.basename(filename),
         });
       });
-
-      console.log(`Time in setup(): ${Date.now() - start}ms`);
     },
   };
 }
 
 module.exports = {
   getEsbuildBabelPlugin,
-  printStats,
 };

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -66,7 +66,7 @@ class BabelTransformCache {
 
     this.map.set(key, transformPromise);
     const transformed = await transformPromise;
-    await fs.outputFile(path.join(CACHE_DIR, key), JSON.stringify(transformed));
+    await fs.outputJson(path.join(CACHE_DIR, key), transformed);
   }
 }
 

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -64,9 +64,8 @@ class BabelTransformCache {
   /**
    * @param {string} hash
    * @param {Promise<{contents: string}>} transformPromise
-   * @return {Promise}
    */
-  async set(hash, transformPromise) {
+  set(hash, transformPromise) {
     const key = this.getKey_(hash);
     if (this.map.has(key)) {
       throw new Error(
@@ -75,8 +74,9 @@ class BabelTransformCache {
     }
 
     this.map.set(key, transformPromise);
-    const transformed = await transformPromise;
-    await fs.outputJson(path.join(CACHE_DIR, key), transformed);
+    transformPromise.then((contents) => {
+      fs.outputJson(path.join(CACHE_DIR, key), contents);
+    });
   }
 }
 
@@ -128,7 +128,7 @@ function getEsbuildBabelPlugin(
     let read = readCache.get(path);
     if (!read) {
       read = fs.promises
-        .readFile(path, 'utf8')
+        .readFile(path)
         .then((contents) => ({
           contents,
           hash: sha256({contents, optionsHash}),

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -29,6 +29,7 @@ const ROOT_DIR = path.resolve(__dirname, '../../');
 async function clean() {
   const pathsToDelete = [
     '.amp-dep-check',
+    '.babel-cache',
     'build',
     'build-system/server/new-server/transforms/dist',
     'deps.txt',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -31,7 +31,7 @@ const {
 } = require('../compile/internal-version');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
-const {getEsbuildBabelPlugin, printStats} = require('../common/esbuild-babel');
+const {getEsbuildBabelPlugin} = require('../common/esbuild-babel');
 const {green, red, cyan} = require('kleur/colors');
 const {isCiBuild} = require('../common/ci');
 const {jsBundles} = require('../compile/bundles.config');
@@ -504,7 +504,6 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
       logLevel: 'silent',
     })
     .then((result) => {
-      printStats();
       finishBundle(srcFilename, destDir, destFilename, options, startTime);
       return result;
     })

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -31,7 +31,7 @@ const {
 } = require('../compile/internal-version');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
 const {closureCompile} = require('../compile/compile');
-const {getEsbuildBabelPlugin} = require('../common/esbuild-babel');
+const {getEsbuildBabelPlugin, printStats} = require('../common/esbuild-babel');
 const {green, red, cyan} = require('kleur/colors');
 const {isCiBuild} = require('../common/ci');
 const {jsBundles} = require('../compile/bundles.config');
@@ -504,6 +504,7 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
       logLevel: 'silent',
     })
     .then((result) => {
+      printStats();
       finishBundle(srcFilename, destDir, destFilename, options, startTime);
       return result;
     })


### PR DESCRIPTION
**summary**
Partial for https://github.com/ampproject/amphtml/issues/33011

Use the filesystem for the babel cache in addition to the in-memory `Map`.
- Cold compilation of `amp.js` drops from ~5s --> ~500ms. 
- Total startup time is down from ~9s --> 4.5s.