### PR TITLE
Add validation rules for amp-timeago:1.0

### DIFF
--- a/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation-error.html
+++ b/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation-error.html
@@ -1,0 +1,46 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-timeago tag.
+-->
+<!DOCTYPE html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="./regular-html-version.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+  </head>
+  <body>
+    <amp-state id="myState">
+      <script type="application/json">
+        {
+          "datetime": "2018-04-11T00:37:33.809Z",
+          "title": "Saturday 11 April 2018 00.37",
+          "layout": "fixed"
+        }
+      </script>
+    </amp-state>
+
+    <!-- invalid, layout cannot be mutated with amp-bind -->
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2018-04-11T00:37:33.809Z" locale="en" cutoff="8640000" [datetime]="myState.datetime" [title]="myState.title" [layout]="myState.layout">Saturday 11 April 2018 00.37</amp-timeago>
+
+  </body>
+</html>

--- a/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation-error.out
+++ b/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation-error.out
@@ -1,0 +1,49 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-timeago tag.
+|  -->
+|  <!DOCTYPE html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"></script>
+|      <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|      <amp-state id="myState">
+|        <script type="application/json">
+|          {
+|            "datetime": "2018-04-11T00:37:33.809Z",
+|            "title": "Saturday 11 April 2018 00.37",
+|            "layout": "fixed"
+|          }
+|        </script>
+|      </amp-state>
+|
+|      <!-- invalid, layout cannot be mutated with amp-bind -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2018-04-11T00:37:33.809Z" locale="en" cutoff="8640000" [datetime]="myState.datetime" [title]="myState.title" [layout]="myState.layout">Saturday 11 April 2018 00.37</amp-timeago>
+>>     ^~~~~~~~~
+amp-timeago/1.0/test/validator-amp-timeago-mutation-error.html:43:4 The attribute '[layout]' may not appear in tag 'amp-timeago'. (see https://amp.dev/documentation/components/amp-timeago/)
+|
+|    </body>
+|  </html>

--- a/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation.html
+++ b/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation.html
@@ -1,0 +1,45 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-timeago tag.
+-->
+<!DOCTYPE html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="./regular-html-version.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+  </head>
+  <body>
+    <amp-state id="myState">
+      <script type="application/json">
+        {
+          "datetime": "2018-04-11T00:37:33.809Z",
+          "title": "Saturday 11 April 2018 00.37"
+        }
+      </script>
+    </amp-state>
+
+    <!-- valid, datetime and title can be mutated with amp-bind -->
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2018-04-11T00:37:33.809Z" locale="en" cutoff="8640000" [datetime]="myState.datetime" [title]="myState.title">Saturday 11 April 2018 00.37</amp-timeago>
+
+  </body>
+</html>

--- a/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation.out
+++ b/extensions/amp-timeago/1.0/test/validator-amp-timeago-mutation.out
@@ -1,0 +1,46 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-timeago tag.
+|  -->
+|  <!DOCTYPE html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"></script>
+|      <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|      <amp-state id="myState">
+|        <script type="application/json">
+|          {
+|            "datetime": "2018-04-11T00:37:33.809Z",
+|            "title": "Saturday 11 April 2018 00.37"
+|          }
+|        </script>
+|      </amp-state>
+|
+|      <!-- valid, datetime and title can be mutated with amp-bind -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2018-04-11T00:37:33.809Z" locale="en" cutoff="8640000" [datetime]="myState.datetime" [title]="myState.title">Saturday 11 April 2018 00.37</amp-timeago>
+|
+|    </body>
+|  </html>

--- a/extensions/amp-timeago/1.0/test/validator-amp-timeago.html
+++ b/extensions/amp-timeago/1.0/test/validator-amp-timeago.html
@@ -1,0 +1,48 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-timeago tag.
+-->
+<!DOCTYPE html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <link rel="canonical" href="./regular-html-version.html">
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"></script>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+  </head>
+  <body>
+
+    <!-- valid -->
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="en" cutoff="8640000">Saturday 11 April 2017 00.37</amp-timeago>
+
+    <!-- valid, international locale -->
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2017-08-11T18:58:58.000Z" locale="fr" cutoff="8640000">Lundi 14 août 2017</amp-timeago>
+
+    <!-- valid, locale optional, cutoff optional -->
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z">Saturday 11 April 2017 00.37</amp-timeago>
+
+    <!-- invalid, datetime is not ISO date format -->
+    <amp-timeago layout="fixed" width="160" height="20" datetime="2017/04/11">Saturday 11 April 2017 00.37</amp-timeago>
+
+    <!-- invalid, needs datetime -->
+    <amp-timeago layout="fixed" width="160" height="20">Saturday 11 April 2017 00.37</amp-timeago>
+
+  </body>
+</html>

--- a/extensions/amp-timeago/1.0/test/validator-amp-timeago.out
+++ b/extensions/amp-timeago/1.0/test/validator-amp-timeago.out
@@ -1,0 +1,53 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-timeago tag.
+|  -->
+|  <!DOCTYPE html>
+|  <html amp lang="en">
+|    <head>
+|      <meta charset="utf-8">
+|      <link rel="canonical" href="./regular-html-version.html">
+|      <meta name="viewport" content="width=device-width,minimum-scale=1">
+|      <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|      <script async custom-element="amp-timeago" src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"></script>
+|      <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    </head>
+|    <body>
+|
+|      <!-- valid -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z" locale="en" cutoff="8640000">Saturday 11 April 2017 00.37</amp-timeago>
+|
+|      <!-- valid, international locale -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017-08-11T18:58:58.000Z" locale="fr" cutoff="8640000">Lundi 14 août 2017</amp-timeago>
+|
+|      <!-- valid, locale optional, cutoff optional -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017-04-11T00:37:33.809Z">Saturday 11 April 2017 00.37</amp-timeago>
+|
+|      <!-- invalid, datetime is not ISO date format -->
+|      <amp-timeago layout="fixed" width="160" height="20" datetime="2017/04/11">Saturday 11 April 2017 00.37</amp-timeago>
+>>     ^~~~~~~~~
+amp-timeago/1.0/test/validator-amp-timeago.html:42:4 The attribute 'datetime' in tag 'amp-timeago' is set to the invalid value '2017/04/11'. (see https://amp.dev/documentation/components/amp-timeago/)
+|
+|      <!-- invalid, needs datetime -->
+|      <amp-timeago layout="fixed" width="160" height="20">Saturday 11 April 2017 00.37</amp-timeago>
+>>     ^~~~~~~~~
+amp-timeago/1.0/test/validator-amp-timeago.html:45:4 The mandatory attribute 'datetime' is missing in tag 'amp-timeago'. (see https://amp.dev/documentation/components/amp-timeago/)
+|
+|    </body>
+|  </html>

--- a/extensions/amp-timeago/validator-amp-timeago.protoascii
+++ b/extensions/amp-timeago/validator-amp-timeago.protoascii
@@ -20,6 +20,7 @@ tags: {  # amp-timeago
   extension_spec: {
     name: "amp-timeago"
     version: "0.1"
+    version: "1.0"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"


### PR DESCRIPTION
Note: `bento-timeago` experiment is still active, so this PR does not "launch" the component, only widens the pool for experimental usage and feedback to include valid AMP documents on the web.

Partial for #29246