### PR TITLE
Dev Server: Allow crossorigin fetch of JS binaries.

### DIFF
--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -33,6 +33,7 @@ const request = require('request');
 const upload = require('multer')();
 const pc = process;
 const autocompleteEmailData = require('./autocomplete-test-data');
+const header = require('connect-header');
 const runVideoTestBench = require('./app-video-testbench');
 const {
   getVariableRequest,
@@ -72,6 +73,9 @@ app.use('/test', require('./routes/test'));
 if (argv.coverage) {
   app.use('/coverage', require('istanbul-middleware').createHandler());
 }
+
+// Built binaries should be fetchable from other origins, i.e. Storybook.
+app.use(header({'Access-Control-Allow-Origin': '*'}));
 
 // Append ?csp=1 to the URL to turn on the CSP header.
 // TODO: shall we turn on CSP all the time?

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -66,7 +66,6 @@ let lazyBuild = false;
  */
 function getMiddleware() {
   const middleware = [require('../server/app')]; // Lazy-required to enable live-reload
-  middleware.push(header({'Access-Control-Allow-Origin': '*'}));
   if (!quiet) {
     middleware.push(morgan('dev'));
   }

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -66,6 +66,7 @@ let lazyBuild = false;
  */
 function getMiddleware() {
   const middleware = [require('../server/app')]; // Lazy-required to enable live-reload
+  middleware.push(header({'Access-Control-Allow-Origin': '*'}));
   if (!quiet) {
     middleware.push(morgan('dev'));
   }


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/pull/33426#discussion_r601037983.

Requests for `ww.js` and `amp-auto-lightbox` fail in Storybook because of CORs.
See: <img width="1353" alt="Screen Shot 2021-03-25 at 3 23 17 PM" src="https://user-images.githubusercontent.com/4656974/112531575-1dc86480-8d7e-11eb-9df6-5ac0827b9cb4.png">


This PR adds the access control headers s.t. crossorigin requests (i.e. from storybook) can `fetch` js binaries.
Open to any and all suggestions of alternative solutions.
