### PR TITLE
🏗 Clean up visual-diff install code

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -719,7 +719,7 @@ async function createEmptyBuild(browser) {
 async function visualDiff() {
   const handlerProcess = createCtrlcHandler('visual-diff');
   await ensureOrBuildAmpRuntimeInTestMode_();
-  const browserFetcher = await installDependencies_();
+  const browserFetcher = await loadBrowserFetcher_();
   maybeOverridePercyEnvironmentVariables();
   setPercyBranch();
   setPercyTargetCommit();
@@ -804,21 +804,14 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
  *
  * @return {!Promise<!puppeteer.BrowserFetcher>}
  */
-async function installDependencies_() {
+async function loadBrowserFetcher_() {
   puppeteer = require('puppeteer');
   percySnapshot = require('@percy/puppeteer');
   Percy = require('@percy/core');
 
   const browserFetcher = puppeteer.createBrowserFetcher();
-  if (argv.noinstall) {
-    return browserFetcher;
-  }
-
-  if (
-    (await browserFetcher.localRevisions()).includes(
-      PUPPETEER_CHROMIUM_REVISION
-    )
-  ) {
+  const chromiumRevisions = await browserFetcher.localRevisions();
+  if (chromiumRevisions.includes(PUPPETEER_CHROMIUM_REVISION)) {
     log(
       'info',
       'Using Percy-compatible version of Chromium',


### PR DESCRIPTION
Renames `installDependencies_()` to `loadBrowserFetcher_()` to better indicate what's left to be done during setup.

Addresses https://github.com/ampproject/amphtml/pull/33452#discussion_r600671280
