### PR TITLE
🐛 [amp-story][amp-story-page-attachment]

### DIFF
--- a/examples/amp-story/attachment.html
+++ b/examples/amp-story/attachment.html
@@ -31,6 +31,16 @@
       amp-story-page-attachment {
         color: rgba(0, 0, 0, 0.93);
       }
+
+      #cover amp-story-page-attachment {
+        background-color: #F8EDD5;
+
+        /* background:
+          radial-gradient(circle at 0% 50%, rgba(96, 16, 48, 0) 9px, #613 10px, rgba(96, 16, 48, 0) 11px) 0px 10px,
+          radial-gradient(at 100% 100%,      rgba(96, 16, 48, 0) 9px, #613 10px, rgba(96, 16, 48, 0) 11px),
+          #8a3; */
+        /* background-size: 20px 20px; */
+      }
     </style>
   </head>
 
@@ -58,7 +68,8 @@
           cta-image="/extensions/amp-story/img/sweater.jpg"
           cta-image-2="/extensions/amp-story/img/boot.jpg"
           >
-          <p> Lots of content. Opens to max of 80% then scrolls.</p>
+          <p>Lots of content. Opens to max of 80% then scrolls.</p>
+          <p>Background color is set from the style on amp-story-page-attachment.</p>
 
           <p>In nisl nisi scelerisque eu ultrices vitae auctor eu. Tristique magna sit amet purus gravida. Tincidunt id aliquet risus feugiat in ante metus dictum. Mattis nunc sed blandit libero volutpat sed. Imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada. Sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus. Proin sagittis nisl rhoncus mattis rhoncus. Pulvinar neque laoreet suspendisse interdum consectetur libero. Nibh tellus molestie nunc non blandit massa enim nec dui. Sagittis eu volutpat odio facilisis. Tristique senectus et netus et malesuada fames ac. Molestie a iaculis at erat. Sit amet cursus sit amet. Suscipit tellus mauris a diam maecenas sed enim ut. Gravida quis blandit turpis cursus in. Tincidunt vitae semper quis lectus nulla at volutpat diam ut. Morbi tempus iaculis urna id. Faucibus et molestie ac feugiat sed lectus vestibulum. Mauris augue neque gravida in. Ac turpis egestas sed tempus.</p>
 
@@ -86,6 +97,7 @@
           cta-image-2="/extensions/amp-story/img/boot.jpg"
           >
           <p>Opens to max of content when less than 80%</p>
+          <p>Background defaults to white when no background style is set on amp-story-page-attachment</p>
 
           <p>Ut tristique et egestas quis ipsum. Aliquam malesuada bibendum arcu vitae elementum curabitur vitae nunc sed. Elementum curabitur vitae nunc sed velit dignissim. Tristique et egestas quis ipsum suspendisse ultrices gravida dictum fusce. At elementum eu facilisis sed odio morbi. Imperdiet proin fermentum leo vel orci porta non. Quam lacus suspendisse faucibus interdum. Eu non diam phasellus vestibulum lorem sed risus. Commodo viverra maecenas accumsan lacus vel facilisis volutpat est velit. Sagittis aliquam malesuada bibendum arcu vitae elementum. Ut sem viverra aliquet eget sit amet. Nulla facilisi morbi tempus iaculis. Sed odio morbi quis commodo odio aenean sed adipiscing diam.</p>
           <a href="https://linkinattachment.com">Link in page attachment</a>

--- a/examples/amp-story/attachment.html
+++ b/examples/amp-story/attachment.html
@@ -34,12 +34,6 @@
 
       #cover amp-story-page-attachment {
         background-color: #F8EDD5;
-
-        /* background:
-          radial-gradient(circle at 0% 50%, rgba(96, 16, 48, 0) 9px, #613 10px, rgba(96, 16, 48, 0) 11px) 0px 10px,
-          radial-gradient(at 100% 100%,      rgba(96, 16, 48, 0) 9px, #613 10px, rgba(96, 16, 48, 0) 11px),
-          #8a3; */
-        /* background-size: 20px 20px; */
       }
     </style>
   </head>

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.css
@@ -154,7 +154,21 @@ amp-story:not([desktop]) .amp-story-page-attachment-ui-v2 .i-amphtml-story-dragg
 }
 
 amp-story:not([desktop]) .amp-story-page-attachment-ui-v2 .i-amphtml-story-draggable-drawer-content {
-  background: #fff !important;
+  border-radius: 16px 16px 0 0 !important;
+  position: relative;
+}
+
+/* Sets default background color if none is set on amp-story-page-attachment. */
+amp-story:not([desktop]) .amp-story-page-attachment-ui-v2:not(.i-amphtml-story-draggable-drawer-bookend) .i-amphtml-story-draggable-drawer-content:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #fff;
+  z-index: -1;
+  border-radius: inherit !important;
 }
 
 amp-story:not([desktop]) .amp-story-page-attachment-ui-v2.i-amphtml-story-draggable-drawer-bookend .i-amphtml-story-draggable-drawer-content {

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -29,7 +29,14 @@ import {dev} from '../../../src/log';
 import {htmlFor} from '../../../src/static-template';
 import {isPageAttachmentUiV2ExperimentOn} from './amp-story-open-page-attachment';
 import {listen} from '../../../src/event-helper';
-import {resetStyles, setImportantStyles, toggle} from '../../../src/style';
+import {
+  resetStyles,
+  setStyles,
+  setImportantStyles,
+  toggle,
+  computedStyle,
+  setStyle,
+} from '../../../src/style';
 
 /** @const {number} */
 const TOGGLE_THRESHOLD_PX = 50;
@@ -159,6 +166,15 @@ export class DraggableDrawer extends AMP.BaseElement {
       this.containerEl_.insertBefore(spacerEl, this.contentEl_);
       this.contentEl_.appendChild(headerShadowRootEl);
       this.element.classList.add('amp-story-page-attachment-ui-v2');
+
+      // Remove background and backgroundColor from parent and put on content element.
+      const bgColor = computedStyle(this.win, this.element)['backgroundColor'];
+      const bg = computedStyle(this.win, this.element)['background'];
+      setStyles(this.contentEl_, {
+        'backgroundColor': bgColor,
+        'background': bg,
+      });
+      setStyle(this.element, 'background', 'none');
     } else {
       templateEl.insertBefore(headerShadowRootEl, templateEl.firstChild);
     }


### PR DESCRIPTION
- Removes background and backgroundColor from amp-story-page-attachment and puts them on the `i-amphtml-story-draggable-drawer-content` element.
- Adds pseudo element for default background color.

[demo](https://stamp-ui.web.app/examples/amp-story/attachment.html) 
page 1 has a custom background color, page 2  defaults to white (will be themed in a follow up).

Be sure experiment flag is active. Paste in console:
`AMP.toggleExperiment('amp-story-page-attachment-ui-v2', true);`