### PR TITLE
🐛 Use customElementExtensions where extensions may not be populated

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -196,6 +196,7 @@ exports.rules = [
       'extensions/amp-ad-custom/0.1/amp-ad-custom.js->extensions/amp-a4a/0.1/template-validator.js',
       'extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js->extensions/amp-a4a/0.1/amp-ad-template-helper.js',
       'extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js->extensions/amp-a4a/0.1/amp-ad-type-defs.js',
+      'extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js->extensions/amp-a4a/0.1/amp-ad-utils.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/refresh-manager.js',
       'extensions/amp-ad-network-valueimpression-impl/0.1/amp-ad-network-valueimpression-impl.js->extensions/amp-a4a/0.1/refresh-manager.js',
 

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -175,6 +175,8 @@ export function mergeExtensionsMetadata(extensions, customElementExtensions) {
     if (!extensionsHasElement(extensions, extensionId)) {
       extensions.push({
         'custom-element': extensionId,
+        // The default version is 0.1. To specify a specific version,
+        // use metadata['extensions'] field instead.
         src: `${urls.cdn}/v0/${extensionId}-0.1.js`,
       });
     }

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -19,6 +19,7 @@ import {isArray, isObject} from '../../../src/types';
 import {isSecureUrlDeprecated} from '../../../src/url';
 import {parseExtensionUrl} from '../../../src/service/extension-script';
 import {parseJson} from '../../../src/json';
+import {urls} from '../../../src/config';
 
 const TAG = 'amp-ad-util';
 
@@ -159,6 +160,24 @@ export function getAmpAdMetadata(creative) {
       creative.slice(metadataStart + metadataString.length, metadataEnd)
     );
     return null;
+  }
+}
+
+/**
+ * Merges any elements from customElementExtensions array into extensions array if
+ * the element is not present.
+ * @param {!Array<{custom-element: string, 'src': string}} extensions
+ * @param {!Array<string>} customElementExtensions
+ */
+export function mergeExtensionsMetadata(extensions, customElementExtensions) {
+  for (let i = 0; i < customElementExtensions.length; i++) {
+    const extensionId = customElementExtensions[i];
+    if (!extensionsHasElement(extensions, extensionId)) {
+      extensions.push({
+        'custom-element': extensionId,
+        src: `${urls.cdn}/v0/${extensionId}-latest.js`,
+      });
+    }
   }
 }
 

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -175,7 +175,7 @@ export function mergeExtensionsMetadata(extensions, customElementExtensions) {
     if (!extensionsHasElement(extensions, extensionId)) {
       extensions.push({
         'custom-element': extensionId,
-        src: `${urls.cdn}/v0/${extensionId}-latest.js`,
+        src: `${urls.cdn}/v0/${extensionId}-0.1.js`,
       });
     }
   }

--- a/extensions/amp-a4a/0.1/template-validator.js
+++ b/extensions/amp-a4a/0.1/template-validator.js
@@ -19,6 +19,7 @@ import {
   extensionsHasElement,
   getAmpAdMetadata,
   getExtensionsFromMetadata,
+  mergeExtensionsMetadata,
 } from './amp-ad-utils';
 import {getAmpAdTemplateHelper} from './amp-ad-template-helper';
 import {preloadFriendlyIframeEmbedExtensions} from '../../../src/friendly-iframe-embed';
@@ -71,6 +72,10 @@ export class TemplateValidator extends Validator {
         const creativeMetadata = getAmpAdMetadata(template);
         creativeMetadata['extensions'] = creativeMetadata['extensions'] || [];
         const extensions = creativeMetadata['extensions'];
+        mergeExtensionsMetadata(
+          extensions,
+          creativeMetadata['customElementExtensions']
+        );
         if (
           parsedResponseBody.analytics &&
           !extensionsHasElement(extensions, 'amp-analytics')

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
@@ -19,6 +19,7 @@ import {
   extensionsHasElement,
   getAmpAdMetadata,
   getExtensionsFromMetadata,
+  mergeExtensionsMetadata,
 } from '../amp-ad-utils';
 
 describe('getAmpAdMetadata', () => {
@@ -58,6 +59,39 @@ describe('getAmpAdMetadata', () => {
       data.reserializedMissingScriptTag
     );
     expect(creativeMetadata).to.be.null;
+  });
+});
+
+describe('mergeExtensionsMetadata', () => {
+  it('should add els that exist in customElementExtensions but not extensions', () => {
+    const customElementExtensions = ['amp-analytics'];
+    const extensions = [];
+    mergeExtensionsMetadata(extensions, customElementExtensions);
+    expect(extensions).to.have.lengthOf(1);
+    expect(extensions).to.deep.include({
+      'custom-element': 'amp-analytics',
+      'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
+    });
+  });
+
+  it('should ignore elements that already exist in extensions', () => {
+    const customElementExtensions = ['amp-analytics', 'amp-foo'];
+    const extensions = [
+      {
+        'custom-element': 'amp-analytics',
+        'src': 'https://cdn.ampproject.org/v0/amp-0.1.js',
+      },
+    ];
+    mergeExtensionsMetadata(extensions, customElementExtensions);
+    expect(extensions).to.have.lengthOf(2);
+    expect(extensions).to.deep.include({
+      'custom-element': 'amp-analytics',
+      'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+    });
+    expect(extensions).to.deep.include({
+      'custom-element': 'amp-foo',
+      'src': 'https://cdn.ampproject.org/v0/amp-foo-latest.js',
+    });
   });
 });
 

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
@@ -70,7 +70,7 @@ describe('mergeExtensionsMetadata', () => {
     expect(extensions).to.have.lengthOf(1);
     expect(extensions).to.deep.include({
       'custom-element': 'amp-analytics',
-      'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
+      'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
     });
   });
 
@@ -79,18 +79,18 @@ describe('mergeExtensionsMetadata', () => {
     const extensions = [
       {
         'custom-element': 'amp-analytics',
-        'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+        'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
       },
     ];
     mergeExtensionsMetadata(extensions, customElementExtensions);
     expect(extensions).to.have.lengthOf(2);
     expect(extensions).to.deep.include({
       'custom-element': 'amp-analytics',
-      'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
+      'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
     });
     expect(extensions).to.deep.include({
       'custom-element': 'amp-foo',
-      'src': 'https://cdn.ampproject.org/v0/amp-foo-latest.js',
+      'src': 'https://cdn.ampproject.org/v0/amp-foo-0.1.js',
     });
   });
 });

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-utils.js
@@ -79,7 +79,7 @@ describe('mergeExtensionsMetadata', () => {
     const extensions = [
       {
         'custom-element': 'amp-analytics',
-        'src': 'https://cdn.ampproject.org/v0/amp-0.1.js',
+        'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
       },
     ];
     mergeExtensionsMetadata(extensions, customElementExtensions);

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -147,6 +147,32 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
     });
   });
 
+  it('should add elements in creativeMetaData to extensions if not present', async () => {
+    const templateHelper = getAmpAdTemplateHelper(env.ampdoc);
+    const response = data.adTemplate.replace(
+      /"customElementExtensions" : \[\]/,
+      '"customElementExtensions" : ["amp-cats"]'
+    );
+    env.sandbox.stub(templateHelper, 'fetch').resolves(response);
+    const validatorOutput = await validator.validate(
+      {win: env.win},
+      containerElement,
+      utf8Encode(
+        JSON.stringify({
+          templateUrl,
+          data: {url: 'https://buy.com/buy-1'},
+          analytics: {foo: 'bar'},
+        })
+      ),
+      headers
+    );
+    const {creativeMetadata} = validatorOutput.creativeData;
+    expect(creativeMetadata.extensions).to.deep.include({
+      'custom-element': 'amp-cats',
+      'src': 'https://cdn.ampproject.org/v0/amp-cats-latest.js',
+    });
+  });
+
   describe('Non-AMP Result', () => {
     it('should have NON_AMP validator result due to lack of headers', () => {
       return validator

--- a/extensions/amp-a4a/0.1/test/test-template-validator.js
+++ b/extensions/amp-a4a/0.1/test/test-template-validator.js
@@ -169,7 +169,7 @@ describes.realWin('TemplateValidator', realWinConfig, (env) => {
     const {creativeMetadata} = validatorOutput.creativeData;
     expect(creativeMetadata.extensions).to.deep.include({
       'custom-element': 'amp-cats',
-      'src': 'https://cdn.ampproject.org/v0/amp-cats-latest.js',
+      'src': 'https://cdn.ampproject.org/v0/amp-cats-0.1.js',
     });
   });
 

--- a/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/amp-ad-network-adzerk-impl.js
@@ -23,6 +23,7 @@ import {AmpTemplateCreativeDef} from '../../amp-a4a/0.1/amp-ad-type-defs';
 import {dev, devAssert} from '../../../src/log';
 import {getAmpAdTemplateHelper} from '../../amp-a4a/0.1/amp-ad-template-helper';
 import {getMode} from '../../../src/mode';
+import {mergeExtensionsMetadata} from '../../amp-a4a/0.1/amp-ad-utils';
 import {tryParseJson} from '../../../src/json';
 import {tryResolve} from '../../../src/utils/promise';
 import {utf8Decode, utf8Encode} from '../../../src/utils/bytes';
@@ -93,6 +94,8 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
 
   /** @override */
   maybeValidateAmpCreative(bytes, headers) {
+    // TODO(wg-monetization): this header name has been deprecated elsewhere,
+    // and is never returned by dev server.
     if (headers.get(AMP_TEMPLATED_CREATIVE_HEADER_NAME) !== 'amp-mustache') {
       return /**@type {!Promise<(ArrayBuffer|null)>}*/ (Promise.resolve(null));
     }
@@ -163,6 +166,12 @@ export class AmpAdNetworkAdzerkImpl extends AmpA4A {
     pushIfNotExist(
       this.creativeMetadata_['customElementExtensions'],
       'amp-mustache'
+    );
+    this.creativeMetadata_['extensions'] =
+      this.creativeMetadata_['extensions'] || [];
+    mergeExtensionsMetadata(
+      this.creativeMetadata_['extensions'],
+      this.creativeMetadata_['customElementExtensions']
     );
     return /**@type {?CreativeMetaDataDef}*/ (this.creativeMetadata_);
   }

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -151,7 +151,12 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
           expect(impl.getAmpAdMetadata()).to.jsonEqual({
             minifiedCreative: creative,
             customElementExtensions: ['amp-mustache'],
-            extensions: [],
+            extensions: [
+              {
+                'custom-element': 'amp-mustache',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+              },
+            ],
           });
         });
     });
@@ -210,13 +215,31 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
           expect(impl.getAmpAdMetadata()).to.jsonEqual({
             minifiedCreative: creative,
             customElementExtensions: ['amp-analytics', 'amp-mustache'],
-            extensions: [],
+            extensions: [
+              {
+                'custom-element': 'amp-analytics',
+                'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
+              },
+              {
+                'custom-element': 'amp-mustache',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+              },
+            ],
           });
           // Won't insert duplicate
           expect(impl.getAmpAdMetadata()).to.jsonEqual({
             minifiedCreative: creative,
             customElementExtensions: ['amp-analytics', 'amp-mustache'],
-            extensions: [],
+            extensions: [
+              {
+                'custom-element': 'amp-analytics',
+                'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
+              },
+              {
+                'custom-element': 'amp-mustache',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+              },
+            ],
           });
         });
     });
@@ -242,7 +265,12 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
           expect(impl.getAmpAdMetadata()).to.jsonEqual({
             minifiedCreative: creative,
             customElementExtensions: ['amp-mustache'],
-            extensions: [],
+            extensions: [
+              {
+                'custom-element': 'amp-mustache',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+              },
+            ],
           });
         });
     });

--- a/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
+++ b/extensions/amp-ad-network-adzerk-impl/0.1/test/test-amp-ad-network-adzerk-impl.js
@@ -154,7 +154,7 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
             extensions: [
               {
                 'custom-element': 'amp-mustache',
-                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
               },
             ],
           });
@@ -218,11 +218,11 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
             extensions: [
               {
                 'custom-element': 'amp-analytics',
-                'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
+                'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
               },
               {
                 'custom-element': 'amp-mustache',
-                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
               },
             ],
           });
@@ -233,11 +233,11 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
             extensions: [
               {
                 'custom-element': 'amp-analytics',
-                'src': 'https://cdn.ampproject.org/v0/amp-analytics-latest.js',
+                'src': 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js',
               },
               {
                 'custom-element': 'amp-mustache',
-                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
               },
             ],
           });
@@ -268,7 +268,7 @@ describes.fakeWin('amp-ad-network-adzerk-impl', {amp: true}, (env) => {
             extensions: [
               {
                 'custom-element': 'amp-mustache',
-                'src': 'https://cdn.ampproject.org/v0/amp-mustache-latest.js',
+                'src': 'https://cdn.ampproject.org/v0/amp-mustache-0.1.js',
               },
             ],
           });


### PR DESCRIPTION
Fixes template ads case where the server sends `customElementExtensions` in metadata, but `extensions` is always an empty array by merging the two sources.

Partial #33020