### PR TITLE
🏗 Clean up all `gulp` style error throwing in build-system

### DIFF
--- a/build-system/global.d.ts
+++ b/build-system/global.d.ts
@@ -1,15 +1,4 @@
 declare global {
-  // TODO(#28387) delete this once all uses of these properties have been removed.
-  interface Error {
-    /**
-     * In the build-system, Error objects contain useful info like underlying
-     * stack traces in the message field, so we print that and hide the less
-     * useful nodejs stack.
-     */
-    showStack?: boolean;
-    status?: string;
-  }
-
   interface CompilerNode {
     type: string;
     name: string;

--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -49,9 +49,7 @@ function setServeMode(modeOptions) {
     if (isRtvMode(rtv)) {
       serveMode = rtv;
     } else {
-      const err = new Error(`Invalid rtv: ${rtv}. (Must be 15 digits long.)`);
-      err.showStack = false;
-      throw err;
+      throw new Error(`Invalid rtv: ${rtv}. (Must be 15 digits long.)`);
     }
   }
 }

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -54,9 +54,7 @@ async function checkExactVersions() {
   if (success) {
     return Promise.resolve();
   } else {
-    const reason = new Error('Check failed');
-    reason.showStack = false;
-    return Promise.reject(reason);
+    return Promise.reject('Check failed');
   }
 }
 

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -51,10 +51,8 @@ async function checkExactVersions() {
       );
     }
   });
-  if (success) {
-    return Promise.resolve();
-  } else {
-    return Promise.reject('Check failed');
+  if (!success) {
+    throw new Error('Check failed');
   }
 }
 

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -28,7 +28,6 @@ const checkerExecutable = 'npx npm-exact-versions';
  * @return {!Promise}
  */
 async function checkExactVersions() {
-  let success = true;
   const packageJsonFiles = globby.sync(['**/package.json', '!**/node_modules']);
   packageJsonFiles.forEach((file) => {
     const checkerCmd = `${checkerExecutable} --path ${file}`;
@@ -41,7 +40,7 @@ async function checkExactVersions() {
         'do not have an exact version.'
       );
       logWithoutTimestamp(gitDiffFileMaster(file));
-      success = false;
+      throw new Error('Check failed');
     } else {
       logLocalDev(
         green('SUCCESS:'),
@@ -51,9 +50,6 @@ async function checkExactVersions() {
       );
     }
   });
-  if (!success) {
-    throw new Error('Check failed');
-  }
 }
 
 module.exports = {

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -38,17 +38,6 @@ const expectedFirstLineFile = 'src/polyfills/abort-controller.js'; // First file
 const expectedFirstLineCode = 'class AbortController {'; // First line of code in that file.
 
 /**
- * Throws an error with the given message
- *
- * @param {string} message
- */
-function throwError(message) {
-  const err = new Error(message);
-  err.showStack = false;
-  throw err;
-}
-
-/**
  * Build runtime with sourcemaps if needed.
  */
 function maybeBuild() {
@@ -68,7 +57,7 @@ function maybeBuild() {
 function getSourcemapJson(map) {
   if (!fs.existsSync(map)) {
     log(red('ERROR:'), 'Could not find', cyan(map));
-    throwError(`Could not find sourcemap file '${map}'`);
+    throw new Error(`Could not find sourcemap file '${map}'`);
   }
   return JSON.parse(fs.readFileSync(map, 'utf8'));
 }
@@ -83,11 +72,11 @@ function checkSourcemapUrl(sourcemapJson, map) {
   log('Inspecting', cyan('sourceRoot'), 'in', cyan(map) + '...');
   if (!sourcemapJson.sourceRoot) {
     log(red('ERROR:'), 'Could not find', cyan('sourceRoot'));
-    throwError('Could not find sourcemap URL');
+    throw new Error('Could not find sourcemap URL');
   }
   if (!sourcemapJson.sourceRoot.match(sourcemapUrlMatcher)) {
     log(red('ERROR:'), cyan(sourcemapJson.sourceRoot), 'is badly formatted');
-    throwError('Badly formatted sourcemap URL');
+    throw new Error('Badly formatted sourcemap URL');
   }
 }
 
@@ -101,7 +90,7 @@ function checkSourcemapSources(sourcemapJson, map) {
   log('Inspecting', cyan('sources'), 'in', cyan(map) + '...');
   if (!sourcemapJson.sources) {
     log(red('ERROR:'), 'Could not find', cyan('sources'));
-    throwError('Could not find sources array');
+    throw new Error('Could not find sources array');
   }
   const invalidSources = sourcemapJson.sources
     .filter((source) => !source.match(/\[.*\]/)) // Ignore non-path sources '[...]'
@@ -113,7 +102,7 @@ function checkSourcemapSources(sourcemapJson, map) {
       cyan('sources') + ':',
       cyan(invalidSources.join(', '))
     );
-    throwError('Invalid paths in sources array');
+    throw new Error('Invalid paths in sources array');
   }
 }
 
@@ -138,7 +127,7 @@ function checkSourcemapMappings(sourcemapJson, map) {
   log('Inspecting', cyan('mappings'), 'in', cyan(map) + '...');
   if (!sourcemapJson.mappings) {
     log(red('ERROR:'), 'Could not find', cyan('mappings'));
-    throwError('Could not find mappings array');
+    throw new Error('Could not find mappings array');
   }
 
   // Zeroth sub-array corresponds to ';' and has no mappings.
@@ -158,14 +147,14 @@ function checkSourcemapMappings(sourcemapJson, map) {
     log('Actual:', cyan(firstLineFile));
     log('Expected:', cyan(expectedFirstLineFile));
     log(helpMessage);
-    throwError('Found mapping for incorrect file');
+    throw new Error('Found mapping for incorrect file');
   }
   if (firstLineCode != expectedFirstLineCode) {
     log(red('ERROR:'), 'Found mapping for incorrect code.');
     log('Actual:', cyan(firstLineCode));
     log('Expected:', cyan(expectedFirstLineCode));
     log(helpMessage);
-    throwError('Found mapping for incorrect code');
+    throw new Error('Found mapping for incorrect code');
   }
 }
 

--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -84,14 +84,10 @@ async function cherryPick() {
   let onto = String(argv.onto || '');
 
   if (!commits.length) {
-    const error = new Error('Must provide commit list with --commits');
-    error.showStack = false;
-    throw error;
+    throw new Error('Must provide commit list with --commits');
   }
   if (!onto) {
-    const error = new Error('Must provide 13-digit AMP version with --onto');
-    error.showStack = false;
-    throw error;
+    throw new Error('Must provide 13-digit AMP version with --onto');
   }
   if (onto.length === 15) {
     log(
@@ -103,9 +99,7 @@ async function cherryPick() {
     onto = onto.substr(2);
   }
   if (onto.length !== 13) {
-    const error = new Error('Expected 13-digit AMP version');
-    error.showStack = false;
-    throw error;
+    throw new Error('Expected 13-digit AMP version');
   }
 
   const branch = cherryPickBranchName(onto, commits.length);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -404,9 +404,7 @@ function handleBundleError(err, continueOnError, destFilename) {
   if (continueOnError) {
     log(red('ERROR:'), reasonMessage);
   } else {
-    const reason = new Error(reasonMessage);
-    reason.showStack = false;
-    throw reason;
+    throw new Error(reasonMessage);
   }
 }
 

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -36,16 +36,13 @@ const jobName = 'pr-check.js';
 /**
  * This file runs tests against the local workspace to mimic the CI build as
  * closely as possible.
- * @param {Function} cb
  */
-async function prCheck(cb) {
+async function prCheck() {
   setLoggingPrefix(jobName);
 
   const failTask = () => {
     stopTimer(jobName, startTime);
-    const err = new Error('Local PR check failed. See logs above.');
-    err.showStack = false;
-    cb(err);
+    throw new Error('Local PR check failed. See logs above.');
   };
 
   const runCheck = (cmd) => {

--- a/build-system/tasks/server-tests.js
+++ b/build-system/tasks/server-tests.js
@@ -162,9 +162,7 @@ function reportResult() {
     `(${cyan(passed)} passed, ${cyan(failed)} failed).`;
   if (failed > 0) {
     log(red('ERROR:'), result);
-    const err = new Error('Tests failed');
-    err.showStack = false;
-    throw err;
+    throw new Error('Tests failed');
   } else {
     log(green('SUCCESS:'), result);
   }

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -42,15 +42,6 @@ const repoDir = path.join(__dirname, '../../..');
 const envConfigDir = (env) => path.join(__dirname, `${env}-env`);
 
 /**
- * @param {string} message Message for amp task (call stack is already in logs)
- */
-const throwError = (message) => {
-  const err = new Error(message);
-  err.showStack = false;
-  throw err;
-};
-
-/**
  * @param {string} env 'amp' or 'preact'
  */
 function launchEnv(env) {
@@ -67,7 +58,7 @@ function launchEnv(env) {
     ].join(' '),
     {cwd: __dirname, stdio: 'inherit'}
   ).on('error', () => {
-    throwError('Launch failed');
+    throw new Error('Launch failed');
   });
 }
 
@@ -103,7 +94,7 @@ function buildEnv(env) {
     {cwd: __dirname, stdio: 'inherit'}
   );
   if (result.status != 0) {
-    throwError('Build failed');
+    throw new Error('Build failed');
   }
 }
 


### PR DESCRIPTION
The old `gulp` task runner used by AMP had a boolean [`showStack`](https://github.com/gulpjs/plugin-error/blob/1d51476e4d7da44c1daea246531ae822617e4565/index.d.ts#L85-L88) field in its Error interface to decide on whether to show the (mostly-useless) nodejs callstack. With the new `amp` task runner, the way to go is to simply throw an error when a task hits a fatal error.

This PR cleans up all old code that used `showStack`.

