### PR TITLE
🏗 Run CircleCI builds on release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ push_builds_only: &push_builds_only
     branches:
       only:
         - master
-        - /^amp-release-.*$/
+        - /amp-release-.*/
 
 executors:
   amphtml-docker-small-executor:


### PR DESCRIPTION
Current regex is misconfigured, see https://circleci.com/docs/2.0/configuration-reference/?section=configuration#filters-1 (the regex is a full match, so using ^ and $ makes it fail)