### PR TITLE
✅ Add amp task to validate assertion DCE-ing

### DIFF
--- a/amp.js
+++ b/amp.js
@@ -35,6 +35,7 @@ createTask('build', 'build', 'build');
 createTask('bundle-size', 'bundleSize', 'bundle-size');
 createTask('caches-json', 'cachesJson', 'caches-json');
 createTask('check-analytics-vendors-list', 'checkAnalyticsVendorsList', 'check-analytics-vendors-list'); // prettier-ignore
+createTask('check-asserts', 'checkAsserts', 'check-asserts'); // prettier-ignore
 createTask('check-build-system', 'checkBuildSystem', 'check-build-system');
 createTask('check-exact-versions', 'checkExactVersions','check-exact-versions'); // prettier-ignore
 createTask('check-links', 'checkLinks', 'check-links');

--- a/build-system/tasks/check-asserts.js
+++ b/build-system/tasks/check-asserts.js
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+const fs = require('fs').promises;
+const {cyan, red, green} = require('kleur/colors');
+const {log} = require('../common/logging');
+
+const DEV_ASSERT_SENTINEL = '__devAssert_sentinel__';
+const PURE_ASSERT_SENTINEL = 'Assertion failed';
+const UNMINIFIED_JS = './dist/amp.js';
+const MINIFIED_JS = './dist/v0.js';
+
+/**
+ * Checks that a provided sentinel is/is not contained in a file.
+ * @param {string} filePath JS binary to check
+ * @param {Map<string, boolean>} sentinels map from sentinels to whether or not
+ *                               they should be present
+ * @throws if a sentinel isn't/is present when it should/shouldn't be
+ */
+async function checkSentinels(filePath, sentinels) {
+  const fileContents = await fs.readFile(filePath, 'utf8');
+  console.log(fileContents.length);
+
+  for (const [sentinel, shouldBePresent] of Object.entries(sentinels)) {
+    const isPresent = fileContents.includes(sentinel);
+
+    if (isPresent != shouldBePresent) {
+      log(
+        red('ERROR:'),
+        cyan(filePath),
+        shouldBePresent ? 'does not contain' : 'contains',
+        `${cyan(sentinel)}.`,
+        'Something may be wrong with assertions or compilation.'
+      );
+      throw new Error('Assertion sentinel check failed');
+    }
+
+    log(
+      green('SUCCESS:'),
+      cyan(sentinel),
+      shouldBePresent ? 'found in' : 'not found in',
+      cyan(filePath)
+    );
+  }
+}
+
+/**
+ * Checks that the file at the provided path does not include devAssert.
+ * This works as follows:
+ * - The devAssert function includes a sentinel string message behind a
+ *   conditional that is always false, but not DCE-able.
+ * - In minified code, devAssert should be removed entirely, so the sentinel
+ *   will not be present.
+ * - In unminified code, it should remain present but never execute.
+ * - Even when devAssert is DCE'd, pureAssert still includes the base assertion
+ *   logic, so the 'Assertion failed' string will be present.
+ * @param {string} unminifiedJsPath
+ * @param {string} minifiedJsPath
+ */
+async function checkAsserts(unminifiedJsPath, minifiedJsPath) {
+  try {
+    await checkSentinels(UNMINIFIED_JS, {
+      [PURE_ASSERT_SENTINEL]: true,
+      [DEV_ASSERT_SENTINEL]: true,
+    });
+    await checkSentinels(MINIFIED_JS, {
+      [PURE_ASSERT_SENTINEL]: true,
+      [DEV_ASSERT_SENTINEL]: false,
+    });
+  } catch (e) {
+    process.exitCode = 1;
+    return;
+  }
+}
+
+module.exports = {
+  checkAsserts,
+};
+
+checkAsserts.description =
+  "Checks amp.js and v0.js to validate that assertions are DCE'd correctly";

--- a/build-system/tasks/check-asserts.js
+++ b/build-system/tasks/check-asserts.js
@@ -68,10 +68,8 @@ async function checkSentinels(filePath, sentinels) {
  * - In unminified code, it should remain present but never execute.
  * - Even when devAssert is DCE'd, pureAssert still includes the base assertion
  *   logic, so the 'Assertion failed' string will be present.
- * @param {string} unminifiedJsPath
- * @param {string} minifiedJsPath
  */
-async function checkAsserts(unminifiedJsPath, minifiedJsPath) {
+async function checkAsserts() {
   try {
     await checkSentinels(UNMINIFIED_JS, {
       [PURE_ASSERT_SENTINEL]: true,

--- a/build-system/tasks/check-asserts.js
+++ b/build-system/tasks/check-asserts.js
@@ -69,19 +69,14 @@ async function checkSentinels(filePath, sentinels) {
  *   logic, so the 'Assertion failed' string will be present.
  */
 async function checkAsserts() {
-  try {
-    await checkSentinels(UNMINIFIED_JS, {
-      [PURE_ASSERT_SENTINEL]: true,
-      [DEV_ASSERT_SENTINEL]: true,
-    });
-    await checkSentinels(MINIFIED_JS, {
-      [PURE_ASSERT_SENTINEL]: true,
-      [DEV_ASSERT_SENTINEL]: false,
-    });
-  } catch (e) {
-    process.exitCode = 1;
-    return;
-  }
+  await checkSentinels(UNMINIFIED_JS, {
+    [PURE_ASSERT_SENTINEL]: true,
+    [DEV_ASSERT_SENTINEL]: true,
+  });
+  await checkSentinels(MINIFIED_JS, {
+    [PURE_ASSERT_SENTINEL]: true,
+    [DEV_ASSERT_SENTINEL]: false,
+  });
 }
 
 module.exports = {

--- a/build-system/tasks/check-asserts.js
+++ b/build-system/tasks/check-asserts.js
@@ -33,7 +33,6 @@ const MINIFIED_JS = './dist/v0.js';
  */
 async function checkSentinels(filePath, sentinels) {
   const fileContents = await fs.readFile(filePath, 'utf8');
-  console.log(fileContents.length);
 
   for (const [sentinel, shouldBePresent] of Object.entries(sentinels)) {
     const isPresent = fileContents.includes(sentinel);

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -181,7 +181,7 @@ export function pureDevAssert(
     return shouldBeTruthy;
   }
 
-  if (window.__thisVariableDoesNotExist) {
+  if (self.__thisVariableDoesNotExist) {
     // This will never execute regardless, but will be included on unminified
     // builds. It will be DCE'd away from minified builds, and so can be used to
     // validate that Babel is properly removing dev assertions in minified

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -181,7 +181,7 @@ export function pureDevAssert(
     return shouldBeTruthy;
   }
 
-  if (self.__thisVariableDoesNotExist) {
+  if (self.__AMP_ASSERTION_CHECK) {
     // This will never execute regardless, but will be included on unminified
     // builds. It will be DCE'd away from minified builds, and so can be used to
     // validate that Babel is properly removing dev assertions in minified

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -181,6 +181,14 @@ export function pureDevAssert(
     return shouldBeTruthy;
   }
 
+  if (window.__thisVariableDoesNotExist) {
+    // This will never execute regardless, but will be included on unminified
+    // builds. It will be DCE'd away from minified builds, and so can be used to
+    // validate that Babel is properly removing dev assertions in minified
+    // builds.
+    console.log('__devAssert_sentinel__');
+  }
+
   return assertion(
     Error,
     shouldBeTruthy,

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -186,7 +186,8 @@ export function pureDevAssert(
     // builds. It will be DCE'd away from minified builds, and so can be used to
     // validate that Babel is properly removing dev assertions in minified
     // builds.
-    console.log('__devAssert_sentinel__');
+    console /*OK*/
+      .log('__devAssert_sentinel__');
   }
 
   return assertion(

--- a/src/log.js
+++ b/src/log.js
@@ -890,7 +890,7 @@ export function devAssert(
   if (getMode().minified) {
     return shouldBeTrueish;
   }
-  if (window.__thisVariableDoesNotExist) {
+  if (self.__thisVariableDoesNotExist) {
     // This will never execute regardless, but will be included on unminified
     // builds. It will be DCE'd away from minified builds, and so can be used to
     // validate that Babel is properly removing dev assertions in minified

--- a/src/log.js
+++ b/src/log.js
@@ -890,7 +890,7 @@ export function devAssert(
   if (getMode().minified) {
     return shouldBeTrueish;
   }
-  if (self.__thisVariableDoesNotExist) {
+  if (self.__AMP_ASSERTION_CHECK) {
     // This will never execute regardless, but will be included on unminified
     // builds. It will be DCE'd away from minified builds, and so can be used to
     // validate that Babel is properly removing dev assertions in minified

--- a/src/log.js
+++ b/src/log.js
@@ -895,7 +895,8 @@ export function devAssert(
     // builds. It will be DCE'd away from minified builds, and so can be used to
     // validate that Babel is properly removing dev assertions in minified
     // builds.
-    console.log('__devAssert_sentinel__');
+    console /*OK*/
+      .log('__devAssert_sentinel__');
   }
 
   return dev()./*Orig call*/ assert(

--- a/src/log.js
+++ b/src/log.js
@@ -890,6 +890,14 @@ export function devAssert(
   if (getMode().minified) {
     return shouldBeTrueish;
   }
+  if (window.__thisVariableDoesNotExist) {
+    // This will never execute regardless, but will be included on unminified
+    // builds. It will be DCE'd away from minified builds, and so can be used to
+    // validate that Babel is properly removing dev assertions in minified
+    // builds.
+    console.log('__devAssert_sentinel__');
+  }
+
   return dev()./*Orig call*/ assert(
     shouldBeTrueish,
     opt_message,


### PR DESCRIPTION
Asserts the expected presence/absence of devAsserts and userAsserts be checking sentinel strings against `amp.js` and `v0.js` (not yet included in the actual CI, this PR is just the task/check itself)