### PR TITLE
🚀  Insert empty ESM export to ensure file is parsed as module

### DIFF
--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -45,6 +45,7 @@ exports.extension = function (name, version, latest, isModule, loadPriority) {
   // Use a numeric value instead of boolean. "m" stands for "module"
   const m = isModule ? 1 : 0;
   return (
+    (isModule ? 'export{};' : '') +
     `(self.AMP=self.AMP||[]).push({n:"${name}",ev:"${version}",l:${latest},` +
     `${priority}` +
     `v:"${VERSION}",m:${m},f:(function(AMP,_){\n` +


### PR DESCRIPTION
From discussions with the Chrome team, apparently using `<link rel=preload>` and pointing it at a script that's used as `type=module` will cause a double parse of the script. Once as a regular Script, and once as an ESM Module. Adding in an ESM `export {}` ensures that the file cannot be parsed as a Script (because `export` is only valid in ESM Modules), thus saving us from processing this file twice.

**This means using `<script src="foo.mjs">` without setting `type=module` will fail!**