### PR TITLE
Provide unlayoutCallback for amp-o2-player

### DIFF
--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -139,6 +139,16 @@ class AmpO2Player extends AMP.BaseElement {
     return this.loadPromise(iframe);
   }
 
+  /** @override */
+  unlayoutCallback() {
+    const iframe = this.iframe_;
+    if (iframe) {
+      this.element.removeChild(iframe);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
   /**
    * Requests consent data from consent module
    * and forwards information to iframe

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -153,6 +153,22 @@ describes.realWin(
       );
     });
 
+    it('unlayout and reloayout', async () => {
+      const o2 = await getO2player({
+        'data-pid': '123',
+        'data-bcid': '456',
+        'data-env': 'stage',
+      });
+      expect(o2.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = o2.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(o2.querySelector('iframe')).to.not.exist;
+
+      await o2.layoutCallback();
+      expect(o2.querySelector('iframe')).to.exist;
+    });
+
     describe('sends a consent-data', () => {
       let sendConsentDataToIframe;
       const resSource = 'my source';

--- a/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/test/test-amp-o2-player.js
@@ -153,7 +153,7 @@ describes.realWin(
       );
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const o2 = await getO2player({
         'data-pid': '123',
         'data-bcid': '456',


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.