### PR TITLE
Provide unlayoutCallback for amp-reach-player

### DIFF
--- a/extensions/amp-reach-player/0.1/amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/amp-reach-player.js
@@ -67,6 +67,16 @@ class AmpReachPlayer extends AMP.BaseElement {
   }
 
   /** @override */
+  unlayoutCallback() {
+    const iframe = this.iframe_;
+    if (iframe) {
+      this.element.removeChild(iframe);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
+  /** @override */
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.iframe_.contentWindow./*OK*/ postMessage(

--- a/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
@@ -76,7 +76,7 @@ describes.realWin(
       });
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const reach = await getReach({
         'data-embed-id': 'default',
       });

--- a/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/test/test-amp-reach-player.js
@@ -75,5 +75,19 @@ describes.realWin(
         expect(iframe.className).to.match(/i-amphtml-fill-content/);
       });
     });
+
+    it('unlayout and reloayout', async () => {
+      const reach = await getReach({
+        'data-embed-id': 'default',
+      });
+      expect(reach.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = reach.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(reach.querySelector('iframe')).to.not.exist;
+
+      await reach.layoutCallback();
+      expect(reach.querySelector('iframe')).to.exist;
+    });
   }
 );


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.