### PR TITLE
🏗️  Ignore .babel-cache directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,7 @@ dist.tools/**
 firebase/**
 out/**
 test/coverage/**
+.babel-cache/**
 
 # Code directories
 build-system/tasks/visual-diff/snippets/*.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,8 @@
-package.json
-package-lock.json
+.babel-cache/**
+.github/ISSUE_TEMPLATE/**
+**/package*.json
+**/node_modules/**
+**/build/**
+**/dist/**
+**/dist.3p/**
+**/dist.tools/**

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -122,12 +122,13 @@ function getFilesFromArgv() {
  *
  * @param {!Array<string>} globs
  * @param {Object=} options
+ * @param {(string|Array<string>)=} ignoreRules
  * @return {!Array<string>}
  */
-function getFilesToCheck(globs, options = {}) {
+function getFilesToCheck(globs, options = {}, ignoreRules = undefined) {
   const ignored = ignore();
-  if (options.ignore) {
-    ignored.add(options.ignore);
+  if (ignoreRules) {
+    ignored.add(ignoreRules);
   }
   if (argv.files) {
     return logFiles(ignored.filter(getFilesFromArgv()));

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -49,7 +49,7 @@ async function prettify() {
   // Prettier ignores the `.prettierignore` file when using the API like we
   // are. So we need to filter our files down before feeding them to the API.
   const ignore = fs.readFileSync('.prettierignore', 'utf8');
-  const filesToCheck = getFilesToCheck(prettifyGlobs, {dot: true, ignore});
+  const filesToCheck = getFilesToCheck(prettifyGlobs, {dot: true}, ignore);
   if (filesToCheck.length == 0) {
     return;
   }

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -34,7 +34,6 @@ const {
   logOnSameLineLocalDev,
   logWithoutTimestamp,
 } = require('../common/logging');
-const {default: ignore} = require('ignore');
 const {exec} = require('../common/exec');
 const {getFilesToCheck} = require('../common/utils');
 const {green, cyan, red, yellow} = require('kleur/colors');
@@ -47,10 +46,10 @@ const tempDir = tempy.directory();
  * Checks files for formatting (and optionally fixes them) with Prettier.
  */
 async function prettify() {
-  const ignored = ignore().add(fs.readFileSync('.prettierignore', 'utf8'));
-  const filesToCheck = ignored.filter(
-    getFilesToCheck(prettifyGlobs, {dot: true})
-  );
+  // Prettier ignores the `.prettierignore` file when using the API like we
+  // are. So we need to filter our files down before feeding them to the API.
+  const ignore = fs.readFileSync('.prettierignore', 'utf8');
+  const filesToCheck = getFilesToCheck(prettifyGlobs, {dot: true, ignore});
   if (filesToCheck.length == 0) {
     return;
   }

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -34,6 +34,7 @@ const {
   logOnSameLineLocalDev,
   logWithoutTimestamp,
 } = require('../common/logging');
+const {default: ignore} = require('ignore');
 const {exec} = require('../common/exec');
 const {getFilesToCheck} = require('../common/utils');
 const {green, cyan, red, yellow} = require('kleur/colors');
@@ -46,7 +47,10 @@ const tempDir = tempy.directory();
  * Checks files for formatting (and optionally fixes them) with Prettier.
  */
 async function prettify() {
-  const filesToCheck = getFilesToCheck(prettifyGlobs, {dot: true});
+  const ignored = ignore().add(fs.readFileSync('.prettierignore', 'utf8'));
+  const filesToCheck = ignored.filter(
+    getFilesToCheck(prettifyGlobs, {dot: true})
+  );
   if (filesToCheck.length == 0) {
     return;
   }

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -176,9 +176,6 @@ const prettifyGlobs = [
   '**/*.json',
   '**/OWNERS',
   '**/*.md',
-  '!**/package*.json',
-  '!.github/ISSUE_TEMPLATE/**',
-  '!**/{node_modules,build,dist,dist.3p,dist.tools}/**',
 ];
 
 /**

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "globby": "11.0.2",
     "gulp-connect": "5.7.0",
     "html-minifier": "4.0.0",
+    "ignore": "5.1.8",
     "istanbul-middleware": "0.2.2",
     "jest-dot-reporter": "1.0.12",
     "jest-silent-reporter": "0.5.0",


### PR DESCRIPTION
Also ensure prettier respects its `.prettierignore` file, which for some reason it ignores when using the API vs the CLI.