### PR TITLE
Provide unlayoutCallback for amp-izlesene

### DIFF
--- a/extensions/amp-izlesene/0.1/amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/amp-izlesene.js
@@ -108,6 +108,15 @@ class AmpIzlesene extends AMP.BaseElement {
   }
 
   /** @override */
+  unlayoutCallback() {
+    if (this.iframe_) {
+      this.element.removeChild(this.iframe_);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
+  /** @override */
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.iframe_.contentWindow./*OK*/ postMessage(

--- a/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
@@ -74,5 +74,17 @@ describes.realWin(
         );
       });
     });
+
+    it('unlayout and reloayout', async () => {
+      const izlesene = await getIzlesene('7221390');
+      expect(izlesene.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = izlesene.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(izlesene.querySelector('iframe')).to.not.exist;
+
+      await izlesene.layoutCallback();
+      expect(izlesene.querySelector('iframe')).to.exist;
+    });
   }
 );

--- a/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/test/test-amp-izlesene.js
@@ -75,7 +75,7 @@ describes.realWin(
       });
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const izlesene = await getIzlesene('7221390');
       expect(izlesene.querySelector('iframe')).to.exist;
 


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.