### PR TITLE
🏗⏪ Downgrade `karma-esbuild` and `esbuild`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12300,12 +12300,13 @@
       }
     },
     "karma-esbuild": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/karma-esbuild/-/karma-esbuild-2.1.1.tgz",
-      "integrity": "sha512-/U81HYgDWF26SV6bEU1Ea3DxY5WkY4+SysEJTsigONvUfJTbLLGICmUPLeyJ97pMKIhX40k5QjpYKiKNIzL7ng==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/karma-esbuild/-/karma-esbuild-2.0.0.tgz",
+      "integrity": "sha512-FfO3Pau0iG38AsGYW2PeNTHusLWV2YwpnsrDUUR0M+kF9OY9rqNUGZSw7y9focEbdYPWbYOOfBMGLVK54GwL9A==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.5.1"
+        "chokidar": "^3.5.1",
+        "karma-sourcemap-loader": "^0.3.8"
       }
     },
     "karma-firefox-launcher": {
@@ -12415,6 +12416,15 @@
       "dev": true,
       "requires": {
         "source-map-support": "^0.5.5"
+      }
+    },
+    "karma-sourcemap-loader": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.8.tgz",
+      "integrity": "sha512-zorxyAakYZuBcHRJE+vbrK2o2JXLFWK8VVjiT/6P+ltLBUGUvqTEkUiQ119MGdOrK7mrmxXHZF1/pfT6GgIZ6g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2"
       }
     },
     "karma-spec-reporter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6293,9 +6293,9 @@
       }
     },
     "esbuild": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.9.3.tgz",
-      "integrity": "sha512-G8k0olucZp3LJ7I/p8y388t+IEyb2Y78nHrLeIxuqZqh6TYqDYP/B/7drAvYKfh83CGwKal9txVP+FTypsPJug==",
+      "version": "0.8.57",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.8.57.tgz",
+      "integrity": "sha512-j02SFrUwFTRUqiY0Kjplwjm1psuzO1d6AjaXKuOR9hrY0HuPsT6sV42B6myW34h1q4CRy+Y3g4RU/cGJeI/nNA==",
       "dev": true
     },
     "escalade": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "3.1.0",
     "karma-coverage-istanbul-reporter": "3.0.3",
-    "karma-esbuild": "2.1.1",
+    "karma-esbuild": "2.0.0",
     "karma-firefox-launcher": "2.1.0",
     "karma-fixture": "0.2.6",
     "karma-html2js-preprocessor": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "del": "6.0.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-preact-pure": "3.0.0",
-    "esbuild": "0.9.3",
+    "esbuild": "0.8.57",
     "escodegen": "2.0.0",
     "eslint": "7.22.0",
     "eslint-config-prettier": "8.1.0",


### PR DESCRIPTION
There's a race in the transformation code that causes the test task [to stall](https://app.circleci.com/pipelines/github/ampproject/amphtml/5088/workflows/7b75d142-a194-4d09-8ca9-ef3189b5020a/jobs/68486/parallel-runs/0/steps/0-109).

![image](https://user-images.githubusercontent.com/26553114/111845791-ef5d0c00-88db-11eb-8571-0ce3b7d6128a.png)

