### PR TITLE
🏗 Consolidate arg processing and file globbing / ignoring across `amp` tasks

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -114,16 +114,18 @@ function getFilesFromArgv() {
 
 /**
  * Gets a list of files to be checked based on command line args and the given
- * file matching globs. Used by tasks like prettify, check-links, etc.
+ * file matching globs. Used by tasks like prettify, lint, check-links, etc.
+ * Optionally takes in options for globbing and a file containing ignore rules.
  *
  * @param {!Array<string>} globs
  * @param {Object=} options
- * @param {(string|Array<string>)=} ignoreRules
+ * @param {string=} ignoreFile
  * @return {!Array<string>}
  */
-function getFilesToCheck(globs, options = {}, ignoreRules = undefined) {
+function getFilesToCheck(globs, options = {}, ignoreFile = undefined) {
   const ignored = ignore();
-  if (ignoreRules) {
+  if (ignoreFile) {
+    const ignoreRules = fs.readFileSync(ignoreFile, 'utf8');
     ignored.add(ignoreRules);
   }
   if (argv.files) {
@@ -172,7 +174,6 @@ module.exports = {
   buildRuntime,
   getExperimentConfig,
   getValidExperiments,
-  getFilesChanged,
   getFilesFromArgv,
   getFilesToCheck,
   usesFilesOrLocalChanges,

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -16,10 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
-const config = require('../test-configs/config');
 const fs = require('fs');
-const globby = require('globby');
-const path = require('path');
 const {
   log,
   logLocalDev,
@@ -28,10 +25,8 @@ const {
 } = require('../common/logging');
 const {cyan, green, red, yellow} = require('kleur/colors');
 const {ESLint} = require('eslint');
-const {getFilesChanged, getFilesFromArgv} = require('../common/utils');
-const {gitDiffNameOnlyMaster} = require('../common/git');
-
-const rootDir = path.dirname(path.dirname(__dirname));
+const {getFilesToCheck} = require('../common/utils');
+const {lintGlobs} = require('../test-configs/config');
 
 const options = {
   fix: argv.fix,
@@ -53,16 +48,13 @@ async function runLinter(filesToLint) {
   for (const file of filesToLint) {
     const text = fs.readFileSync(file, 'utf-8');
     const lintResult = await eslint.lintText(text, {filePath: file});
-    if (lintResult.length == 0) {
-      continue; // File was ignored via .eslintignore.
-    }
     const result = lintResult[0];
     results.errorCount += result.errorCount;
     results.warningCount += result.warningCount;
     const formatter = await eslint.loadFormatter('stylish');
     const resultText = formatter
       .format(lintResult)
-      .replace(`${rootDir}/`, '')
+      .replace(`${process.cwd()}/`, '')
       .trim();
     if (resultText.length) {
       logOnSameLine(resultText);
@@ -134,53 +126,19 @@ function summarizeResults(results, fixedFiles) {
 }
 
 /**
- * Checks if there are eslint rule changes, in which case we must lint all
- * files.
- *
- * @return {boolean}
- */
-function eslintRulesChanged() {
-  return (
-    gitDiffNameOnlyMaster().filter(function (file) {
-      return (
-        path.basename(file).includes('.eslintrc.js') ||
-        path.dirname(file) === 'build-system/eslint-rules'
-      );
-    }).length > 0
-  );
-}
-
-/**
- * Gets the list of files to be linted.
- *
- * @param {!Array<string>} files
- * @return {!Array<string>}
- */
-function getFilesToLint(files) {
-  const filesToLint = globby.sync(files, {gitignore: true});
-  logLocalDev(green('INFO: ') + 'Running lint on the following files:');
-  filesToLint.forEach((file) => {
-    logLocalDev(cyan(file));
-  });
-  return filesToLint;
-}
-
-/**
- * Run eslint on JS files and log the output
+ * Checks files for formatting (and optionally fixes them) with Eslint.
+ * Explicitly makes sure the API doesn't check files in `.eslintignore`.
  */
 async function lint() {
-  let filesToLint = globby.sync(config.lintGlobs, {gitignore: true});
-  if (argv.files) {
-    filesToLint = getFilesToLint(getFilesFromArgv());
-  } else if (!eslintRulesChanged() && argv.local_changes) {
-    const lintableFiles = getFilesChanged(config.lintGlobs);
-    if (lintableFiles.length == 0) {
-      log(green('INFO: ') + 'No JS files in this PR');
-      return;
-    }
-    filesToLint = getFilesToLint(lintableFiles);
+  const filesToCheck = getFilesToCheck(
+    lintGlobs,
+    {gitignore: true},
+    '.eslintignore'
+  );
+  if (filesToCheck.length == 0) {
+    return;
   }
-  await runLinter(filesToLint);
+  await runLinter(filesToCheck);
 }
 
 module.exports = {

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -44,12 +44,14 @@ const tempDir = tempy.directory();
 
 /**
  * Checks files for formatting (and optionally fixes them) with Prettier.
+ * Explicitly makes sure the API doesn't check files in `.prettierignore`.
  */
 async function prettify() {
-  // Prettier ignores the `.prettierignore` file when using the API like we
-  // are. So we need to filter our files down before feeding them to the API.
-  const ignore = fs.readFileSync('.prettierignore', 'utf8');
-  const filesToCheck = getFilesToCheck(prettifyGlobs, {dot: true}, ignore);
+  const filesToCheck = getFilesToCheck(
+    prettifyGlobs,
+    {dot: true},
+    '.prettierignore'
+  );
   if (filesToCheck.length == 0) {
     return;
   }


### PR DESCRIPTION
This PR implements the idea that I did a terrible job of describing in https://github.com/ampproject/amphtml/pull/33449#discussion_r600064303 and https://github.com/ampproject/amphtml/pull/33462#discussion_r600777934. Now that there is a way to explicitly ignore patterns from an ignore file like `.prettierignore` or `.eslintignore`, we can get rid of a bunch of unnecessary code in `lint.js`.

Bonus cleanup: The logic in `eslintRulesChanged()` to force-lint the entire repo if even a single rule changed was more trouble than it was worth during local development, so I've removed it. (We already lint all files during CI, there's no reason to annoy developers when they're running `amp lint --local_changes`.)