### PR TITLE
Provide unlayoutCallback for amp-kaltura-player

### DIFF
--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -105,6 +105,16 @@ class AmpKaltura extends AMP.BaseElement {
   }
 
   /** @override */
+  unlayoutCallback() {
+    const iframe = this.iframe_;
+    if (iframe) {
+      this.element.removeChild(iframe);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
+  /** @override */
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('amp-img');
     this.propagateAttributes(['aria-label'], placeholder);

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -120,7 +120,7 @@ describes.realWin(
       });
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const kp = await getKaltura({
         'data-partner': '1281471',
         'data-entryid': '1_3ts1ms9c',

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -120,6 +120,23 @@ describes.realWin(
       });
     });
 
+    it('unlayout and reloayout', async () => {
+      const kp = await getKaltura({
+        'data-partner': '1281471',
+        'data-entryid': '1_3ts1ms9c',
+        'data-uiconf': '33502051',
+        'data-param-my-param': 'hello world',
+      });
+      expect(kp.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = kp.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(kp.querySelector('iframe')).to.not.exist;
+
+      await kp.layoutCallback();
+      expect(kp.querySelector('iframe')).to.exist;
+    });
+
     describe('createPlaceholderCallback', () => {
       it('should create a placeholder image', () => {
         return getKaltura({


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.