### PR TITLE
Bento Carousel: Remove doubly rendered JSX

### DIFF
--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -340,7 +340,6 @@ function BaseCarouselWithRef(
       <Scroller
         advanceCount={advanceCount}
         alignment={snapAlign}
-        autoAdvanceCount={autoAdvanceCount}
         axis={axis}
         lightbox={lightbox}
         loop={loop}

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -57,7 +57,6 @@ function ScrollerWithRef(
   {
     advanceCount,
     alignment,
-    autoAdvanceCount,
     axis,
     children,
     lightbox,
@@ -268,11 +267,6 @@ function ScrollerWithRef(
     debouncedResetScrollReferencePoint();
   };
 
-  const incrementCount = Math.max(advanceCount, autoAdvanceCount);
-  const needMoreSlidesToScroll =
-    loop &&
-    incrementCount > 1 &&
-    children.length - pivotIndex - visibleCount < incrementCount;
   return (
     <div
       ref={containerRef}
@@ -284,7 +278,6 @@ function ScrollerWithRef(
       {...rest}
     >
       {slides}
-      {needMoreSlidesToScroll && slides}
     </div>
   );
 }


### PR DESCRIPTION
Depending on the props given, looping instances of the carousel may inflate the size of its container to enable scroll navigation when advancing. When there is not enough room to scroll to later slides when advancing, the carousel instead re-renders to the slides in place. 

This feature is expected to impact a small number of cases overall. Specifically, it impacts carousels with `loop=true` that are given slides such that the `advanceCount` or (`autoAdvanceCount` when `autoAdvance=true`) is >=25% of the total slides. For instance, advancing by `2` for carousels with `8` slides are transitioned with new renders, as opposed to slide lengths of `9` which transition via scrolling. 

When we double the slides, we roughly double the proportion necessary to meet this threshold, making it easier for publishers to meet it with less effort. In the above example, if we artificially render 16 when given 8 slides, the advancing by number can be flexible up to 4 instead of up to 2.

This PR however removes the above because the artificial space inflation was done by naively rendering the given user JSX twice, which is not clear to be a safe technical approach for all possible user-given JSX, and leaves potential to bring up unexpected behavior such as when using `ref`s. Eventually it would be good to still artificially inflate the space, perhaps with empty `<div>` instead, but for now at least it should be removed.

**Relevant PR deploy bot link to try this out will go here once build is ready** 

Partial for #28284

cc @dvoytenko 