### PR TITLE
amp-ad-custom: resolve the template in the right context for amp-release-2103060631003-cp-base

### DIFF
--- a/extensions/amp-a4a/0.1/amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/amp-ad-template-helper.js
@@ -46,7 +46,7 @@ export class AmpAdTemplateHelper {
    */
   constructor(ampdoc) {
     /** @private @const */
-    this.ampdoc_ = ampdoc;
+    this.parentAmpdoc_ = ampdoc;
 
     /** @private {LruCache} */
     this.cache_ = new LruCache(5);
@@ -59,7 +59,7 @@ export class AmpAdTemplateHelper {
    * @return {!Promise<string>}
    */
   fetch(templateUrl) {
-    const {win} = this.ampdoc_;
+    const {win} = this.parentAmpdoc_;
     const proxyUrl =
       getMode(win).localDev && !isNaN(templateUrl)
         ? `http://ads.localhost:${win.location.port}` +
@@ -82,7 +82,7 @@ export class AmpAdTemplateHelper {
    * @return {!Promise<!Element>} Promise which resolves after rendering completes.
    */
   render(templateValues, element) {
-    return Services.templatesForDoc(this.ampdoc_).findAndRenderTemplate(
+    return Services.templatesForDoc(element).findAndRenderTemplate(
       element,
       templateValues
     );

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
+import '../../../amp-mustache/0.2/amp-mustache';
 import {AmpAdTemplateHelper} from '../amp-ad-template-helper';
-import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {Xhr} from '../../../../src/service/xhr-impl';
-import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 
 describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
   const cdnUrl =
@@ -36,6 +35,13 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
     ampdoc = env.ampdoc;
     fetchTextMock = env.sandbox.stub(Xhr.prototype, 'fetchText');
     ampAdTemplateHelper = new AmpAdTemplateHelper(ampdoc);
+
+    env.installExtension(
+      'amp-mustache',
+      '0.2',
+      /* latest */ true,
+      /* auto */ false
+    );
   });
 
   it('should return a promise resolving to a string template', () => {
@@ -69,7 +75,6 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
   });
 
   it('should render a template with correct values', () => {
-    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
     const parentDiv = doc.createElement('div');
     parentDiv./*OK*/ innerHTML =
       '<template type="amp-mustache"><p>{{foo}}</p></template>';

--- a/extensions/amp-a4a/0.1/test/test-template-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-template-renderer.js
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
+import '../../../amp-mustache/0.2/amp-mustache';
 import {
   AMP_TEMPLATED_CREATIVE_HEADER_NAME,
   TemplateValidator,
 } from '../template-validator';
-import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {TemplateRenderer} from '../template-renderer';
 import {ValidatorResult} from '../amp-ad-type-defs';
 import {data} from './testdata/valid_css_at_rules_amp.reserialized';
 import {getAmpAdTemplateHelper} from '../amp-ad-template-helper';
-import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 import {utf8Encode} from '../../../../src/utils/bytes';
 
 const realWinConfig = {
@@ -108,7 +107,12 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should append iframe child with correct template values', () => {
-    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
+    env.installExtension(
+      'amp-mustache',
+      '0.2',
+      /* latest */ true,
+      /* auto */ false
+    );
     return validatorPromise.then((validatorOutput) => {
       // Sanity check. This behavior is tested in test-template-validator.js.
       expect(validatorOutput).to.be.ok;
@@ -121,8 +125,8 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
           const iframe = containerElement.querySelector('iframe');
           expect(iframe).to.be.ok;
           expect(iframe.contentWindow.document.body.innerHTML.trim()).to.equal(
-            '<div>\n      <p>ipsum lorem</p>\n      <a href=' +
-              '"https://buy.com/buy-1" target="_top">Click for ad!</a>' +
+            '<div>\n      <p>ipsum lorem</p>\n      <a target="_top" href=' +
+              '"https://buy.com/buy-1">Click for ad!</a>' +
               '\n    <amp-analytics class="i-amphtml-element i-amphtml' +
               '-notbuilt amp-notbuilt i-amphtml-layout-fixed i-amphtml' +
               '-layout-size-defined amp-unresolved i-amphtml-' +
@@ -134,7 +138,12 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should set correct attributes on the iframe', () => {
-    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
+    env.installExtension(
+      'amp-mustache',
+      '0.2',
+      /* latest */ true,
+      /* auto */ false
+    );
     return validatorPromise.then((validatorOutput) => {
       // Sanity check. This behavior is tested in test-template-validator.js.
       expect(validatorOutput).to.be.ok;
@@ -157,7 +166,12 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should style body of iframe document to be visible', () => {
-    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
+    env.installExtension(
+      'amp-mustache',
+      '0.2',
+      /* latest */ true,
+      /* auto */ false
+    );
     return validatorPromise.then((validatorOutput) => {
       // Sanity check. This behavior is tested in test-template-validator.js.
       expect(validatorOutput).to.be.ok;
@@ -177,7 +191,12 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
   });
 
   it('should insert analytics', () => {
-    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
+    env.installExtension(
+      'amp-mustache',
+      '0.2',
+      /* latest */ true,
+      /* auto */ false
+    );
     const insertAnalyticsSpy = env.sandbox.spy(
       getAmpAdTemplateHelper(ampdoc),
       'insertAnalytics'

--- a/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
+import '../../../amp-mustache/0.2/amp-mustache';
 import {AMP_TEMPLATED_CREATIVE_HEADER_NAME} from '../../../amp-a4a/0.1/template-validator';
 import {AmpAdTemplate} from '../amp-ad-custom';
-import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {data} from '../../../amp-a4a/0.1/test/testdata/valid_css_at_rules_amp.reserialized';
 import {getAmpAdTemplateHelper} from '../../../amp-a4a/0.1/amp-ad-template-helper';
-import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 import {tryParseJson} from '../../../../src/json';
 import {utf8Encode} from '../../../../src/utils/bytes';
 
@@ -69,7 +68,13 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
       impl.element.style.width = width;
       impl.element.style.height = height;
     };
-    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
+
+    env.installExtension(
+      'amp-mustache',
+      '0.2',
+      /* latest */ true,
+      /* auto */ false
+    );
   });
 
   afterEach(() => {
@@ -117,8 +122,8 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
         const iframe = containerElement.querySelector('iframe');
         expect(iframe).to.be.ok;
         expect(iframe.contentWindow.document.body.innerHTML.trim()).to.equal(
-          '<div>\n      <p>ipsum lorem</p>\n      <a href="https://' +
-            'www.google.com/" target="_top">Click for ad!</a>\n    ' +
+          '<div>\n      <p>ipsum lorem</p>\n      <a target="_top"' +
+            ' href="https://www.google.com/">Click for ad!</a>\n    ' +
             '</div>'
         );
       });

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -19,18 +19,17 @@
 // always available for them. However, when we test an impl in isolation,
 // AmpAd is not loaded already, so we need to load it separately.
 import '../../../amp-ad/0.1/amp-ad';
+import '../../../amp-mustache/0.1/amp-mustache';
 import {
   AMP_TEMPLATED_CREATIVE_HEADER_NAME,
   AmpAdNetworkAdzerkImpl,
 } from '../amp-ad-network-adzerk-impl';
-import {AmpMustache} from '../../../amp-mustache/0.1/amp-mustache';
 import {Xhr} from '../../../../src/service/xhr-impl';
 import {createElementWithAttributes} from '../../../../src/dom';
-import {registerExtendedTemplateForDoc} from '../../../../src/service/template-impl';
 import {utf8Decode, utf8Encode} from '../../../../src/utils/bytes';
 
 describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
-  let win, doc, ampdoc;
+  let win, doc;
   let element, impl;
   let fetchTextMock;
 
@@ -38,8 +37,14 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
     win = env.win;
     win.__AMP_MODE = {localDev: false};
     doc = win.document;
-    ampdoc = env.ampdoc;
-    registerExtendedTemplateForDoc(ampdoc, 'amp-mustache', AmpMustache);
+
+    env.installExtension(
+      'amp-mustache',
+      '0.1',
+      /* latest */ true,
+      /* auto */ false
+    );
+
     fetchTextMock = env.sandbox.stub(Xhr.prototype, 'fetchText');
     element = createElementWithAttributes(doc, 'amp-ad', {
       'type': 'adzerk',

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -788,10 +788,16 @@ class AmpFixture {
     /**
      * Installs the specified extension.
      * @param {string} extensionId
-     * @param {string=} opt_version
+     * @param {string=} version
+     * @param {boolean=} latest
+     * @param {boolean=} auto
      */
-    env.installExtension = function (extensionId, opt_version) {
-      const version = opt_version || '0.1';
+    env.installExtension = function (
+      extensionId,
+      version = '0.1',
+      latest = false,
+      auto = true
+    ) {
       const installer = extensionsBuffer[`${extensionId}:${version}`];
       if (!installer) {
         throw new Error(
@@ -799,7 +805,7 @@ class AmpFixture {
             ' Make sure the module is imported'
         );
       }
-      if (env.ampdoc) {
+      if (env.ampdoc && auto) {
         env.ampdoc.declareExtension(extensionId, version);
       }
       env.extensions.registerExtension(extensionId, installer, win.AMP);

--- a/testing/describes.js
+++ b/testing/describes.js
@@ -789,13 +789,13 @@ class AmpFixture {
      * Installs the specified extension.
      * @param {string} extensionId
      * @param {string=} version
-     * @param {boolean=} latest
+     * @param {boolean=} unusedLatest
      * @param {boolean=} auto
      */
     env.installExtension = function (
       extensionId,
       version = '0.1',
-      latest = false,
+      unusedLatest = false,
       auto = true
     ) {
       const installer = extensionsBuffer[`${extensionId}:${version}`];


### PR DESCRIPTION
Copy of https://github.com/ampproject/amphtml/pull/33324 for `amp-release-2103060631003-cp-base` branch.

Fixes #33317.