### PR TITLE
🏗 Bump @ampproject/storybook-addon

### DIFF
--- a/build-system/tasks/storybook/package-lock.json
+++ b/build-system/tasks/storybook/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ampproject/storybook-addon": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.7.tgz",
-      "integrity": "sha512-gl/e+Fj36v6cqdoFYfGIqdATdsUdrkXSwE0TwwBg2kFAiVwNbwbgzXH9iWqeBYHHKceZRAhl0cL205YCpMdHjg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.8.tgz",
+      "integrity": "sha512-Qi2XR8/HDYbOPuMU73zEuHSdPf5uYNWUm8POuli/IfnaDD2bXc17mXz85p1cG6C3vunGVJzHZ+HCoAkue5SvQA==",
       "dev": true,
       "requires": {
         "@storybook/client-api": "^5.3.19",

--- a/build-system/tasks/storybook/package.json
+++ b/build-system/tasks/storybook/package.json
@@ -4,7 +4,7 @@
   "description": "amp storybook tasks",
   "main": "index.js",
   "devDependencies": {
-    "@ampproject/storybook-addon": "1.1.7",
+    "@ampproject/storybook-addon": "1.1.8",
     "@babel/core": "7.13.10",
     "@babel/preset-react": "7.12.13",
     "@babel/runtime-corejs3": "7.13.10",


### PR DESCRIPTION
Introduces `<meta>` hashes for inline `amp-script`.