### PR TITLE
📖 Update SOASTA -> Akamai

### DIFF
--- a/extensions/amp-analytics/analytics-vendors-list.md
+++ b/extensions/amp-analytics/analytics-vendors-list.md
@@ -363,13 +363,13 @@ Type attribute value: `mparticle`
 
 Adds support for mParticle. More details for adding mParticle support can be found at [docs.mparticle.com](http://docs.mparticle.com/?javascript#amp).
 
-### SOASTA mPulse
+### Akamai mPulse
 
 Type attribute value: `mpulse`
 
 <!-- markdown-link-check-disable -->
 
-Adds support for [SOASTA mPulse](https://www.soasta.com/mPulse). Configuration details can be found at [docs.soasta.com](http://docs.soasta.com/).
+Adds support for [Akamai mPulse](https://www.akamai.com/uk/en/products/performance/mpulse-real-user-monitoring.jsp). Configuration details can be found at [learn.akamai.com](https://learn.akamai.com/en-us/products/web_performance/mpulse.html).
 
 <!-- markdown-link-check-enable -->
 


### PR DESCRIPTION
Updates documentation to replace SOASTA links and references with the correct Akamai links. Akamai acquired SOASTA (and thus mPulse) in 2017: https://www.akamai.com/uk/en/about/news/press/2017-press/akamai-completes-acquisition-of-soasta.jsp