### PR TITLE
🏗 Bump @ampproject/storybook-addon

### DIFF
--- a/build-system/tasks/storybook/package-lock.json
+++ b/build-system/tasks/storybook/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@ampproject/storybook-addon": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.7.tgz",
-      "integrity": "sha512-gl/e+Fj36v6cqdoFYfGIqdATdsUdrkXSwE0TwwBg2kFAiVwNbwbgzXH9iWqeBYHHKceZRAhl0cL205YCpMdHjg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.9.tgz",
+      "integrity": "sha512-msn6ElmpnvvEJ6xc7AOfdWmOrIHwvd29SZmbm/NUVXfvrUy9W9bS+t62/g0N2R3CrNG/tvH7f54DFjy8u9Xp5w==",
       "dev": true,
       "requires": {
         "@storybook/client-api": "^5.3.19",

--- a/build-system/tasks/storybook/package.json
+++ b/build-system/tasks/storybook/package.json
@@ -4,7 +4,7 @@
   "description": "amp storybook tasks",
   "main": "index.js",
   "devDependencies": {
-    "@ampproject/storybook-addon": "1.1.7",
+    "@ampproject/storybook-addon": "1.1.9",
     "@babel/core": "7.13.10",
     "@babel/preset-react": "7.12.13",
     "@babel/runtime-corejs3": "7.13.10",

--- a/extensions/amp-render/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-render/1.0/storybook/Basic.amp.js
@@ -112,11 +112,6 @@ WithBindableSrc.story = {
 export const WithAmpScriptSrc = () => {
   return (
     <>
-      {/* TODO(alanorozco): Remove hash once storybook-addon-amp#22 is mainlined */}
-      <meta
-        name="amp-script-src"
-        content="sha384-W71daLvaG1fVtSoGC4xq80vkUeKAZPo2hPEj4ofjtSOSfK1m02U0gQXp1ChLV1O8"
-      ></meta>
       <amp-script id="dataFunctions" script="local-script" nodom></amp-script>
       <script id="local-script" type="text/plain" target="amp-script">
         {`


### PR DESCRIPTION
Upgrades to version 1.1.9. 1.1.8 was skipped due to bugfix.

With this upgrade we're now generating `amp-script` hashes. A previous story included a hardcoded hash, so we remove it.