### PR TITLE
Revert async pause for an iframe due to zero-size iframes

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -19,7 +19,6 @@ import {ActionTrust} from '../../../src/action-constants';
 import {IntersectionObserver3pHost} from '../../../src/utils/intersection-observer-3p-host';
 import {LayoutPriority, isLayoutSizeDefined} from '../../../src/layout';
 import {MessageType} from '../../../src/3p-frame-messaging';
-import {PauseHelper} from '../../../src/utils/pause-helper';
 import {Services} from '../../../src/services';
 import {base64EncodeFromBytes} from '../../../src/utils/base64.js';
 import {createCustomEvent, getData, listen} from '../../../src/event-helper';
@@ -127,9 +126,6 @@ export class AmpIframe extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.hasErroredEmbedSize_ = false;
-
-    /** @private @const */
-    this.pauseHelper_ = new PauseHelper(this.element);
   }
 
   /** @override */
@@ -493,8 +489,6 @@ export class AmpIframe extends AMP.BaseElement {
           });
         }, 1000);
       }
-
-      this.pauseHelper_.updatePlaying(true);
     });
   }
 
@@ -589,7 +583,6 @@ export class AmpIframe extends AMP.BaseElement {
         this.intersectionObserverHostApi_ = null;
       }
     }
-    this.pauseHelper_.updatePlaying(false);
     return true;
   }
 

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -24,7 +24,6 @@ import {
   whenUpgradedToCustomElement,
 } from '../../../../src/dom';
 
-import {installResizeObserverStub} from '../../../../testing/resize-observer-stub';
 import {isAdLike} from '../../../../src/iframe-helper';
 import {macroTask} from '../../../../testing/yield';
 import {poll} from '../../../../testing/iframe';
@@ -52,7 +51,6 @@ describes.realWin(
     let content;
     let win;
     let doc;
-    let resizeObserverStub;
 
     beforeEach(() => {
       iframeSrc =
@@ -81,7 +79,6 @@ describes.realWin(
         }
       });
       setTrackingIframeTimeoutForTesting(20);
-      resizeObserverStub = installResizeObserverStub(env.sandbox, win);
     });
 
     function stubUserAsserts() {
@@ -1080,24 +1077,6 @@ describes.realWin(
 
         ampIframe.pause();
         expect(ampIframe.querySelector('iframe')).to.not.exist;
-      });
-
-      it('should unlayout on pause when loses size', async () => {
-        const ampIframe = createAmpIframe(env, {
-          src: iframeSrc,
-          width: 100,
-          height: 100,
-        });
-        await ampIframe.getImpl(false);
-        env.sandbox./*OK*/ stub(ampIframe, 'pause');
-        await waitForAmpIframeLayoutPromise(doc, ampIframe);
-        expect(ampIframe.pause).to.not.be.called;
-
-        resizeObserverStub.notifySync({
-          target: ampIframe,
-          contentRect: {width: 0, height: 0},
-        });
-        expect(ampIframe.pause).to.be.calledOnce;
       });
     });
 


### PR DESCRIPTION
Partial revert of https://github.com/ampproject/amphtml/pull/33382

In some circumstances the `ResizeObserver` produces incomplete measurement results. Research is ongoing still why and when. But due to the incorrect results, the iframe believes it has been unloaded.

Test is available here: https://forest-spark-school.glitch.me/original.html