### PR TITLE
Add validations for Bento carousels on websites

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -532,7 +532,7 @@
   {
     "name": "amp-stream-gallery",
     "version": ["0.1", "1.0"],
-    "latestVersion": "0.1",
+    "latestVersion": "1.0",
     "options": {"hasCss": true}
   },
   {

--- a/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.html
+++ b/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.html
@@ -1,0 +1,159 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-base-carousel tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
+</head>
+<body>
+  <!-- Boolean values -->
+  <section>
+    <!-- Valid: true -->
+    <amp-base-carousel width="4" height="3" auto-advance="true">
+    </amp-base-carousel>
+    <!-- Valid: false -->
+    <amp-base-carousel width="4" height="3" auto-advance="false">
+    </amp-base-carousel>
+    <!-- Valid: booleans with a media query -->
+    <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, false">
+    </amp-base-carousel>
+    <!-- Valid: booleans with multiple media queries -->
+    <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, (max-height: 1000px) true, false">
+    </amp-base-carousel>
+    <!-- Invalid: no default value-->
+    <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true">
+    </amp-base-carousel>
+    <!-- Invalid: no value -->
+    <amp-base-carousel width="4" height="3" auto-advance>
+    </amp-base-carousel>
+    <!-- Invalid: incorrect value -->
+    <amp-base-carousel width="4" height="3" auto-advance="5">
+    </amp-base-carousel>
+    <!-- Invalid: incorrect in media query -->
+    <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, (max-height: 1000px) 5, false">
+    </amp-base-carousel>
+  </section>
+
+  <!-- Integer values-->
+  <section>
+    <!-- Valid: positive integer value -->
+    <amp-base-carousel width="4" height="3" advance-count="2">
+    </amp-base-carousel>
+    <!-- Valid: negative integer value -->
+    <amp-base-carousel width="4" height="3" advance-count="-2">
+    </amp-base-carousel>
+    <!-- Valid: integer values with media queries -->
+    <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) 3, 1">
+    </amp-base-carousel>
+    <!-- Valid: integer values with multiple media queries -->
+    <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
+    </amp-base-carousel>
+    <!-- Invalid: no default value-->
+    <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) 3">
+    </amp-base-carousel>
+    <!-- Invalid: no value -->
+    <amp-base-carousel width="4" height="3" advance-count>
+    </amp-base-carousel>
+    <!-- Invalid: floating point value -->
+    <amp-base-carousel width="4" height="3" advance-count="3.2">
+    </amp-base-carousel>
+    <!-- Invalid: floating point value in media query -->
+    <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3.2, 1">
+    </amp-base-carousel>
+  </section>
+
+  <!-- Positive float values-->
+  <section>
+    <!-- Valid: integer value -->
+    <amp-base-carousel width="4" height="3" visible-count="2">
+    </amp-base-carousel>
+    <!-- Valid: floating point value -->
+    <amp-base-carousel width="4" height="3" visible-count="3.2">
+    </amp-base-carousel>
+    <!-- Valid: mixed value with one media query -->
+    <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3.2, 1">
+    </amp-base-carousel>
+    <!-- Valid: mixed values with multiple media queries -->
+    <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3, (max-height: 1000px) 3, 1.1">
+    </amp-base-carousel>
+    <!-- Invalid: negative integer value -->
+    <amp-base-carousel width="4" height="3" visible-count="-2">
+    </amp-base-carousel>
+    <!-- Invalid: no default value-->
+    <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3">
+    </amp-base-carousel>
+    <!-- Invalid: no value -->
+    <amp-base-carousel width="4" height="3" visible-count>
+    </amp-base-carousel>
+    <!-- Invalid: string value -->
+    <amp-base-carousel width="4" height="3" visible-count="foo">
+    </amp-base-carousel>
+    <!-- Invalid: negative value in media query -->
+    <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
+    </amp-base-carousel>
+  </section>
+
+  <!-- String values -->
+  <section>
+    <!-- Valid: horizontal -->
+    <amp-base-carousel width="4" height="3" orientation="horizontal">
+    </amp-base-carousel>
+    <!-- Valid: vertical -->
+    <amp-base-carousel width="4" height="3" orientation="vertical">
+    </amp-base-carousel>
+    <!-- Valid: strings with a media query -->
+    <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) horizontal, vertical">
+    </amp-base-carousel>
+    <!-- Valid: strings with multiple media queries -->
+    <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) horizontal, (max-height: 1000px) horizontal, vertical">
+    </amp-base-carousel>
+    <!-- Invalid: no default value-->
+    <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) horizontal">
+    </amp-base-carousel>
+    <!-- Invalid: no value -->
+    <amp-base-carousel width="4" height="3" orientation>
+    </amp-base-carousel>
+    <!-- Invalid: incorrect value -->
+    <amp-base-carousel width="4" height="3" orientation="true">
+    </amp-base-carousel>
+    <!-- Invalid: incorrect in media query -->
+    <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) vertical, (max-height: 1000px) true, horizontal">
+    </amp-base-carousel>
+  </section>
+
+  <!-- Spaces-->
+  <section>
+    <!-- Valid: spaces between groups -->
+    <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, false">
+    </amp-base-carousel>
+    <!-- Valid: no spaces between groups -->
+    <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true,(max-height: 1000px) true,false">
+    </amp-base-carousel>
+    <!-- Invalid: no space between media query and value -->
+    <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px)true, false">
+    </amp-base-carousel>
+  </section>
+</body>
+</html>

--- a/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.out
+++ b/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.out
@@ -1,0 +1,196 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-base-carousel tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-base-carousel" src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Boolean values -->
+|    <section>
+|      <!-- Valid: true -->
+|      <amp-base-carousel width="4" height="3" auto-advance="true">
+|      </amp-base-carousel>
+|      <!-- Valid: false -->
+|      <amp-base-carousel width="4" height="3" auto-advance="false">
+|      </amp-base-carousel>
+|      <!-- Valid: booleans with a media query -->
+|      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, false">
+|      </amp-base-carousel>
+|      <!-- Valid: booleans with multiple media queries -->
+|      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, (max-height: 1000px) true, false">
+|      </amp-base-carousel>
+|      <!-- Invalid: no default value-->
+|      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:46:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) true'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: no value -->
+|      <amp-base-carousel width="4" height="3" auto-advance>
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:49:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: incorrect value -->
+|      <amp-base-carousel width="4" height="3" auto-advance="5">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:52:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '5'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: incorrect in media query -->
+|      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, (max-height: 1000px) 5, false">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:55:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) true, (max-height: 1000px) 5, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|    </section>
+|
+|    <!-- Integer values-->
+|    <section>
+|      <!-- Valid: positive integer value -->
+|      <amp-base-carousel width="4" height="3" advance-count="2">
+|      </amp-base-carousel>
+|      <!-- Valid: negative integer value -->
+|      <amp-base-carousel width="4" height="3" advance-count="-2">
+|      </amp-base-carousel>
+|      <!-- Valid: integer values with media queries -->
+|      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) 3, 1">
+|      </amp-base-carousel>
+|      <!-- Valid: integer values with multiple media queries -->
+|      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
+|      </amp-base-carousel>
+|      <!-- Invalid: no default value-->
+|      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) 3">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:74:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: no value -->
+|      <amp-base-carousel width="4" height="3" advance-count>
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:77:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: floating point value -->
+|      <amp-base-carousel width="4" height="3" advance-count="3.2">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:80:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '3.2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: floating point value in media query -->
+|      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3.2, 1">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:83:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3.2, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|    </section>
+|
+|    <!-- Positive float values-->
+|    <section>
+|      <!-- Valid: integer value -->
+|      <amp-base-carousel width="4" height="3" visible-count="2">
+|      </amp-base-carousel>
+|      <!-- Valid: floating point value -->
+|      <amp-base-carousel width="4" height="3" visible-count="3.2">
+|      </amp-base-carousel>
+|      <!-- Valid: mixed value with one media query -->
+|      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3.2, 1">
+|      </amp-base-carousel>
+|      <!-- Valid: mixed values with multiple media queries -->
+|      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3, (max-height: 1000px) 3, 1.1">
+|      </amp-base-carousel>
+|      <!-- Invalid: negative integer value -->
+|      <amp-base-carousel width="4" height="3" visible-count="-2">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:102:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '-2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: no default value-->
+|      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:105:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: no value -->
+|      <amp-base-carousel width="4" height="3" visible-count>
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:108:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: string value -->
+|      <amp-base-carousel width="4" height="3" visible-count="foo">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:111:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: negative value in media query -->
+|      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:114:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|    </section>
+|
+|    <!-- String values -->
+|    <section>
+|      <!-- Valid: horizontal -->
+|      <amp-base-carousel width="4" height="3" orientation="horizontal">
+|      </amp-base-carousel>
+|      <!-- Valid: vertical -->
+|      <amp-base-carousel width="4" height="3" orientation="vertical">
+|      </amp-base-carousel>
+|      <!-- Valid: strings with a media query -->
+|      <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) horizontal, vertical">
+|      </amp-base-carousel>
+|      <!-- Valid: strings with multiple media queries -->
+|      <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) horizontal, (max-height: 1000px) horizontal, vertical">
+|      </amp-base-carousel>
+|      <!-- Invalid: no default value-->
+|      <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) horizontal">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:133:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) horizontal'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: no value -->
+|      <amp-base-carousel width="4" height="3" orientation>
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:136:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: incorrect value -->
+|      <amp-base-carousel width="4" height="3" orientation="true">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:139:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value 'true'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|      <!-- Invalid: incorrect in media query -->
+|      <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) vertical, (max-height: 1000px) true, horizontal">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:142:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) vertical, (max-height: 1000px) true, horizontal'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|    </section>
+|
+|    <!-- Spaces-->
+|    <section>
+|      <!-- Valid: spaces between groups -->
+|      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, false">
+|      </amp-base-carousel>
+|      <!-- Valid: no spaces between groups -->
+|      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true,(max-height: 1000px) true,false">
+|      </amp-base-carousel>
+|      <!-- Invalid: no space between media query and value -->
+|      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px)true, false">
+>>     ^~~~~~~~~
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:155:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px)true, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+|      </amp-base-carousel>
+|    </section>
+|  </body>
+|  </html>

--- a/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
+++ b/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
@@ -20,6 +20,7 @@ tags: {  # amp-base-carousel
   extension_spec: {
     name: "amp-base-carousel"
     version: "0.1"
+    version: "1.0"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
@@ -62,7 +63,7 @@ attr_lists: {
     value_regex: "([^,]+\\s+(always|auto|never),\\s*)*(always|auto|never)"
   }
   attrs: {
-    name: "horizontal"
+    name: "horizontal" # 0.1 only
     # Media query / boolean pairs
     value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
   }
@@ -75,6 +76,11 @@ attr_lists: {
     name: "mixed-length"
     # Media query / boolean pairs
     value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+  }
+  attrs: {
+    name: "orientation" # 1.0 only
+    # Media query / boolean pairs
+    value_regex: "([^,]+\\s+(horizontal|vertical),\\s*)*(horizontal|vertical)"
   }
   attrs: {
     name: "slide"
@@ -108,9 +114,10 @@ attr_lists: {
   attrs: { name: "[auto-advance-count]" }
   attrs: { name: "[auto-advance-interval]" }
   attrs: { name: "[auto-advance-loops]" }
-  attrs: { name: "[horizontal]" }
+  attrs: { name: "[horizontal]" } # 0.1 only
   attrs: { name: "[loop]" }
   attrs: { name: "[mixed-length]" }
+  attrs: { name: "[orientation]" } # 1.0 only
   attrs: { name: "[slide]" }
   attrs: { name: "[snap]" }
   attrs: { name: "[snap-align]" }

--- a/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-pagination.html
+++ b/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-pagination.html
@@ -1,0 +1,57 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-inline-gallery-pagination tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.js"></script>
+</head>
+<body>
+  <!-- Valid: Inset with nodisplay -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-pagination layout="nodisplay" inset>
+    </amp-inline-gallery-pagination>
+  </amp-inline-gallery>
+  <!-- Valid: Wrapped with a parent div -->
+  <amp-inline-gallery layout="container">
+    <div>
+      <amp-inline-gallery-pagination layout="nodisplay"inset>
+      </amp-inline-gallery-pagination>
+    </div>
+  </amp-inline-gallery>
+  <!-- Valid: Non-inset with fixed-height -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-pagination layout="fixed-height" height="24">
+    </amp-inline-gallery-pagination>
+  </amp-inline-gallery>
+  <!-- Invalid: Not in a gallery -->
+  <amp-inline-gallery-pagination layout="fixed-height" height="24">
+  </amp-inline-gallery-pagination>
+  <!-- Invalid: Inset without nodisplay -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-pagination layout="fixed-height" height="24" inset>
+    </amp-inline-gallery-pagination>
+  </amp-inline-gallery>
+</body>
+</html>

--- a/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-pagination.out
+++ b/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-pagination.out
@@ -1,0 +1,62 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-inline-gallery-pagination tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Inset with nodisplay -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-pagination layout="nodisplay" inset>
+|      </amp-inline-gallery-pagination>
+|    </amp-inline-gallery>
+|    <!-- Valid: Wrapped with a parent div -->
+|    <amp-inline-gallery layout="container">
+|      <div>
+|        <amp-inline-gallery-pagination layout="nodisplay"inset>
+|        </amp-inline-gallery-pagination>
+|      </div>
+|    </amp-inline-gallery>
+|    <!-- Valid: Non-inset with fixed-height -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-pagination layout="fixed-height" height="24">
+|      </amp-inline-gallery-pagination>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Not in a gallery -->
+|    <amp-inline-gallery-pagination layout="fixed-height" height="24">
+>>   ^~~~~~~~~
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-pagination.html:49:2 The tag 'amp-inline-gallery-pagination' may only appear as a descendant of tag 'amp-inline-gallery'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+|    </amp-inline-gallery-pagination>
+|    <!-- Invalid: Inset without nodisplay -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-pagination layout="fixed-height" height="24" inset>
+>>     ^~~~~~~~~
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-pagination.html:53:4 The specified layout 'FIXED_HEIGHT' is not supported by tag 'amp-inline-gallery-pagination'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+|      </amp-inline-gallery-pagination>
+|    </amp-inline-gallery>
+|  </body>
+|  </html>

--- a/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html
+++ b/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html
@@ -1,0 +1,77 @@
+<!--
+  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-inline-gallery-thumbnails tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.js"></script>
+</head>
+<body>
+  <!-- Valid: Wrapped with a parent div -->
+  <amp-inline-gallery layout="container">
+    <div>
+      <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+      </amp-inline-gallery-thumbnails>
+    </div>
+  </amp-inline-gallery>
+  <!-- Valid: Loop attribute specified -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Valid: Aspect ratio -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="3">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Valid: Aspect ratio (float) -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="3.5">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Not in a gallery -->
+  <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+  </amp-inline-gallery-thumbnails>
+  <!-- Invalid: Non-number aspect ratio-->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="two">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Aspect ratio of zero -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="0">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Aspect ratio of zero (float) -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0.00">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Invalid: Loop attribute without value -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+</body>
+</html>

--- a/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.out
+++ b/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.out
@@ -1,0 +1,88 @@
+FAIL
+|  <!--
+|    Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-inline-gallery-thumbnails tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-inline-gallery" src="https://cdn.ampproject.org/v0/amp-inline-gallery-1.0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid: Wrapped with a parent div -->
+|    <amp-inline-gallery layout="container">
+|      <div>
+|        <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+|        </amp-inline-gallery-thumbnails>
+|      </div>
+|    </amp-inline-gallery>
+|    <!-- Valid: Loop attribute specified -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Valid: Aspect ratio -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="3">
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Valid: Aspect ratio (float) -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="3.5">
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Not in a gallery -->
+|    <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
+>>   ^~~~~~~~~
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:54:2 The tag 'amp-inline-gallery-thumbnails' may only appear as a descendant of tag 'amp-inline-gallery'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+|    </amp-inline-gallery-thumbnails>
+|    <!-- Invalid: Non-number aspect ratio-->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="two">
+>>     ^~~~~~~~~
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:58:4 The attribute 'aspect-ratio' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value 'two'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Aspect ratio of zero -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="0">
+>>     ^~~~~~~~~
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:63:4 The attribute 'aspect-ratio' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Aspect ratio of zero (float) -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0.00">
+>>     ^~~~~~~~~
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:68:4 The attribute 'aspect-ratio-height' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0.00'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Invalid: Loop attribute without value -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+>>     ^~~~~~~~~
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:73:4 The attribute 'loop' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|  </body>
+|  </html>

--- a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
+++ b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
@@ -20,6 +20,7 @@ tags: {  # amp-inline-gallery
   extension_spec: {
     name: "amp-inline-gallery"
     version: "0.1"
+    version: "1.0"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
@@ -81,14 +82,20 @@ tags: {  # <amp-inline-gallery-thumbnails>
       also_requires_attr: "aspect-ratio-width"
     }
   }
-  attrs: {
-    name: "aspect-ratio-width"
+  attrs: { 
+    name: "aspect-ratio-width" # 0.1 only
     # Non-zero number
     value_regex: "\\d+(\\.\\d+)?"
     disallowed_value_regex: "^0+(\\.0+)?$"
     trigger: {
       also_requires_attr: "aspect-ratio-height"
     }
+  }
+  attrs: { 
+    name: "aspect-ratio" # 1.0 only
+    # Non-zero number
+    value_regex: "\\d+(\\.\\d+)?"
+    disallowed_value_regex: "^0+(\\.0+)?$"
   }
   attrs: {
     name: "loop"

--- a/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html
+++ b/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html
@@ -1,0 +1,162 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-stream-gallery tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-stream-gallery" src="https://cdn.ampproject.org/v0/amp-stream-gallery-1.0.js"></script>
+</head>
+<body>
+  <!-- Boolean values -->
+  <section>
+    <!-- Valid: true -->
+    <amp-stream-gallery width="4" height="3" loop="true">
+    </amp-stream-gallery>
+    <!-- Valid: false -->
+    <amp-stream-gallery width="4" height="3" loop="false">
+    </amp-stream-gallery>
+    <!-- Valid: booleans with a media query -->
+    <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, false">
+    </amp-stream-gallery>
+    <!-- Valid: booleans with multiple media queries -->
+    <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, (max-height: 1000px) true, false">
+    </amp-stream-gallery>
+    <!-- Invalid: no default value-->
+    <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true">
+    </amp-stream-gallery>
+    <!-- Invalid: no value -->
+    <amp-stream-gallery width="4" height="3" loop>
+    </amp-stream-gallery>
+    <!-- Invalid: incorrect value -->
+    <amp-stream-gallery width="4" height="3" loop="5">
+    </amp-stream-gallery>
+    <!-- Invalid: incorrect in media query -->
+    <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, (max-height: 1000px) 5, false">
+    </amp-stream-gallery>
+  </section>
+
+  <!-- Integer values-->
+  <section>
+    <!-- Valid: positive integer value -->
+    <amp-stream-gallery width="4" height="3" min-item-width="200">
+    </amp-stream-gallery>
+    <!-- Valid: integer values with media queries -->
+    <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) 300, 100">
+    </amp-stream-gallery>
+    <!-- Valid: integer values with multiple media queries -->
+    <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) 200, (max-height: 1000px) 300, 100">
+    </amp-stream-gallery>
+    <!-- Invalid: no default value-->
+    <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) 300">
+    </amp-stream-gallery>
+    <!-- Invalid: no value -->
+    <amp-stream-gallery width="4" height="3" min-item-width>
+    </amp-stream-gallery>
+    <!-- Invalid: negative integer value -->
+    <amp-stream-gallery width="4" height="3" min-item-width="-2">
+    </amp-stream-gallery>
+    <!-- Invalid: floating point value -->
+    <amp-stream-gallery width="4" height="3" min-item-width="300.5">
+    </amp-stream-gallery>
+    <!-- Invalid: floating point value in media query -->
+    <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) -300, (max-height: 1000px) 300.5, 1">
+    </amp-stream-gallery>
+  </section>
+
+  <!-- Positive float values-->
+  <section>
+    <!-- Valid: integer value -->
+    <amp-stream-gallery width="4" height="3" min-visible-count="2">
+    </amp-stream-gallery>
+    <!-- Valid: floating point value -->
+    <amp-stream-gallery width="4" height="3" min-visible-count="3.2">
+    </amp-stream-gallery>
+    <!-- Valid: mixed value with one media query -->
+    <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) 3.2, 1">
+    </amp-stream-gallery>
+    <!-- Valid: mixed values with multiple media queries -->
+    <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) 3, (max-height: 1000px) 3, 1.1">
+    </amp-stream-gallery>
+    <!-- Invalid: negative integer value -->
+    <amp-stream-gallery width="4" height="3" min-visible-count="-2">
+    </amp-stream-gallery>
+    <!-- Invalid: no default value-->
+    <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) 3">
+    </amp-stream-gallery>
+    <!-- Invalid: no value -->
+    <amp-stream-gallery width="4" height="3" min-visible-count>
+    </amp-stream-gallery>
+    <!-- Invalid: string value -->
+    <amp-stream-gallery width="4" height="3" min-visible-count="foo">
+    </amp-stream-gallery>
+    <!-- Invalid: negative value in media query -->
+    <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
+    </amp-stream-gallery>
+  </section>
+
+  <!-- String values -->
+  <section>
+    <!-- Valid: always -->
+    <amp-stream-gallery width="4" height="3" controls="always">
+    </amp-stream-gallery>
+    <!-- Valid: auto -->
+    <amp-stream-gallery width="4" height="3" controls="auto">
+    </amp-stream-gallery>
+    <!-- Valid: never -->
+    <amp-stream-gallery width="4" height="3" controls="never">
+    </amp-stream-gallery>
+    <!-- Valid: strings with a media query -->
+    <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) never, auto">
+    </amp-stream-gallery>
+    <!-- Valid: strings with multiple media queries -->
+    <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) always, (max-height: 1000px) auto, never">
+    </amp-stream-gallery>
+    <!-- Invalid: no default value-->
+    <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) always">
+    </amp-stream-gallery>
+    <!-- Invalid: no value -->
+    <amp-stream-gallery width="4" height="3" controls>
+    </amp-stream-gallery>
+    <!-- Invalid: incorrect value -->
+    <amp-stream-gallery width="4" height="3" controls="true">
+    </amp-stream-gallery>
+    <!-- Invalid: incorrect in media query -->
+    <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) auto, (max-height: 1000px) true, never">
+    </amp-stream-gallery>
+  </section>
+
+  <!-- Spaces-->
+  <section>
+    <!-- Valid: spaces between groups -->
+    <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, false">
+    </amp-stream-gallery>
+    <!-- Valid: no spaces between groups -->
+    <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true,(max-height: 1000px) true,false">
+    </amp-stream-gallery>
+    <!-- Invalid: no space between media query and value -->
+    <amp-stream-gallery width="4" height="3" loop="(min-width: 800px)true, false">
+    </amp-stream-gallery>
+  </section>
+</body>
+</html>

--- a/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.out
+++ b/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.out
@@ -1,0 +1,201 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-stream-gallery tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-stream-gallery" src="https://cdn.ampproject.org/v0/amp-stream-gallery-1.0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Boolean values -->
+|    <section>
+|      <!-- Valid: true -->
+|      <amp-stream-gallery width="4" height="3" loop="true">
+|      </amp-stream-gallery>
+|      <!-- Valid: false -->
+|      <amp-stream-gallery width="4" height="3" loop="false">
+|      </amp-stream-gallery>
+|      <!-- Valid: booleans with a media query -->
+|      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, false">
+|      </amp-stream-gallery>
+|      <!-- Valid: booleans with multiple media queries -->
+|      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, (max-height: 1000px) true, false">
+|      </amp-stream-gallery>
+|      <!-- Invalid: no default value-->
+|      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:46:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) true'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: no value -->
+|      <amp-stream-gallery width="4" height="3" loop>
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:49:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: incorrect value -->
+|      <amp-stream-gallery width="4" height="3" loop="5">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:52:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '5'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: incorrect in media query -->
+|      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, (max-height: 1000px) 5, false">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:55:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) true, (max-height: 1000px) 5, false'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|    </section>
+|
+|    <!-- Integer values-->
+|    <section>
+|      <!-- Valid: positive integer value -->
+|      <amp-stream-gallery width="4" height="3" min-item-width="200">
+|      </amp-stream-gallery>
+|      <!-- Valid: integer values with media queries -->
+|      <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) 300, 100">
+|      </amp-stream-gallery>
+|      <!-- Valid: integer values with multiple media queries -->
+|      <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) 200, (max-height: 1000px) 300, 100">
+|      </amp-stream-gallery>
+|      <!-- Invalid: no default value-->
+|      <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) 300">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:71:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) 300'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: no value -->
+|      <amp-stream-gallery width="4" height="3" min-item-width>
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:74:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: negative integer value -->
+|      <amp-stream-gallery width="4" height="3" min-item-width="-2">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:77:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '-2'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: floating point value -->
+|      <amp-stream-gallery width="4" height="3" min-item-width="300.5">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:80:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '300.5'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: floating point value in media query -->
+|      <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) -300, (max-height: 1000px) 300.5, 1">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:83:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) -300, (max-height: 1000px) 300.5, 1'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|    </section>
+|
+|    <!-- Positive float values-->
+|    <section>
+|      <!-- Valid: integer value -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="2">
+|      </amp-stream-gallery>
+|      <!-- Valid: floating point value -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="3.2">
+|      </amp-stream-gallery>
+|      <!-- Valid: mixed value with one media query -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) 3.2, 1">
+|      </amp-stream-gallery>
+|      <!-- Valid: mixed values with multiple media queries -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) 3, (max-height: 1000px) 3, 1.1">
+|      </amp-stream-gallery>
+|      <!-- Invalid: negative integer value -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="-2">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:102:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '-2'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: no default value-->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) 3">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:105:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) 3'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: no value -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count>
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:108:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: string value -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="foo">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:111:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value 'foo'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: negative value in media query -->
+|      <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:114:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|    </section>
+|
+|    <!-- String values -->
+|    <section>
+|      <!-- Valid: always -->
+|      <amp-stream-gallery width="4" height="3" controls="always">
+|      </amp-stream-gallery>
+|      <!-- Valid: auto -->
+|      <amp-stream-gallery width="4" height="3" controls="auto">
+|      </amp-stream-gallery>
+|      <!-- Valid: never -->
+|      <amp-stream-gallery width="4" height="3" controls="never">
+|      </amp-stream-gallery>
+|      <!-- Valid: strings with a media query -->
+|      <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) never, auto">
+|      </amp-stream-gallery>
+|      <!-- Valid: strings with multiple media queries -->
+|      <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) always, (max-height: 1000px) auto, never">
+|      </amp-stream-gallery>
+|      <!-- Invalid: no default value-->
+|      <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) always">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:136:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) always'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: no value -->
+|      <amp-stream-gallery width="4" height="3" controls>
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:139:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: incorrect value -->
+|      <amp-stream-gallery width="4" height="3" controls="true">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:142:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value 'true'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|      <!-- Invalid: incorrect in media query -->
+|      <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) auto, (max-height: 1000px) true, never">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:145:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) auto, (max-height: 1000px) true, never'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|    </section>
+|
+|    <!-- Spaces-->
+|    <section>
+|      <!-- Valid: spaces between groups -->
+|      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, false">
+|      </amp-stream-gallery>
+|      <!-- Valid: no spaces between groups -->
+|      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true,(max-height: 1000px) true,false">
+|      </amp-stream-gallery>
+|      <!-- Invalid: no space between media query and value -->
+|      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px)true, false">
+>>     ^~~~~~~~~
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:158:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px)true, false'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+|      </amp-stream-gallery>
+|    </section>
+|  </body>
+|  </html>

--- a/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii
+++ b/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii
@@ -1,0 +1,118 @@
+#
+# Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-stream-gallery
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-stream-gallery"
+    version: "1.0"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-stream-gallery>
+  html_format: AMP
+  tag_name: "AMP-STREAM-GALLERY"
+  requires_extension: "amp-stream-gallery"
+  attr_lists: "amp-stream-gallery-common"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
+# Examples for media query / value pairs:
+# (min-width: 600px) and (min-height: 800px)  false, true
+# (min-width: 600px) false,(min-width: 600px) true,false
+# true
+attr_lists: {
+  name: "amp-stream-gallery-common"
+  attrs: {
+    name: "controls"
+    # Media query / (always|auto|never)
+    value_regex: "([^,]+\\s+(always|auto|never),\\s*)*(always|auto|never)"
+  }
+  attrs: {
+    name: "extra-space"
+    value: "between"
+  }
+  attrs: {
+    name: "loop"
+    # Media query / boolean pairs
+    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+  }
+  attrs: {
+    name: "min-visible-count"
+    # Media query / positive float pairs
+    value_regex: "([^,]+\\s+(\\d+(\\.\\d+)?),\\s*)*(\\d+(\\.\\d+)?)"
+  }
+  attrs: {
+    name: "max-visible-count"
+    # Media query / positive float pairs
+    value_regex: "([^,]+\\s+(\\d+(\\.\\d+)?),\\s*)*(\\d+(\\.\\d+)?)"
+  }
+  attrs: {
+    name: "min-item-width"
+    # Media query / positive integer pairs
+    value_regex: "([^,]+\\s+(\\d+),\\s*)*(\\d+)"
+  }
+  attrs: {
+    name: "max-item-width"
+    # Media query / positive integer pairs
+    value_regex: "([^,]+\\s+(\\d+),\\s*)*(\\d+)"
+  }
+  attrs: {
+    name: "outset-arrows"
+    # Media query / boolean pairs
+    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+  }
+  attrs: {
+    name: "peek"
+    # Media query / positive float pairs
+    value_regex: "([^,]+\\s+(\\d+(\\.\\d+)?),\\s*)*(\\d+(\\.\\d+)?)"
+  }
+  attrs: {
+    name: "slide-align"
+    # Media query / (start|center) pairs
+    value_regex: "([^,]+\\s+(start|center),\\s*)*(start|center)"
+  }
+  attrs: {
+    name: "snap"
+    # Media query / boolean pairs
+    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+  }
+
+  # amp-bind
+  attrs: { name: "[controls]" }
+  attrs: { name: "[extra-space]" }
+  attrs: { name: "[loop]" }
+  attrs: { name: "[min-visible-count]" }
+  attrs: { name: "[max-visible-count]" } # 0.1 only
+  attrs: { name: "[min-item-width]" }
+  attrs: { name: "[max-item-width]" }
+  attrs: { name: "[outset-arrows]" }
+  attrs: { name: "[peek]" }
+  attrs: { name: "[slide-align]" }
+  attrs: { name: "[snap]" }
+}


### PR DESCRIPTION
This PR adds validation rules for:
- `amp-base-carousel:1.0` - `latest` still goes to `0.1.`
- `amp-inline-gallery:1.0` and usage of `amp-inline-gallery-pagination` and `amp-inline-gallery-thumbnails`  - `latest` still goes to `0.1.`
- `amp-stream-gallery:1.0` and `amp-stream-gallery-latest`
  - `amp-stream-gallery:0.1` and `latest` were never valid AMP, so `1.0` can use `latest` without affecting any valid AMP users. On a related note, this PR also updates the bundle `latestVersion` for `amp-stream-gallery` to point to `1.0` as no valid AMP documents should be able to use `amp-stream-gallery-latest.js` now anyhow.

Note: `bento-carousel`, `bento-inline-gallery`, and `bento-stream-gallery` experiments are still active, so this PR does not "launch" these components, only widens the pool for experimental usage and feedback to include valid AMP documents on the web.

Partial for #28284