### PR TITLE
🏗 Fix folder creation for test reports

### DIFF
--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -35,8 +35,7 @@ const {inherits} = require('mocha').utils;
  */
 async function writeOutput(output, filename) {
   try {
-    await fs.ensureDir('result-reports');
-    await fs.writeFile(filename, JSON.stringify(output, null, 4));
+    await fs.outputJson(filename, output, {spaces: 4});
   } catch (error) {
     process.stdout.write(
       Base.color(

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -15,7 +15,7 @@
  */
 'use strict';
 
-const fs = require('fs').promises;
+const fs = require('fs-extra');
 const {
   EVENT_TEST_PASS,
   EVENT_TEST_FAIL,
@@ -35,13 +35,13 @@ const {inherits} = require('mocha').utils;
  */
 async function writeOutput(output, filename) {
   try {
-    await fs.mkdir('result-reports');
+    await fs.ensureDir('result-reports');
     await fs.writeFile(filename, JSON.stringify(output, null, 4));
   } catch (error) {
     process.stdout.write(
       Base.color(
         'fail',
-        `Could not write test result report to file '${filename}'`
+        `Could not write test result report to file '${filename}': ${error}`
       )
     );
   }

--- a/build-system/tasks/e2e/mocha-custom-json-reporter.js
+++ b/build-system/tasks/e2e/mocha-custom-json-reporter.js
@@ -29,7 +29,7 @@ const {inherits} = require('mocha').utils;
 
 /**
  *
- * @param {string} output
+ * @param {!Object} output
  * @param {string} filename
  * @return {Promise<void>}
  */


### PR DESCRIPTION
Enabling test case reporting for experiment tests exposed a bug in `writeOutput()`, which assumes that the `result-reports/` directory doesn't exist. This is no longer true because integration and E2E tests are run on the same job.
