### PR TITLE
Provide unlayoutCallback for amp-springboard-player

### DIFF
--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -127,6 +127,16 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
   }
 
   /** @override */
+  unlayoutCallback() {
+    const iframe = this.iframe_;
+    if (iframe) {
+      this.element.removeChild(iframe);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
+  /** @override */
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.iframe_.contentWindow./*OK*/ postMessage('ampPause', '*');

--- a/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
@@ -142,7 +142,7 @@ describes.realWin(
       );
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const bc = await getSpringboardPlayer({
         'data-site-id': '261',
         'data-mode': 'video',

--- a/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
@@ -142,6 +142,25 @@ describes.realWin(
       );
     });
 
+    it('unlayout and reloayout', async () => {
+      const bc = await getSpringboardPlayer({
+        'data-site-id': '261',
+        'data-mode': 'video',
+        'data-content-id': '1578473',
+        'data-player-id': 'test401',
+        'data-domain': 'test.com',
+        'data-items': '10',
+      });
+      expect(bc.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = bc.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(bc.querySelector('iframe')).to.not.exist;
+
+      await bc.layoutCallback();
+      expect(bc.querySelector('iframe')).to.exist;
+    });
+
     describe('createPlaceholderCallback', () => {
       it('should create a placeholder image', () => {
         return getSpringboardPlayer({


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.