### PR TITLE
Provide unlayoutCallback for amp-vine

### DIFF
--- a/extensions/amp-vine/0.1/amp-vine.js
+++ b/extensions/amp-vine/0.1/amp-vine.js
@@ -72,6 +72,16 @@ class AmpVine extends AMP.BaseElement {
   }
 
   /** @override */
+  unlayoutCallback() {
+    const iframe = this.iframe_;
+    if (iframe) {
+      this.element.removeChild(iframe);
+      this.iframe_ = null;
+    }
+    return true;
+  }
+
+  /** @override */
   pauseCallback() {
     if (this.iframe_ && this.iframe_.contentWindow) {
       this.iframe_.contentWindow./*OK*/ postMessage('pause', '*');

--- a/extensions/amp-vine/0.1/test/test-amp-vine.js
+++ b/extensions/amp-vine/0.1/test/test-amp-vine.js
@@ -70,5 +70,17 @@ describes.realWin(
         /The data-vineid attribute is required for/
       );
     });
+
+    it('unlayout and reloayout', async () => {
+      const vine = await getVine('MdKjXez002d', true);
+      expect(vine.querySelector('iframe')).to.exist;
+
+      const unlayoutResult = vine.unlayoutCallback();
+      expect(unlayoutResult).to.be.true;
+      expect(vine.querySelector('iframe')).to.not.exist;
+
+      await vine.layoutCallback();
+      expect(vine.querySelector('iframe')).to.exist;
+    });
   }
 );

--- a/extensions/amp-vine/0.1/test/test-amp-vine.js
+++ b/extensions/amp-vine/0.1/test/test-amp-vine.js
@@ -71,7 +71,7 @@ describes.realWin(
       );
     });
 
-    it('unlayout and reloayout', async () => {
+    it('unlayout and relayout', async () => {
       const vine = await getVine('MdKjXez002d', true);
       expect(vine.querySelector('iframe')).to.exist;
 


### PR DESCRIPTION
The iframe-based elements require `unlayoutCallback`. This one appears to be simply missed, so adding it here. The implementation is trivial.

Partial for #31915.
Partial for #31540.