### PR TITLE
[amp-story-player] Change name of build/layout callbacks

### DIFF
--- a/extensions/amp-story-player/0.1/amp-story-player.js
+++ b/extensions/amp-story-player/0.1/amp-story-player.js
@@ -32,12 +32,12 @@ class AmpStoryPlayerWrapper extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.player_.buildCallback();
+    this.player_.buildPlayer();
   }
 
   /** @override */
   layoutCallback() {
-    this.player_.layoutCallback();
+    this.player_.layoutPlayer();
     return Promise.resolve();
   }
 

--- a/src/amp-story-player/amp-story-component-manager.js
+++ b/src/amp-story-player/amp-story-component-manager.js
@@ -30,17 +30,17 @@ export class AmpStoryComponentManager {
   }
 
   /**
-   * Calls layoutCallback on the element when it is close to the viewport.
+   * Calls layoutPlayer on the element when it is close to the viewport.
    * @param {!Element} element
    * @private
    */
   layoutEl_(element) {
     new AmpStoryPlayerViewportObserver(this.win_, element, () =>
-      element.layoutCallback()
+      element.layoutPlayer()
     );
 
     const scrollHandler = () => {
-      element.layoutCallback();
+      element.layoutPlayer();
       this.win_.removeEventListener('scroll', scrollHandler);
     };
 
@@ -58,7 +58,7 @@ export class AmpStoryComponentManager {
     for (let i = 0; i < players.length; i++) {
       const playerEl = players[i];
       const player = new AmpStoryPlayer(this.win_, playerEl);
-      player.buildCallback();
+      player.buildPlayer();
       this.layoutEl_(player);
     }
   }

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -244,8 +244,8 @@ export class AmpStoryPlayer {
    * @private
    */
   attachCallbacksToElement_() {
-    this.element_.buildCallback = this.buildCallback.bind(this);
-    this.element_.layoutCallback = this.layoutCallback.bind(this);
+    this.element_.buildPlayer = this.buildPlayer.bind(this);
+    this.element_.layoutPlayer = this.layoutPlayer.bind(this);
     this.element_.getElement = this.getElement.bind(this);
     this.element_.getStories = this.getStories.bind(this);
     this.element_.load = this.load.bind(this);
@@ -273,8 +273,8 @@ export class AmpStoryPlayer {
     if (!!this.element_.isBuilt_) {
       throw new Error(`[${TAG}] calling load() on an already loaded element.`);
     }
-    this.buildCallback();
-    this.layoutCallback();
+    this.buildPlayer();
+    this.layoutPlayer();
   }
 
   /**
@@ -365,7 +365,7 @@ export class AmpStoryPlayer {
   }
 
   /** @public */
-  buildCallback() {
+  buildPlayer() {
     if (!!this.element_.isBuilt_) {
       return;
     }
@@ -682,7 +682,7 @@ export class AmpStoryPlayer {
   /**
    * @public
    */
-  layoutCallback() {
+  layoutPlayer() {
     if (!!this.element_.isLaidOut_) {
       return;
     }

--- a/src/amp-story-player/amp-story-player-viewport-observer.js
+++ b/src/amp-story-player/amp-story-player-viewport-observer.js
@@ -77,7 +77,7 @@ export class AmpStoryPlayerViewportObserver {
 
   /**
    * Fallback for when IntersectionObserver is not supported. Calls
-   * layoutCallback on the element when it is close to the viewport.
+   * layoutPlayer on the element when it is close to the viewport.
    * @private
    */
   createInObFallback_() {


### PR DESCRIPTION
Closes #33546

Attaching our own custom `layoutCallback` in the `amp-story-player-impl.js` class to the `<amp-story-player>` element was confusing the AMP runtime, which would call our custom `layoutCallback()` instead of the `custom-element.js`'s `layoutCallback()`. This would cause the loader to get stuck since it's waiting for `AMP.BaseElement.layoutCallback()` to finish.