### PR TITLE
🏗 Ensure that forbidden term allowlists are updated

### DIFF
--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -58,8 +58,7 @@ module.exports = {
           if (!stringLiteral.type.endsWith('Literal')) {
             context.report({
               node: stringLiteral,
-              message:
-                'Forbidden terms allowlist should only contain string literals',
+              message: `${node.key.name} should only contain string literals`,
             });
             continue;
           }

--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {readFileSync} = require('fs');
+
+/**
+ * @fileoverview
+ * Ensures that forbidden-terms.js is up-to-date by reporting listed files that
+ * do not include the allowed term.
+ */
+
+module.exports = {
+  meta: {fixable: 'code'},
+  create: function (context) {
+    function removeFromArray(fixer, {start, end}) {
+      const {text} = context.getSourceCode();
+      while (/\s/.test(text[start - 1])) {
+        start--;
+      }
+      while (/[,\n]/.test(text[end])) {
+        end++;
+      }
+      return fixer.removeRange([start, end]);
+    }
+
+    return {
+      ['Property' +
+      "[key.name='allowlist']" +
+      "[value.type='ArrayExpression']" +
+      "[parent.parent.type='Property']"]: function (node) {
+        const {value: term} = node.parent.parent.key;
+        const termRegexp = new RegExp(term, 'gm');
+
+        if (node.value.elements.length < 1) {
+          context.report({
+            node,
+            message: `Remove empty ${node.key.name}`,
+            fix(fixer) {
+              return removeFromArray(fixer, node);
+            },
+          });
+          return;
+        }
+
+        for (const stringLiteral of node.value.elements) {
+          if (!stringLiteral.type.endsWith('Literal')) {
+            context.report({
+              node: stringLiteral,
+              message:
+                'Forbidden terms allowlist should only contain string literals',
+            });
+            continue;
+          }
+
+          const filename = stringLiteral.value;
+
+          let content;
+          try {
+            content = readFileSync(filename, 'utf-8');
+          } catch (_) {}
+
+          if (content && content.match(termRegexp)) {
+            continue;
+          }
+
+          context.report({
+            node: stringLiteral,
+            message: content
+              ? 'File does not use this term.'
+              : 'File does not exist.',
+            suggest: [
+              {
+                desc: `Remove from ${node.key.name}`,
+                fix(fixer) {
+                  return removeFromArray(fixer, stringLiteral);
+                },
+              },
+            ],
+          });
+        }
+      },
+    };
+  },
+};

--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -41,9 +41,6 @@ module.exports = {
       "[key.name='allowlist']" +
       "[value.type='ArrayExpression']" +
       "[parent.parent.type='Property']"]: function (node) {
-        const {value: term} = node.parent.parent.key;
-        const termRegexp = new RegExp(term, 'gm');
-
         if (node.value.elements.length < 1) {
           context.report({
             node,
@@ -54,6 +51,8 @@ module.exports = {
           });
           return;
         }
+
+        const termRegexp = new RegExp(node.parent.parent.key, 'gm');
 
         for (const stringLiteral of node.value.elements) {
           if (!stringLiteral.type.endsWith('Literal')) {

--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -24,7 +24,7 @@ const {readFileSync} = require('fs');
 
 module.exports = {
   meta: {fixable: 'code'},
-  create: function (context) {
+  create(context) {
     function removeFromArray(fixer, {start, end}) {
       const {text} = context.getSourceCode();
       while (/\s/.test(text[start - 1])) {

--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -27,6 +27,21 @@ const allowlistProperty = 'allowlist';
 module.exports = {
   meta: {fixable: 'code'},
   create(context) {
+    // Some files are allowlisted for multiple terms, so caching their content
+    // greatly speeds up this rule.
+    const fileContent = {};
+
+    function readFileContent(filename) {
+      try {
+        return (
+          fileContent[filename] ||
+          (fileContent[filename] = readFileSync(filename, 'utf-8'))
+        );
+      } catch (_) {
+        return null;
+      }
+    }
+
     function* removeFromArray(fixer, node) {
       const {text} = context.getSourceCode();
       let {start} = node;
@@ -98,11 +113,7 @@ module.exports = {
           }
 
           const filename = stringLiteral.value;
-
-          let content;
-          try {
-            content = readFileSync(filename, 'utf-8');
-          } catch (_) {}
+          const content = readFileContent(filename);
 
           if (content && content.match(termRegexp)) {
             continue;

--- a/build-system/test-configs/.eslintrc.js
+++ b/build-system/test-configs/.eslintrc.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+  'overrides': [
+    {
+      'files': ['forbidden-terms.js'],
+      'rules': {
+        // The terms referenced by this rule are defined in this file.
+        'local/no-forbidden-terms': 0,
+        // Ensures that allowlists in file are up-to-date.
+        'local/forbidden-terms-config': 2,
+      },
+    },
+  ],
+};

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1144,19 +1144,6 @@ function isInTestFolder(path) {
 }
 
 /**
- * Check if file is inside the build-system/babel-plugins test/fixture folder.
- * @param {string} srcFile
- * @return {boolean}
- */
-function isInBuildSystemFixtureFolder(srcFile) {
-  const folder = path.dirname(srcFile);
-  return (
-    folder.startsWith('build-system/babel-plugins') &&
-    folder.includes('test/fixtures')
-  );
-}
-
-/**
  * Strip Comments
  * @param {string} contents
  * @return {string}

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -339,7 +339,7 @@ const forbiddenTerms = {
       // iframe-messaging-client.sendMessage
       '3p/iframe-messaging-client.js',
       '3p/ampcontext.js',
-      '3p/ampcontext-integration.js', // includes previous
+      '3p/ampcontext-integration.js',
     ],
   },
   '\\.sendMessageAwaitResponse\\(': {

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -16,12 +16,6 @@
 
 const path = require('path');
 
-// Terms are defined in this file.
-/* eslint-disable local/no-forbidden-terms */
-
-// Ensures that file is up-to-date.
-/* eslint "local/forbidden-terms-config": 2 */
-
 const requiresReviewPrivacy =
   'Usage of this API requires dedicated review due to ' +
   'being privacy sensitive. Please file an issue asking for permission' +

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1198,10 +1198,8 @@ function matchForbiddenTerms(srcFile, contents, terms) {
       // NOTE: we could do a glob test instead of exact check in the future
       // if needed but that might be too permissive.
       if (
-        isInBuildSystemFixtureFolder(srcFile) ||
-        (Array.isArray(allowlist) &&
-          (allowlist.indexOf(srcFile) != -1 ||
-            (isInTestFolder(srcFile) && !checkInTestFolder)))
+        (Array.isArray(allowlist) && allowlist.indexOf(srcFile) != -1) ||
+        (isInTestFolder(srcFile) && !checkInTestFolder)
       ) {
         return [];
       }

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -19,6 +19,9 @@ const path = require('path');
 // Terms are defined in this file.
 /* eslint-disable local/no-forbidden-terms */
 
+// Ensures that file is up-to-date.
+/* eslint "local/forbidden-terms-config": 2 */
+
 const requiresReviewPrivacy =
   'Usage of this API requires dedicated review due to ' +
   'being privacy sensitive. Please file an issue asking for permission' +
@@ -64,7 +67,6 @@ const forbiddenTerms = {
   'grandfather|grandfathered': {
     message: 'Please use the term legacy instead',
   },
-  // TODO(dvoytenko, #8464): cleanup allowlist.
   '(^-amp-|\\W-amp-)': {
     message: 'Switch to new internal class form',
     allowlist: [
@@ -72,8 +74,6 @@ const forbiddenTerms = {
       'build-system/server/app-index/boilerplate.js',
       'build-system/server/variable-substitution.js',
       'build-system/tasks/extension-generator/index.js',
-      'css/ampdoc.css',
-      'css/ampshared.css',
       'extensions/amp-pinterest/0.1/amp-pinterest.css',
       'extensions/amp-pinterest/0.1/follow-button.js',
       'extensions/amp-pinterest/0.1/pin-widget.js',
@@ -85,8 +85,6 @@ const forbiddenTerms = {
     message: 'Switch to new internal ID form',
     allowlist: [
       'build-system/tasks/create-golden-css/css/main.css',
-      'build-system/tasks/extension-generator/index.js',
-      'css/ampdoc.css',
       'css/ampshared.css',
     ],
   },
@@ -121,26 +119,20 @@ const forbiddenTerms = {
       'build-system/common/check-package-manager.js',
       'build-system/common/logging.js',
       'src/purifier/noop.js',
-      'validator/js/engine/parse-css.js',
       'validator/js/engine/validator-in-browser.js',
-      'validator/js/engine/validator.js',
-      'validator/js/nodejs/index.js', // NodeJs only.
+      'validator/js/engine/validator.js', // NodeJs only.
     ],
     checkInTestFolder: true,
   },
   '\\bgetModeObject\\(': {
     message: realiasGetMode,
-    allowlist: [
-      'src/mode-object.js',
-      'src/iframe-attributes.js',
-      'dist.3p/current/integration.js',
-    ],
+    allowlist: ['src/mode-object.js', 'src/iframe-attributes.js'],
   },
   '(?:var|let|const) +IS_DEV +=': {
     message:
       'IS_DEV local var only allowed in mode.js and ' +
       'dist.3p/current/integration.js',
-    allowlist: ['src/mode.js', 'dist.3p/current/integration.js'],
+    allowlist: ['src/mode.js'],
   },
   '\\.prefetch\\(': {
     message: 'Do not use preconnect.prefetch, use preconnect.preload instead.',
@@ -164,7 +156,7 @@ const forbiddenTerms = {
   },
   '\\.mountInternal': {
     message: 'can only be called by the framework',
-    allowlist: ['src/service/scheduler.js', 'testing/iframe.js'],
+    allowlist: ['src/service/scheduler.js'],
   },
   'getSchedulerForDoc': {
     message: 'can only be used by the runtime',
@@ -177,7 +169,6 @@ const forbiddenTerms = {
       'src/inabox/inabox-services.js',
       'src/service/action-impl.js',
       'src/service/core-services.js',
-      'src/service/standard-actions-impl.js',
     ],
   },
   'installActionHandler': {
@@ -190,10 +181,7 @@ const forbiddenTerms = {
   },
   'installActivityService': {
     message: privateServiceFactory,
-    allowlist: [
-      'extensions/amp-analytics/0.1/activity-impl.js',
-      'extensions/amp-analytics/0.1/amp-analytics.js',
-    ],
+    allowlist: ['extensions/amp-analytics/0.1/activity-impl.js'],
   },
   'cidServiceForDocForTesting': {
     message: privateServiceFactory,
@@ -201,11 +189,7 @@ const forbiddenTerms = {
   },
   'installCryptoService': {
     message: privateServiceFactory,
-    allowlist: [
-      'src/runtime.js',
-      'src/service/core-services.js',
-      'src/service/crypto-impl.js',
-    ],
+    allowlist: ['src/service/core-services.js', 'src/service/crypto-impl.js'],
   },
   'installDocService': {
     message: privateServiceFactory,
@@ -220,17 +204,12 @@ const forbiddenTerms = {
   },
   'installMutatorServiceForDoc': {
     message: privateServiceFactory,
-    allowlist: [
-      'src/inabox/inabox-services.js',
-      'src/service/core-services.js',
-      'src/service/mutator-impl.js',
-    ],
+    allowlist: ['src/service/core-services.js', 'src/service/mutator-impl.js'],
   },
   'installPerformanceService': {
     message: privateServiceFactory,
     allowlist: [
       'src/amp.js',
-      'src/amp-shadow.js',
       'src/inabox/amp-inabox.js',
       'src/service/performance-impl.js',
     ],
@@ -238,23 +217,17 @@ const forbiddenTerms = {
   'installResourcesServiceForDoc': {
     message: privateServiceFactory,
     allowlist: [
-      'src/inabox/inabox-services.js',
       'src/service/core-services.js',
       'src/service/resources-impl.js',
     ],
   },
   'installStorageServiceForDoc': {
     message: privateServiceFactory,
-    allowlist: [
-      'src/runtime.js',
-      'src/service/core-services.js',
-      'src/service/storage-impl.js',
-    ],
+    allowlist: ['src/service/core-services.js', 'src/service/storage-impl.js'],
   },
   'installTemplatesServiceForDoc': {
     message: privateServiceFactory,
     allowlist: [
-      'src/runtime.js',
       'src/inabox/inabox-services.js',
       'src/service/core-services.js',
       'src/service/template-impl.js',
@@ -270,52 +243,32 @@ const forbiddenTerms = {
   },
   'installViewerServiceForDoc': {
     message: privateServiceFactory,
-    allowlist: [
-      'src/runtime.js',
-      'src/inabox/inabox-services.js',
-      'src/service/core-services.js',
-      'src/service/viewer-impl.js',
-    ],
+    allowlist: ['src/service/core-services.js', 'src/service/viewer-impl.js'],
   },
   'installViewportServiceForDoc': {
     message: privateServiceFactory,
     allowlist: [
-      'src/runtime.js',
       'src/service/core-services.js',
       'src/service/viewport/viewport-impl.js',
     ],
   },
   'installVsyncService': {
     message: privateServiceFactory,
-    allowlist: [
-      'src/runtime.js',
-      'src/service/core-services.js',
-      'src/service/resources-impl.js',
-      'src/service/viewport/viewport-impl.js',
-      'src/service/vsync-impl.js',
-    ],
+    allowlist: ['src/service/core-services.js', 'src/service/vsync-impl.js'],
   },
   'installXhrService': {
     message: privateServiceFactory,
-    allowlist: [
-      'src/runtime.js',
-      'src/service/core-services.js',
-      'src/service/xhr-impl.js',
-    ],
+    allowlist: ['src/service/core-services.js', 'src/service/xhr-impl.js'],
   },
   'installPositionObserverServiceForDoc': {
     message: privateServiceFactory,
     allowlist: [
       // Please keep list alphabetically sorted.
       'extensions/amp-fx-collection/0.1/providers/fx-provider.js',
-      'extensions/amp-list/0.1/amp-list.js',
       'extensions/amp-next-page/0.1/next-page-service.js',
       'extensions/amp-next-page/1.0/visibility-observer.js',
       'extensions/amp-position-observer/0.1/amp-position-observer.js',
-      'extensions/amp-video-docking/0.1/amp-video-docking.js',
       'src/service/position-observer/position-observer-impl.js',
-      'src/service/video-manager-impl.js',
-      'src/service/video/autoplay.js',
     ],
   },
   'getServiceForDoc': {
@@ -351,9 +304,7 @@ const forbiddenTerms = {
       '3p/recaptcha.js',
       'ads/alp/install-alp.js',
       'ads/inabox/inabox-host.js',
-      'dist.3p/current/integration.js',
       'extensions/amp-access/0.1/amp-login-done.js',
-      'extensions/amp-viewer-integration/0.1/examples/amp-viewer-host.js',
       'src/amp-story-player/amp-story-component-manager.js',
       'src/runtime.js',
       'src/log.js',
@@ -365,9 +316,7 @@ const forbiddenTerms = {
     message: 'Use parseUrl instead.',
     allowlist: [
       'src/url.js',
-      'src/service/navigation.js',
       'src/service/url-impl.js',
-      'dist.3p/current/integration.js',
       'src/amp-story-player/amp-story-player-impl.js',
     ],
   },
@@ -377,7 +326,6 @@ const forbiddenTerms = {
       // viewer-impl.sendMessage
       'src/error.js',
       'src/service/navigation.js',
-      'src/service/viewer-impl.js',
       'src/service/viewport/viewport-impl.js',
       'src/service/performance-impl.js',
       'src/service/resources-impl.js',
@@ -391,16 +339,13 @@ const forbiddenTerms = {
       // iframe-messaging-client.sendMessage
       '3p/iframe-messaging-client.js',
       '3p/ampcontext.js',
-      '3p/ampcontext-integration.js',
-      '3p/recaptcha.js',
-      'dist.3p/current/integration.js', // includes previous
+      '3p/ampcontext-integration.js', // includes previous
     ],
   },
   '\\.sendMessageAwaitResponse\\(': {
     message: 'Usages must be reviewed.',
     allowlist: [
       'extensions/amp-access/0.1/login-dialog.js',
-      'extensions/amp-access/0.1/signin.js',
       'extensions/amp-story-education/0.1/amp-story-education.js',
       'extensions/amp-subscriptions/0.1/viewer-subscription-platform.js',
       'src/impression.js',
@@ -408,7 +353,6 @@ const forbiddenTerms = {
       'src/service/history-impl.js',
       'src/service/storage-impl.js',
       'src/ssr-template-helper.js',
-      'src/service/viewer-impl.js',
       'src/service/viewer-cid-api.js',
       'src/utils/xhr-utils.js',
     ],
@@ -422,7 +366,6 @@ const forbiddenTerms = {
       // https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec
       'src/ad-cid.js',
       'src/services.js',
-      'src/service/cid-impl.js',
       'src/service/standard-actions-impl.js',
       'src/service/url-replacements-impl.js',
       'extensions/amp-access/0.1/amp-access.js',
@@ -436,7 +379,7 @@ const forbiddenTerms = {
   },
   'getBaseCid': {
     message: requiresReviewPrivacy,
-    allowlist: ['src/service/cid-impl.js', 'src/service/viewer-impl.js'],
+    allowlist: ['src/service/cid-impl.js'],
   },
   'isTrustedViewer': {
     message: requiresReviewPrivacy,
@@ -464,7 +407,6 @@ const forbiddenTerms = {
   },
   'eval\\(': {
     message: shouldNeverBeUsed,
-    allowlist: ['extension/amp-bind/0.1/test/test-bind-expr.js'],
   },
   'storageForDoc|storageForTopLevelDoc': {
     message:
@@ -489,7 +431,6 @@ const forbiddenTerms = {
     message: requiresReviewPrivacy,
     allowlist: [
       'extensions/amp-access/0.1/amp-access-iframe.js',
-      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
       'extensions/amp-script/0.1/amp-script.js',
       'extensions/amp-story/1.0/history.js',
       'extensions/amp-web-push/0.1/amp-web-push-helper-frame.js',
@@ -521,7 +462,6 @@ const forbiddenTerms = {
       'build-system/externs/amp.extern.js',
       'extensions/amp-access/0.1/amp-access.js',
       'extensions/amp-access/0.1/access-vars.js',
-      'extensions/amp-access-scroll/0.1/scroll-impl.js',
       'extensions/amp-subscriptions/0.1/amp-subscriptions.js',
       'src/service/url-replacements-impl.js',
     ],
@@ -543,7 +483,6 @@ const forbiddenTerms = {
     allowlist: [
       '3p/integration-lib.js',
       'ads/google/a4a/utils.js',
-      'dist.3p/current/integration.js',
       'src/inabox/inabox-viewer.js',
       'src/service/viewer-impl.js',
       'src/error.js',
@@ -554,7 +493,6 @@ const forbiddenTerms = {
     message: 'Use Viewer.getReferrerUrl() instead.',
     allowlist: [
       'extensions/amp-dynamic-css-classes/0.1/amp-dynamic-css-classes.js',
-      'src/3p-frame.js',
       'src/iframe-attributes.js',
       'src/service/viewer-impl.js',
       'src/service/viewer-interface.js',
@@ -568,13 +506,11 @@ const forbiddenTerms = {
     allowlist: [
       'src/3p-frame-messaging.js',
       'src/event-helper.js',
-      'src/event-helper-listen.js',
-      'dist.3p/current/integration.js', // includes previous
+      'src/event-helper-listen.js', // includes previous
     ],
   },
   'setTimeout.*throw': {
     message: 'Use dev.error or user.error instead.',
-    allowlist: ['src/log.js'],
   },
   '(dev|user)\\(\\)\\.(fine|info|warn|error)\\((?!\\s*([A-Z0-9-]+|[\'"`][A-Z0-9-]+[\'"`]))[^,)\n]*': {
     message:
@@ -591,11 +527,7 @@ const forbiddenTerms = {
   '\\.requireLayout\\(': {
     message:
       'requireLayout is restricted b/c it affects non-contained elements',
-    allowlist: [
-      'extensions/amp-animation/0.1/web-animations.js',
-      'extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js',
-      'src/service/resources-impl.js',
-    ],
+    allowlist: ['extensions/amp-animation/0.1/web-animations.js'],
   },
   '\\.updateLayoutPriority\\(': {
     message: 'updateLayoutPriority is a restricted API.',
@@ -624,13 +556,11 @@ const forbiddenTerms = {
   },
   '\\.getWin\\(': {
     message: backwardCompat,
-    allowlist: [],
   },
   '/\\*\\* @type \\{\\!Element\\} \\*/': {
     message: 'Use assertElement instead of casting to !Element.',
     allowlist: [
       'src/log.js', // Has actual implementation of assertElement.
-      'dist.3p/current/integration.js', // Includes the previous.
       'src/polyfills/custom-elements.js',
       'ads/google/imaVideo.js', // Required until #22277 is fixed.
       '3p/twitter.js', // Runs in a 3p window context, so cannot import log.js.
@@ -665,7 +595,6 @@ const forbiddenTerms = {
       'build-system/tasks/default-task.js',
       'build-system/tasks/dist.js',
       'build-system/tasks/helpers.js',
-      'dist.3p/current/integration.js',
       'src/config.js',
       'src/experiments.js',
       'src/mode.js',
@@ -682,7 +611,6 @@ const forbiddenTerms = {
   },
   'new CustomEvent\\(': {
     message: 'Use createCustomEvent() helper instead.',
-    allowlist: ['src/event-helper.js'],
   },
   'new FormData\\(': {
     message:
@@ -713,7 +641,6 @@ const forbiddenTerms = {
       'body after an error please use `makeBodyVisibleRecovery`',
     allowlist: [
       'src/amp.js',
-      'src/amp-shadow.js',
       'src/style-installer.js',
       'src/inabox/amp-inabox.js',
     ],
@@ -779,8 +706,6 @@ const forbiddenTerms = {
       'extensions/amp-analytics/0.1/test/test-linker-reader.js',
       'extensions/amp-analytics/0.1/test/test-linker.js',
       'extensions/amp-analytics/0.1/test/test-transport-serializers.js',
-      'extensions/amp-analytics/0.1/test/test-vendors.js',
-      'extensions/amp-animation/0.1/test/test-css-expr.js',
       'extensions/amp-auto-ads/0.1/test/test-attributes.js',
       'extensions/amp-bind/0.1/test/test-bind-evaluator.js',
       'extensions/amp-bind/0.1/test/test-bind-expression.js',
@@ -795,20 +720,14 @@ const forbiddenTerms = {
       'extensions/amp-truncate-text/0.1/test/test-binary-search.js',
       'extensions/amp-viewer-integration/0.1/test/test-findtext.js',
       'test/integration/test-3p-nameframe.js',
-      'test/integration/test-actions.js',
       'test/integration/test-amp-ad-3p.js',
-      'test/integration/test-amp-ad-fake.js',
-      'test/integration/test-amp-analytics.js',
       'test/integration/test-amp-pixel.js',
-      'test/integration/test-amp-recaptcha-input.js',
       'test/integration/test-amp-skimlinks.js',
-      'test/integration/test-amphtml-ads.js',
       'test/integration/test-boilerplates.js',
       'test/integration/test-configuration.js',
       'test/integration/test-css.js',
       'test/integration/test-extensions-loading.js',
       'test/integration/test-released.js',
-      'test/integration/test-toggle-display.js',
       'test/integration/test-video-manager.js',
       'test/integration/test-video-players.js',
       'test/unit/3p/test-3p-messaging.js',
@@ -822,7 +741,6 @@ const forbiddenTerms = {
       'test/unit/test-ads-config.js',
       'test/unit/test-alp-handler.js',
       'test/unit/test-amp-context.js',
-      'test/unit/test-amp-img.js',
       'test/unit/test-amp-inabox.js',
       'test/unit/test-animation.js',
       'test/unit/test-batched-json.js',
@@ -833,7 +751,6 @@ const forbiddenTerms = {
       'test/unit/test-curve.js',
       'test/unit/test-describes.js',
       'test/unit/test-document-ready.js',
-      'test/unit/test-element-service.js',
       'test/unit/test-error.js',
       'test/unit/test-event-helper.js',
       'test/unit/test-experiments.js',
@@ -844,11 +761,9 @@ const forbiddenTerms = {
       'test/unit/test-gesture.js',
       'test/unit/test-get-html.js',
       'test/unit/test-ie-media-bug.js',
-      'test/unit/test-impression.js',
       'test/unit/test-input.js',
       'test/unit/test-integration.js',
       'test/unit/test-intersection-observer-polyfill.js',
-      'test/unit/test-intersection-observer.js',
       'test/unit/test-json.js',
       'test/unit/test-layout-rect.js',
       'test/unit/test-layout.js',
@@ -856,7 +771,6 @@ const forbiddenTerms = {
       'test/unit/test-mode.js',
       'test/unit/test-motion.js',
       'test/unit/test-mustache.js',
-      'test/unit/test-mutator.js',
       'test/unit/test-object.js',
       'test/unit/test-observable.js',
       'test/unit/test-pass.js',
@@ -865,15 +779,12 @@ const forbiddenTerms = {
       'test/unit/test-polyfill-math-sign.js',
       'test/unit/test-polyfill-object-assign.js',
       'test/unit/test-polyfill-object-values.js',
-      'test/unit/test-preconnect.js',
       'test/unit/test-pull-to-refresh.js',
       'test/unit/test-purifier.js',
       'test/unit/test-render-delaying-services.js',
       'test/unit/test-resource.js',
-      'test/unit/test-resources.js',
       'test/unit/test-sanitizer.js',
       'test/unit/test-service.js',
-      'test/unit/test-size-list.js',
       'test/unit/test-srcset.js',
       'test/unit/test-static-template.js',
       'test/unit/test-string.js',
@@ -887,10 +798,8 @@ const forbiddenTerms = {
       'test/unit/test-viewport.js',
       'test/unit/test-web-components.js',
       'test/unit/utils/test-array.js',
-      'test/unit/utils/test-base64.js',
       'test/unit/utils/test-bytes.js',
       'test/unit/utils/test-lru-cache.js',
-      'test/unit/utils/test-pem.js',
       'test/unit/utils/test-priority-queue.js',
       'test/unit/utils/test-rate-limit.js',
       'test/unit/web-worker/test-amp-worker.js',
@@ -969,18 +878,13 @@ const forbiddenTermsSrcInclusive = {
     message: bannedTermsHelpString,
     allowlist: [
       'extensions/amp-install-serviceworker/0.1/amp-install-serviceworker.js',
-      'src/service/viewport/viewport-impl.js',
     ],
   },
   'getComputedStyle\\(': {
     message:
       'Due to various bugs in Firefox, you must use the computedStyle ' +
       'helper in style.js.',
-    allowlist: [
-      'src/style.js',
-      'dist.3p/current/integration.js',
-      'build-system/tasks/coverage-map/index.js',
-    ],
+    allowlist: ['src/style.js', 'build-system/tasks/coverage-map/index.js'],
   },
   'decodeURIComponent\\(': {
     message:
@@ -988,12 +892,10 @@ const forbiddenTermsSrcInclusive = {
       'use tryDecodeUriComponent from src/url.js',
     allowlist: [
       '3p/integration-lib.js',
-      'dist.3p/current/integration.js',
       'examples/pwa/pwa.js',
       'validator/js/engine/parse-url.js',
       'validator/js/engine/validator.js',
       'validator/js/webui/webui.js',
-      'extensions/amp-pinterest/0.1/util.js',
       'src/url.js',
       'src/url-try-decode-uri-component.js',
       'src/utils/bytes.js',
@@ -1025,32 +927,18 @@ const forbiddenTermsSrcInclusive = {
   'preloadExtension': {
     message: bannedTermsHelpString,
     allowlist: [
-      'src/element-stub.js',
       'src/friendly-iframe-embed.js',
       'src/polyfillstub/intersection-observer-stub.js',
       'src/polyfillstub/resize-observer-stub.js',
-      'src/runtime.js',
       'src/service/extensions-impl.js',
-      'src/service/lightbox-manager-discovery.js',
       'src/service/crypto-impl.js',
-      'src/shadow-embed.js',
-      'src/analytics.js',
-      'src/extension-analytics.js',
-      'src/services.js',
-      'extensions/amp-ad/0.1/amp-ad.js',
-      'extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js',
-      'extensions/amp-animation/0.1/install-polyfill.js',
     ],
   },
   'loadElementClass': {
     message: bannedTermsHelpString,
     allowlist: [
-      'src/runtime.js',
       'src/service/extensions-impl.js',
       'extensions/amp-ad/0.1/amp-ad.js',
-      'extensions/amp-a4a/0.1/amp-a4a.js',
-      'extensions/amp-auto-ads/0.1/amp-auto-ads.js',
-      'extensions/amp-auto-ads/0.1/anchor-ad-strategy.js',
     ],
   },
   'reject\\(\\)': {
@@ -1064,17 +952,13 @@ const forbiddenTermsSrcInclusive = {
       'src/base-element.js',
       'src/event-helper.js',
       'src/friendly-iframe-embed.js',
-      'src/service/performance-impl.js',
       'src/service/resources-impl.js',
-      'src/service/url-replacements-impl.js',
       'src/service/variable-source.js',
       'src/validator-integration.js',
-      'extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js',
       'extensions/amp-image-lightbox/0.1/amp-image-lightbox.js',
       'extensions/amp-analytics/0.1/transport.js',
       'extensions/amp-web-push/0.1/iframehost.js',
       'extensions/amp-recaptcha-input/0.1/amp-recaptcha-service.js',
-      'dist.3p/current/integration.js',
     ],
   },
   '\\.getTime\\(\\)': {
@@ -1088,16 +972,10 @@ const forbiddenTermsSrcInclusive = {
   },
   '\\.expandStringSync\\(': {
     message: requiresReviewPrivacy,
-    allowlist: [
-      'extensions/amp-form/0.1/amp-form.js',
-      'src/service/url-replacements-impl.js',
-    ],
   },
   '\\.expandStringAsync\\(': {
     message: requiresReviewPrivacy,
     allowlist: [
-      'extensions/amp-form/0.1/amp-form.js',
-      'src/service/url-replacements-impl.js',
       'extensions/amp-analytics/0.1/config.js',
       'extensions/amp-analytics/0.1/cookie-writer.js',
       'extensions/amp-analytics/0.1/requests.js',
@@ -1107,17 +985,11 @@ const forbiddenTermsSrcInclusive = {
   },
   '\\.expandInputValueSync\\(': {
     message: requiresReviewPrivacy,
-    allowlist: [
-      'extensions/amp-form/0.1/amp-form.js',
-      'src/service/url-replacements-impl.js',
-    ],
+    allowlist: ['extensions/amp-form/0.1/amp-form.js'],
   },
   '\\.expandInputValueAsync\\(': {
     message: requiresReviewPrivacy,
-    allowlist: [
-      'extensions/amp-form/0.1/amp-form.js',
-      'src/service/url-replacements-impl.js',
-    ],
+    allowlist: ['extensions/amp-form/0.1/amp-form.js'],
   },
   '\\.setNonBoolean\\(': {
     message: requiresReviewPrivacy,
@@ -1140,18 +1012,14 @@ const forbiddenTermsSrcInclusive = {
       'build-system/server/app.js',
       'build-system/server/shadow-viewer.js',
       'build-system/server/variable-substitution.js',
-      'build-system/tasks/check-links.js',
       'build-system/tasks/dist.js',
       'build-system/tasks/extension-generator/index.js',
       'build-system/tasks/helpers.js',
       'build-system/tasks/performance/helpers.js',
-      'dist.3p/current/integration.js',
-      'extensions/amp-iframe/0.1/amp-iframe.js',
       'src/3p-frame.js',
       'src/amp-story-player/amp-story-player-impl.js',
       'src/config.js',
       'testing/local-amp-chrome-extension/background.js',
-      'tools/errortracker/errortracker.go',
       'tools/experiments/experiments.js',
       'validator/js/engine/htmlparser-interface.js',
       'validator/js/engine/validator-in-browser.js',
@@ -1168,12 +1036,12 @@ const forbiddenTermsSrcInclusive = {
   },
   '\\.indexOf\\([\'"][^)]+\\)\\s*===?\\s*0\\b': {
     message: 'use startsWith helper in src/string.js',
-    allowlist: ['dist.3p/current/integration.js', 'build-system/server/app.js'],
+    allowlist: ['build-system/server/app.js'],
   },
   '\\.indexOf\\(.*===?.*\\.length': 'use endsWith helper in src/string.js',
   '/url-parse-query-string': {
     message: 'Import parseQueryString from `src/url.js`',
-    allowlist: ['src/url.js', 'src/mode.js', 'dist.3p/current/integration.js'],
+    allowlist: ['src/url.js', 'src/mode.js'],
   },
   '\\.trim(Left|Right)\\(\\)': {
     message: 'Unsupported on IE; use trim() or a helper instead.',
@@ -1235,8 +1103,6 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
       'extensions/amp-iframe/0.1/amp-iframe.js',
       'extensions/amp-script/0.1/amp-script.js',
-      'extensions/amp-sidebar/0.1/amp-sidebar.js',
-      'extensions/amp-sidebar/0.2/amp-sidebar.js',
       'extensions/amp-story/1.0/amp-story-page.js',
     ],
   },

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -120,7 +120,7 @@ const forbiddenTerms = {
       'build-system/common/logging.js',
       'src/purifier/noop.js',
       'validator/js/engine/validator-in-browser.js',
-      'validator/js/engine/validator.js', // NodeJs only.
+      'validator/js/engine/validator.js',
     ],
     checkInTestFolder: true,
   },
@@ -506,7 +506,7 @@ const forbiddenTerms = {
     allowlist: [
       'src/3p-frame-messaging.js',
       'src/event-helper.js',
-      'src/event-helper-listen.js', // includes previous
+      'src/event-helper-listen.js',
     ],
   },
   'setTimeout.*throw': {


### PR DESCRIPTION
Adds a lint rule `local/forbidden-terms-config` that's used on one file:

- Term keys should be string literals.
- Allowlist items should be string literals.
- Allowed files should contain the term.
- `allowlist` property should be removed if empty.