### PR TITLE
Maybe fix amp-ad css experiment issue

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1796,7 +1796,14 @@ export class AmpA4A extends AMP.BaseElement {
       height,
       width
     );
-    this.applyFillContent(this.iframe);
+    divertStickyAdTransition(this.win);
+    if (
+      !this.uiHandler.isStickyAd() ||
+      getExperimentBranch(this.win, STICKY_AD_TRANSITION_EXP.id) !==
+        STICKY_AD_TRANSITION_EXP.experiment
+    ) {
+      this.applyFillContent(this.iframe);
+    }
 
     let body = '';
     const transferComplete = new Deferred();
@@ -1885,8 +1892,9 @@ export class AmpA4A extends AMP.BaseElement {
     ));
     divertStickyAdTransition(this.win);
     if (
+      !this.uiHandler.isStickyAd() ||
       getExperimentBranch(this.win, STICKY_AD_TRANSITION_EXP.id) !==
-      STICKY_AD_TRANSITION_EXP.experiment
+        STICKY_AD_TRANSITION_EXP.experiment
     ) {
       this.applyFillContent(this.iframe);
     }

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -100,7 +100,9 @@ export class AmpAdXOriginIframeHandler {
     devAssert(!this.iframe, 'multiple invocations of init without destroy!');
     this.iframe = iframe;
     this.iframe.setAttribute('scrolling', 'no');
-    this.baseInstance_.applyFillContent(this.iframe);
+    if (!this.uiHandler_.isStickyAd()) {
+      this.baseInstance_.applyFillContent(this.iframe);
+    }
     const timer = Services.timerFor(this.baseInstance_.win);
 
     // Init the legacy observeInterection API service.


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/32135 This experiment is coming back negative. This PR attempts to fix it by only not calling `applyFillContent` when it is a sticky ad. In theory, it should not affect non-sticky ad any more.