### PR TITLE
🖍 Fix visible UI that mentions "Accelerated Mobile Pages"

### DIFF
--- a/ads/google/a4a/docs/RTBExchangeGuide.md
+++ b/ads/google/a4a/docs/RTBExchangeGuide.md
@@ -20,9 +20,9 @@ Exchanges will need to indicate in the RTB bid request whether a page is built i
 
 A new field is added to the `Site` object of the OpenRTB standard to indicate whether a webpage is built on AMP. In OpenRTB 2.5, this is section 3.2.13.
 
-| Field | Scope    | Type    | Default | Description                                                                                                                                 |
-| ----- | -------- | ------- | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `amp` | optional | integer |    -    | Whether the request is for an Accelerated Mobile Page. 0 = page is non-AMP, 1 = page is built with AMP HTML. AMP status unknown if omitted. |
+| Field | Scope    | Type    | Default | Description                                                                                                                      |
+| ----- | -------- | ------- | :-----: | -------------------------------------------------------------------------------------------------------------------------------- |
+| `amp` | optional | integer |    -    | Whether the request is for an AMP Document. 0 = page is non-AMP, 1 = page is built with AMP HTML. AMP status unknown if omitted. |
 
 **`Imp` Object additional field: `ampad`**
 

--- a/extensions/amp-access/0.1/amp-login-done.html
+++ b/extensions/amp-access/0.1/amp-login-done.html
@@ -105,8 +105,7 @@
       </svg>
     </div>
     <div class="logo-text">
-      <div>Accelerated</div>
-      <div>Mobile Pages</div>
+      <div>AMP</div>
     </div>
   </header>
 

--- a/tools/experiments/experiments.html
+++ b/tools/experiments/experiments.html
@@ -24,7 +24,7 @@
       padding-left: 0;
       padding-top: 18px;
       text-transform: uppercase;
-      width: 10%;
+      width: 100%;
       display: inline-block;
       padding: 10px 15px;
       text-decoration: none;
@@ -213,10 +213,7 @@
 <body>
   <header>
     <div class="tab header-title">
-      Accelerated
-      Mobile
-      Pages
-      Project
+      AMP Project
     </div>
   </header>
 

--- a/validator/js/webui/index.html
+++ b/validator/js/webui/index.html
@@ -39,7 +39,7 @@
     .ampproject-error { color: #F44336; }
   </style>
   <meta name="description"
-        content="AMP HTML Project Web Validator. Tests Accelerated Mobile Pages for valid markup.">
+        content="AMP HTML Project Web Validator. Tests AMP Documents for valid markup.">
 </head>
 <body unresolved>
   <webui-mainpage></webui-mainpage>


### PR DESCRIPTION
A few of our UI elements use the old name of "Accelerated Mobile Pages". They should be "AMP", stylized in all caps.