### PR TITLE
Add validation rules for amp-date-display:1.0 on websites

### DIFF
--- a/extensions/amp-date-display/1.0/test/validator-amp-date-display.html
+++ b/extensions/amp-date-display/1.0/test/validator-amp-date-display.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/extensions/amp-date-display/1.0/test/validator-amp-date-display.html
+++ b/extensions/amp-date-display/1.0/test/validator-amp-date-display.html
@@ -1,0 +1,178 @@
+<!--
+  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-date-display tag.
+-->
+<!DOCTYPE html>
+<html amp lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript>
+    <style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>
+  </noscript>
+  <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+  <script async custom-element="amp-date-display" src="https://cdn.ampproject.org/v0/amp-date-display-1.0.js"></script>
+  <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+
+<body>
+
+  <!-- valid -->
+  <amp-date-display datetime="2017-08-02T15:05:05.000Z" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="2017-08-02T15:05:05.000" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="2017-08-02T15:05:05.000+04:00" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="2017-08-02T15:05:05.00+04:00" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="2017-08-02T15:05:05.0+04:00" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="2017-08-02T15:05+04:00" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="2017-08-02T15:05" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="now" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display timestamp-seconds="1501686305" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display timestamp-ms="1501686305000" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid -->
+  <amp-date-display datetime="now" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid, with display-in -->
+  <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- valid, with referenced template -->
+  <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
+  </amp-date-display>
+  <template type="amp-mustache" id="myTemplate">{{iso}}</template>
+
+  <!-- invalid, with dangling reference to template -->
+  <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="notMyTemplate">
+  </amp-date-display>
+
+  <!-- valid, within amp-list with script mustache -->
+  <amp-list src="https://cors-test.appspot.com/test"
+            single-item
+            items="."
+            layout="fixed-height"
+            height="50">
+
+    <script type="text/plain" template="amp-mustache">
+      This should be a proper formatted date:
+      <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+    </script>
+  </amp-list>
+
+  <template type="amp-mustache" id="date-template">
+    <small>{{ day }}.{{ month }}.{{ year }} {{ hourTwoDigit }}:{{ minuteTwoDigit }}</small>
+  </template>
+
+  <!-- valid, within amp-list with template mustache -->
+  <amp-list src="https://cors-test.appspot.com/test"
+            single-item
+            items="."
+            layout="fixed-height"
+            height="50">
+
+    <template type="amp-mustache">
+      This should be a proper formatted date:
+      <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+    </template>
+  </amp-list>
+
+  <!-- invalid, no date provided -->
+  <amp-date-display layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- invalid, wrong date format -->
+  <amp-date-display datetime="20170802" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- invalid, date with time zone -->
+  <amp-date-display datetime="2017-08-02+04:00" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- invalid, no minutes in time zone -->
+  <amp-date-display datetime="2017-08-02T15:05:05+04" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- invalid, no date -->
+  <amp-date-display datetime="T15:05:05.000Z" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- invalid, missing hour (hour > 23) -->
+  <amp-date-display datetime="2017-08-02T59:05.000Z" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- invalid, sub miliseconds -->
+  <amp-date-display datetime="2017-08-02T15:05:05.0001+04:00" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+
+  <!-- invalid, missing fractions-->
+  <amp-date-display datetime="2017-08-02T15:05:05.+04:00" layout="fixed" width="360" height="20">
+    <template type="amp-mustache">{{iso}}</template>
+  </amp-date-display>
+</body>
+
+</html>

--- a/extensions/amp-date-display/1.0/test/validator-amp-date-display.out
+++ b/extensions/amp-date-display/1.0/test/validator-amp-date-display.out
@@ -1,0 +1,197 @@
+FAIL
+|  <!--
+|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-date-display tag.
+|  -->
+|  <!DOCTYPE html>
+|  <html amp lang="en">
+|
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript>
+|      <style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>
+|    </noscript>
+|    <script async custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js"></script>
+|    <script async custom-element="amp-date-display" src="https://cdn.ampproject.org/v0/amp-date-display-1.0.js"></script>
+|    <script async custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-latest.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|
+|  <body>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="2017-08-02T15:05:05.000Z" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="2017-08-02T15:05:05.000" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="2017-08-02T15:05:05.000+04:00" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="2017-08-02T15:05:05.00+04:00" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="2017-08-02T15:05:05.0+04:00" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="2017-08-02T15:05+04:00" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="2017-08-02T15:05" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="now" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display timestamp-seconds="1501686305" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display timestamp-ms="1501686305000" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid -->
+|    <amp-date-display datetime="now" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid, with display-in -->
+|    <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20">
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- valid, with referenced template -->
+|    <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="myTemplate">
+|    </amp-date-display>
+|    <template type="amp-mustache" id="myTemplate">{{iso}}</template>
+|
+|    <!-- invalid, with dangling reference to template -->
+|    <amp-date-display datetime="now" display-in="utc" layout="fixed" width="360" height="20" template="notMyTemplate">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:104:2 Attribute 'template' in tag 'amp-date-display' contains a value that does not match any other tags on the page. (see https://amp.dev/documentation/components/amp-date-display)
+|    </amp-date-display>
+|
+|    <!-- valid, within amp-list with script mustache -->
+|    <amp-list src="https://cors-test.appspot.com/test"
+|              single-item
+|              items="."
+|              layout="fixed-height"
+|              height="50">
+|
+|      <script type="text/plain" template="amp-mustache">
+|        This should be a proper formatted date:
+|        <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+|      </script>
+|    </amp-list>
+|
+|    <template type="amp-mustache" id="date-template">
+|      <small>{{ day }}.{{ month }}.{{ year }} {{ hourTwoDigit }}:{{ minuteTwoDigit }}</small>
+|    </template>
+|
+|    <!-- valid, within amp-list with template mustache -->
+|    <amp-list src="https://cors-test.appspot.com/test"
+|              single-item
+|              items="."
+|              layout="fixed-height"
+|              height="50">
+|
+|      <template type="amp-mustache">
+|        This should be a proper formatted date:
+|        <amp-date-display datetime="2006-02-14T15:27:33+01:00" layout="fixed-height" height="20" template="date-template"> </amp-date-display>
+|      </template>
+|    </amp-list>
+|
+|    <!-- invalid, no date provided -->
+|    <amp-date-display layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:138:2 The tag 'amp-date-display' is missing a mandatory attribute - pick one of ['datetime', 'timestamp-ms', 'timestamp-seconds']. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- invalid, wrong date format -->
+|    <amp-date-display datetime="20170802" layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:143:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '20170802'. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- invalid, date with time zone -->
+|    <amp-date-display datetime="2017-08-02+04:00" layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:148:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02+04:00'. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- invalid, no minutes in time zone -->
+|    <amp-date-display datetime="2017-08-02T15:05:05+04" layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:153:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05+04'. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- invalid, no date -->
+|    <amp-date-display datetime="T15:05:05.000Z" layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:158:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value 'T15:05:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- invalid, missing hour (hour > 23) -->
+|    <amp-date-display datetime="2017-08-02T59:05.000Z" layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:163:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T59:05.000Z'. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- invalid, sub miliseconds -->
+|    <amp-date-display datetime="2017-08-02T15:05:05.0001+04:00" layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:168:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.0001+04:00'. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|
+|    <!-- invalid, missing fractions-->
+|    <amp-date-display datetime="2017-08-02T15:05:05.+04:00" layout="fixed" width="360" height="20">
+>>   ^~~~~~~~~
+amp-date-display/1.0/test/validator-amp-date-display.html:173:2 The attribute 'datetime' in tag 'amp-date-display' is set to the invalid value '2017-08-02T15:05:05.+04:00'. (see https://amp.dev/documentation/components/amp-date-display)
+|      <template type="amp-mustache">{{iso}}</template>
+|    </amp-date-display>
+|  </body>
+|
+|  </html>

--- a/extensions/amp-date-display/1.0/test/validator-amp-date-display.out
+++ b/extensions/amp-date-display/1.0/test/validator-amp-date-display.out
@@ -1,6 +1,6 @@
 FAIL
 |  <!--
-|    Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
 |
 |    Licensed under the Apache License, Version 2.0 (the "License");
 |    you may not use this file except in compliance with the License.

--- a/extensions/amp-date-display/validator-amp-date-display.protoascii
+++ b/extensions/amp-date-display/validator-amp-date-display.protoascii
@@ -20,6 +20,7 @@ tags: {  # amp-date-display
   extension_spec: {
     name: "amp-date-display"
     version: "0.1"
+    version: "1.0"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"


### PR DESCRIPTION
Note: `bento-date-display` experiment is still active, so this PR does not "launch" the component, only widens the pool for experimental usage and feedback to include valid AMP documents on the web.

Partial for #30189. 