### PR TITLE
🏗 Make warning levels for `check-types` more granular

### DIFF
--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -31,7 +31,7 @@ function logClosureCompilerError(message) {
   log(red('ERROR:'));
   const babelCacheDir = `${getBabelCacheDir()}/`;
   const loggingPrefix = /^.*?gulp-google-closure-compiler.*?: /;
-  const highlight = require('cli-highlight'); // Lazy-required to speed up task loading.
+  const {highlight} = require('cli-highlight'); // Lazy-required to speed up task loading.
   const highlightedMessage = highlight(message, {ignoreIllegals: true});
   const formattedMessage = highlightedMessage
     .replace(loggingPrefix, '')

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -49,6 +49,7 @@ const MAX_PARALLEL_CLOSURE_INVOCATIONS =
  *  verboseLogging?: boolean,
  *  typeCheckOnly?: boolean,
  *  skipUnknownDepsCheck?: boolean,
+ *  warningLevel?: boolean,
  * }}
  */
 let OptionsDef;
@@ -272,8 +273,8 @@ function generateCompilerOptions(outputDir, outputFilename, options) {
     jscomp_off: [],
     define,
     hide_warnings_for: hideWarningsFor,
-    // TODO(amphtml): Change 'QUIET' to 'DEFAULT' after #32875 is merged.
-    warning_level: argv.warning_level || 'QUIET',
+    // TODO(amphtml): Change 'QUIET' to 'DEFAULT'.
+    warning_level: argv.warning_level ?? options.warningLevel ?? 'QUIET',
   };
   if (argv.pseudo_names) {
     // Some optimizations get turned off when pseudo_names is on.


### PR DESCRIPTION
As requested in https://github.com/ampproject/error-reporting/issues/73#issuecomment-806217750, this PR lets you set different warning levels while type checking different parts of the AMP codebase.

Once this is merged, it should be possible to change the `warningLevel` option for the calls to `closureCompile()` in `check-types.js` one by one and fix resulting errors / warnings via separate PRs. This should make it more feasible to split up #32875.

**Bonus fixes:**
- Correctly destructure the `highlight` package that is used to print closure error messages
- Modernize `check-types.js` to use arrow functions and `async` / `await` (no functional changes)

**Note:** For easy reviewing, use [this link](https://github.com/ampproject/amphtml/pull/33469/files?w=1) to hide whitespace-only changes.