### PR TITLE
📖  amp-script: Recommend "utf8" for Utf8AsciiLatin1Encoding

### DIFF
--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -330,7 +330,7 @@ const crypto = require('crypto');
 const hash = crypto.createHash('sha384');
 
 function generateCSPHash(script) {
-  const data = hash.update(script, 'utf-8');
+  const data = hash.update(script, 'utf8');
   return (
     'sha384-' +
     data


### PR DESCRIPTION
`utf8` fixes the following TS error:

![image](https://user-images.githubusercontent.com/254946/113326174-2ebd2c80-92ce-11eb-9518-3f290dfbc95e.png)
