### PR TITLE
Provide unlayoutCallback for amp-soundcloud

### DIFF
--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -113,6 +113,16 @@ class AmpSoundcloud extends AMP.BaseElement {
   }
 
   /** @override */
+  unlayoutCallback() {
+    const iframe = this.iframe_;
+    if (iframe) {
+      this.element.removeChild(iframe);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
+  /** @override */
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.iframe_.contentWindow./*OK*/ postMessage(

--- a/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
@@ -128,5 +128,17 @@ describes.realWin(
         /The data-trackid attribute is required for/
       );
     });
+
+    it('unlayout and reloayout', async () => {
+      const scplayer = await getSCPlayer('1595551', true);
+      expect(scplayer.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = scplayer.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(scplayer.querySelector('iframe')).to.not.exist;
+
+      await scplayer.layoutCallback();
+      expect(scplayer.querySelector('iframe')).to.exist;
+    });
   }
 );

--- a/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/test/test-amp-soundcloud.js
@@ -129,7 +129,7 @@ describes.realWin(
       );
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const scplayer = await getSCPlayer('1595551', true);
       expect(scplayer.querySelector('iframe')).to.exist;
 


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.