### PR TITLE
Revert "[amp-story-player] Fix duplicate player loading scenario"

### DIFF
--- a/spec/amp-story-player.md
+++ b/spec/amp-story-player.md
@@ -123,23 +123,20 @@ URL pointing to the story.
 
 ## Programmatic Control
 
-Call the player's various methods to programmatically control the player. These methods are exposed on the HTML element, `const playerEl = document.querySelector('amp-story-player')`.
+Call the player's various methods to programmatically control the player. These methods are exposed on the HTML element, `const playerEl = document.querySelector('amp-story-player')` and on instances of the global class variable, `const player = new AmpStoryPlayer(window, playerEl)`.
 
 ### Methods
 
 #### load
 
-Will initialize the player manually. This can be useful when creating the player dynamically.
+Will initialize the player manually. This can be useful when the player is dynamically.
 
-Note that the amp-story-player JS will automatically do this when the player is already in the HTML markup, so only do this when you really need to.
-
-Also note that the element must be connected to the DOM before calling `load()`.
+Note that the element must be connected to the DOM before calling `load()`.
 
 ```javascript
-const playerEl = document.createElement('amp-story-player');
-new AmpStoryPlayer(window, playerEl);
-document.body.appendChild(playerEl);
-playerEl.load();
+const playerEl = document.body.querySelector('amp-story-player');
+const player = new AmpStoryPlayer(window, playerEl);
+player.load();
 ```
 
 #### go

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -31,16 +31,18 @@ export class AmpStoryComponentManager {
 
   /**
    * Calls layoutCallback on the element when it is close to the viewport.
-   * @param {!Element} element
+   * @param {!AmpStoryPlayer|!AmpStoryEntryPoint} elImpl
    * @private
    */
-  layoutEl_(element) {
-    new AmpStoryPlayerViewportObserver(this.win_, element, () =>
-      element.layoutCallback()
+  layoutEl_(elImpl) {
+    new AmpStoryPlayerViewportObserver(
+      this.win_,
+      elImpl.getElement(),
+      elImpl.layoutCallback.bind(elImpl)
     );
 
     const scrollHandler = () => {
-      element.layoutCallback();
+      elImpl.layoutCallback();
       this.win_.removeEventListener('scroll', scrollHandler);
     };
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -199,6 +199,12 @@ export class AmpStoryPlayer {
     /** @private {?Element} */
     this.rootEl_ = null;
 
+    /** @private {boolean} */
+    this.isLaidOut_ = false;
+
+    /** @private {boolean} */
+    this.isBuilt_ = false;
+
     /** @private {number} */
     this.currentIdx_ = 0;
 
@@ -235,8 +241,6 @@ export class AmpStoryPlayer {
 
     /** @private {boolean} */
     this.autoplay_ = true;
-
-    return this.element_;
   }
 
   /**
@@ -244,9 +248,6 @@ export class AmpStoryPlayer {
    * @private
    */
   attachCallbacksToElement_() {
-    this.element_.buildCallback = this.buildCallback.bind(this);
-    this.element_.layoutCallback = this.layoutCallback.bind(this);
-    this.element_.getElement = this.getElement.bind(this);
     this.element_.getStories = this.getStories.bind(this);
     this.element_.load = this.load.bind(this);
     this.element_.show = this.show.bind(this);
@@ -269,9 +270,6 @@ export class AmpStoryPlayer {
       throw new Error(
         `[${TAG}] element must be connected to the DOM before calling load().`
       );
-    }
-    if (!!this.element_.isBuilt_) {
-      throw new Error(`[${TAG}] calling load() on an already loaded element.`);
     }
     this.buildCallback();
     this.layoutCallback();
@@ -366,7 +364,7 @@ export class AmpStoryPlayer {
 
   /** @public */
   buildCallback() {
-    if (!!this.element_.isBuilt_) {
+    if (this.isBuilt_) {
       return;
     }
 
@@ -380,7 +378,7 @@ export class AmpStoryPlayer {
     this.initializePageScroll_();
     this.initializeCircularWrapping_();
     this.signalReady_();
-    this.element_.isBuilt_ = true;
+    this.isBuilt_ = true;
   }
 
   /**
@@ -683,7 +681,7 @@ export class AmpStoryPlayer {
    * @public
    */
   layoutCallback() {
-    if (!!this.element_.isLaidOut_) {
+    if (this.isLaidOut_) {
       return;
     }
 
@@ -693,7 +691,7 @@ export class AmpStoryPlayer {
 
     this.render_();
 
-    this.element_.isLaidOut_ = true;
+    this.isLaidOut_ = true;
   }
 
   /**


### PR DESCRIPTION
Reverts ampproject/amphtml#32971
Closes https://github.com/ampproject/amphtml/issues/33546

Attaching our own custom `layoutCallback` in the `amp-story-player-impl.js` class to the `<amp-story-player>` element was confusing the AMP runtime, which would call our custom `layoutCallback()` but never the actual `AMP.BaseElement.layoutCallback()` from the AMP `AmpStoryPlayerWrapper` class. This would cause the loader to get stuck since it's waiting for `AMP.BaseElement.layoutCallback()` to finish.
