### PR TITLE
amp-iframe: add async pause

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -19,6 +19,7 @@ import {ActionTrust} from '../../../src/action-constants';
 import {IntersectionObserver3pHost} from '../../../src/utils/intersection-observer-3p-host';
 import {LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
 import {MessageType} from '../../../src/3p-frame-messaging';
+import {PauseHelper} from '../../../src/utils/pause-helper';
 import {Services} from '../../../src/services';
 import {base64EncodeFromBytes} from '../../../src/utils/base64.js';
 import {createCustomEvent, getData, listen} from '../../../src/event-helper';
@@ -124,10 +125,11 @@ export class AmpIframe extends AMP.BaseElement {
      */
     this.targetOrigin_ = null;
 
-    /**
-     * @private {boolean}
-     */
+    /** @private {boolean} */
     this.hasErroredEmbedSize_ = false;
+
+    /** @private @const */
+    this.pauseHelper_ = new PauseHelper(this.element);
   }
 
   /** @override */
@@ -491,6 +493,8 @@ export class AmpIframe extends AMP.BaseElement {
           });
         }, 1000);
       }
+
+      this.pauseHelper_.updatePlaying(true);
     });
   }
 
@@ -585,6 +589,7 @@ export class AmpIframe extends AMP.BaseElement {
         this.intersectionObserverHostApi_ = null;
       }
     }
+    this.pauseHelper_.updatePlaying(false);
     return true;
   }
 

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -24,6 +24,7 @@ import {
   whenUpgradedToCustomElement,
 } from '../../../../src/dom';
 
+import {installResizeObserverStub} from '../../../../testing/resize-observer-stub';
 import {isAdLike} from '../../../../src/iframe-helper';
 import {macroTask} from '../../../../testing/yield';
 import {poll} from '../../../../testing/iframe';
@@ -51,6 +52,7 @@ describes.realWin(
     let content;
     let win;
     let doc;
+    let resizeObserverStub;
 
     beforeEach(() => {
       iframeSrc =
@@ -79,6 +81,7 @@ describes.realWin(
         }
       });
       setTrackingIframeTimeoutForTesting(20);
+      resizeObserverStub = installResizeObserverStub(env.sandbox, win);
     });
 
     function stubUserAsserts() {
@@ -1063,16 +1066,39 @@ describes.realWin(
       expect(iframe.getAttribute('title')).to.equal(newTitle);
     });
 
-    it('should unlayout on pause', async () => {
-      const ampIframe = createAmpIframe(env, {
-        src: iframeSrc,
-        width: 100,
-        height: 100,
+    describe('pause', () => {
+      it('should have unlayoutOnPause', async () => {
+        const ampIframe = createAmpIframe(env, {
+          src: iframeSrc,
+          width: 100,
+          height: 100,
+        });
+        const impl = await ampIframe.getImpl(false);
+        await waitForAmpIframeLayoutPromise(doc, ampIframe);
+        expect(ampIframe.querySelector('iframe')).to.exist;
+        expect(impl.unlayoutOnPause()).to.be.true;
+
+        ampIframe.pause();
+        expect(ampIframe.querySelector('iframe')).to.not.exist;
       });
-      const impl = await ampIframe.getImpl(false);
-      await waitForAmpIframeLayoutPromise(doc, ampIframe);
-      expect(ampIframe.querySelector('iframe')).to.exist;
-      expect(impl.unlayoutOnPause()).to.be.true;
+
+      it('should unlayout on pause when loses size', async () => {
+        const ampIframe = createAmpIframe(env, {
+          src: iframeSrc,
+          width: 100,
+          height: 100,
+        });
+        await ampIframe.getImpl(false);
+        env.sandbox.stub(ampIframe, 'pause');
+        await waitForAmpIframeLayoutPromise(doc, ampIframe);
+        expect(ampIframe.pause).to.not.be.called;
+
+        resizeObserverStub.notifySync({
+          target: ampIframe,
+          contentRect: {width: 0, height: 0},
+        });
+        expect(ampIframe.pause).to.be.calledOnce;
+      });
     });
 
     describe('throwIfCannotNavigate()', () => {

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -1089,7 +1089,7 @@ describes.realWin(
           height: 100,
         });
         await ampIframe.getImpl(false);
-        env.sandbox.stub(ampIframe, 'pause');
+        env.sandbox./*OK*/ stub(ampIframe, 'pause');
         await waitForAmpIframeLayoutPromise(doc, ampIframe);
         expect(ampIframe.pause).to.not.be.called;
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -716,9 +716,9 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         this.pause();
       }
 
-      // Legacy pre-V1 elements simply unload.
+      // Legacy pre-V1 elements simply unlayout.
       if (!this.V1()) {
-        this.getResource_().unlayout();
+        this.unlayout_();
         return;
       }
 
@@ -1642,7 +1642,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
 
       // Legacy unlayoutOnPause support.
       if (!this.V1() && this.impl_.unlayoutOnPause()) {
-        this.getResource_().unlayout();
+        this.unlayout_();
       }
     }
 
@@ -1683,6 +1683,17 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       }
       this.dispatchCustomEventForTesting(AmpEvents.UNLOAD);
       return isReLayoutNeeded;
+    }
+
+    /** @private */
+    unlayout_() {
+      if (!this.isBuilt()) {
+        return;
+      }
+      this.getResource_().unlayout();
+      if (this.isConnected_ && this.resources_) {
+        this.resources_.schedulePass();
+      }
     }
 
     /** @private */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1692,7 +1692,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       }
       this.getResource_().unlayout();
       if (this.isConnected_ && this.resources_) {
-        this.resources_.schedulePass();
+        this.resources_./*OK*/ schedulePass();
       }
     }
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1687,9 +1687,6 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
 
     /** @private */
     unlayout_() {
-      if (!this.isBuilt()) {
-        return;
-      }
       this.getResource_().unlayout();
       if (this.isConnected_ && this.resources_) {
         this.resources_./*OK*/ schedulePass();


### PR DESCRIPTION
A small change: use `PauseHelper` for `amp-iframe` and make sure the resources pass is scheduled after unlayout.

Partial for #31915.
Partial for #31540.