### PR TITLE
♻️ [story-ads]: Hook up StoryAdPageManager and StoryAdAlgorithm

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -261,8 +261,10 @@ exports.rules = [
       // AMP Story Panning Media
       'extensions/amp-story-panning-media/0.1/amp-story-panning-media.js->extensions/amp-story/1.0/amp-story-store-service.js',
       // Story ads
+      'extensions/amp-story-auto-ads/0.1/algorithm-count-pages.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-auto-ads/0.1/story-ad-page.js->extensions/amp-story/1.0/amp-story-store-service.js',
+      'extensions/amp-story-auto-ads/0.1/story-ad-page-manager.js->extensions/amp-story/1.0/amp-story-store-service.js',
       'extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js->extensions/amp-story/1.0/events.js',
       // TODO(#24080) Remove this when story ads have full ad network support.
       'extensions/amp-story-auto-ads/0.1/story-ad-page.js->extensions/amp-ad-exit/0.1/config.js',

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -134,6 +134,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
           this.config_
         );
         this.placementAlgorithm_ = getPlacementAlgo(
+          this.win,
           this.storeService_,
           this.adPageManager_
         );

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -397,7 +397,6 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const adIndex = this.adPageManager_.getIndexById(adPageId);
 
     if (!adPage.hasBeenViewed()) {
-      this.pendingAdView_ = false;
       this.placementAlgorithm_.onNewAdView(pageIndex);
     }
 

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -20,7 +20,6 @@ import {
   STORY_AD_ANALYTICS,
   StoryAdAnalytics,
 } from './story-ad-analytics';
-import {ButtonTextFitter} from './story-ad-button-text-fitter';
 import {CSS} from '../../../build/amp-story-auto-ads-0.1.css';
 import {CommonSignals} from '../../../src/common-signals';
 import {EventType, dispatch} from '../../amp-story/1.0/events';
@@ -30,21 +29,14 @@ import {
   UIType,
 } from '../../amp-story/1.0/amp-story-store-service';
 import {StoryAdConfig} from './story-ad-config';
-import {StoryAdLocalization} from './story-ad-localization';
-import {StoryAdPage} from './story-ad-page';
+import {StoryAdPageManager} from './story-ad-page-manager';
 import {CSS as adBadgeCSS} from '../../../build/amp-story-auto-ads-ad-badge-0.1.css';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 import {dev, devAssert, userAssert} from '../../../src/log';
-import {dict, hasOwn} from '../../../src/utils/object';
+import {dict} from '../../../src/utils/object';
+import {getPlacementAlgo} from './algorithm-utils';
 import {getServicePromiseForDoc} from '../../../src/service';
-import {lastItem} from '../../../src/utils/array';
 import {CSS as sharedCSS} from '../../../build/amp-story-auto-ads-shared-0.1.css';
-
-/** @const {number} */
-const FIRST_AD_MIN = 7;
-
-/** @const {number} */
-const MIN_INTERVAL = 7;
 
 /** @const {string} */
 const TAG = 'amp-story-auto-ads';
@@ -60,14 +52,6 @@ export const Attributes = {
   AD_SHOWING: 'ad-showing',
   DESKTOP_PANELS: 'desktop-panels',
   DIR: 'dir',
-  NEXT_PAGE_NO_AD: 'next-page-no-ad',
-};
-
-/** @enum {number} */
-const AD_STATE = {
-  PENDING: 0,
-  INSERTED: 1,
-  FAILED: 2,
 };
 
 export class AmpStoryAutoAds extends AMP.BaseElement {
@@ -81,22 +65,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     /** @private {?../../amp-story/1.0/amp-story.AmpStory} */
     this.ampStory_ = null;
 
-    /** @private {number} */
-    this.uniquePagesCount_ = 0;
-
-    /** @private {!Object<string, boolean>} */
-    this.uniquePageIds_ = dict({});
-
-    /** @private {!Array<StoryAdPage>} */
-    this.adPages_ = [];
-
-    /** @private {number} */
-    this.adsPlaced_ = 0;
-
-    /** @private {number} */
-    this.adPagesCreated_ = 0;
-
-    /** @private {?StoryAdPage}} */
+    /** @private {?StoryAdPage} */
     this.visibleAdPage_ = null;
 
     /** @private {!JsonObject} */
@@ -105,37 +74,17 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     /** @private {?Promise} */
     this.analytics_ = null;
 
-    /** @private {Object<string, number>} */
-    this.adPageIds_ = {};
-
-    /** @private {number|null} */
-    this.idOfAdShowing_ = null;
-
-    /** @private {boolean} */
-    this.firstAdViewed_ = false;
-
-    /** @private {boolean} */
-    this.pendingAdView_ = false;
-
     /** @private {?Element} */
     this.adBadgeContainer_ = null;
 
-    /**
-     * @private {?../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService}
-     */
+    /** @private {?../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = null;
 
-    /** @private {!./story-ad-localization.StoryAdLocalization} */
-    this.localizationService_ = new StoryAdLocalization(this.element);
+    /** @private {?StoryAdPlacementAlgorithm} */
+    this.placementAlgorithm_ = null;
 
-    /** @private {boolean} */
-    this.hasForcedRender_ = false;
-
-    /** @private {boolean} */
-    this.tryingToPlace_ = false;
-
-    /** @private {?./story-ad-button-text-fitter.ButtonTextFitter} */
-    this.buttonFitter_ = null;
+    /** @private {?StoryAdPageManager} */
+    this.adPageManager_ = null;
   }
 
   /** @override */
@@ -158,9 +107,6 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
         const ampdoc = this.getAmpDoc();
         const extensionService = Services.extensionsFor(this.win);
         extensionService./*OK*/ installExtensionForDoc(ampdoc, AD_TAG);
-
-        this.buttonFitter_ = new ButtonTextFitter(ampdoc);
-
         return ampStoryElement.getImpl().then((impl) => {
           this.ampStory_ = impl;
         });
@@ -178,46 +124,57 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     if (!this.isAutomaticAdInsertionAllowed_()) {
       return Promise.resolve();
     }
-
     return this.ampStory_
       .signals()
       .whenSignal(CommonSignals.INI_LOAD)
       .then(() => {
         this.handleConfig_();
+        this.adPageManager_ = new StoryAdPageManager(
+          this.ampStory_,
+          this.config_
+        );
+        this.placementAlgorithm_ = getPlacementAlgo(
+          this.storeService_,
+          this.adPageManager_
+        );
+        // Bail out early on short stories.
+        if (!this.placementAlgorithm_.isStoryEligible()) {
+          return;
+        }
         this.analytics_ = getServicePromiseForDoc(
           this.element,
           STORY_AD_ANALYTICS
         );
         this.createAdOverlay_();
         this.initializeListeners_();
-        this.schedulePage_();
+        this.initializePages_();
       });
   }
 
   /**
    * Force an immediate ad placement without waiting for ad being loaded,
    * and then navigate to the ad page.
-   * @param {string=} pageBeforeAdId
-   * @visibleForTesting
+   * @param {!StoryAdPage} adPage
    */
-  forcePlaceAdAfterPage(pageBeforeAdId) {
-    const pageBeforeId =
-      pageBeforeAdId ||
-      /** @type {string} */ (this.storeService_.get(
-        StateProperty.CURRENT_PAGE_ID
-      ));
-    this.tryToPlaceAdAfterPage_(pageBeforeId);
-    this.navigateToFirstAdPage_();
-    this.hasForcedRender_ = true;
+  forcePlaceAdAfterPage_(adPage) {
+    const pageBeforeAdId = /** @type {string} */ (this.storeService_.get(
+      StateProperty.CURRENT_PAGE_ID
+    ));
+    adPage.registerLoadCallback(() =>
+      this.adPageManager_
+        .maybeInsertPageAfter(pageBeforeAdId, adPage)
+        .then(() => this.navigateToFirstAdPage_(adPage))
+    );
   }
 
   /**
    * Fires event to navigate to ad page once inserted into the story.
+   * @param {!StoryAdPage} adPage
    */
-  navigateToFirstAdPage_() {
-    const lastPageElement = lastItem(this.adPages_).getPageElement();
+  navigateToFirstAdPage_(adPage) {
+    const firstAdPageElement = adPage.getPageElement();
     // Setting distance manually to avoid flash of next page.
-    lastPageElement.setAttribute('distance', '1');
+    firstAdPageElement.setAttribute('distance', '1');
     const payload = dict({
       'targetPageId': 'i-amphtml-ad-page-1',
       'direction': 'next',
@@ -225,7 +182,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     const eventInit = {bubbles: true};
     dispatch(
       this.win,
-      lastPageElement,
+      firstAdPageElement,
       EventType.SWITCH_PAGE,
       payload,
       eventInit
@@ -254,24 +211,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * @private
    */
   isAutomaticAdInsertionAllowed_() {
-    return (
-      !!this.storeService_.get(StateProperty.CAN_INSERT_AUTOMATIC_AD) &&
-      this.enoughPagesLeftInStory_(0) // Beginning of story.
-    );
-  }
-
-  /**
-   * Determine if enough pages in the story are left for ad placement to be
-   * possible.
-   * @param {number} pageIndex
-   * @return {boolean}
-   * @private
-   */
-  enoughPagesLeftInStory_(pageIndex) {
-    return (
-      this.storeService_.get(StateProperty.PAGE_IDS).length - pageIndex >
-      MIN_INTERVAL
-    );
+    return !!this.storeService_.get(StateProperty.CAN_INSERT_AUTOMATIC_AD);
   }
 
   /**
@@ -388,135 +328,87 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    * Create new page containing ad and start preloading.
    * @private
    */
-  schedulePage_() {
-    const index = ++this.adPagesCreated_;
-    const page = new StoryAdPage(
-      this.getAmpDoc(),
-      this.config_,
-      index,
-      this.localizationService_,
-      devAssert(this.buttonFitter_),
-      devAssert(this.storeService_)
-    );
-
-    this.maybeForceAdPlacement_(page);
-
-    const pageElement = page.build();
-    this.adPages_.push(page);
-
-    // Keep track of ids created so far and a mapping to their index. This
-    // is used to check if a page id is an ad later.
-    this.adPageIds_[page.getId()] = index;
-
-    this.ampStory_.element.appendChild(pageElement);
-
-    pageElement.getImpl().then((impl) => {
-      this.ampStory_.addPage(impl);
-    });
+  initializePages_() {
+    const pages = this.placementAlgorithm_.initializePages();
+    this.maybeForceAdPlacement_(devAssert(pages[0]));
   }
 
   /**
    * Development mode forces navigation to ad page for better dev-x.
-   * Only do this once to prevent an infinite view->request->navigate loop.
-   * @param {StoryAdPage} page
+   * @param {StoryAdPage} adPage
    */
-  maybeForceAdPlacement_(page) {
+  maybeForceAdPlacement_(adPage) {
     if (
       this.element.hasAttribute('development') &&
-      this.config_['type'] === 'fake' &&
-      !this.hasForcedRender_
+      this.config_['type'] === 'fake'
     ) {
-      page.registerLoadCallback(() => this.forcePlaceAdAfterPage());
+      this.forcePlaceAdAfterPage_(adPage);
     }
   }
 
   /**
    * Respond to page navigation event. This method is not called for the first
    * page that is shown on load.
-   * @param {number} pageIndex
+   * @param {number} pageIndex Does not update when ad is showing.
    * @param {string} pageId
    * @private
    */
   handleActivePageChange_(pageIndex, pageId) {
-    if (!hasOwn(this.uniquePageIds_, pageId)) {
-      this.uniquePagesCount_++;
-      this.uniquePageIds_[pageId] = true;
-    }
-
-    if (this.adPagesCreated_ === 0) {
+    if (this.adPageManager_.numberOfAdsCreated() === 0) {
       // This is protection against us running our placement algorithm in a
       // story where no ads have been created. Most likely because INI_LOAD on
-      // the story has not fired yet.
+      // the story has not fired yet but we still are receiving page changes.
       return;
     }
 
-    if (this.idOfAdShowing_) {
-      // We are transitioning away from an ad
-      this.removeVisibleAttribute_();
-      // Fire the exit event.
-      this.analyticsEvent_(AnalyticsEvents.AD_EXITED, {
-        [AnalyticsVars.AD_EXITED]: Date.now(),
-        [AnalyticsVars.AD_INDEX]: this.idOfAdShowing_,
-      });
-      this.idOfAdShowing_ = null;
+    this.placementAlgorithm_.onPageChange(pageId);
+
+    if (this.visibleAdPage_) {
+      this.transitionFromAdShowing_();
     }
 
-    if (this.adPageIds_[pageId]) {
-      // We are switching to an ad.
-      const adIndex = this.adPageIds_[pageId];
-      const adPage = this.adPages_[adIndex - 1];
+    if (this.adPageManager_.hasId(pageId)) {
+      this.transitionToAdShowing_(pageIndex, pageId);
+    }
+  }
 
-      if (!adPage.hasBeenViewed()) {
-        this.pendingAdView_ = false;
-        this.resetPageCount_();
-        if (this.enoughPagesLeftInStory_(pageIndex)) {
-          this.startNextAdPage_();
-        }
-      }
+  /**
+   * Called when switching away from an ad.
+   */
+  transitionFromAdShowing_() {
+    // We are transitioning away from an ad
+    const adPageId = this.visibleAdPage_.getId();
+    const adIndex = this.adPageManager_.getIndexById(adPageId);
+    this.removeVisibleAttribute_();
+    // Fire the exit event.
+    this.analyticsEvent_(AnalyticsEvents.AD_EXITED, {
+      [AnalyticsVars.AD_EXITED]: Date.now(),
+      [AnalyticsVars.AD_INDEX]: adIndex,
+    });
+  }
 
-      // Tell the iframe that it is visible.
-      this.setVisibleAttribute_(adPage);
+  /**
+   * We are switching to an ad.
+   * @param {number} pageIndex
+   * @param {string} adPageId
+   */
+  transitionToAdShowing_(pageIndex, adPageId) {
+    const adPage = this.adPageManager_.getAdPageById(adPageId);
+    const adIndex = this.adPageManager_.getIndexById(adPageId);
 
-      // Fire the view event on the corresponding Ad.
-      this.analyticsEvent_(AnalyticsEvents.AD_VIEWED, {
-        [AnalyticsVars.AD_VIEWED]: Date.now(),
-        [AnalyticsVars.AD_INDEX]: adIndex,
-      });
-
-      // Keeping track of this here so that we can contain the logic for when
-      // we exit the ad within this extension.
-      this.idOfAdShowing_ = adIndex;
+    if (!adPage.hasBeenViewed()) {
+      this.pendingAdView_ = false;
+      this.placementAlgorithm_.onNewAdView(pageIndex);
     }
 
-    if (
-      !this.pendingAdView_ &&
-      this.enoughContentPagesViewed_() &&
-      // If there is already an ad inserted, but not viewed it doesn't matter how
-      // many pages we have seen, we should not keep trying to insert more ads.
-      !this.tryingToPlace_ &&
-      // Prevent edge case where we try to place an ad twice. See #28840.
-      this.adsPlaced_ < this.adPagesCreated_
-    ) {
-      this.tryToPlaceAdAfterPage_(pageId).then((adState) => {
-        this.tryingToPlace_ = false;
+    // Tell the iframe that it is visible.
+    this.setVisibleAttribute_(adPage);
 
-        if (adState === AD_STATE.INSERTED) {
-          this.analyticsEventWithCurrentAd_(AnalyticsEvents.AD_INSERTED, {
-            [AnalyticsVars.AD_INSERTED]: Date.now(),
-          });
-          this.adsPlaced_++;
-          // We have an ad inserted that has yet to be viewed.
-          this.pendingAdView_ = true;
-        }
-
-        if (adState === AD_STATE.FAILED) {
-          this.analyticsEventWithCurrentAd_(AnalyticsEvents.AD_DISCARDED, {
-            [AnalyticsVars.AD_DISCARDED]: Date.now(),
-          });
-          this.startNextAdPage_();
-        }
-      });
-    }
+    // Fire the view event on the corresponding Ad.
+    this.analyticsEvent_(AnalyticsEvents.AD_VIEWED, {
+      [AnalyticsVars.AD_VIEWED]: Date.now(),
+      [AnalyticsVars.AD_INDEX]: adIndex,
+    });
   }
 
   /**
@@ -541,152 +433,6 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
         this.visibleAdPage_ = null;
       }
     });
-  }
-
-  /**
-   * Determine if user has seen enough pages to show an ad. We want a certain
-   * number of pages before the first ad, and then a separate interval
-   * thereafter.
-   * @return {boolean}
-   * @private
-   */
-  enoughContentPagesViewed_() {
-    // In desktop we have to insert ads two pages away, because the next page is
-    // already visible. This adjustment ensures the ads show in the same place
-    // on mobile and desktop.
-    const adjustedInterval = this.isDesktopView_
-      ? MIN_INTERVAL - 1
-      : MIN_INTERVAL;
-    const adjustedFirst = this.isDesktopView_ ? FIRST_AD_MIN - 1 : FIRST_AD_MIN;
-
-    if (this.firstAdViewed_ && this.uniquePagesCount_ >= adjustedInterval) {
-      return true;
-    }
-
-    if (!this.firstAdViewed_ && this.uniquePagesCount_ >= adjustedFirst) {
-      return true;
-    }
-
-    return false;
-  }
-
-  /**
-   * Start the process over.
-   * @private
-   */
-  startNextAdPage_() {
-    if (!this.firstAdViewed_) {
-      this.firstAdViewed_ = true;
-    }
-    this.schedulePage_();
-  }
-
-  /**
-   * Reset the counter that tracks when to place ads.
-   * @private
-   */
-  resetPageCount_() {
-    this.uniquePagesCount_ = 0;
-  }
-
-  /**
-   * Place ad based on user config
-   * @param {string} pageBeforeAdId
-   * @return {Promise<AD_STATE>}
-   * @private
-   */
-  tryToPlaceAdAfterPage_(pageBeforeAdId) {
-    this.tryingToPlace_ = true;
-
-    return Promise.resolve().then(() => {
-      const nextAdPage = lastItem(this.adPages_);
-      if (!nextAdPage.isLoaded() && nextAdPage.hasTimedOut()) {
-        // Timeout fail.
-        return AD_STATE.FAILED;
-      }
-
-      let pageBeforeAd = this.ampStory_.getPageById(pageBeforeAdId);
-      let pageAfterAd = this.ampStory_.getNextPage(pageBeforeAd);
-
-      if (!pageAfterAd) {
-        return AD_STATE.PENDING;
-      }
-
-      if (this.isDesktopView_()) {
-        // If we are in desktop view the ad must be inserted 2 pages away because
-        // the next page will already be in view
-        pageBeforeAd = pageAfterAd;
-        pageBeforeAdId = pageAfterAd.element.id;
-        pageAfterAd = this.ampStory_.getNextPage(pageAfterAd);
-      }
-
-      if (!pageAfterAd) {
-        return AD_STATE.PENDING;
-      }
-
-      // There are three checks here that we check before inserting an ad. If
-      // any of these fail we will try again on next page navigation.
-      if (
-        !nextAdPage.isLoaded() || // 1. Ad must be loaded.
-        // 2. Pubs can opt out of ad placement using 'next-page-no-ad' attribute
-        this.nextPageNoAd_(pageBeforeAd) ||
-        // 3. We will not show two ads in a row.
-        pageBeforeAd.isAd() ||
-        pageAfterAd.isAd()
-      ) {
-        return AD_STATE.PENDING;
-      }
-
-      return nextAdPage.maybeCreateCta().then((ctaCreated) => {
-        if (!ctaCreated) {
-          // Failed on outlink creation.
-          return AD_STATE.FAILED;
-        }
-
-        const nextAdPageId = nextAdPage.getId();
-        this.ampStory_.insertPage(pageBeforeAdId, nextAdPageId);
-
-        // If we are inserted we now have a `position` macro available for any
-        // analytics events moving forward.
-        const adIndex = this.adPageIds_[nextAdPageId];
-        const pageNumber = this.ampStory_.getPageIndexById(pageBeforeAdId);
-        this.analytics_.then((analytics) =>
-          analytics.setVar(adIndex, AnalyticsVars.POSITION, pageNumber + 1)
-        );
-
-        return AD_STATE.INSERTED;
-      });
-    });
-  }
-
-  /**
-   * @private
-   * @return {boolean}
-   */
-  isDesktopView_() {
-    return !!this.storeService_.get(StateProperty.DESKTOP_STATE);
-  }
-
-  /**
-   * Users may put an 'next-page-no-ad' attribute on their pages to prevent ads
-   * from showing as the next page.
-   * @param {?../../amp-story/1.0/amp-story-page.AmpStoryPage} page
-   * @return {boolean}
-   * @private
-   */
-  nextPageNoAd_(page) {
-    return page.element.hasAttribute(Attributes.NEXT_PAGE_NO_AD);
-  }
-
-  /**
-   * Call an analytics event with the last created Ad.
-   * @param {string} eventType
-   * @param {!Object<string, number>} vars A map of vars and their values.
-   * @private
-   */
-  analyticsEventWithCurrentAd_(eventType, vars) {
-    Object.assign(vars, {[AnalyticsVars.AD_INDEX]: this.adPagesCreated_});
-    this.analyticsEvent_(eventType, vars);
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -24,7 +24,6 @@ import {
 import {AmpStory} from '../../../amp-story/1.0/amp-story';
 import {AmpStoryAutoAds, Attributes} from '../amp-story-auto-ads';
 import {CommonSignals} from '../../../../src/common-signals';
-import {LocalizationService} from '../../../../src/service/localization';
 import {
   MockStoryImpl,
   addStoryAutoAdsConfig,
@@ -38,7 +37,7 @@ import {registerServiceBuilder} from '../../../../src/service';
 
 const NOOP = () => {};
 
-// TODO(ccordry): Continue to refactor the rest of this file to use new test helpers.
+// TODO(ccordry): Refactor these tests using new associated classes & try to remove stubbing private methods.
 describes.realWin(
   'amp-story-auto-ads',
   {
@@ -59,10 +58,6 @@ describes.realWin(
     beforeEach(() => {
       win = env.win;
       doc = win.document;
-      const localizationService = new LocalizationService(win.document.body);
-      env.sandbox
-        .stub(Services, 'localizationForDoc')
-        .returns(localizationService);
       const viewer = Services.viewerForDoc(env.ampdoc);
       env.sandbox.stub(Services, 'viewerForDoc').returns(viewer);
       registerServiceBuilder(win, 'performance', function () {
@@ -262,7 +257,7 @@ describes.realWin(
         );
         await autoAds.buildCallback();
         await autoAds.layoutCallback();
-        autoAds.idOfAdShowing_ = 'ad-page-1';
+        autoAds.visibleAdPage_ = {getId: () => 'i-amphtml-ad-page-1'};
         autoAds.handleActivePageChange_(
           /* pageIndex */ 2,
           /* pageId */ 'non-ad-page'
@@ -315,51 +310,23 @@ describes.realWin(
     });
 
     describe('analytics triggers', () => {
-      it('should fire "story-ad-insert" upon insertion', async () => {
-        autoAds.uniquePagesCount_ = 10;
-        autoAds.adPagesCreated_ = 1;
-        env.sandbox.stub(autoAds, 'startNextAdPage_');
-        env.sandbox
-          .stub(autoAds, 'tryToPlaceAdAfterPage_')
-          .resolves(/* placed */ 1);
-        const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
-        autoAds.handleActivePageChange_(3, 'fakePage');
-        await macroTask();
-        expect(analyticsStub).to.be.called;
-        expect(analyticsStub).to.have.been.calledWithMatch('story-ad-insert', {
-          'insertTime': env.sandbox.match.number,
-        });
-      });
-
-      it('should fire "story-ad-discard" upon discarded ad', async () => {
-        autoAds.uniquePagesCount_ = 10;
-        autoAds.adPagesCreated_ = 1;
-        env.sandbox.stub(autoAds, 'startNextAdPage_');
-        env.sandbox
-          .stub(autoAds, 'tryToPlaceAdAfterPage_')
-          .resolves(/* discard */ 2);
-        const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
-        autoAds.handleActivePageChange_(3, 'fakePage');
-        await macroTask();
-        expect(analyticsStub).to.be.called;
-        expect(analyticsStub).to.have.been.calledWithMatch('story-ad-discard', {
-          'discardTime': env.sandbox.match.number,
-        });
-      });
-
       it('should fire "story-ad-view" upon ad visible', () => {
         autoAds.ampStory_ = {
           element: storyElement,
           addPage: NOOP,
         };
-        autoAds.adPages_ = [{hasBeenViewed: () => false}];
         autoAds.setVisibleAttribute_ = NOOP;
-        autoAds.enoughPagesLeftInStory_ = NOOP;
-        autoAds.adPagesCreated_ = 1;
-        env.sandbox.stub(autoAds, 'startNextAdPage_');
+        autoAds.placementAlgorithm_ = {onPageChange: NOOP};
+        autoAds.adPageManager_ = {
+          getAdPageById: () => ({
+            hasBeenViewed: () => true,
+          }),
+          getIndexById: () => 1,
+          hasId: () => true,
+          numberOfAdsCreated: () => 1,
+        };
         const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
-        autoAds.adPageIds_ = {'ad-page-1': 1};
-        autoAds.handleActivePageChange_(1, 'ad-page-1');
+        autoAds.handleActivePageChange_(1, 'i-amphtml-ad-page-1');
         expect(analyticsStub).to.be.called;
         expect(analyticsStub).to.have.been.calledWithMatch('story-ad-view', {
           'viewTime': env.sandbox.match.number,
@@ -371,12 +338,14 @@ describes.realWin(
           element: storyElement,
           addPage: NOOP,
         };
-        autoAds.adPagesCreated_ = 1;
-        const page = win.document.createElement('amp-story-page');
-        page.getImpl = () => Promise.resolve();
-
+        autoAds.placementAlgorithm_ = {onPageChange: NOOP};
+        autoAds.visibleAdPage_ = {getId: () => 'page-1'};
+        autoAds.adPageManager_ = {
+          hasId: () => false,
+          numberOfAdsCreated: () => 1,
+          getIndexById: () => 1,
+        };
         const analyticsStub = env.sandbox.stub(autoAds, 'analyticsEvent_');
-        autoAds.idOfAdShowing_ = 'ad-page-1';
         autoAds.handleActivePageChange_(1, 'page-3');
 
         expect(analyticsStub).to.be.called;


### PR DESCRIPTION
And delete a bunch of state keeping logic from `amp-story-auto-ads` that has moved to these new classes. 

Partial #33147

~~Do not merge before #33387 so we can do clean revert if necessary.~~ Merged.