### PR TITLE
Make `build-system` code main-branch-agnostic

### DIFF
--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -15,6 +15,8 @@
  */
 'use strict';
 
+const {mainBranch} = require('./main-branch');
+
 /**
  * @fileoverview Provides various kinds of CI state.
  *
@@ -70,7 +72,7 @@ const isCircleci = isCircleciBuild();
  * @return {boolean}
  */
 function isCircleciPushBranch(branchName) {
-  return branchName == 'master' || /^amp-release-.*$/.test(branchName);
+  return branchName == mainBranch || /^amp-release-.*$/.test(branchName);
 }
 
 /**

--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -26,32 +26,34 @@ const {
   ciPullRequestSha,
 } = require('./ci');
 const {getStdout} = require('./exec');
+const {mainBranch} = require('./main-branch');
 
 /**
- * Returns the commit at which the current PR branch was forked off of master.
- * During CI, there is an additional merge commit, so we must pick the first of
- * the boundary commits (prefixed with a -) returned by git rev-list.
- * On local branches, this is merge base of the current branch off of master.
+ * Returns the commit at which the current PR branch was forked off of the main
+ * branch. During CI, there is an additional merge commit, so we must pick the
+ * first of the boundary commits (prefixed with a -) returned by git rev-list.
+ * On local branches, this is merge base of the current branch off of the main
+ * branch.
  * @return {string}
  */
 function gitBranchCreationPoint() {
   if (isPullRequestBuild()) {
     const prSha = ciPullRequestSha();
     return getStdout(
-      `git rev-list --boundary ${prSha}...origin/master | grep "^-" | head -n 1 | cut -c2-`
+      `git rev-list --boundary ${prSha}...origin/${mainBranch} | grep "^-" | head -n 1 | cut -c2-`
     ).trim();
   }
-  return gitMergeBaseLocalMaster();
+  return gitMergeBaseLocalMain();
 }
 
 /**
- * Returns the `master` parent of the merge commit (current HEAD) during CI
- * builds. This is not the same as origin/master (a moving target), since
+ * Returns the main branch parent of the merge commit (current HEAD) during CI
+ * builds. This is not the same as origin/<main branch> (a moving target), since
  * new commits can be merged while a CI build is in progress.
  * @return {string}
  */
-function gitCiMasterBaseline() {
-  return getStdout('git merge-base origin/master HEAD').trim();
+function gitCiMainBaseline() {
+  return getStdout(`git merge-base origin/${mainBranch} HEAD`).trim();
 }
 
 /**
@@ -73,29 +75,29 @@ function gitDiffNameOnly() {
 }
 
 /**
- * Returns the list of files changed relative to the branch point off of master,
- * one on each line.
+ * Returns the list of files changed relative to the branch point off of the
+ * main branch, one on each line.
  * @return {!Array<string>}
  */
-function gitDiffNameOnlyMaster() {
-  const masterBaseline = gitMasterBaseline();
-  return getStdout(`git diff --name-only ${masterBaseline}`).trim().split('\n');
+function gitDiffNameOnlyMain() {
+  const mainBaseline = gitMainBaseline();
+  return getStdout(`git diff --name-only ${mainBaseline}`).trim().split('\n');
 }
 
 /**
- * Returns the list of files changed relative to the branch point off of master,
- * in diffstat format.
+ * Returns the list of files changed relative to the branch point off of the
+ * main branch in diffstat format.
  * @return {string}
  */
-function gitDiffStatMaster() {
-  const masterBaseline = gitMasterBaseline();
-  return getStdout(`git -c color.ui=always diff --stat ${masterBaseline}`);
+function gitDiffStatMain() {
+  const mainBaseline = gitMainBaseline();
+  return getStdout(`git -c color.ui=always diff --stat ${mainBaseline}`);
 }
 
 /**
  * Returns a detailed log of commits included in a PR check, starting with (and
- * including) the branch point off of master. Limited to commits in the past
- * 30 days to keep the output sane.
+ * including) the branch point off of the main branch. Limited to commits in the
+ * past 30 days to keep the output length manageable.
  *
  * @return {string}
  */
@@ -110,11 +112,11 @@ function gitDiffCommitLog() {
 
 /**
  * Returns the list of files added by the local branch relative to the branch
- * point off of master, one on each line.
+ * point off of the main branch, one on each line.
  * @return {!Array<string>}
  */
-function gitDiffAddedNameOnlyMaster() {
-  const branchPoint = gitMergeBaseLocalMaster();
+function gitDiffAddedNameOnlyMain() {
+  const branchPoint = gitMergeBaseLocalMain();
   return getStdout(`git diff --name-only --diff-filter=ARC ${branchPoint}`)
     .trim()
     .split('\n');
@@ -129,13 +131,14 @@ function gitDiffColor() {
 }
 
 /**
- * Returns the full color diff of the given file relative to the branch point off of master.
+ * Returns the full color diff of the given file relative to the branch point
+ * off of the main branch.
  * @param {string} file
  * @return {string}
  */
-function gitDiffFileMaster(file) {
-  const masterBaseline = gitMasterBaseline();
-  return getStdout(`git -c color.ui=always diff -U1 ${masterBaseline} ${file}`);
+function gitDiffFileMain(file) {
+  const mainBaseline = gitMainBaseline();
+  return getStdout(`git -c color.ui=always diff -U1 ${mainBaseline} ${file}`);
 }
 
 /**
@@ -168,7 +171,8 @@ function gitCommitterEmail() {
 }
 
 /**
- * Returns list of commit SHAs and their cherry-pick status from master.
+ * Returns list of commit SHAs and their cherry-pick status from the main
+ * branch.
  *
  * `git cherry <branch>` returns a list of commit SHAs. While the exact
  * mechanism is too complicated for this comment (run `git help cherry` for a
@@ -178,8 +182,8 @@ function gitCommitterEmail() {
  *
  * @return {!Array<string>}
  */
-function gitCherryMaster() {
-  const stdout = getStdout('git cherry master').trim();
+function gitCherryMain() {
+  const stdout = getStdout(`git cherry ${mainBranch}`).trim();
   return stdout ? stdout.split('\n') : [];
 }
 
@@ -198,23 +202,24 @@ function gitCommitFormattedTime(ref = 'HEAD') {
 }
 
 /**
- * Returns the merge base of the current branch off of master when running on
- * a local workspace.
+ * Returns the merge base of the current branch off of the main branch when
+ * running on a local workspace.
  * @return {string}
  */
-function gitMergeBaseLocalMaster() {
-  return getStdout('git merge-base master HEAD').trim();
+function gitMergeBaseLocalMain() {
+  return getStdout(`git merge-base ${mainBranch} HEAD`).trim();
 }
 
 /**
- * Returns the master baseline commit, regardless of running environment.
+ * Returns the baseline commit from the main branch, regardless of running
+ * environment.
  * @return {string}
  */
-function gitMasterBaseline() {
+function gitMainBaseline() {
   if (isCiBuild()) {
-    return gitCiMasterBaseline();
+    return gitCiMainBaseline();
   }
-  return gitMergeBaseLocalMaster();
+  return gitMergeBaseLocalMain();
 }
 
 /**
@@ -230,18 +235,18 @@ function gitDiffPath(path, commit) {
 module.exports = {
   gitBranchCreationPoint,
   gitBranchName,
-  gitCherryMaster,
+  gitCherryMain,
   gitCommitFormattedTime,
   gitCommitHash,
   gitCommitterEmail,
-  gitDiffAddedNameOnlyMaster,
+  gitDiffAddedNameOnlyMain,
   gitDiffColor,
   gitDiffCommitLog,
-  gitDiffFileMaster,
+  gitDiffFileMain,
   gitDiffNameOnly,
-  gitDiffNameOnlyMaster,
+  gitDiffNameOnlyMain,
   gitDiffPath,
-  gitDiffStatMaster,
-  gitCiMasterBaseline,
+  gitDiffStatMain,
+  gitCiMainBaseline,
   shortSha,
 };

--- a/build-system/common/main-branch.js
+++ b/build-system/common/main-branch.js
@@ -15,7 +15,8 @@
  */
 
 /**
- * TODO(rsimha, #32195): Change this to main.
+ * TODO(rsimha, #32195): Change this to main when branch is renamed, and delete
+ * this file once the dust settles.
  */
 const mainBranch = 'master';
 

--- a/build-system/common/main-branch.js
+++ b/build-system/common/main-branch.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * TODO(rsimha, #32195): Change this to main.
+ */
+const mainBranch = 'master';
+
+module.exports = {
+  mainBranch,
+};

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -22,7 +22,7 @@ const {clean} = require('../tasks/clean');
 const {default: ignore} = require('ignore');
 const {doBuild} = require('../tasks/build');
 const {doDist} = require('../tasks/dist');
-const {gitDiffNameOnlyMaster} = require('./git');
+const {gitDiffNameOnlyMain} = require('./git');
 const {green, cyan, yellow} = require('kleur/colors');
 const {log, logLocalDev} = require('./logging');
 
@@ -75,7 +75,7 @@ function getValidExperiments() {
  */
 function getFilesChanged(globs) {
   const allFiles = globby.sync(globs, {dot: true});
-  return gitDiffNameOnlyMaster().filter((changedFile) => {
+  return gitDiffNameOnlyMain().filter((changedFile) => {
     return fs.existsSync(changedFile) && allFiles.includes(changedFile);
   });
 }

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -16,7 +16,7 @@
 'use strict';
 
 const minimist = require('minimist');
-const {gitCherryMaster, gitCommitFormattedTime} = require('../common/git');
+const {gitCherryMain, gitCommitFormattedTime} = require('../common/git');
 
 // Allow leading zeros in --version_override, e.g. 0000000000001
 const argv = minimist(process.argv.slice(2), {
@@ -27,15 +27,16 @@ const argv = minimist(process.argv.slice(2), {
  * Generates the AMP version number.
  *
  * Version numbers are determined using the following algorithm:
- * - Count the number (<X>) of cherry-picked commits on this branch,
- *   including non `master` commits. If this branch only contains new commits
+ * - Count the number (<X>) of cherry-picked commits on this branch, including
+ *   commits not on the main branch . If this branch only contains new commits
  *   that are not cherry-picked, then <X> is 0).
  * - Find the commit (<C>) before the last cherry-picked commit from the
- *   `master` branch (if the current branch is `master`, or otherwise in
- *   `master`'s commit history, then the current commit is <C>).
+ *   main branch (if the current branch is the main branch, or otherwise in
+ *   its commit history, then the current commit is <C>).
  * - Find the commit time of <C> (<C>.time). Note that commit time might be
  *   different from author time! e.g., commit time might be the time that a PR
- *   was merged into `master`, or a commit was cherry-picked onto the branch;
+ *   was merged into the main branch, or a commit was cherry-picked onto the
+ *   branch;
  *   author time is when the original author of the commit ran the "git commit"
  *   command.
  * - The version number is <C>.time.format("YYmmDDHHMM", "UTC") + <X> (the
@@ -45,29 +46,29 @@ const argv = minimist(process.argv.slice(2), {
  *     that will fail to build. This should never happen.
  *
  * Examples:
- * 1. The version number of a release built from the HEAD commit on `master`,
- *    where that HEAD commit was committed on April 25, 2020 2:31 PM EDT would
- *    be `2004251831000`.
+ * 1. The version number of a release built from the HEAD commit on the main
+ *    branch, where that HEAD commit was committed on April 25, 2020 2:31 PM EDT
+ *    would be `2004251831000`.
  *    - EDT is UTC-4, so the hour value changes from EDT's 14 to UTC's 18.
- *    - The last three digits are 000 as this commit is on `master`.
+ *    - The last three digits are 000 as this commit is on the main branch.
  *
  * 2. The version number of a release built from a local working branch (e.g.,
- *    on a developer's workstation) that was split off from a `master` commit
+ *    on a developer's workstation) that was split off from a main branch commit
  *    from May 6, 2021 10:40 AM PDT and has multiple commits that exist only on
  *    local working branch would be `2105061840000`.
  *    - PDT is UTC-7, so the hour value changes from PDT's 10 to UTC's 17.
  *    - The last three digits are 000 as this commit is on a branch that was
- *      split from `master`, and does not have any cherry-picked commits.
+ *      split from the main branch, and does not have any cherry-picked commits.
  *
  * 3. For a release built from a local working branch that was split off from a
- *    `master` commit from November 9, 2021 11:48 PM PST, and then:
- *    - had one commit that was cherry-picked from `master`,
+ *    main branch commit from November 9, 2021 11:48 PM PST, and then:
+ *    - had one commit that was cherry-picked from the main branch,
  *    - followed by two commits that were created directly on the branch, the
  *      last of which was commited on November 23, 2021 6:38 PM PST,
- *    - followed by twelve commits that were cherry-picked from `master`, then
- *      its version number would be `2111240238012`.
- *    - The latest twelve commits are cherry-picks from `master`, and the one
- *      before them is not, so our last three digits are set to 012.
+ *    - followed by twelve commits that were cherry-picked from the main branch,
+ *      then its version number would be `2111240238012`.
+ *    - The latest twelve commits are cherry-picks from the main branch, and the
+ *      one before them is not, so our last three digits are set to 012.
  *    - PST is UTC-8, so the hour value changes from PST's 18 to UTC's 2, and
  *      one day is added.
  *
@@ -85,12 +86,12 @@ function getVersion() {
     return version;
   }
 
-  const numberOfCherryPicks = gitCherryMaster().length;
+  const numberOfCherryPicks = gitCherryMain().length;
   if (numberOfCherryPicks > 999) {
     throw new Error(
       `This branch has ${numberOfCherryPicks} cherry-picks, which is more ` +
         'than 999, the maximum allowed number of cherry-picks! Please make ' +
-        'sure your local master branch is up to date.'
+        'sure your local main branch is up to date.'
     );
   }
 

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -26,7 +26,7 @@ const minimatch = require('minimatch');
 const path = require('path');
 const {cyan} = require('kleur/colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
-const {gitDiffNameOnlyMaster} = require('../common/git');
+const {gitDiffNameOnlyMain} = require('../common/git');
 const {isCiBuild} = require('../common/ci');
 
 /**
@@ -306,7 +306,7 @@ function determineBuildTargets() {
   lintFiles = globby.sync(config.lintGlobs);
   presubmitFiles = globby.sync(config.presubmitGlobs);
   prettifyFiles = globby.sync(config.prettifyGlobs);
-  const filesChanged = gitDiffNameOnlyMaster();
+  const filesChanged = gitDiffNameOnlyMain();
   for (const file of filesChanged) {
     let isRuntimeFile = true;
     Object.keys(targetMatchers).forEach((target) => {

--- a/build-system/pr-check/npm-checks.js
+++ b/build-system/pr-check/npm-checks.js
@@ -27,6 +27,7 @@ const {cyan, red} = require('kleur/colors');
 const {exec} = require('../common/exec');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {gitDiffColor, gitDiffNameOnly} = require('../common/git');
+const {mainBranch} = require('../common/main-branch');
 
 /**
  * Makes sure package.json and package-lock.json are in sync.
@@ -103,7 +104,7 @@ function isPackageLockFileProperlyUpdated() {
     logWithoutTimestamp(
       loggingPrefix,
       '⤷ To fix this, sync your branch to',
-      cyan('ampproject/amphtml:master') + ', run',
+      cyan(`ampproject/amphtml:${mainBranch}`) + ', run',
       cyan('npm install') + ', and push a new commit containing the changes.'
     );
     logWithoutTimestamp(loggingPrefix, 'Expected changes:');

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -20,14 +20,15 @@ const {
   gitBranchName,
   gitCommitHash,
   gitDiffCommitLog,
-  gitDiffStatMaster,
-  gitCiMasterBaseline,
+  gitDiffStatMain,
+  gitCiMainBaseline,
   shortSha,
 } = require('../common/git');
 const {ciBuildSha, ciPullRequestSha, isCiBuild} = require('../common/ci');
 const {cyan, green, yellow} = require('kleur/colors');
 const {execOrDie, execOrThrow, execWithError, exec} = require('../common/exec');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
+const {mainBranch} = require('../common/main-branch');
 const {replaceUrls} = require('../tasks/pr-deploy-bot-utils');
 
 const UNMINIFIED_OUTPUT_FILE = `amp_unminified_${ciBuildSha()}.zip`;
@@ -54,8 +55,8 @@ function printChangeSummary() {
 
   if (isCiBuild()) {
     logWithoutTimestamp(
-      `${loggingPrefix} Latest commit from ${cyan('master')} included ` +
-        `in this build: ${cyan(shortSha(gitCiMasterBaseline()))}`
+      `${loggingPrefix} Latest commit from ${cyan(mainBranch)} included ` +
+        `in this build: ${cyan(shortSha(gitCiMainBaseline()))}`
     );
     commitSha = ciPullRequestSha();
   } else {
@@ -66,7 +67,7 @@ function printChangeSummary() {
       `${cyan(shortSha(commitSha))}`
   );
 
-  const filesChanged = gitDiffStatMaster();
+  const filesChanged = gitDiffStatMain();
   logWithoutTimestamp(filesChanged);
 
   const branchCreationPoint = gitBranchCreationPoint();
@@ -74,7 +75,7 @@ function printChangeSummary() {
     logWithoutTimestamp(
       `${loggingPrefix} Commit log since branch`,
       `${cyan(gitBranchName())} was forked from`,
-      `${cyan('master')} at`,
+      `${cyan(mainBranch)} at`,
       `${cyan(shortSha(branchCreationPoint))}:`
     );
     logWithoutTimestamp(gitDiffCommitLog() + '\n');
@@ -85,13 +86,13 @@ function printChangeSummary() {
       'Could not find a common ancestor for',
       cyan(gitBranchName()),
       'and',
-      cyan('master') + '. (This can happen with older PR branches.)'
+      cyan(mainBranch) + '. (This can happen with older PR branches.)'
     );
     logWithoutTimestamp(
       loggingPrefix,
       yellow('NOTE 1:'),
       'If this causes unexpected test failures, try rebasing the PR branch on',
-      cyan('master') + '.'
+      cyan(mainBranch) + '.'
     );
     logWithoutTimestamp(
       loggingPrefix,

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -33,7 +33,7 @@ const jobName = 'visual-diff-tests.js';
 function pushBuildWorkflow() {
   downloadNomoduleOutput();
   process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
-  timedExecOrDie('amp visual-diff --nobuild --master');
+  timedExecOrDie('amp visual-diff --nobuild --main');
 }
 
 function prBuildWorkflow() {

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -22,7 +22,7 @@ const url = require('url');
 const util = require('util');
 const {
   gitCommitHash,
-  gitCiMasterBaseline,
+  gitCiMainBaseline,
   shortSha,
 } = require('../../common/git');
 const {
@@ -37,6 +37,7 @@ const {
 } = require('../../compile/internal-version');
 const {cyan, red, yellow} = require('kleur/colors');
 const {log, logWithoutTimestamp} = require('../../common/logging');
+const {mainBranch} = require('../../common/main-branch');
 const {report, NoTTYReport} = require('@ampproject/filesize');
 
 const filesizeConfigPath = require.resolve('./filesize.json');
@@ -103,11 +104,11 @@ async function requestPost(...args) {
  * repository to the passed value.
  */
 async function storeBundleSize() {
-  if (!isPushBuild() || ciPushBranch() !== 'master') {
+  if (!isPushBuild() || ciPushBranch() !== mainBranch) {
     log(
       yellow('Skipping'),
       cyan('--on_push_build') + ':',
-      'this action can only be performed on `master` push builds during CI'
+      'this action can only be performed on main branch push builds during CI'
     );
     return;
   }
@@ -182,7 +183,7 @@ async function skipBundleSize() {
 async function reportBundleSize() {
   if (isPullRequestBuild()) {
     const headSha = gitCommitHash();
-    const baseSha = gitCiMasterBaseline();
+    const baseSha = gitCiMainBaseline();
     const mergeSha = circleciPrMergeCommit();
     log(
       'Reporting bundle sizes for commit',
@@ -268,8 +269,7 @@ bundleSize.description =
   'Checks if the minified AMP binary has exceeded its size cap';
 bundleSize.flags = {
   'on_push_build':
-    'Store bundle sizes in the AMP build artifacts repo ' +
-    '(also implies --on_pr_build)',
+    'Store bundle sizes in the AMP build artifacts repo for main branch builds',
   'on_pr_build': 'Report the bundle sizes for this pull request to GitHub',
   'on_skipped_build':
     "Set the status of this pull request's bundle " +

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -19,7 +19,7 @@ const fs = require('fs-extra');
 const globby = require('globby');
 const semver = require('semver');
 const {cyan, green, red} = require('kleur/colors');
-const {gitDiffFileMaster} = require('../common/git');
+const {gitDiffFileMain} = require('../common/git');
 const {log, logLocalDev, logWithoutTimestamp} = require('../common/logging');
 
 /**
@@ -66,7 +66,7 @@ async function checkExactVersions() {
         cyan(file),
         'do not have an exact version.'
       );
-      logWithoutTimestamp(gitDiffFileMaster(file));
+      logWithoutTimestamp(gitDiffFileMain(file));
       throw new Error('Check failed');
     }
   });

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -19,7 +19,7 @@ const fs = require('fs-extra');
 const markdownLinkCheck = require('markdown-link-check');
 const path = require('path');
 const {getFilesToCheck, usesFilesOrLocalChanges} = require('../common/utils');
-const {gitDiffAddedNameOnlyMaster} = require('../common/git');
+const {gitDiffAddedNameOnlyMain} = require('../common/git');
 const {green, cyan, red, yellow} = require('kleur/colors');
 const {linkCheckGlobs} = require('../test-configs/config');
 const {log, logLocalDev} = require('../common/logging');
@@ -45,7 +45,7 @@ async function checkLinks() {
     return;
   }
   logLocalDev(green('Starting checks...'));
-  filesIntroducedByPr = gitDiffAddedNameOnlyMaster();
+  filesIntroducedByPr = gitDiffAddedNameOnlyMain();
   const results = await Promise.all(filesToCheck.map(checkLinksInFile));
   reportResults(results);
 }

--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -19,6 +19,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const {execOrThrow, getOutput} = require('../common/exec');
 const {green, cyan, red, yellow} = require('kleur/colors');
 const {log} = require('../common/logging');
+const {mainBranch} = require('../common/main-branch');
 
 /**
  * Determines the name of the cherry-pick branch.
@@ -128,7 +129,7 @@ async function cherryPick() {
   } catch (e) {
     log(red('ERROR:'), e.message);
     log('Deleting branch', cyan(branch));
-    getOutput(`git checkout master && git branch -d ${branch}`);
+    getOutput(`git checkout ${mainBranch} && git branch -d ${branch}`);
     throw e;
   }
 }

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -22,6 +22,7 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const {log} = require('../../common/logging');
+const {mainBranch} = require('../../common/main-branch');
 
 const exec = util.promisify(childProcess.exec);
 
@@ -68,7 +69,7 @@ async function fetchConfigFromBranch_(filename, opt_localBranch, opt_branch) {
   if (opt_localBranch) {
     return fs.promises.readFile(filename, 'utf8');
   }
-  const branch = opt_branch || 'origin/master';
+  const branch = opt_branch || `origin/${mainBranch}`;
   return (await exec(`git show ${branch}:${filename}`)).stdout;
 }
 
@@ -317,8 +318,7 @@ prependGlobal.flags = {
     'Takes in an optional value for a custom prod config source.',
   'local_dev': 'Enables runtime to be used for local development.',
   'branch':
-    'Switch to a git branch to get config source from. ' +
-    'Uses master by default.',
+    'Get config source from the given branch. Uses the main branch by default.',
   'local_branch':
     "Don't switch branches and use the config from the local branch.",
   'fortesting': 'Force the config to return true for getMode().test',

--- a/build-system/tasks/runtime-test/helpers-unit.js
+++ b/build-system/tasks/runtime-test/helpers-unit.js
@@ -23,7 +23,7 @@ const path = require('path');
 const testConfig = require('../../test-configs/config');
 const {execOrDie} = require('../../common/exec');
 const {extensions, maybeInitializeExtensions} = require('../extension-helpers');
-const {gitDiffNameOnlyMaster} = require('../../common/git');
+const {gitDiffNameOnlyMain} = require('../../common/git');
 const {green, cyan} = require('kleur/colors');
 const {isCiBuild} = require('../../common/ci');
 const {log, logLocalDev} = require('../../common/logging');
@@ -40,7 +40,7 @@ let testsToRun = null;
  * @return {boolean}
  */
 function isLargeRefactor() {
-  const filesChanged = gitDiffNameOnlyMaster();
+  const filesChanged = gitDiffNameOnlyMain();
   return filesChanged.length >= LARGE_REFACTOR_THRESHOLD;
 }
 
@@ -186,7 +186,7 @@ function unitTestsToRun() {
     return testsToRun;
   }
   const cssJsFileMap = extractCssJsFileMap();
-  const filesChanged = gitDiffNameOnlyMaster();
+  const filesChanged = gitDiffNameOnlyMain();
   const {unitTestPaths} = testConfig;
   testsToRun = [];
   let srcFiles = [];

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -34,7 +34,7 @@ const {
 const {
   gitBranchName,
   gitCommitterEmail,
-  gitCiMasterBaseline,
+  gitCiMainBaseline,
   shortSha,
 } = require('../../common/git');
 const {buildRuntime} = require('../../common/utils');
@@ -126,7 +126,7 @@ function maybeOverridePercyEnvironmentVariables() {
  * as baselines for future builds.
  */
 function setPercyBranch() {
-  if (!process.env['PERCY_BRANCH'] && (!argv.master || !isCiBuild())) {
+  if (!process.env['PERCY_BRANCH'] && (!argv.main || !isCiBuild())) {
     const userName = gitCommitterEmail();
     const branchName = gitBranchName();
     process.env['PERCY_BRANCH'] = userName + '-' + branchName;
@@ -139,13 +139,13 @@ function setPercyBranch() {
  * This will let Percy determine which build to use as the baseline for this new
  * build.
  *
- * Only does something during CI, and for non-master branches, since master
+ * Only does something during CI, and for non-main branches, since main branch
  * builds are always built on top of the previous commit (we use the squash and
  * merge method for pull requests.)
  */
 function setPercyTargetCommit() {
-  if (isCiBuild() && !argv.master) {
-    process.env['PERCY_TARGET_COMMIT'] = gitCiMasterBaseline();
+  if (isCiBuild() && !argv.main) {
+    process.env['PERCY_TARGET_COMMIT'] = gitCiMainBaseline();
   }
 }
 
@@ -422,7 +422,7 @@ async function runVisualTests(browser, webpages) {
     );
   }
 
-  if (argv.master) {
+  if (argv.main) {
     const page = await newPage(browser);
     await page.goto(
       `http://${HOST}:${PORT}/examples/visual-tests/blank-page/blank.html`
@@ -841,7 +841,7 @@ module.exports = {
 
 visualDiff.description = 'Runs the AMP visual diff tests.';
 visualDiff.flags = {
-  'master': 'Includes a blank snapshot (baseline for skipped builds)',
+  'main': 'Includes a blank snapshot (baseline for skipped builds)',
   'empty': 'Creates a dummy Percy build with only a blank snapshot',
   'config':
     'Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',


### PR DESCRIPTION
**PR Highlights:**
- Remove all hard-coded references to `master` in the `build-system/` implementation
- Add a single source of truth in `common/main-branch.js` (will be changed to `main` later)

**Notes:**
- As written, this PR should be a no-op. 
- Documentation / comment URLs in our codebase will be changed in a follow up PR.

Partial fix for #32195

