### PR TITLE
Remove intersect-resources from bento experiment

### DIFF
--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -205,7 +205,7 @@ export class ResourcesImpl {
      */
     this.intersectionObserverCallbackFired_ = false;
 
-    if (isExperimentOn(this.win, 'bento')) {
+    if (isExperimentOn(this.win, 'intersect-resources')) {
       const iframed = isIframed(this.win);
 
       // Classic IntersectionObserver doesn't support viewport tracking and

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -33,7 +33,6 @@ import {hasNextNodeInDocumentOrder, isIframed} from '../dom';
 import {ieIntrinsicCheckAndFix} from './ie-intrinsic-bug';
 import {ieMediaCheckAndFix} from './ie-media-bug';
 import {isBlockedByConsent, reportError} from '../error';
-import {isExperimentOn} from '../experiments';
 import {listen, loadPromise} from '../event-helper';
 import {registerServiceBuilderForDoc} from '../service';
 import {remove} from '../utils/array';
@@ -205,7 +204,8 @@ export class ResourcesImpl {
      */
     this.intersectionObserverCallbackFired_ = false;
 
-    if (isExperimentOn(this.win, 'intersect-resources')) {
+    // TODO(#33262): cleanup intersect-resources experiment.
+    if (false) {
       const iframed = isIframed(this.win);
 
       // Classic IntersectionObserver doesn't support viewport tracking and


### PR DESCRIPTION
This is a preparation for the `intersect-resources` experiment cleanup.