### PR TITLE
🚮  [Story sidebar] Added warning to deprecate amp-sidebar in stories

### DIFF
--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -84,6 +84,8 @@ tags: { # <amp-sidebar> in amp-story
     marker: AUTOSCROLL
   }
   spec_url: "https://amp.dev/documentation/components/amp-sidebar/"
+  deprecation: "anchor tags or amp-story-player controls"
+  deprecation_url: "https://github.com/ampproject/amphtml/issues/33293"
 }
 tags: {  # amp-sidebar > nav
   html_format: AMP

--- a/extensions/amp-story/1.0/test/validator-amp-story-sidebar.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-sidebar.out
@@ -46,6 +46,8 @@ PASS
 |        publisher-logo-src="https://example.com/logo/1x1.png"
 |        poster-portrait-src="https://example.com/my-story/poster/3x4.jpg">
 |        <amp-sidebar id="sidebar1" layout="nodisplay">
+>>       ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-sidebar.html:47:6 The tag 'amp-sidebar' is deprecated - use 'anchor tags or amp-story-player controls' instead. (see https://github.com/ampproject/amphtml/issues/33293)
 |          <ul>
 |            <li>Nav item 1</li>
 |            <li><a href="#idTwo" on="tap:idTwo.scrollTo">Nav item 2</a></li>


### PR DESCRIPTION
Contributes to I2R: #33293

It adds a warning on `amp-sidebar` when it's in an `amp-story`, and suggests to use anchor tags or amp-story-player controls.