### PR TITLE
🐛  amp-carousel:0.2 off-by-one bug for initialSlide when non-looping

### DIFF
--- a/extensions/amp-base-carousel/0.1/carousel.js
+++ b/extensions/amp-base-carousel/0.1/carousel.js
@@ -617,14 +617,15 @@ export class Carousel {
     if (!length) {
       const TAG = this.element_.tagName.toUpperCase();
       dev().warn(TAG, 'No slides were found.');
+      return;
     }
     this.slides_ = slides;
     // Normalize current index to updated slide length.
     this.currentIndex_ = this.isLooping()
       ? mod(this.currentIndex_, length)
-      : clamp(this.currentIndex_, 0, length) || 0;
+      : clamp(this.currentIndex_, 0, length - 1) || 0;
     this.carouselAccessibility_.updateSlides(slides);
-    // TODO(sparhami) Should need to call `this.updateUi()` here.
+    this.updateUi();
   }
 
   /**

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
@@ -24,7 +24,7 @@ describes.endtoend(
   {
     version: '0.1',
     fixture: 'amp-base-carousel/initial-slide.amp.html',
-    experiments: ['amp-base-carousel', 'layers'],
+    environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
   async (env) => {
@@ -34,8 +34,7 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    //TODO(spaharmi): fails on all environments
-    it.skip('should render with the correct initial slide', async () => {
+    it('should render with the correct initial slide', async () => {
       const thirdSlide = await getSlide(controller, 2);
 
       // Normally, resizing would cause the position to change. We're testing

--- a/extensions/amp-base-carousel/0.1/test/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test/test-carousel.js
@@ -301,12 +301,12 @@ describes.realWin('carousel implementation', {}, (env) => {
       expect(carousel.isAtStart()).to.be.true;
     });
 
-    it('should start at slide 0 with initialIndex that is greater than number of slides', async () => {
+    it('should clamp to last index with initialIndex that is greater than last slide index', async () => {
       const carousel = await createCarousel({
         slideCount: 3,
         initialIndex: 4,
       });
-      expect(carousel.isAtStart()).to.be.true;
+      expect(carousel.isAtEnd()).to.be.true;
     });
 
     it('should start at slide 0 with invalid initialIndex', async () => {
@@ -335,7 +335,7 @@ describes.realWin('carousel implementation', {}, (env) => {
       expect(carousel.getCurrentIndex()).to.equal(2);
     });
 
-    it('should normalize slide with initialIndex that is greater than number of slides when looping', async () => {
+    it('should normalize slide with initialIndex that is greater than last slide index when looping', async () => {
       const carousel = await createCarousel({
         slideCount: 3,
         initialIndex: 4,

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -157,7 +157,7 @@ class AmpCarousel extends AMP.BaseElement {
       win,
       element,
       scrollContainer: dev().assertElement(this.scrollContainer_),
-      initialIndex: Number(this.element.getAttribute('slide')),
+      initialIndex: Number(this.element.getAttribute('slide') || '0'),
       runMutate: (cb) => this.mutateElement(cb),
     });
     this.configureCarousel_(slides);


### PR DESCRIPTION
This PR:
- Fixes the normalized `initialSlide` value for non-looping carousels introduced in #32914. It's an off-by-one bug - we want to clamp so that the maximum value is the last index, not the length
- Applies the fix to the `slide` attribute behavior for the following scenarios:
  - on first render and any changes with `amp-bind` 
  - on both `amp-base-carousel:0.1` and `amp-carousel:0.2` (Note that `amp-carousel` does not support responsive attribute values.)
- Unskips the e2e test which tests for this attribute
- Updates unit tests accordingly

Resolve #33512 because the class does not assume the given initial index is valid, but normalized the value incorrectly:
https://github.com/ampproject/amphtml/blob/4f2b7f0081a3be32b2886ddb815cbb069058016f/extensions/amp-base-carousel/0.1/carousel.js#L622-L625