### PR TITLE
❄️ Use `await` for e2e test controller methods

### DIFF
--- a/test/e2e/test-amp-bind-brightcove.js
+++ b/test/e2e/test-amp-bind-brightcove.js
@@ -32,11 +32,11 @@ describes.endtoend(
         const iframe = await controller.findElement('#brightcove iframe');
 
         await expect(
-          controller.getElementProperty(iframe, 'src')
+          await controller.getElementProperty(iframe, 'src')
         ).to.not.contain('bound');
 
         await controller.click(button);
-        await expect(controller.getElementProperty(iframe, 'src')).to.contain(
+        await expect(await controller.getElementProperty(iframe, 'src')).to.contain(
           'bound'
         );
       });

--- a/test/e2e/test-amp-bind-iframe.js
+++ b/test/e2e/test-amp-bind-iframe.js
@@ -34,17 +34,17 @@ describes.endtoend(
 
         const newSrc = 'https://giphy.com/embed/DKG1OhBUmxL4Q';
         await expect(
-          controller.getElementAttribute(ampIframe, 'src')
+          await controller.getElementAttribute(ampIframe, 'src')
         ).to.not.contain(newSrc);
         await expect(
-          controller.getElementProperty(iframe, 'src')
+          await controller.getElementProperty(iframe, 'src')
         ).to.not.contain(newSrc);
 
         await controller.click(button);
         await expect(
-          controller.getElementAttribute(ampIframe, 'src')
+          await controller.getElementAttribute(ampIframe, 'src')
         ).to.contain(newSrc);
-        await expect(controller.getElementProperty(iframe, 'src')).to.contain(
+        await expect(await controller.getElementProperty(iframe, 'src')).to.contain(
           newSrc
         );
       });


### PR DESCRIPTION
All functional controller methods are async, so not using `await` means that a Promise is being returned, which is probably not wanted.