### PR TITLE
✅ Unit tests for amp-lightbox:0.1 should always build component

### DIFF
--- a/extensions/amp-lightbox/0.1/test/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/test/test-amp-lightbox.js
@@ -85,6 +85,13 @@ describes.realWin(
       env.sandbox.spy(element, 'enqueAction');
       env.sandbox.stub(element, 'getDefaultActionAlias');
       await dom.whenUpgradedToCustomElement(element);
+      const impl = await element.getImpl(true);
+      impl.getHistory_ = () => {
+        return {
+          pop: () => {},
+          push: () => Promise.resolve(11),
+        };
+      };
 
       ['open', 'close'].forEach((method) => {
         action.execute(
@@ -96,6 +103,7 @@ describes.realWin(
           'event',
           ActionTrust.HIGH
         );
+        expect(element.enqueAction.callCount).to.be.above(0);
         expect(element.enqueAction).to.be.calledWith(
           env.sandbox.match({
             actionEventType: '?',
@@ -113,7 +121,7 @@ describes.realWin(
 
     it('should close on ESC', async () => {
       const lightbox = createLightbox();
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
       impl.getHistory_ = () => {
         return {
           pop: () => {},
@@ -137,7 +145,7 @@ describes.realWin(
       myLink.setAttribute('autofocus', '');
       lightbox.appendChild(myLink);
 
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
       impl.getHistory_ = () => {
         return {
           pop: () => {},
@@ -164,7 +172,7 @@ describes.realWin(
       const lightbox = createLightbox();
       const closeButton = createCloseButton();
       lightbox.appendChild(closeButton);
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
 
       const tryFocusSpy = env.sandbox.spy(dom, 'tryFocus');
       const finalizeSpy = env.sandbox.spy(impl, 'finalizeOpen_');
@@ -195,7 +203,7 @@ describes.realWin(
 
     it('should create close button and focus on it if no handmade focus and no close button', async () => {
       const lightbox = createLightbox();
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
 
       const tryFocusSpy = env.sandbox.spy(dom, 'tryFocus');
       const finalizeSpy = env.sandbox.spy(impl, 'finalizeOpen_');
@@ -228,7 +236,7 @@ describes.realWin(
       const lightbox = createLightbox();
       const insideLink = createLink('insideLink');
       lightbox.appendChild(insideLink);
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
 
       const outsideLink = createLink('outsideLink');
       doc.body.appendChild(outsideLink);
@@ -269,7 +277,7 @@ describes.realWin(
       const lightbox = createLightbox();
       const closeButton = createCloseButton();
       lightbox.appendChild(closeButton);
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
 
       const openSpy = env.sandbox.spy(impl, 'finalizeOpen_');
       const closeSpy = env.sandbox.spy(impl, 'finalizeClose_');
@@ -292,7 +300,7 @@ describes.realWin(
     it('should create `i-amphtml-ad-close-header` but no close button if param then focus on it', async () => {
       const lightbox = createLightbox();
       lightbox.setAttribute('close-button', '');
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
 
       const tryFocusSpy = env.sandbox.spy(dom, 'tryFocus');
       const finalizeSpy = env.sandbox.spy(impl, 'finalizeOpen_');
@@ -325,7 +333,7 @@ describes.realWin(
 
     it('should set itself as a container when fully opened', async () => {
       const lightbox = createLightbox();
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
       env.sandbox.stub(lightbox, 'setAsContainerInternal');
 
       const finalizeSpy = env.sandbox.spy(impl, 'finalizeOpen_');
@@ -365,7 +373,7 @@ describes.realWin(
       const closeButton = createCloseButton();
       lightbox.appendChild(closeButton);
 
-      const impl = await lightbox.getImpl(false);
+      const impl = await lightbox.getImpl(true);
       env.sandbox.stub(lightbox, 'setAsContainerInternal');
       env.sandbox.stub(lightbox, 'removeAsContainerInternal');
 


### PR DESCRIPTION
This PR:
1. Fixes local failure for `should allow default actions in email documents` case by waiting for the element to build before invoking any actions.
2. Fixes console warning `ERROR: '[History] failed to execute a task: Error: No messaging channel: undefined'` for the above by stubbing history impl
3. Makes all other test cases wait for build because the test is configured with `runtimeOn: true` and was showing errors despite passing anyway, i.e:
  - `ERROR: '[Resource] Error: layoutComplete race'`
  - `INFO: '[Resources] task failed:', 'amp-lightbox#1#L', 'amp-lightbox#1', Error: CANCELLED`
  - `ERROR: 'Error: CANCELLED'`
  - Note that waiting for build (via `getImpl(true)`) eliminated these messages.

Open question: 
- Why was (1) not caught in CI? 🦇 🚨 @ampproject/wg-infra any ideas? One theory: Since it is async build with `runtimeOn: true` it's possible that CI more consistently happened to have build occur by the time test assertions were run.

Related: #33468