### PR TITLE
Gracefully halt downstream jobs on CircleCI when parent jobs are skipped

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,13 +175,7 @@ jobs:
     executor:
       name: amphtml-large-executor
     steps:
-      # NOTE: deliberately not running the `maybe_gracefully_halt` step because
-      # visual diff tests need to at least run with --empty when skipped.
-      # Instead we must create an empty workspace to prevent `teardown_vm` from
-      # crashing.
-      - run:
-          name: 'Create Workspace'
-          command: mkdir -p /tmp/workspace
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,15 @@ commands:
           key: git-{{ .Branch }}-{{ .Revision }}
   setup_vm:
     steps:
+      - attach_workspace:
+          at: /tmp
+      - run:
+          name: 'Maybe Gracefully Stop'
+          command: if [[ -f "/tmp/workspace/CI_GRACEFULLY_HALT" ]]; then echo "Gracefully halting this job."; circleci-agent step halt; fi
+          # TODO(danielrozenberg): visual-diffs still need to run, even if the previous job gracefully halted, because it needs to run with --skip
+      - run:
+          name: 'Create Workspace'
+          command: mkdir -p /tmp/workspace
       - checkout
       - restore_merge_commit
       - run:
@@ -66,6 +75,12 @@ commands:
       - run:
           name: 'Install Dependencies'
           command: ./.circleci/install_dependencies.sh
+  teardown_vm:
+    steps:
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - workspace
   install_chrome:
     steps:
       - browser-tools/install-chrome:
@@ -95,6 +110,7 @@ jobs:
           name: 'Checks'
           command: node build-system/pr-check/checks.js
       - fail_fast
+      - teardown_vm
   'Unminified Build':
     executor:
       name: amphtml-xlarge-executor
@@ -104,6 +120,7 @@ jobs:
           name: 'Unminified Build'
           command: node build-system/pr-check/unminified-build.js
       - fail_fast
+      - teardown_vm
   'Nomodule Build':
     executor:
       name: amphtml-xlarge-executor
@@ -113,6 +130,7 @@ jobs:
           name: 'Nomodule Build'
           command: node build-system/pr-check/nomodule-build.js
       - fail_fast
+      - teardown_vm
   'Module Build':
     executor:
       name: amphtml-xlarge-executor
@@ -122,6 +140,7 @@ jobs:
           name: 'Module Build'
           command: node build-system/pr-check/module-build.js
       - fail_fast
+      - teardown_vm
   'Bundle Size':
     executor:
       name: amphtml-xlarge-executor
@@ -131,6 +150,7 @@ jobs:
           name: 'Bundle Size'
           command: node build-system/pr-check/bundle-size.js
       - fail_fast
+      - teardown_vm
   'Validator Tests':
     executor:
       name: amphtml-xlarge-executor
@@ -143,6 +163,7 @@ jobs:
           name: 'Validator Tests'
           command: node build-system/pr-check/validator-tests.js
       - fail_fast
+      - teardown_vm
   'Visual Diff Tests':
     executor:
       name: amphtml-large-executor
@@ -153,6 +174,7 @@ jobs:
           name: 'Visual Diff Tests'
           command: node build-system/pr-check/visual-diff-tests.js
       - fail_fast
+      - teardown_vm
   'Unit Tests':
     executor:
       name: amphtml-large-executor
@@ -163,6 +185,7 @@ jobs:
           name: 'Unit Tests'
           command: node build-system/pr-check/unit-tests.js
       - fail_fast
+      - teardown_vm
   'Unminified Tests':
     executor:
       name: amphtml-large-executor
@@ -173,6 +196,7 @@ jobs:
           name: 'Unminified Tests'
           command: node build-system/pr-check/unminified-tests.js
       - fail_fast
+      - teardown_vm
   'Nomodule Tests':
     executor:
       name: amphtml-large-executor
@@ -188,6 +212,7 @@ jobs:
           name: 'Nomodule Tests (<< parameters.config >>)'
           command: node build-system/pr-check/nomodule-tests.js --config=<< parameters.config >>
       - fail_fast
+      - teardown_vm
   'Module Tests':
     executor:
       name: amphtml-large-executor
@@ -203,6 +228,7 @@ jobs:
           name: 'Module Tests (<< parameters.config >>)'
           command: node build-system/pr-check/module-tests.js --config=<< parameters.config >>
       - fail_fast
+      - teardown_vm
   'End-to-End Tests':
     executor:
       name: amphtml-large-executor
@@ -213,6 +239,7 @@ jobs:
           name: 'End-to-End Tests'
           command: node build-system/pr-check/e2e-tests.js
       - fail_fast
+      - teardown_vm
   'Performance Tests':
     executor:
       name: amphtml-xlarge-executor
@@ -223,6 +250,7 @@ jobs:
           name: 'Performance Tests'
           command: node build-system/pr-check/performance-tests.js
       - fail_fast
+      - teardown_vm
   'Experiment Build':
     executor:
       name: amphtml-xlarge-executor
@@ -237,6 +265,7 @@ jobs:
           name: 'Experiment << parameters.exp >> Build'
           command: node build-system/pr-check/experiment-build.js --experiment=experiment<< parameters.exp >>
       - fail_fast
+      - teardown_vm
   'Experiment Tests':
     executor:
       name: amphtml-large-executor
@@ -252,6 +281,7 @@ jobs:
           name: 'Experiment << parameters.exp >> Tests'
           command: node build-system/pr-check/experiment-tests.js --experiment=experiment<< parameters.exp >>
       - fail_fast
+      - teardown_vm
 
 workflows:
   'CircleCI':

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
           at: /tmp
       - run:
           name: 'Maybe Gracefully Halt'
-          command: if [[ -f "/tmp/workspace/CI_GRACEFULLY_HALT" ]]; then echo "Gracefully halting this job."; circleci-agent step halt; fi
+          command: if [[ -f "/tmp/workspace/.CI_GRACEFULLY_HALT" ]]; then echo "Gracefully halting this job."; circleci-agent step halt; fi
   setup_vm:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,14 +47,15 @@ commands:
       - restore_cache:
           name: 'Restore Merge Commit'
           key: git-{{ .Branch }}-{{ .Revision }}
-  setup_vm:
+  maybe_gracefully_halt:
     steps:
       - attach_workspace:
           at: /tmp
       - run:
-          name: 'Maybe Gracefully Stop'
+          name: 'Maybe Gracefully Halt'
           command: if [[ -f "/tmp/workspace/CI_GRACEFULLY_HALT" ]]; then echo "Gracefully halting this job."; circleci-agent step halt; fi
-          # TODO(danielrozenberg): visual-diffs still need to run, even if the previous job gracefully halted, because it needs to run with --skip
+  setup_vm:
+    steps:
       - run:
           name: 'Create Workspace'
           command: mkdir -p /tmp/workspace
@@ -105,6 +106,7 @@ jobs:
     executor:
       name: amphtml-medium-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - run:
           name: 'Checks'
@@ -115,6 +117,7 @@ jobs:
     executor:
       name: amphtml-xlarge-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - run:
           name: 'Unminified Build'
@@ -125,6 +128,7 @@ jobs:
     executor:
       name: amphtml-xlarge-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - run:
           name: 'Nomodule Build'
@@ -135,6 +139,7 @@ jobs:
     executor:
       name: amphtml-xlarge-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - run:
           name: 'Module Build'
@@ -145,6 +150,7 @@ jobs:
     executor:
       name: amphtml-xlarge-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - run:
           name: 'Bundle Size'
@@ -155,6 +161,7 @@ jobs:
     executor:
       name: amphtml-xlarge-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - run:
           name: 'Install Validator Dependencies'
@@ -168,6 +175,11 @@ jobs:
     executor:
       name: amphtml-large-executor
     steps:
+      # NOTE: deliberately not running the `maybe_gracefully_halt` step because
+      # visual diff tests need to at least run with --empty when skipped.
+      # Instead we must attach the workspace to prevent crashing `teardown_vm`.
+      - attach_workspace:
+          at: /tmp
       - setup_vm
       - install_chrome
       - run:
@@ -179,6 +191,7 @@ jobs:
     executor:
       name: amphtml-large-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:
@@ -190,6 +203,7 @@ jobs:
     executor:
       name: amphtml-large-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:
@@ -206,6 +220,7 @@ jobs:
         type: enum
         enum: ['prod', 'canary']
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:
@@ -222,6 +237,7 @@ jobs:
         type: enum
         enum: ['prod', 'canary']
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:
@@ -233,6 +249,7 @@ jobs:
     executor:
       name: amphtml-large-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:
@@ -244,6 +261,7 @@ jobs:
     executor:
       name: amphtml-xlarge-executor
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:
@@ -260,6 +278,7 @@ jobs:
         type: enum
         enum: ['A', 'B', 'C']
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - run:
           name: 'Experiment << parameters.exp >> Build'
@@ -275,6 +294,7 @@ jobs:
         type: enum
         enum: ['A', 'B', 'C']
     steps:
+      - maybe_gracefully_halt
       - setup_vm
       - install_chrome
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,9 +177,11 @@ jobs:
     steps:
       # NOTE: deliberately not running the `maybe_gracefully_halt` step because
       # visual diff tests need to at least run with --empty when skipped.
-      # Instead we must attach the workspace to prevent crashing `teardown_vm`.
-      - attach_workspace:
-          at: /tmp
+      # Instead we must create an empty workspace to prevent `teardown_vm` from
+      # crashing.
+      - run:
+          name: 'Create Workspace'
+          command: mkdir -p /tmp/workspace
       - setup_vm
       - install_chrome
       - run:

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -15,7 +15,6 @@
  */
 'use strict';
 
-const fs = require('fs');
 const {mainBranch} = require('./main-branch');
 
 /**
@@ -226,17 +225,6 @@ function ciBuildSha() {
   return isPullRequestBuild() ? ciPullRequestSha() : ciCommitSha();
 }
 
-/**
- * Signal to dependent jobs that they should be skipped.
- *
- * Currently only relevant for CircleCI builds.
- */
-function signalGracefulHalt() {
-  if (isCircleciBuild()) {
-    fs.closeSync(fs.openSync('/tmp/workspace/.CI_GRACEFULLY_HALT', 'w'));
-  }
-}
-
 module.exports = {
   ciBuildId,
   ciBuildSha,
@@ -254,5 +242,4 @@ module.exports = {
   isGithubActionsBuild,
   isPullRequestBuild,
   isPushBuild,
-  signalGracefulHalt,
 };

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+const fs = require('fs');
 const {mainBranch} = require('./main-branch');
 
 /**
@@ -225,6 +226,17 @@ function ciBuildSha() {
   return isPullRequestBuild() ? ciPullRequestSha() : ciCommitSha();
 }
 
+/**
+ * Signal to dependent jobs that they should be skipped.
+ *
+ * Currently only relevant for CircleCI builds.
+ */
+function signalGracefulHalt() {
+  if (isCircleciBuild()) {
+    fs.closeSync(fs.openSync('/tmp/workspace/.CI_GRACEFULLY_HALT', 'w'));
+  }
+}
+
 module.exports = {
   ciBuildId,
   ciBuildSha,
@@ -242,4 +254,5 @@ module.exports = {
   isGithubActionsBuild,
   isPullRequestBuild,
   isPushBuild,
+  signalGracefulHalt,
 };

--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -21,7 +21,7 @@
 
 const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
-const {skipFollowupJobs, timedExecOrDie} = require('./utils');
+const {skipDependentJobs, timedExecOrDie} = require('./utils');
 
 const jobName = 'bundle-size.js';
 
@@ -38,7 +38,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp bundle-size --on_pr_build');
   } else {
     timedExecOrDie('amp bundle-size --on_skipped_build');
-    skipFollowupJobs(jobName, 'this PR does not affect the runtime');
+    skipDependentJobs(jobName, 'this PR does not affect the runtime');
   }
 }
 

--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -20,8 +20,8 @@
  */
 
 const {buildTargetsInclude, Targets} = require('./build-targets');
-const {printSkipMessage, timedExecOrDie} = require('./utils');
 const {runCiJob} = require('./ci-job');
+const {skipFollowupJobs, timedExecOrDie} = require('./utils');
 
 const jobName = 'bundle-size.js';
 
@@ -38,7 +38,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp bundle-size --on_pr_build');
   } else {
     timedExecOrDie('amp bundle-size --on_skipped_build');
-    printSkipMessage(jobName, 'this PR does not affect the runtime');
+    skipFollowupJobs(jobName, 'this PR does not affect the runtime');
   }
 }
 

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -21,7 +21,7 @@
 
 const {buildTargetsInclude, Targets} = require('./build-targets');
 const {log} = require('../common/logging');
-const {printSkipMessage, timedExecOrDie} = require('./utils');
+const {skipFollowupJobs, timedExecOrDie} = require('./utils');
 const {red, cyan} = require('kleur/colors');
 const {reportAllExpectedTests} = require('../tasks/report-test-status');
 const {runCiJob} = require('./ci-job');
@@ -120,7 +120,7 @@ async function prBuildWorkflow() {
       Targets.INTEGRATION_TEST
     )
   ) {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime, unit tests, integration tests, or end-to-end tests'
     );

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -21,10 +21,10 @@
 
 const {buildTargetsInclude, Targets} = require('./build-targets');
 const {log} = require('../common/logging');
-const {skipFollowupJobs, timedExecOrDie} = require('./utils');
 const {red, cyan} = require('kleur/colors');
 const {reportAllExpectedTests} = require('../tasks/report-test-status');
 const {runCiJob} = require('./ci-job');
+const {skipFollowupJobs, timedExecOrDie} = require('./utils');
 
 const jobName = 'cross-browser-tests.js';
 

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -24,7 +24,7 @@ const {log} = require('../common/logging');
 const {red, cyan} = require('kleur/colors');
 const {reportAllExpectedTests} = require('../tasks/report-test-status');
 const {runCiJob} = require('./ci-job');
-const {skipFollowupJobs, timedExecOrDie} = require('./utils');
+const {skipDependentJobs, timedExecOrDie} = require('./utils');
 
 const jobName = 'cross-browser-tests.js';
 
@@ -120,7 +120,7 @@ async function prBuildWorkflow() {
       Targets.INTEGRATION_TEST
     )
   ) {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, unit tests, integration tests, or end-to-end tests'
     );

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -21,7 +21,7 @@
 
 const {
   downloadNomoduleOutput,
-  printSkipMessage,
+  skipFollowupJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -51,7 +51,7 @@ function prBuildWorkflow() {
     downloadNomoduleOutput();
     timedExecOrDie('amp e2e --nobuild --headless --compiled');
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or end-to-end tests'
     );

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -21,7 +21,7 @@
 
 const {
   downloadNomoduleOutput,
-  skipFollowupJobs,
+  skipDependentJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -51,7 +51,7 @@ function prBuildWorkflow() {
     downloadNomoduleOutput();
     timedExecOrDie('amp e2e --nobuild --headless --compiled');
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or end-to-end tests'
     );

--- a/build-system/pr-check/experiment-build.js
+++ b/build-system/pr-check/experiment-build.js
@@ -20,7 +20,7 @@
  */
 
 const {
-  skipFollowupJobs: skipFollowupJobs,
+  skipDependentJobs: skipDependentJobs,
   timedExecOrDie,
   uploadExperimentOutput,
 } = require('./utils');
@@ -38,7 +38,7 @@ function pushBuildWorkflow() {
     timedExecOrDie(`amp dist --fortesting ${defineFlag}`);
     uploadExperimentOutput(experiment);
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       `${experiment} is expired, misconfigured, or does not exist`
     );
@@ -55,7 +55,7 @@ function prBuildWorkflow() {
   ) {
     pushBuildWorkflow();
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, or end-to-end tests'
     );

--- a/build-system/pr-check/experiment-build.js
+++ b/build-system/pr-check/experiment-build.js
@@ -20,7 +20,7 @@
  */
 
 const {
-  printSkipMessage,
+  skipFollowupJobs: skipFollowupJobs,
   timedExecOrDie,
   uploadExperimentOutput,
 } = require('./utils');
@@ -38,7 +38,7 @@ function pushBuildWorkflow() {
     timedExecOrDie(`amp dist --fortesting ${defineFlag}`);
     uploadExperimentOutput(experiment);
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       `${experiment} is expired, misconfigured, or does not exist`
     );
@@ -55,7 +55,7 @@ function prBuildWorkflow() {
   ) {
     pushBuildWorkflow();
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, or end-to-end tests'
     );

--- a/build-system/pr-check/experiment-tests.js
+++ b/build-system/pr-check/experiment-tests.js
@@ -21,7 +21,7 @@
 
 const {
   downloadExperimentOutput,
-  skipFollowupJobs: skipFollowupJobs,
+  skipDependentJobs: skipDependentJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -65,7 +65,7 @@ function pushBuildWorkflow() {
     downloadExperimentOutput(experiment);
     runExperimentTests(config);
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       `${experiment} is expired, misconfigured, or does not exist`
     );
@@ -82,7 +82,7 @@ function prBuildWorkflow() {
   ) {
     pushBuildWorkflow();
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, or end-to-end tests'
     );

--- a/build-system/pr-check/experiment-tests.js
+++ b/build-system/pr-check/experiment-tests.js
@@ -21,7 +21,7 @@
 
 const {
   downloadExperimentOutput,
-  printSkipMessage,
+  skipFollowupJobs: skipFollowupJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -65,7 +65,7 @@ function pushBuildWorkflow() {
     downloadExperimentOutput(experiment);
     runExperimentTests(config);
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       `${experiment} is expired, misconfigured, or does not exist`
     );
@@ -82,7 +82,7 @@ function prBuildWorkflow() {
   ) {
     pushBuildWorkflow();
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, or end-to-end tests'
     );

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -20,7 +20,7 @@
  */
 
 const {
-  skipFollowupJobs,
+  skipDependentJobs,
   timedExecOrDie,
   uploadModuleOutput,
 } = require('./utils');
@@ -42,7 +42,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp dist --esm --fortesting');
     uploadModuleOutput();
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -20,7 +20,7 @@
  */
 
 const {
-  printSkipMessage,
+  skipFollowupJobs,
   timedExecOrDie,
   uploadModuleOutput,
 } = require('./utils');
@@ -42,7 +42,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp dist --esm --fortesting');
     uploadModuleOutput();
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -23,7 +23,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const {
   downloadModuleOutput,
   downloadNomoduleOutput,
-  skipFollowupJobs,
+  skipDependentJobs,
   timedExecOrDie,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
@@ -58,7 +58,7 @@ function prBuildWorkflow() {
       `amp integration --nobuild --compiled --headless --esm --config=${argv.config}`
     );
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -23,7 +23,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const {
   downloadModuleOutput,
   downloadNomoduleOutput,
-  printSkipMessage,
+  skipFollowupJobs,
   timedExecOrDie,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
@@ -58,7 +58,7 @@ function prBuildWorkflow() {
       `amp integration --nobuild --compiled --headless --esm --config=${argv.config}`
     );
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -72,6 +72,11 @@ async function prBuildWorkflow() {
       jobName,
       'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'
     );
+
+    // Special case for visual diffs - Percy is a required check and must pass,
+    // but we just called `skipFollowupJobs` so the Visual Diffs job will not
+    // run. Instead, we create an empty, passing check on Percy here.
+    timedExecOrDie('amp visual-diff --empty');
   }
 }
 

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -68,15 +68,16 @@ async function prBuildWorkflow() {
     await signalPrDeployUpload('success');
   } else {
     await signalPrDeployUpload('skipped');
-    skipDependentJobs(
-      jobName,
-      'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'
-    );
 
     // Special case for visual diffs - Percy is a required check and must pass,
     // but we just called `skipDependentJobs` so the Visual Diffs job will not
     // run. Instead, we create an empty, passing check on Percy here.
     timedExecOrDie('amp visual-diff --empty');
+
+    skipDependentJobs(
+      jobName,
+      'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'
+    );
   }
 }
 

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -21,7 +21,7 @@
 
 const {
   abortTimedJob,
-  skipFollowupJobs,
+  skipDependentJobs,
   processAndUploadNomoduleOutput,
   startTimer,
   timedExecWithError,
@@ -68,13 +68,13 @@ async function prBuildWorkflow() {
     await signalPrDeployUpload('success');
   } else {
     await signalPrDeployUpload('skipped');
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'
     );
 
     // Special case for visual diffs - Percy is a required check and must pass,
-    // but we just called `skipFollowupJobs` so the Visual Diffs job will not
+    // but we just called `skipDependentJobs` so the Visual Diffs job will not
     // run. Instead, we create an empty, passing check on Percy here.
     timedExecOrDie('amp visual-diff --empty');
   }

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -21,7 +21,7 @@
 
 const {
   abortTimedJob,
-  printSkipMessage,
+  skipFollowupJobs,
   processAndUploadNomoduleOutput,
   startTimer,
   timedExecWithError,
@@ -68,7 +68,7 @@ async function prBuildWorkflow() {
     await signalPrDeployUpload('success');
   } else {
     await signalPrDeployUpload('skipped');
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'
     );

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -22,7 +22,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const {
   downloadNomoduleOutput,
-  skipFollowupJobs,
+  skipDependentJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -66,7 +66,7 @@ function prBuildWorkflow() {
       `amp integration --nobuild --compiled --headless --config=${argv.config}`
     );
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -22,7 +22,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const {
   downloadNomoduleOutput,
-  printSkipMessage,
+  skipFollowupJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -66,7 +66,7 @@ function prBuildWorkflow() {
       `amp integration --nobuild --compiled --headless --config=${argv.config}`
     );
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/unit-tests.js
+++ b/build-system/pr-check/unit-tests.js
@@ -19,9 +19,13 @@
  * @fileoverview Script that runs the unit tests during CI.
  */
 
+const {
+  skipDependentJobs,
+  timedExecOrDie,
+  timedExecOrThrow,
+} = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
-const {skipFollowupJobs, timedExecOrDie, timedExecOrThrow} = require('./utils');
 
 const jobName = 'unit-tests.js';
 
@@ -50,7 +54,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp unit --headless --coverage');
     timedExecOrDie('amp codecov-upload');
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or unit tests'
     );

--- a/build-system/pr-check/unit-tests.js
+++ b/build-system/pr-check/unit-tests.js
@@ -20,8 +20,8 @@
  */
 
 const {buildTargetsInclude, Targets} = require('./build-targets');
-const {printSkipMessage, timedExecOrDie, timedExecOrThrow} = require('./utils');
 const {runCiJob} = require('./ci-job');
+const {skipFollowupJobs, timedExecOrDie, timedExecOrThrow} = require('./utils');
 
 const jobName = 'unit-tests.js';
 
@@ -50,7 +50,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp unit --headless --coverage');
     timedExecOrDie('amp codecov-upload');
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or unit tests'
     );

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -20,7 +20,7 @@
  */
 
 const {
-  printSkipMessage,
+  skipFollowupJobs,
   timedExecOrDie,
   uploadUnminifiedOutput,
 } = require('./utils');
@@ -39,7 +39,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp build --fortesting');
     uploadUnminifiedOutput();
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -20,7 +20,7 @@
  */
 
 const {
-  skipFollowupJobs,
+  skipDependentJobs,
   timedExecOrDie,
   uploadUnminifiedOutput,
 } = require('./utils');
@@ -39,7 +39,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp build --fortesting');
     uploadUnminifiedOutput();
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/unminified-tests.js
+++ b/build-system/pr-check/unminified-tests.js
@@ -21,7 +21,7 @@
 
 const {
   downloadUnminifiedOutput,
-  printSkipMessage,
+  skipFollowupJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -57,7 +57,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp integration --nobuild --headless --coverage');
     timedExecOrDie('amp codecov-upload');
   } else {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/unminified-tests.js
+++ b/build-system/pr-check/unminified-tests.js
@@ -21,7 +21,7 @@
 
 const {
   downloadUnminifiedOutput,
-  skipFollowupJobs,
+  skipDependentJobs,
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
@@ -57,7 +57,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp integration --nobuild --headless --coverage');
     timedExecOrDie('amp codecov-upload');
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or integration tests'
     );

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -114,7 +114,7 @@ function skipFollowupJobs(jobName, skipReason) {
   logWithoutTimestamp(
     `${loggingPrefix} Skipping ${cyan(jobName)} because ${skipReason}.`
   );
-  fs.closeSync(fs.openSync('/tmp/workspace/CI_GRACEFULLY_HALT', 'w'));
+  fs.closeSync(fs.openSync('/tmp/workspace/.CI_GRACEFULLY_HALT', 'w'));
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -15,6 +15,7 @@
  */
 'use strict';
 
+const fs = require('fs');
 const {
   gitBranchCreationPoint,
   gitBranchName,
@@ -113,6 +114,7 @@ function skipFollowupJobs(jobName, skipReason) {
   logWithoutTimestamp(
     `${loggingPrefix} Skipping ${cyan(jobName)} because ${skipReason}.`
   );
+  fs.closeSync(fs.openSync('/tmp/workspace/CI_GRACEFULLY_HALT', 'w'));
 }
 
 /**

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -108,7 +108,7 @@ function printChangeSummary() {
  * @param {string} jobName
  * @param {string} skipReason
  */
-function printSkipMessage(jobName, skipReason) {
+function skipFollowupJobs(jobName, skipReason) {
   const loggingPrefix = getLoggingPrefix();
   logWithoutTimestamp(
     `${loggingPrefix} Skipping ${cyan(jobName)} because ${skipReason}.`
@@ -342,7 +342,7 @@ module.exports = {
   downloadNomoduleOutput,
   downloadModuleOutput,
   printChangeSummary,
-  printSkipMessage,
+  skipFollowupJobs,
   processAndUploadNomoduleOutput,
   startTimer,
   stopTimer,

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -15,11 +15,12 @@
  */
 'use strict';
 
+const fs = require('fs');
 const {
   ciBuildSha,
   ciPullRequestSha,
   isCiBuild,
-  signalGracefulHalt,
+  isCircleciBuild,
 } = require('../common/ci');
 const {
   gitBranchCreationPoint,
@@ -105,6 +106,17 @@ function printChangeSummary() {
       "If rebasing doesn't work, you may have to recreate the branch. See",
       cyan(GIT_BRANCH_URL) + '.\n'
     );
+  }
+}
+
+/**
+ * Signal to dependent jobs that they should be skipped.
+ *
+ * Currently only relevant for CircleCI builds.
+ */
+function signalGracefulHalt() {
+  if (isCircleciBuild()) {
+    fs.closeSync(fs.openSync('/tmp/workspace/.CI_GRACEFULLY_HALT', 'w'));
   }
 }
 

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -21,7 +21,7 @@
 
 const {buildTargetsInclude, Targets} = require('./build-targets');
 const {runCiJob} = require('./ci-job');
-const {skipFollowupJobs, timedExecOrDie} = require('./utils');
+const {skipDependentJobs, timedExecOrDie} = require('./utils');
 
 const jobName = 'validator-tests.js';
 
@@ -39,7 +39,7 @@ function prBuildWorkflow() {
       Targets.VALIDATOR_WEBUI
     )
   ) {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, validator, or validator web UI'
     );

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -20,8 +20,8 @@
  */
 
 const {buildTargetsInclude, Targets} = require('./build-targets');
-const {printSkipMessage, timedExecOrDie} = require('./utils');
 const {runCiJob} = require('./ci-job');
+const {skipFollowupJobs, timedExecOrDie} = require('./utils');
 
 const jobName = 'validator-tests.js';
 
@@ -39,7 +39,7 @@ function prBuildWorkflow() {
       Targets.VALIDATOR_WEBUI
     )
   ) {
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime, validator, or validator web UI'
     );

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -22,7 +22,7 @@
 const atob = require('atob');
 const {
   downloadNomoduleOutput,
-  printSkipMessage,
+  skipFollowupJobs,
   timedExecOrDie,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
@@ -43,7 +43,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp visual-diff --nobuild');
   } else {
     timedExecOrDie('amp visual-diff --empty');
-    printSkipMessage(
+    skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or visual diff tests'
     );

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -42,7 +42,6 @@ function prBuildWorkflow() {
     downloadNomoduleOutput();
     timedExecOrDie('amp visual-diff --nobuild');
   } else {
-    timedExecOrDie('amp visual-diff --empty');
     skipFollowupJobs(
       jobName,
       'this PR does not affect the runtime or visual diff tests'

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -22,7 +22,7 @@
 const atob = require('atob');
 const {
   downloadNomoduleOutput,
-  skipFollowupJobs,
+  skipDependentJobs,
   timedExecOrDie,
 } = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
@@ -42,7 +42,7 @@ function prBuildWorkflow() {
     downloadNomoduleOutput();
     timedExecOrDie('amp visual-diff --nobuild');
   } else {
-    skipFollowupJobs(
+    skipDependentJobs(
       jobName,
       'this PR does not affect the runtime or visual diff tests'
     );


### PR DESCRIPTION
This PR uses [CircleCI's workspaces](https://circleci.com/blog/persisting-data-in-workflows-when-to-use-caching-artifacts-and-workspaces/) to indicate to downstream jobs that they should not be executed; this happens before checking out the code, so a job that is going to be skipped completes within ~15-20 seconds instead of ~2-3 minutes