### PR TITLE
🖍  [Story responsiveness] Show overflow on preset layers

### DIFF
--- a/extensions/amp-story/1.0/amp-story-user-overridable.css
+++ b/extensions/amp-story/1.0/amp-story-user-overridable.css
@@ -18,7 +18,7 @@ amp-story {
   font-display: optional;
 }
 
-amp-story-grid-layer {
+amp-story-grid-layer:not([aspect-ratio]) {
   overflow: hidden;
 }
 


### PR DESCRIPTION
Closes #32678

Removes the `overflow: hidden` on preset layers since the layers shouldn't cut off items that are partially outside the layer