### PR TITLE
🐛 Move minified check to devAsserts only

### DIFF
--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -65,7 +65,7 @@ export class UserError extends Error {
  * @throws {Error} when shouldBeTruthy is not truthy.
  */
 function assertion(errorCls, shouldBeTruthy, opt_message, var_args) {
-  if (isMinifiedMode() || shouldBeTruthy) {
+  if (shouldBeTruthy) {
     return shouldBeTruthy;
   }
 
@@ -177,6 +177,10 @@ export function pureDevAssert(
   opt_8,
   opt_9
 ) {
+  if (isMinifiedMode()) {
+    return shouldBeTruthy;
+  }
+
   return assertion(
     Error,
     shouldBeTruthy,


### PR DESCRIPTION
In #32407, when splitting user/dev assertions into `src/core/assert`, I mistakenly dropped the `isMinified` check and user/dev asserts stopped being DCE'd out of builds. Justin identified this after some time (we do not have testing for this) and I created #33087, which re-introduced the minified check, but in the shared `assertion` method rather than exclusively in `devAssert`, leading to both `userAssert` and `devAssert` being stripped in minified builds.

This PR moves the minified check into `devAssert` only