### PR TITLE
🏗 Automatically update `npm` packages if needed before any task is run

### DIFF
--- a/amp.js
+++ b/amp.js
@@ -18,7 +18,13 @@
 const {
   createTask,
   finalizeRunner,
+  initializeRunner,
 } = require('./build-system/tasks/amp-task-runner');
+
+/**
+ * Initialize the task runner before any task is created.
+ */
+initializeRunner();
 
 /**
  * All the AMP tasks. Keep this list alphabetized.

--- a/build-system/tasks/amp-task-runner.js
+++ b/build-system/tasks/amp-task-runner.js
@@ -23,7 +23,9 @@ const argv = require('minimist')(process.argv.slice(2));
 const commander = require('commander');
 const path = require('path');
 const {cyan, red, green, magenta, yellow} = require('kleur/colors');
+const {isCiBuild} = require('../common/ci');
 const {log, logWithoutTimestamp} = require('../common/logging');
+const {updatePackages} = require('./update-packages');
 
 /**
  * Special-case constant that indicates if `amp --help` was invoked.
@@ -138,6 +140,17 @@ function validateUsage(task, taskName, taskFunc) {
 }
 
 /**
+ * Initializes the task runner by running the package updater before any task
+ * code can be loaded. As an optimization, we skip this during CI because it is
+ * already done as a prereqisite step before every CI job.
+ */
+function initializeRunner() {
+  if (!isCiBuild()) {
+    updatePackages();
+  }
+}
+
+/**
  * Finalizes the task runner by doing special-case setup for `amp --help`,
  * parsing the invoked command, and printing an error message if an unknown task
  * was called.
@@ -189,5 +202,6 @@ function printGulpDeprecationNotice(withTimestamps) {
 module.exports = {
   createTask,
   finalizeRunner,
+  initializeRunner,
   printGulpDeprecationNotice,
 };

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -28,7 +28,6 @@ const {
 const {buildExtensions} = require('./extension-helpers');
 const {buildVendorConfigs} = require('./3p-vendor-helpers');
 const {compileCss} = require('./css');
-const {maybeUpdatePackages} = require('./update-packages');
 const {parseExtensionFlags} = require('./extension-helpers');
 
 const argv = require('minimist')(process.argv.slice(2));
@@ -57,7 +56,6 @@ async function build() {
  * @param {Object=} extraArgs
  */
 async function doBuild(extraArgs = {}) {
-  maybeUpdatePackages();
   const handlerProcess = createCtrlcHandler('build');
   process.env.NODE_ENV = 'development';
   const options = {

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -23,7 +23,6 @@ const {gitDiffAddedNameOnlyMaster} = require('../common/git');
 const {green, cyan, red, yellow} = require('kleur/colors');
 const {linkCheckGlobs} = require('../test-configs/config');
 const {log, logLocalDev} = require('../common/logging');
-const {maybeUpdatePackages} = require('./update-packages');
 
 const LARGE_REFACTOR_THRESHOLD = 20;
 const GITHUB_BASE_PATH = 'https://github.com/ampproject/amphtml/blob/master/';
@@ -34,7 +33,6 @@ let filesIntroducedByPr;
  * Checks for dead links in .md files passed in via --files or --local_changes.
  */
 async function checkLinks() {
-  maybeUpdatePackages();
   if (!usesFilesOrLocalChanges('check-links')) {
     return;
   }

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -25,7 +25,6 @@ const {cleanupBuildDir, closureCompile} = require('../compile/compile');
 const {compileCss} = require('./css');
 const {extensions, maybeInitializeExtensions} = require('./extension-helpers');
 const {log} = require('../common/logging');
-const {maybeUpdatePackages} = require('./update-packages');
 const {typecheckNewServer} = require('../server/typescript-compile');
 
 /**
@@ -33,7 +32,6 @@ const {typecheckNewServer} = require('../server/typescript-compile');
  * @return {!Promise}
  */
 async function checkTypes() {
-  maybeUpdatePackages();
   const handlerProcess = createCtrlcHandler('check-types');
   process.env.NODE_ENV = 'production';
   cleanupBuildDir();

--- a/build-system/tasks/css/index.js
+++ b/build-system/tasks/css/index.js
@@ -21,14 +21,12 @@ const path = require('path');
 const {buildExtensions} = require('../extension-helpers');
 const {endBuildStep, watchDebounceDelay} = require('../helpers');
 const {jsifyCssAsync} = require('./jsify-css');
-const {maybeUpdatePackages} = require('../update-packages');
 const {watch} = require('chokidar');
 
 /**
  * Entry point for 'amp css'
  */
 async function css() {
-  maybeUpdatePackages();
   await compileCss();
 }
 

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -19,7 +19,6 @@ const {createCtrlcHandler} = require('../common/ctrlcHandler');
 const {cyan, green} = require('kleur/colors');
 const {doServe} = require('./serve');
 const {log} = require('../common/logging');
-const {maybeUpdatePackages} = require('./update-packages');
 const {parseExtensionFlags} = require('./extension-helpers');
 const {printConfigHelp} = require('./helpers');
 const {runPreBuildSteps} = require('./build');
@@ -43,7 +42,6 @@ function printDefaultTaskHelp() {
  * @return {!Promise}
  */
 async function defaultTask() {
-  maybeUpdatePackages();
   createCtrlcHandler('amp');
   process.env.NODE_ENV = 'development';
   printConfigHelp('amp');

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -45,7 +45,6 @@ const {compileCss, copyCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {formatExtractedMessages} = require('../compile/log-messages');
 const {log} = require('../common/logging');
-const {maybeUpdatePackages} = require('./update-packages');
 const {VERSION} = require('../compile/internal-version');
 
 const {green, cyan} = colors;
@@ -124,7 +123,6 @@ async function dist() {
  * @param {Object=} extraArgs
  */
 async function doDist(extraArgs = {}) {
-  maybeUpdatePackages();
   const handlerProcess = createCtrlcHandler('dist');
   process.env.NODE_ENV = 'production';
   const options = {

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -30,7 +30,6 @@ const {cyan, green, red, yellow} = require('kleur/colors');
 const {ESLint} = require('eslint');
 const {getFilesChanged, getFilesFromArgv} = require('../common/utils');
 const {gitDiffNameOnlyMaster} = require('../common/git');
-const {maybeUpdatePackages} = require('./update-packages');
 
 const rootDir = path.dirname(path.dirname(__dirname));
 
@@ -170,7 +169,6 @@ function getFilesToLint(files) {
  * Run eslint on JS files and log the output
  */
 async function lint() {
-  maybeUpdatePackages();
   let filesToLint = globby.sync(config.lintGlobs, {gitignore: true});
   if (argv.files) {
     filesToLint = getFilesToLint(getFilesFromArgv());

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -37,7 +37,6 @@ const {
 const {exec} = require('../common/exec');
 const {getFilesToCheck} = require('../common/utils');
 const {green, cyan, red, yellow} = require('kleur/colors');
-const {maybeUpdatePackages} = require('./update-packages');
 const {prettifyGlobs} = require('../test-configs/config');
 
 const rootDir = path.dirname(path.dirname(__dirname));
@@ -47,7 +46,6 @@ const tempDir = tempy.directory();
  * Checks files for formatting (and optionally fixes them) with Prettier.
  */
 async function prettify() {
-  maybeUpdatePackages();
   const filesToCheck = getFilesToCheck(prettifyGlobs, {dot: true});
   if (filesToCheck.length == 0) {
     return;


### PR DESCRIPTION
**PR Highlights:**

- Automates `npm` package updates during `amp` tasks by doing it as part of task initialization
- Prevents the case where a task loads a dependency that then gets updated during execution

**Screenshots:**

**Updates necessary:**

![image](https://user-images.githubusercontent.com/26553114/111708536-6cc14780-881c-11eb-8785-a9ac7a681a0d.png)

**Updates not necessary:**

![image](https://user-images.githubusercontent.com/26553114/111708576-7ea2ea80-881c-11eb-91c7-c261e5639674.png)


Fixes #33364
Partial fix for #33141