### PR TITLE
Bento: add container to the amp-sidebar 1.0

### DIFF
--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -18,9 +18,9 @@ import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Sidebar} from './component';
 import {dict} from '../../../src/utils/object';
+import {pauseAll} from '../../../src/utils/resource-container-helper';
 import {toggle} from '../../../src/style';
 import {toggleAttribute} from '../../../src/dom';
-import {unmountAll} from '../../../src/utils/resource-container-helper';
 
 export class BaseElement extends PreactBaseElement {
   /** @param {!AmpElement} element */
@@ -65,7 +65,7 @@ export class BaseElement extends PreactBaseElement {
     toggle(this.element, false);
 
     this.removeAsContainer();
-    unmountAll(this.element, /* includeSelf */ false);
+    pauseAll(this.element, /* includeSelf */ false);
   }
 
   /** @override */

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -20,6 +20,7 @@ import {Sidebar} from './component';
 import {dict} from '../../../src/utils/object';
 import {toggle} from '../../../src/style';
 import {toggleAttribute} from '../../../src/dom';
+import {unmountAll} from '../../../src/utils/resource-container-helper';
 
 export class BaseElement extends PreactBaseElement {
   /** @param {!AmpElement} element */
@@ -33,18 +34,38 @@ export class BaseElement extends PreactBaseElement {
   /** @override */
   init() {
     return dict({
-      'onBeforeOpen': this.toggle_.bind(this, true),
-      'onAfterClose': this.toggle_.bind(this, false),
+      'onBeforeOpen': () => this.beforeOpen_(),
+      'onAfterOpen': () => this.afterOpen_(),
+      'onAfterClose': () => this.afterClose_(),
     });
   }
 
-  /**
-   * Toggle open/closed attributes.
-   * @param {boolean} opt_state
-   */
-  toggle_(opt_state) {
-    this.open_ = toggleAttribute(this.element, 'open', opt_state);
-    toggle(this.element, this.open_);
+  /** @override */
+  unmountCallback() {
+    this.removeAsContainer();
+  }
+
+  /** @private */
+  beforeOpen_() {
+    this.open_ = true;
+    toggleAttribute(this.element, 'open', true);
+    toggle(this.element, true);
+  }
+
+  /** @private */
+  afterOpen_() {
+    const sidebar = this.element.shadowRoot.querySelector('[part=sidebar]');
+    this.setAsContainer(sidebar);
+  }
+
+  /** @private */
+  afterClose_() {
+    this.open_ = false;
+    toggleAttribute(this.element, 'open', false);
+    toggle(this.element, false);
+
+    this.removeAsContainer();
+    unmountAll(this.element, /* includeSelf */ false);
   }
 
   /** @override */

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -42,6 +42,7 @@ function SidebarWithRef(
     as: Comp = 'div',
     side: sideProp,
     onBeforeOpen,
+    onAfterOpen,
     onAfterClose,
     backdropStyle,
     backdropClassName,
@@ -68,9 +69,7 @@ function SidebarWithRef(
   const onBeforeOpenRef = useValueRef(onBeforeOpen);
 
   const open = useCallback(() => {
-    if (onBeforeOpenRef.current) {
-      onBeforeOpenRef.current();
-    }
+    onBeforeOpenRef.current?.();
     setMounted(true);
     setOpened(true);
   }, [onBeforeOpenRef]);
@@ -106,6 +105,7 @@ function SidebarWithRef(
   useSidebarAnimation(
     mounted,
     opened,
+    onAfterOpen,
     onAfterClose,
     side,
     sidebarRef,

--- a/extensions/amp-sidebar/1.0/component.type.js
+++ b/extensions/amp-sidebar/1.0/component.type.js
@@ -24,6 +24,7 @@ var SidebarDef = {};
  *   as: (string|PreactDef.FunctionalComponent|undefined),
  *   side: (string|undefined),
  *   onBeforeOpen: (function|undefined),
+ *   onAfterOpen: (function|undefined),
  *   onAfterClose: (function|undefined),
  *   backdropStyle: (?Object|undefined),
  *   backdropClassName: (string|undefined),

--- a/extensions/amp-sidebar/1.0/sidebar-animations-hook.js
+++ b/extensions/amp-sidebar/1.0/sidebar-animations-hook.js
@@ -49,6 +49,7 @@ function safelySetStyles(element, styles) {
 /**
  * @param {boolean} mounted
  * @param {boolean} opened
+ * @param {{current: function|undefined}} onAfterOpen
  * @param {{current: function|undefined}} onAfterClose
  * @param {string} side
  * @param {{current: Element|null}} sidebarRef
@@ -58,12 +59,14 @@ function safelySetStyles(element, styles) {
 export function useSidebarAnimation(
   mounted,
   opened,
+  onAfterOpen,
   onAfterClose,
   side,
   sidebarRef,
   backdropRef,
   setMounted
 ) {
+  const onAfterOpenRef = useValueRef(onAfterOpen);
   const onAfterCloseRef = useValueRef(onAfterClose);
   const sidebarAnimationRef = useRef(null);
   const backdropAnimationRef = useRef(null);
@@ -86,11 +89,10 @@ export function useSidebarAnimation(
       sidebarAnimationRef.current = null;
       backdropAnimationRef.current = null;
       currentlyAnimatingRef.current = false;
+      onAfterOpenRef.current?.();
     };
     const postInvisibleAnim = () => {
-      if (onAfterCloseRef.current) {
-        onAfterCloseRef.current();
-      }
+      onAfterCloseRef.current?.();
       sidebarAnimationRef.current = null;
       backdropAnimationRef.current = null;
       currentlyAnimatingRef.current = false;
@@ -183,6 +185,7 @@ export function useSidebarAnimation(
   }, [
     mounted,
     opened,
+    onAfterOpenRef,
     onAfterCloseRef,
     side,
     sidebarRef,

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -16,6 +16,7 @@
 import '../amp-sidebar';
 import {ActionInvocation} from '../../../../src/service/action-impl';
 import {ActionTrust} from '../../../../src/action-constants';
+import {createElementWithAttributes} from '../../../../src/dom';
 import {htmlFor} from '../../../../src/static-template';
 import {toggleExperiment} from '../../../../src/experiments';
 import {waitFor, whenCalled} from '../../../../testing/test-helper';
@@ -140,6 +141,14 @@ describes.realWin(
         env.sandbox.stub(element, 'setAsContainerInternal');
         env.sandbox.stub(element, 'removeAsContainerInternal');
 
+        // Sidebar has a child.
+        const child = createElementWithAttributes(win.document, 'amp-img', {
+          layout: 'nodisplay',
+        });
+        element.appendChild(child);
+        env.sandbox.stub(child, 'pause');
+        env.sandbox.stub(child, 'unmount');
+
         element.setAttribute('open', '');
         await waitForOpen(element, true);
 
@@ -162,6 +171,8 @@ describes.realWin(
 
         expect(element.removeAsContainerInternal).to.be.calledOnce;
         expect(element.setAsContainerInternal).to.be.calledOnce; // no change.
+        expect(child.pause).to.be.calledOnce;
+        expect(child.unmount).to.not.be.called;
       });
 
       it('should close when the backdrop is clicked', async () => {


### PR DESCRIPTION
Follow up on #33503 for 1.0 version.

Partial for #31915.
Partial for #31540.