### PR TITLE
fix server transformer not respecting host and port overrides

### DIFF
--- a/build-system/server/new-server/transforms/scripts/scripts-transform.ts
+++ b/build-system/server/new-server/transforms/scripts/scripts-transform.ts
@@ -16,7 +16,7 @@
 
 import posthtml from 'posthtml';
 import {isJsonScript, isValidScript, tryGetUrl} from '../utilities/script';
-import {CDNURLToLocalDistURL} from '../utilities/cdn';
+import {CDNURLToLocalHostRelativeAbsoluteDist} from '../utilities/cdn';
 import {OptionSet} from '../utilities/option-set';
 import {parse} from 'path';
 
@@ -38,7 +38,7 @@ function modifySrc(script: posthtml.Node, options: OptionSet): posthtml.Node {
 
   const url = tryGetUrl(script.attrs.src || '');
   const parsedPath = parse(url.pathname);
-  const src = CDNURLToLocalDistURL(url, [null, null], parsedPath.ext, options.port, options.useMaxNames)
+  const src = CDNURLToLocalHostRelativeAbsoluteDist(url, [null, null], parsedPath.ext, options.port, options.useMaxNames)
       .toString();
   script.attrs.src = src;
   return script;

--- a/build-system/server/new-server/transforms/scripts/test/convert-to-max-names/input.html
+++ b/build-system/server/new-server/transforms/scripts/test/convert-to-max-names/input.html
@@ -1,3 +1,3 @@
-<script src="https://cdn.ampproject.org/v0.js" async></script>
+<script src="https://cdn.ampproject.org/v0.js?a=b&c=d#hello=world" async></script>
 <script src="https://cdn.ampproject.org/v0/amp-bind-0.1.js" async></script>
 <script src="https://cdn.ampproject.org/v0/amp-bind-0.2.js" async></script>

--- a/build-system/server/new-server/transforms/scripts/test/convert-to-max-names/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/convert-to-max-names/output.html
@@ -1,3 +1,3 @@
-<script src="http://localhost:8000/dist/amp.js" async=""></script>
-<script src="http://localhost:8000/dist/v0/amp-bind-0.1.max.js" async=""></script>
-<script src="http://localhost:8000/dist/v0/amp-bind-0.2.max.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/amp.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/v0/amp-bind-0.1.max.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/v0/amp-bind-0.2.max.js" async=""></script>

--- a/build-system/server/new-server/transforms/scripts/test/convert-to-max-names/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/convert-to-max-names/output.html
@@ -1,3 +1,3 @@
-<script src="http://0.0.0.0:8000/dist/amp.js" async=""></script>
-<script src="http://0.0.0.0:8000/dist/v0/amp-bind-0.1.max.js" async=""></script>
-<script src="http://0.0.0.0:8000/dist/v0/amp-bind-0.2.max.js" async=""></script>
+<script src="/dist/amp.js?a=b&c=d#hello=world" async=""></script>
+<script src="/dist/v0/amp-bind-0.1.max.js" async=""></script>
+<script src="/dist/v0/amp-bind-0.2.max.js" async=""></script>

--- a/build-system/server/new-server/transforms/scripts/test/invalid-src-loose/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/invalid-src-loose/output.html
@@ -1,3 +1,3 @@
-<script src="http://localhost:8000/dist/v0.js" async=""></script>
-<script src="http://localhost:8000/dist/amp.js" async=""></script>
-<script src="http://localhost:8000/dist/amp.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/amp.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/amp.js" async=""></script>

--- a/build-system/server/new-server/transforms/scripts/test/invalid-src-loose/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/invalid-src-loose/output.html
@@ -1,3 +1,3 @@
-<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>
-<script src="http://0.0.0.0:8000/dist/amp.js" async=""></script>
-<script src="http://0.0.0.0:8000/dist/amp.js" async=""></script>
+<script src="/dist/v0.js" async=""></script>
+<script src="/dist/amp.js" async=""></script>
+<script src="/dist/amp.js" async=""></script>

--- a/build-system/server/new-server/transforms/scripts/test/multiple/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/multiple/output.html
@@ -1,2 +1,2 @@
-<script src="http://localhost:8000/dist/v0.js" async=""></script>
-<script src="http://localhost:8000/dist/v0.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>

--- a/build-system/server/new-server/transforms/scripts/test/multiple/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/multiple/output.html
@@ -1,2 +1,2 @@
-<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>
-<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>
+<script src="/dist/v0.js" async=""></script>
+<script src="/dist/v0.js" async=""></script>

--- a/build-system/server/new-server/transforms/scripts/test/port-transform-loose/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/port-transform-loose/output.html
@@ -1,5 +1,5 @@
-<script async="" src="http://localhost:9876/dist/amp.js"></script>
-<script async="" src="http://localhost:9876/dist/v0.js" nomodule=""></script>
-<script async="" src="http://localhost:9876/dist/v0.mjs" type="module"></script>
-<script async="" src="http://localhost:9876/dist/v0/amp-bind-0.1.js"></script>
-<script async="" src="http://localhost:9876/dist/dist/amp.js"></script>
+<script async="" src="http://0.0.0.0:9876/dist/amp.js"></script>
+<script async="" src="http://0.0.0.0:9876/dist/v0.js" nomodule=""></script>
+<script async="" src="http://0.0.0.0:9876/dist/v0.mjs" type="module"></script>
+<script async="" src="http://0.0.0.0:9876/dist/v0/amp-bind-0.1.js"></script>
+<script async="" src="http://0.0.0.0:9876/dist/dist/amp.js"></script>

--- a/build-system/server/new-server/transforms/scripts/test/port-transform-loose/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/port-transform-loose/output.html
@@ -1,5 +1,5 @@
-<script async="" src="http://0.0.0.0:9876/dist/amp.js"></script>
-<script async="" src="http://0.0.0.0:9876/dist/v0.js" nomodule=""></script>
-<script async="" src="http://0.0.0.0:9876/dist/v0.mjs" type="module"></script>
-<script async="" src="http://0.0.0.0:9876/dist/v0/amp-bind-0.1.js"></script>
-<script async="" src="http://0.0.0.0:9876/dist/dist/amp.js"></script>
+<script async="" src="/dist/amp.js"></script>
+<script async="" src="/dist/v0.js" nomodule=""></script>
+<script async="" src="/dist/v0.mjs" type="module"></script>
+<script async="" src="/dist/v0/amp-bind-0.1.js"></script>
+<script async="" src="/dist/dist/amp.js"></script>

--- a/build-system/server/new-server/transforms/scripts/test/port-transform-strict/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/port-transform-strict/output.html
@@ -1,5 +1,5 @@
 <script async="" src="http://localhost:8000/amp.js"></script>
-<script async="" src="http://localhost:9876/dist/v0.js" nomodule=""></script>
-<script async="" src="http://localhost:9876/dist/v0.mjs" type="module"></script>
+<script async="" src="http://0.0.0.0:9876/dist/v0.js" nomodule=""></script>
+<script async="" src="http://0.0.0.0:9876/dist/v0.mjs" type="module"></script>
 <script async="" src="http://localhost:8000/v0/amp-bind-0.1.js"></script>
 <script async="" src="/dist/amp.js"></script>

--- a/build-system/server/new-server/transforms/scripts/test/port-transform-strict/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/port-transform-strict/output.html
@@ -1,5 +1,5 @@
 <script async="" src="http://localhost:8000/amp.js"></script>
-<script async="" src="http://0.0.0.0:9876/dist/v0.js" nomodule=""></script>
-<script async="" src="http://0.0.0.0:9876/dist/v0.mjs" type="module"></script>
+<script async="" src="/dist/v0.js" nomodule=""></script>
+<script async="" src="/dist/v0.mjs" type="module"></script>
 <script async="" src="http://localhost:8000/v0/amp-bind-0.1.js"></script>
 <script async="" src="/dist/amp.js"></script>

--- a/build-system/server/new-server/transforms/scripts/test/retain-extension/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/retain-extension/output.html
@@ -1,3 +1,3 @@
-<script async="" src="http://0.0.0.0:8000/dist/v0.js"></script>
-<script async="" src="http://0.0.0.0:8000/dist/v0.mjs"></script>
-<script async="" src="http://0.0.0.0:8000/dist/v0.sxg.js"></script>
+<script async="" src="/dist/v0.js"></script>
+<script async="" src="/dist/v0.mjs"></script>
+<script async="" src="/dist/v0.sxg.js"></script>

--- a/build-system/server/new-server/transforms/scripts/test/retain-extension/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/retain-extension/output.html
@@ -1,3 +1,3 @@
-<script async="" src="http://localhost:8000/dist/v0.js"></script>
-<script async="" src="http://localhost:8000/dist/v0.mjs"></script>
-<script async="" src="http://localhost:8000/dist/v0.sxg.js"></script>
+<script async="" src="http://0.0.0.0:8000/dist/v0.js"></script>
+<script async="" src="http://0.0.0.0:8000/dist/v0.mjs"></script>
+<script async="" src="http://0.0.0.0:8000/dist/v0.sxg.js"></script>

--- a/build-system/server/new-server/transforms/scripts/test/runtime/input.html
+++ b/build-system/server/new-server/transforms/scripts/test/runtime/input.html
@@ -1,2 +1,2 @@
-<script src="https://cdn.ampproject.org/v0.js" async></script>
+<script src="https://cdn.ampproject.org/v0.js?a=b&c=d#hello=world" async></script>
 <script src="https://cdn.ampproject.org/v0/amp-bind-0.1.js" async></script>

--- a/build-system/server/new-server/transforms/scripts/test/runtime/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/runtime/output.html
@@ -1,2 +1,2 @@
-<script src="http://localhost:8000/dist/v0.js" async=""></script>
-<script src="http://localhost:8000/dist/v0/amp-bind-0.1.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>
+<script src="http://0.0.0.0:8000/dist/v0/amp-bind-0.1.js" async=""></script>

--- a/build-system/server/new-server/transforms/scripts/test/runtime/output.html
+++ b/build-system/server/new-server/transforms/scripts/test/runtime/output.html
@@ -1,2 +1,2 @@
-<script src="http://0.0.0.0:8000/dist/v0.js" async=""></script>
-<script src="http://0.0.0.0:8000/dist/v0/amp-bind-0.1.js" async=""></script>
+<script src="/dist/v0.js?a=b&c=d#hello=world" async=""></script>
+<script src="/dist/v0/amp-bind-0.1.js" async=""></script>

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -23,12 +23,14 @@ import transformCss from './css/css-transform';
 
 const argv = minimist(process.argv.slice(2));
 const FOR_TESTING = argv._.includes('integration');
+const HOST = argv.host ? argv.host : '0.0.0.0';
 // Use 9876 if running integration tests as this is the KARMA_SERVER_PORT
-const PORT = FOR_TESTING ? 9876 : 8000;
+const PORT = FOR_TESTING ? 9876 : (argv.port ? argv.port : 8000);
 const ESM = !!argv.esm;
 
 const defaultTransformConfig = {
   esm: ESM,
+  host: HOST,
   port: PORT,
   fortesting: FOR_TESTING,
   useMaxNames: !argv.compiled,

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -23,7 +23,7 @@ import transformCss from './css/css-transform';
 
 const argv = minimist(process.argv.slice(2));
 const FOR_TESTING = argv._.includes('integration');
-const HOST = argv.host ? argv.host : '0.0.0.0';
+const HOST = argv.host ?? '0.0.0.0';
 // Use 9876 if running integration tests as this is the KARMA_SERVER_PORT
 const PORT = FOR_TESTING ? 9876 : (argv.port ? argv.port : 8000);
 const ESM = !!argv.esm;

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -23,14 +23,12 @@ import transformCss from './css/css-transform';
 
 const argv = minimist(process.argv.slice(2));
 const FOR_TESTING = argv._.includes('integration');
-const HOST = argv.host ?? '0.0.0.0';
 // Use 9876 if running integration tests as this is the KARMA_SERVER_PORT
 const PORT = FOR_TESTING ? 9876 : (argv.port ?? 8000);
 const ESM = !!argv.esm;
 
 const defaultTransformConfig = {
   esm: ESM,
-  host: HOST,
   port: PORT,
   fortesting: FOR_TESTING,
   useMaxNames: !argv.compiled,

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -25,7 +25,7 @@ const argv = minimist(process.argv.slice(2));
 const FOR_TESTING = argv._.includes('integration');
 const HOST = argv.host ?? '0.0.0.0';
 // Use 9876 if running integration tests as this is the KARMA_SERVER_PORT
-const PORT = FOR_TESTING ? 9876 : (argv.port ? argv.port : 8000);
+const PORT = FOR_TESTING ? 9876 : (argv.port ?? 8000);
 const ESM = !!argv.esm;
 
 const defaultTransformConfig = {

--- a/build-system/server/new-server/transforms/utilities/cdn.ts
+++ b/build-system/server/new-server/transforms/utilities/cdn.ts
@@ -55,7 +55,7 @@ export function CDNURLToLocalDistURL(
   useMaxNames = false,
 ): URL {
   url.protocol = 'http';
-  url.hostname = '0.0.0.0';
+  url.hostname = 'localhost';
   url.port = String(port);
 
   const [overwriteablePathname, newPathname] = pathnames;
@@ -75,6 +75,17 @@ export function CDNURLToLocalDistURL(
   url.pathname = format(parsedPath);
 
   return url;
+}
+
+export function CDNURLToLocalHostRelativeAbsoluteDist(
+  url: URL,
+  pathnames: [string | null, string | null] = [null, null],
+  extension: string = '.js',
+  port: number = 8000,
+  useMaxNames = false,
+): string {
+  const newUrl = CDNURLToLocalDistURL(url, pathnames, extension, port, useMaxNames);
+  return `${newUrl.pathname}${newUrl.search}${newUrl.hash}`;
 }
 
 /**

--- a/build-system/server/new-server/transforms/utilities/cdn.ts
+++ b/build-system/server/new-server/transforms/utilities/cdn.ts
@@ -55,7 +55,7 @@ export function CDNURLToLocalDistURL(
   useMaxNames = false,
 ): URL {
   url.protocol = 'http';
-  url.hostname = 'localhost';
+  url.hostname = '0.0.0.0';
   url.port = String(port);
 
   const [overwriteablePathname, newPathname] = pathnames;

--- a/build-system/server/new-server/transforms/utilities/script.ts
+++ b/build-system/server/new-server/transforms/utilities/script.ts
@@ -76,12 +76,12 @@ export function toExtension(url: URL, extension: string): URL {
  * This is a temporary measure to allow for a relaxed parsing of our
  * fixture files' src urls before they are all fixed accordingly.
  */
-export function tryGetUrl(src: string, port: number = 8000): URL {
+export function tryGetUrl(src: string, host: string = '0.0.0.0', port: number = 8000): URL {
   let url;
   try {
     url = new URL(src);
   } catch (e) {
-    url = new URL(src, `http://localhost:${port}`);
+    url = new URL(src, `http://${host}:${port}`);
   } finally {
     return url as URL;
   }

--- a/build-system/server/new-server/transforms/utilities/script.ts
+++ b/build-system/server/new-server/transforms/utilities/script.ts
@@ -77,12 +77,5 @@ export function toExtension(url: URL, extension: string): URL {
  * fixture files' src urls before they are all fixed accordingly.
  */
 export function tryGetUrl(src: string, host: string = '0.0.0.0', port: number = 8000): URL {
-  let url;
-  try {
-    url = new URL(src);
-  } catch (e) {
-    url = new URL(src, `http://${host}:${port}`);
-  } finally {
-    return url as URL;
-  }
+  return new URL(src, `http://${host}:${port}`);
 }


### PR DESCRIPTION
currently when a port and host override is passed in from `gulp serve` the transformer does not currently apply the values to the transformed document. this breaks some port forwarding scenarios as well as being able to override the host and port values manually.