### PR TITLE
🏗 Move term list fileset to eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -328,12 +328,6 @@ module.exports = {
       },
     },
     {
-      'files': ['build-system/babel-plugins/**/test/fixtures/**/*'],
-      'rules': {
-        'local/no-forbidden-terms': 0,
-      },
-    },
-    {
       'files': [
         '**/.eslintrc.js',
         'amp.js',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -317,7 +317,6 @@ module.exports = {
     },
     {
       'files': [
-        'build-system/babel-plugins/**/test/fixtures/**/*',
         '**/test-*',
         '**/_init_tests*',
         '**/*_test.js',
@@ -326,6 +325,12 @@ module.exports = {
       ],
       'rules': {
         'local/no-forbidden-terms': [2, forbiddenTermsGlobal],
+      },
+    },
+    {
+      'files': ['build-system/babel-plugins/**/test/fixtures/**/*'],
+      'rules': {
+        'local/no-forbidden-terms': 0,
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,10 @@
  */
 
 const fs = require('fs');
+const {
+  forbiddenTermsGlobal,
+  forbiddenTermsSrcInclusive,
+} = require('./build-system/test-configs/forbidden-terms');
 
 /**
  * Dynamically extracts experiment globals from the config file.
@@ -140,7 +144,11 @@ module.exports = {
     'local/no-es2015-number-props': 2,
     'local/no-export-side-effect': 2,
     'local/no-for-of-statement': 2,
-    'local/no-forbidden-terms': 2,
+    'local/no-forbidden-terms': [
+      2,
+      forbiddenTermsGlobal,
+      forbiddenTermsSrcInclusive,
+    ],
     'local/no-function-async': 2,
     'local/no-function-generator': 2,
     'local/no-global': 0,
@@ -305,6 +313,19 @@ module.exports = {
         'restoreAsyncErrorThrows': false,
         'stubAsyncErrorThrows': false,
         'Key': false,
+      },
+    },
+    {
+      'files': [
+        'build-system/babel-plugins/**/test/fixtures/**/*',
+        '**/test-*',
+        '**/_init_tests*',
+        '**/*_test.js',
+        '**/testing/**',
+        '**/storybook/*.js',
+      ],
+      'rules': {
+        'local/no-forbidden-terms': [2, forbiddenTermsGlobal],
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -318,7 +318,7 @@ module.exports = {
     {
       'files': [
         '**/test-*',
-        '**/_init_tests*',
+        '**/_init_tests.js',
         '**/*_test.js',
         '**/testing/**',
         '**/storybook/*.js',

--- a/build-system/eslint-rules/no-forbidden-terms.js
+++ b/build-system/eslint-rules/no-forbidden-terms.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const {getForbiddenTerms} = require('../test-configs/forbidden-terms');
+const {matchForbiddenTerms} = require('../test-configs/forbidden-terms');
 const {relative} = require('path');
 
 /**
@@ -28,13 +28,16 @@ module.exports = function (context) {
     Program() {
       const filename = relative(process.cwd(), context.getFilename());
       const sourceCode = context.getSourceCode();
+      const contents = sourceCode.text;
 
-      for (const report of getForbiddenTerms(filename, sourceCode.text)) {
-        const {match, message, loc} = report;
-        context.report({
-          loc,
-          message: `Forbidden: "${match}".${message ? `\n${message}.` : ''}`,
-        });
+      for (const terms of context.options) {
+        for (const report of matchForbiddenTerms(filename, contents, terms)) {
+          const {match, message, loc} = report;
+          context.report({
+            loc,
+            message: `Forbidden: "${match}".${message ? `\n${message}.` : ''}`,
+          });
+        }
       }
     },
   };

--- a/build-system/tasks/presubmit-checks.js
+++ b/build-system/tasks/presubmit-checks.js
@@ -18,8 +18,11 @@
 const fs = require('fs');
 const globby = require('globby');
 const srcGlobs = require('../test-configs/config').presubmitGlobs;
+const {
+  matchForbiddenTerms,
+  forbiddenTermsGlobal,
+} = require('../test-configs/forbidden-terms');
 const {cyan, red, yellow} = require('kleur/colors');
-const {getForbiddenTerms} = require('../test-configs/forbidden-terms');
 const {log} = require('../common/logging');
 
 /**
@@ -46,7 +49,7 @@ const requiredTermsExcluded = /amp-__component_name_hyphenated__/;
  */
 function hasForbiddenTerms(srcFile) {
   const contents = fs.readFileSync(srcFile, 'utf-8');
-  const terms = getForbiddenTerms(srcFile, contents);
+  const terms = matchForbiddenTerms(srcFile, contents, forbiddenTermsGlobal);
   for (const {match, loc, message} of terms) {
     log(
       red('ERROR:'),

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-const path = require('path');
-
 // Terms are defined in this file.
 /* eslint-disable local/no-forbidden-terms */
 
@@ -53,7 +51,7 @@ let ForbiddenTermDef;
  * Terms that must not appear in our source files.
  * @const {Object<string, string|!ForbiddenTermDef>}
  */
-const forbiddenTerms = {
+const forbiddenTermsGlobal = {
   'DO NOT SUBMIT': '',
   'whitelist|white-list': {
     message: 'Please use the term allowlist instead',
@@ -1284,19 +1282,6 @@ function isInTestFolder(path) {
 }
 
 /**
- * Check if file is inside the build-system/babel-plugins test/fixture folder.
- * @param {string} srcFile
- * @return {boolean}
- */
-function isInBuildSystemFixtureFolder(srcFile) {
-  const folder = path.dirname(srcFile);
-  return (
-    folder.startsWith('build-system/babel-plugins') &&
-    folder.includes('test/fixtures')
-  );
-}
-
-/**
  * Strip Comments
  * @param {string} contents
  * @return {string}
@@ -1338,10 +1323,9 @@ function matchForbiddenTerms(srcFile, contents, terms) {
       // NOTE: we could do a glob test instead of exact check in the future
       // if needed but that might be too permissive.
       if (
-        isInBuildSystemFixtureFolder(srcFile) ||
-        (Array.isArray(allowlist) &&
-          (allowlist.indexOf(srcFile) != -1 ||
-            (isInTestFolder(srcFile) && !checkInTestFolder)))
+        Array.isArray(allowlist) &&
+        (allowlist.indexOf(srcFile) != -1 ||
+          (isInTestFolder(srcFile) && !checkInTestFolder))
       ) {
         return [];
       }
@@ -1388,30 +1372,8 @@ function matchForbiddenTerms(srcFile, contents, terms) {
     .reduce((a, b) => a.concat(b));
 }
 
-/**
- * @param {string} srcFile
- * @param {string} contents
- * @return {Array<!ForbiddenTermMatchDef>}
- */
-function getForbiddenTerms(srcFile, contents) {
-  const basename = path.basename(srcFile);
-
-  const terms = matchForbiddenTerms(srcFile, contents, forbiddenTerms);
-
-  const isTestFile =
-    /^test-/.test(basename) ||
-    /^_init_tests/.test(basename) ||
-    /_test\.js$/.test(basename) ||
-    /testing\//.test(srcFile) ||
-    /storybook\/[^/]+\.js$/.test(srcFile);
-  if (!isTestFile) {
-    return [
-      ...terms,
-      ...matchForbiddenTerms(srcFile, contents, forbiddenTermsSrcInclusive),
-    ];
-  }
-
-  return terms;
-}
-
-module.exports = {getForbiddenTerms};
+module.exports = {
+  forbiddenTermsGlobal,
+  forbiddenTermsSrcInclusive,
+  matchForbiddenTerms,
+};


### PR DESCRIPTION
Replaces hardcoded filename logic with globs on `.estlintrc.js`.