### PR TITLE
Async pause: simplify adoption with a helper

### DIFF
--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -15,6 +15,7 @@
  */
 
 import {EMPTY_METADATA} from '../../../src/mediasession-helper';
+import {PauseHelper} from '../../../src/utils/pause-helper';
 import {Services} from '../../../src/services';
 import {VideoEvents} from '../../../src/video-interface';
 import {VisibilityState} from '../../../src/visibility-state';
@@ -39,10 +40,6 @@ import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {listen, listenOncePromise} from '../../../src/event-helper';
 import {mutedOrUnmutedEvent} from '../../../src/iframe-video';
-import {
-  observeContentSize,
-  unobserveContentSize,
-} from '../../../src/utils/size-observer';
 import {
   propagateObjectFitStyles,
   setImportantStyles,
@@ -166,13 +163,11 @@ export class AmpVideo extends AMP.BaseElement {
     /** @visibleForTesting {?Element} */
     this.posterDummyImageForTesting_ = null;
 
-    /** @private {boolean} */
-    this.isPlaying_ = false;
-
     /** @private {?boolean} whether there are sources that will use a BitrateManager */
     this.hasBitrateSources_ = null;
 
-    this.pauseWhenNoSize_ = this.pauseWhenNoSize_.bind(this);
+    /** @private @const */
+    this.pauseHelper_ = new PauseHelper(this.element);
   }
 
   /**
@@ -699,26 +694,7 @@ export class AmpVideo extends AMP.BaseElement {
     if (this.isManagedByPool_()) {
       return;
     }
-    if (isPlaying === this.isPlaying_) {
-      return;
-    }
-    this.isPlaying_ = isPlaying;
-    if (isPlaying) {
-      observeContentSize(this.element, this.pauseWhenNoSize_);
-    } else {
-      unobserveContentSize(this.element, this.pauseWhenNoSize_);
-    }
-  }
-
-  /**
-   * @param {!../../../src/layout-rect.LayoutSizeDef} size
-   * @private
-   */
-  pauseWhenNoSize_({width, height}) {
-    const hasSize = width > 0 && height > 0;
-    if (!hasSize && this.video_) {
-      this.video_.pause();
-    }
+    this.pauseHelper_.updatePlaying(isPlaying);
   }
 
   /** @private */

--- a/src/utils/pause-helper.js
+++ b/src/utils/pause-helper.js
@@ -14,13 +14,9 @@
  * limitations under the License.
  */
 
-import {
-  observeContentSize,
-  unobserveContentSize,
-} from './size-observer';
+import {observeContentSize, unobserveContentSize} from './size-observer';
 
 export class PauseHelper {
-
   /**
    * @param {!AmpElement} element
    */

--- a/src/utils/pause-helper.js
+++ b/src/utils/pause-helper.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  observeContentSize,
+  unobserveContentSize,
+} from './size-observer';
+
+export class PauseHelper {
+
+  /**
+   * @param {!AmpElement} element
+   */
+  constructor(element) {
+    /** @private @const */
+    this.element_ = element;
+
+    /** @private {boolean} */
+    this.isPlaying_ = false;
+
+    this.pauseWhenNoSize_ = this.pauseWhenNoSize_.bind(this);
+  }
+
+  /**
+   * @param {boolean} isPlaying
+   */
+  updatePlaying(isPlaying) {
+    if (isPlaying === this.isPlaying_) {
+      return;
+    }
+    this.isPlaying_ = isPlaying;
+    if (isPlaying) {
+      observeContentSize(this.element_, this.pauseWhenNoSize_);
+    } else {
+      unobserveContentSize(this.element_, this.pauseWhenNoSize_);
+    }
+  }
+
+  /**
+   * @param {!../layout-rect.LayoutSizeDef} size
+   * @private
+   */
+  pauseWhenNoSize_({width, height}) {
+    const hasSize = width > 0 && height > 0;
+    if (!hasSize) {
+      this.element_.pause();
+    }
+  }
+}

--- a/test/unit/utils/test-pause-helper.js
+++ b/test/unit/utils/test-pause-helper.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {PauseHelper} from '../../../src/utils/pause-helper';
+import {installResizeObserverStub} from '../../../testing/resize-observer-stub';
+
+describes.realWin('PauseHelper', {}, (env) => {
+  let win, doc;
+  let resizeObserverStub;
+  let element;
+  let helper;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    resizeObserverStub = installResizeObserverStub(env.sandbox, win);
+
+    element = doc.createElement('amp-test');
+    element.pause = () => {};
+    env.sandbox.stub(element, 'pause');
+
+    helper = new PauseHelper(element);
+  });
+
+  it('should start observing', () => {
+    expect(resizeObserverStub.isObserved(element)).to.be.false;
+    helper.updatePlaying(true);
+    expect(resizeObserverStub.isObserved(element)).to.be.true;
+
+    resizeObserverStub.notifySync({
+      target: element,
+      contentRect: {width: 100, height: 100},
+    });
+    expect(element.pause).to.not.be.called;
+  });
+
+  it('should start observing and pause', () => {
+    expect(resizeObserverStub.isObserved(element)).to.be.false;
+    helper.updatePlaying(true);
+    expect(resizeObserverStub.isObserved(element)).to.be.true;
+
+    resizeObserverStub.notifySync({
+      target: element,
+      contentRect: {width: 0, height: 0},
+    });
+    expect(element.pause).to.be.calledOnce;
+  });
+
+  it('should unobserve', () => {
+    helper.updatePlaying(true);
+    expect(resizeObserverStub.isObserved(element)).to.be.true;
+
+    helper.updatePlaying(false);
+    expect(resizeObserverStub.isObserved(element)).to.be.false;
+  });
+});


### PR DESCRIPTION
I think a simple helper would simplify the support for us. Instead of having several state vars we'd just encapsulate them inside a single helper.

Partial for #31915.
Partial for #31540.
