### PR TITLE
set technically correct defaults for amp-bind example

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -91,6 +91,9 @@ Calling `AMP.setState()` in some examples may set or change states of other exam
     .redBorder {
       border: 5px solid red;
     }
+    .defaultBorder {
+      border: 5px solid transparent;
+    }
   </style>
 </head>
 <body>
@@ -108,7 +111,7 @@ Calling `AMP.setState()` in some examples may set or change states of other exam
       }
     </script>
   </amp-state>
-  <div class="greenBorder" [class]="theFood[currentMeal].style">
+  <div class="defaultBorder" [class]="theFood[currentMeal].style || 'defaultBorder'">
     <p>Each food has a different border color.</p>
     <p [text]="'I want to eat ' + currentMeal + '.'">I want to eat cupcakes.</p>
     <amp-img


### PR DESCRIPTION
fixes ampproject/amp.dev#5440

Technically not invalid currently, but since the playground is calling the debugger to get information, it is flagging the example with a scary warning.