### PR TITLE
Stop Preact from exposing VNode as ref

### DIFF
--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -792,7 +792,7 @@ export class PreactBaseElement extends AMP.BaseElement {
       return;
     }
     // Hack around https://github.com/preactjs/preact/issues/3084
-    if (current.constructor && current.constructor !== 'Object') {
+    if (current.constructor && current.constructor.name !== 'Object') {
       return;
     }
     const api = this.apiWrapper_;

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -791,6 +791,10 @@ export class PreactBaseElement extends AMP.BaseElement {
     if (!getMode().localDev) {
       return;
     }
+    // Hack around https://github.com/preactjs/preact/issues/3084
+    if (current.constructor && current.constructor !== 'Object') {
+      return;
+    }
     const api = this.apiWrapper_;
     const newKeys = Object.keys(current);
     for (let i = 0; i < newKeys.length; i++) {

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -79,6 +79,19 @@ describes.realWin('PreactBaseElement', {amp: true}, (env) => {
     });
   }
 
+  it('preact ref passing vnode smoke test', () => {
+    function App() {
+      // Don't call useImperativeHandle.
+    }
+    const ref = env.sandbox.spy();
+    Preact.render(<App ref={ref} />, document.body);
+    // When this test fails, that means Preact has fixed their ref setting.
+    // See https://github.com/preactjs/preact/issues/3084
+    // Please remove the hack in src/preact/base-element.js inside `checkApiWrapper_`,
+    // and add a `.not` below so we don't regress again.
+    expect(ref).to.be.called;
+  });
+
   describe('context', () => {
     let element;
 


### PR DESCRIPTION
This is a hacky (only need in local dev) workaround for https://github.com/preactjs/preact/issues/3084.