### PR TITLE
Provide unlayout callback for amp-dailymotion

### DIFF
--- a/extensions/amp-dailymotion/0.1/amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/amp-dailymotion.js
@@ -176,6 +176,16 @@ class AmpDailymotion extends AMP.BaseElement {
     return this.loadPromise(this.iframe_);
   }
 
+  /** @override */
+  unlayoutCallback() {
+    const iframe = this.iframe_;
+    if (iframe) {
+      this.element.removeChild(iframe);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
   /**
    * @param {!Event} event
    * @private

--- a/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
@@ -83,5 +83,17 @@ describes.realWin(
         );
       });
     });
+
+    it('unlayout and reloayout', async () => {
+      const dailymotion = await getDailymotion('x2m8jpp');
+      expect(dailymotion.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = dailymotion.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(dailymotion.querySelector('iframe')).to.not.exist;
+
+      await dailymotion.layoutCallback();
+      expect(dailymotion.querySelector('iframe')).to.exist;
+    });
   }
 );

--- a/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
+++ b/extensions/amp-dailymotion/0.1/test/test-amp-dailymotion.js
@@ -84,7 +84,7 @@ describes.realWin(
       });
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const dailymotion = await getDailymotion('x2m8jpp');
       expect(dailymotion.querySelector('iframe')).to.exist;
 


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.

