### PR TITLE
Teach amp-analytics how to forward events to amp-script

### DIFF
--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -652,9 +652,7 @@ export class AmpAnalytics extends AMP.BaseElement {
         this.allowParentPostMessage_() &&
         isIframed(this.win);
       if (shouldSendToAmpAd) {
-        this.expandEventToMessage_(trigger, event).then((message) => {
-          this.win.parent./*OK*/ postMessage(message, '*');
-        });
+        this.expandAndPostMessage_(trigger, event);
       }
     });
   }
@@ -678,20 +676,21 @@ export class AmpAnalytics extends AMP.BaseElement {
    * Expand and post message to parent window if applicable.
    * @param {!JsonObject} trigger JSON config block that resulted in this event.
    * @param {!JsonObject|!./events.AnalyticsEvent} event Object with details about the event.
-   * @return {JsonObject}
    * @private
    */
-  expandEventToMessage_(trigger, event) {
+  expandAndPostMessage_(trigger, event) {
     const msg = trigger['parentPostMessage'];
     const expansionOptions = this.expansionOptions_(event, trigger);
-    return expandPostMessage(
+    expandPostMessage(
       this.getAmpDoc(),
       msg,
       this.config_['extraUrlParams'],
       trigger,
       expansionOptions,
       this.element
-    );
+    ).then((message) => {
+      this.win.parent./*OK*/ postMessage(message, '*');
+    });
   }
 
   /**

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -152,8 +152,8 @@ export class AmpAnalytics extends AMP.BaseElement {
     }
 
     // TODO: bikeshed attribute name.
-    if (this.hasAttribute('amp-script-target')) {
-      const target = this.getAttribute('amp-script-target').split('.');
+    if (this.element.hasAttribute('amp-script-target')) {
+      const target = this.element.getAttribute('amp-script-target').split('.');
       userAssert(
         target.length === 2 && target[0].length > 0 && target[1].length > 0,
         '[amp-analytics]: "amp-script" target must be specified as "scriptId.functionIdentifier".'

--- a/extensions/amp-analytics/0.1/amp-analytics.js
+++ b/extensions/amp-analytics/0.1/amp-analytics.js
@@ -647,16 +647,10 @@ export class AmpAnalytics extends AMP.BaseElement {
       }
       this.expandAndSendRequest_(request, trigger, event);
 
-      /**
-       * Only expand for either:
-       * 1. An amp-ad with parentPostMessage specified
-       * 2. An amp-script target
-       */
       const shouldSendToAmpAd =
         trigger['parentPostMessage'] &&
         this.allowParentPostMessage_() &&
         isIframed(this.win);
-
       if (shouldSendToAmpAd) {
         this.expandEventToMessage_(trigger, event).then((message) => {
           this.win.parent./*OK*/ postMessage(message, '*');

--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -33,6 +33,7 @@ describes.realWin(
   },
   (env) => {
     let win;
+    let ampdoc;
     let doc;
     let openXhrStub;
     let sendXhrStub;
@@ -41,6 +42,7 @@ describes.realWin(
 
     beforeEach(() => {
       win = env.win;
+      ampdoc = env.ampdoc
       doc = win.document;
       openXhrStub = env.sandbox.stub();
       sendXhrStub = env.sandbox.stub();
@@ -163,7 +165,7 @@ describes.realWin(
 
     it('send single segment request', () => {
       setupStubs(true, true);
-      new Transport(win, {beacon: true}).sendRequest(
+      new Transport(ampdoc, {beacon: true}).sendRequest(
         'https://e.com/test',
         [
           {
@@ -182,7 +184,7 @@ describes.realWin(
 
     it('send single segment request in batch', () => {
       setupStubs(true, true);
-      new Transport(win, {beacon: true}).sendRequest(
+      new Transport(ampdoc, {beacon: true}).sendRequest(
         'https://e.com/test',
         [
           {
@@ -201,7 +203,7 @@ describes.realWin(
 
     it('send single segment request useBody', () => {
       setupStubs(true, true);
-      new Transport(win, {beacon: true, useBody: true}).sendRequest(
+      new Transport(ampdoc, {beacon: true, useBody: true}).sendRequest(
         'https://e.com/test',
         [
           {
@@ -220,7 +222,7 @@ describes.realWin(
 
     it('send single segment request useBody in batch', () => {
       setupStubs(true, true);
-      new Transport(win, {beacon: true, useBody: true}).sendRequest(
+      new Transport(ampdoc, {beacon: true, useBody: true}).sendRequest(
         'https://e.com/test',
         [
           {
@@ -239,7 +241,7 @@ describes.realWin(
 
     it('send multi-segment request w/o batch (only 1st sent)', () => {
       setupStubs(true, true);
-      new Transport(win, {beacon: true}).sendRequest(
+      new Transport(ampdoc, {beacon: true}).sendRequest(
         'https://e.com/test',
         [
           {
@@ -264,7 +266,7 @@ describes.realWin(
 
     it('send multi-segment request in batch', () => {
       setupStubs(true, true);
-      new Transport(win, {beacon: true}).sendRequest(
+      new Transport(ampdoc, {beacon: true}).sendRequest(
         'https://e.com/test',
         [
           {
@@ -289,7 +291,7 @@ describes.realWin(
 
     it('send multi-segment request useBody in batch', () => {
       setupStubs(true, true);
-      new Transport(win, {beacon: true, useBody: true}).sendRequest(
+      new Transport(ampdoc, {beacon: true, useBody: true}).sendRequest(
         'https://e.com/test',
         [
           {
@@ -338,7 +340,7 @@ describes.realWin(
         'http://iframe.localhost:9876/test/fixtures/served/iframe.html';
 
       function sendRequestUsingIframe(win, url) {
-        new Transport(win).sendRequestUsingIframe(url, {});
+        new Transport(ampdoc).sendRequestUsingIframe(url, {});
       }
 
       it('should create and delete an iframe', () => {
@@ -382,7 +384,7 @@ describes.realWin(
 
     describe('iframe transport', () => {
       it('does not initialize transport iframe if not used', () => {
-        const transport = new Transport(win, {
+        const transport = new Transport(ampdoc, {
           image: true,
           xhrpost: true,
           beacon: false,
@@ -395,7 +397,7 @@ describes.realWin(
       });
 
       it('initialize iframe transport when used', () => {
-        const transport = new Transport(win, {
+        const transport = new Transport(ampdoc, {
           iframe: '//test',
         });
 
@@ -424,7 +426,7 @@ describes.realWin(
         win.__AMP_MODE.runtime = 'inabox';
         expect(getMode(win).runtime).to.equal('inabox');
 
-        const transport = new Transport(win, {
+        const transport = new Transport(ampdoc, {
           iframe: '//test',
         });
 
@@ -447,7 +449,7 @@ describes.realWin(
 
       it('send via iframe transport', () => {
         setupStubs(true, true);
-        const transport = new Transport(win, {
+        const transport = new Transport(ampdoc, {
           beacon: true,
           xhrpost: true,
           image: true,
@@ -484,7 +486,7 @@ describes.realWin(
     }
 
     function sendRequest(win, request, options) {
-      new Transport(win, options).sendRequest(request, [{}], false);
+      new Transport(ampdoc, options).sendRequest(request, [{}], false);
     }
 
     function expectBeacon(url, payload) {

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -331,13 +331,13 @@ export class Transport {
   static forwardRequestToAmpScript(ampdoc, request) {
     userAssert(
       request.url.startsWith(AMP_SCRIPT_URI_SCHEME),
-      `[${TAG}]: "amp-script" URL must begin with "amp-script:"`
+      `[${TAG_}]: "amp-script" URL must begin with "amp-script:"`
     );
 
     const target = request.url.slice(AMP_SCRIPT_URI_SCHEME.length).split('.');
     userAssert(
       target.length === 2 && target[0].length > 0 && target[1].length > 0,
-      `[${TAG}]: "amp-script" target must be specified as "scriptId.functionIdentifier".`
+      `[${TAG_}]: "amp-script" target must be specified as "scriptId.functionIdentifier".`
     );
 
     const ampScriptId = target[0];
@@ -345,7 +345,7 @@ export class Transport {
     const ampScriptEl = ampdoc.getElementById(ampScriptId);
     userAssert(
       ampScriptEl && ampScriptEl.tagName === 'AMP-SCRIPT',
-      `[${TAG}]: could not find <amp-script> with ID "${ampScriptId}"`
+      `[${TAG_}]: could not find <amp-script> with ID "${ampScriptId}"`
     );
 
     ampScriptEl

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -331,13 +331,13 @@ export class Transport {
   static forwardRequestToAmpScript(ampdoc, request) {
     userAssert(
       request.url.startsWith(AMP_SCRIPT_URI_SCHEME),
-      '[amp-analytics]: "amp-script" URL must begin with "amp-script:"'
+      `[${TAG}]: "amp-script" URL must begin with "amp-script:"`
     );
 
     const target = request.url.slice(AMP_SCRIPT_URI_SCHEME.length).split('.');
     userAssert(
       target.length === 2 && target[0].length > 0 && target[1].length > 0,
-      '[amp-analytics]: "amp-script" target must be specified as "scriptId.functionIdentifier".'
+      `[${TAG}]: "amp-script" target must be specified as "scriptId.functionIdentifier".`
     );
 
     const ampScriptId = target[0];
@@ -345,7 +345,7 @@ export class Transport {
     const ampScriptEl = ampdoc.getElementById(ampScriptId);
     userAssert(
       ampScriptEl && ampScriptEl.tagName === 'AMP-SCRIPT',
-      `[amp-analytics]: could not find <amp-script> with ID "${ampScriptId}"`
+      `[${TAG}]: could not find <amp-script> with ID "${ampScriptId}"`
     );
 
     ampScriptEl

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -197,7 +197,7 @@ export class AmpScript extends AMP.BaseElement {
     return this.userActivation_;
   }
 
-   // * @param {Array<*>} args
+  // * @param {Array<*>} args
 
   /**
    * Calls the specified function on this amp-script's worker-dom instance.
@@ -208,7 +208,11 @@ export class AmpScript extends AMP.BaseElement {
   callFunction(functionIdentifier) {
     // TODO: how to property expand arguments
     return this.initialize_.promise.then(() => {
-      return this.workerDom_.callFunction.apply(this.workerDom_, functionIdentifier, arguments.slice(1));
+      return this.workerDom_.callFunction.apply(
+        this.workerDom_,
+        functionIdentifier,
+        arguments.slice(1)
+      );
     });
   }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -202,17 +202,12 @@ export class AmpScript extends AMP.BaseElement {
   /**
    * Calls the specified function on this amp-script's worker-dom instance.
    *
-   * @param {string} functionIdentifier
+   * @param {string} unused - function identifier
    * @return {!Promise<*>}
    */
-  callFunction(functionIdentifier) {
-    // TODO: how to property expand arguments
+  callFunction(unused /*, ...args */) {
     return this.initialize_.promise.then(() => {
-      return this.workerDom_.callFunction.apply(
-        this.workerDom_,
-        functionIdentifier,
-        arguments.slice(1)
-      );
+      return this.workerDom_.callFunction.apply(this.workerDom_, arguments);
     });
   }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -197,6 +197,8 @@ export class AmpScript extends AMP.BaseElement {
     return this.userActivation_;
   }
 
+   // * @param {Array<*>} args
+
   /**
    * Calls the specified function on this amp-script's worker-dom instance.
    *
@@ -204,8 +206,9 @@ export class AmpScript extends AMP.BaseElement {
    * @return {!Promise<*>}
    */
   callFunction(functionIdentifier) {
+    // TODO: how to property expand arguments
     return this.initialize_.promise.then(() => {
-      return this.workerDom_.callFunction(functionIdentifier);
+      return this.workerDom_.callFunction.apply(this.workerDom_, functionIdentifier, arguments.slice(1));
     });
   }
 

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -149,7 +149,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     script.callFunction('fetchData', true);
     expect(script.workerDom_.callFunction).not.called;
 
-    script.initialize_.resolve();
+    await script.initialize_.resolve();
     expect(script.workerDom_.callFunction).calledWithExactly('fetchData', true);
   });
 

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -144,17 +144,13 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
 
   it('callFunction waits for initialization to complete before returning', async () => {
     element.setAttribute('script', 'local-script');
-    const result = script.callFunction('fetchData');
-    script.workerDom_ = {
-      callFunction(fnIdent) {
-        if (fnIdent === 'fetchData') {
-          return Promise.resolve(42);
-        }
-        return Promise.reject();
-      },
-    };
+    script.workerDom_ = {callFunction: env.sandbox.spy()};
+
+    script.callFunction('fetchData', true);
+    expect(script.workerDom_.callFunction).not.called;
+
     script.initialize_.resolve();
-    expect(await result).to.equal(42);
+    expect(script.workerDom_.callFunction).calledWithExactly('fetchData', true);
   });
 
   describe('Initialization skipped warning due to zero height/width', () => {

--- a/test/manual/analytics-script-target.html
+++ b/test/manual/analytics-script-target.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>AMP Analytics: amp-script target</title>
+  <link rel="canonical" href="analytics.amp.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/v0/amp-analytics-0.1.js"></script>
+  <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+</head>
+<body>
+<p>Hi there! Open devtools to inspect the amp-analytics pings.</p>
+<div id="container">
+<amp-analytics id="analytics1">
+<script type="application/json">
+{
+  "transport": {"amp-script": true},
+  "requests": {
+    "endpoint": "amp-script:analytics-script.receive"
+  },
+  "triggers": {
+    "trackPageview": {
+      "on": "visible",
+      "request": "endpoint"
+    }
+  }
+}
+</script>
+</amp-analytics>
+<amp-script id="analytics-script" script="analytics-script-txt" nodom data-ampdevmode></amp-script>
+<script id="analytics-script-txt" type="text/plain" target="amp-script">
+  function receive(msg) {
+    console.log(`amp-script received: ${msg}`);
+  }
+  exportFunction('receive', receive)
+</script>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
**summary**
Fixes: https://github.com/ampproject/amphtml/issues/33580

Enables the usage of the `amp-script: ` protocol as an amp-analytics request endpoint.