### PR TITLE
Bento Carousel: Support passing in custom arrows with `as`

### DIFF
--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -84,6 +84,24 @@ class AmpBaseCarousel extends PreactBaseElement {
       this.api().goToSlide(slide);
     }
   }
+
+  /** @override */
+  updatePropsForRendering(props) {
+    if (props['arrowPrev']) {
+      const Comp = props['arrowPrev'];
+      props['arrowPrevAs'] = (props) => {
+        Comp.props = {...Comp.props, ...props};
+        return Comp;
+      };
+    }
+    if (props['arrowNext']) {
+      const Comp = props['arrowNext'];
+      props['arrowNextAs'] = (props) => {
+        Comp.props = {...Comp.props, ...props};
+        return Comp;
+      };
+    }
+  }
 }
 
 /** @override */

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -21,6 +21,7 @@ import {CSS} from '../../../build/amp-base-carousel-1.0.css';
 import {CarouselContextProp} from './carousel-props';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Services} from '../../../src/services';
+import {cloneElement} from '../../../src/preact';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
 import {dispatchCustomEvent} from '../../../src/dom';
@@ -87,19 +88,12 @@ class AmpBaseCarousel extends PreactBaseElement {
 
   /** @override */
   updatePropsForRendering(props) {
-    if (props['arrowPrev']) {
-      const Comp = props['arrowPrev'];
-      props['arrowPrevAs'] = (props) => {
-        Comp.props = {...Comp.props, ...props};
-        return Comp;
-      };
+    const {arrowPrev, arrowNext} = props;
+    if (arrowPrev) {
+      props['arrowPrevAs'] = (props) => cloneElement(arrowPrev, props);
     }
-    if (props['arrowNext']) {
-      const Comp = props['arrowNext'];
-      props['arrowNextAs'] = (props) => {
-        Comp.props = {...Comp.props, ...props};
-        return Comp;
-      };
+    if (arrowNext) {
+      props['arrowNextAs'] = (props) => cloneElement(arrowNext, props);
     }
   }
 }

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -16,6 +16,7 @@
 
 import * as Preact from '../../../src/preact';
 import {useStyles} from './base-carousel.jss';
+import objstr from 'obj-str';
 
 /**
  * @param {!BaseCarouselDef.ArrowProps} props
@@ -23,41 +24,37 @@ import {useStyles} from './base-carousel.jss';
  */
 export function Arrow({
   advance,
+  as: Comp = DefaultArrow,
   by,
-  customArrow = <DefaultArrow by={by} />,
   disabled,
   outsetArrows,
   rtl,
+  ...rest
 }) {
-  const {
-    'disabled': customDisabled,
-    'onClick': onCustomClick,
-  } = customArrow.props;
-  const isDisabled = disabled || customDisabled;
-  const onClick = (e) => {
-    if (isDisabled) {
-      return;
-    }
-    if (onCustomClick) {
-      onCustomClick(e);
-    }
-    advance();
-  };
   const classes = useStyles();
-  const classNames = `${classes.arrow} ${
-    by < 0 ? classes.arrowPrev : classes.arrowNext
-  } ${isDisabled ? classes.arrowDisabled : ''} ${
-    outsetArrows ? classes.outsetArrow : classes.insetArrow
-  } ${rtl ? classes.rtl : classes.ltr}`;
-
+  const onClick = () => {
+    if (!disabled) {
+      advance();
+    }
+  };
   return (
-    <div class={classNames}>
-      {Preact.cloneElement(customArrow, {
-        'onClick': onClick,
-        'disabled': isDisabled,
-        'aria-disabled': String(!!isDisabled),
+    <Comp
+      aria-disabled={String(!!disabled)}
+      by={by}
+      className={objstr({
+        [classes.arrow]: true,
+        [classes.arrowDisabled]: disabled,
+        [classes.arrowPrev]: by < 0,
+        [classes.arrowNext]: by > 0,
+        [classes.outsetArrow]: outsetArrows,
+        [classes.insetArrow]: !outsetArrows,
+        [classes.rtl]: rtl,
+        [classes.ltr]: !rtl,
       })}
-    </div>
+      disabled={disabled}
+      onClick={onClick}
+      {...rest}
+    />
   );
 }
 
@@ -65,28 +62,38 @@ export function Arrow({
  * @param {!BaseCarouselDef.ArrowProps} props
  * @return {PreactDef.Renderable}
  */
-function DefaultArrow({by, ...rest}) {
+function DefaultArrow({by, className, ...rest}) {
   const classes = useStyles();
   return (
-    <button
-      class={classes.defaultArrowButton}
-      aria-label={
-        by < 0 ? 'Previous item in carousel' : 'Next item in carousel'
-      }
-      {...rest}
-    >
-      <div class={`${classes.arrowBaseStyle} ${classes.arrowFrosting}`}></div>
-      <div class={`${classes.arrowBaseStyle} ${classes.arrowBackdrop}`}></div>
-      <div class={`${classes.arrowBaseStyle} ${classes.arrowBackground}`}></div>
-      <svg class={classes.arrowIcon} viewBox="0 0 24 24">
-        <path
-          d={by < 0 ? 'M14,7.4 L9.4,12 L14,16.6' : 'M10,7.4 L14.6,12 L10,16.6'}
-          fill="none"
-          stroke-width="2px"
-          stroke-linejoin="round"
-          stroke-linecap="round"
-        />
-      </svg>
-    </button>
+    <div className={className}>
+      <button
+        aria-label={
+          by < 0 ? 'Previous item in carousel' : 'Next item in carousel'
+        }
+        className={classes.defaultArrowButton}
+        {...rest}
+      >
+        <div
+          className={`${classes.arrowBaseStyle} ${classes.arrowFrosting}`}
+        ></div>
+        <div
+          className={`${classes.arrowBaseStyle} ${classes.arrowBackdrop}`}
+        ></div>
+        <div
+          className={`${classes.arrowBaseStyle} ${classes.arrowBackground}`}
+        ></div>
+        <svg className={classes.arrowIcon} viewBox="0 0 24 24">
+          <path
+            d={
+              by < 0 ? 'M14,7.4 L9.4,12 L14,16.6' : 'M10,7.4 L14.6,12 L10,16.6'
+            }
+            fill="none"
+            stroke-width="2px"
+            stroke-linejoin="round"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+    </div>
   );
 }

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -53,6 +53,8 @@ export function Arrow({
       })}
       disabled={disabled}
       onClick={onClick}
+      outsetArrows={outsetArrows}
+      rtl={rtl}
       {...rest}
     />
   );

--- a/extensions/amp-base-carousel/1.0/base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/base-carousel.js
@@ -83,8 +83,8 @@ const MIN_AUTO_ADVANCE_INTERVAL = 1000;
 function BaseCarouselWithRef(
   {
     advanceCount = 1,
-    arrowPrev,
-    arrowNext,
+    arrowPrevAs,
+    arrowNextAs,
     autoAdvance: shouldAutoAdvance = false,
     autoAdvanceCount = 1,
     autoAdvanceInterval: customAutoAdvanceInterval = MIN_AUTO_ADVANCE_INTERVAL,
@@ -101,7 +101,7 @@ function BaseCarouselWithRef(
     onSlideChange,
     onTouchStart,
     orientation = Orientation.HORIZONTAL,
-    outsetArrows,
+    outsetArrows = false,
     snap = true,
     snapAlign = Alignment.START,
     snapBy = 1,
@@ -330,8 +330,8 @@ function BaseCarouselWithRef(
       {!hideControls && (
         <Arrow
           advance={prev}
+          as={arrowPrevAs}
           by={-advanceCount}
-          customArrow={arrowPrev}
           disabled={disableForDir(-1)}
           outsetArrows={outsetArrows}
           rtl={rtl}
@@ -387,7 +387,7 @@ function BaseCarouselWithRef(
         <Arrow
           advance={next}
           by={advanceCount}
-          customArrow={arrowNext}
+          as={arrowNextAs}
           disabled={disableForDir(1)}
           outsetArrows={outsetArrows}
           rtl={rtl}

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -161,4 +161,30 @@ export const mixedLength = () => {
   );
 };
 
+export const customArrows = () => {
+  const width = number('width', 400);
+  const height = number('height', 200);
+  const slideCount = number('slide count', 7, {min: 0, max: 99});
+  const colorIncrement = Math.floor(255 / (slideCount + 1));
+  return (
+    <amp-base-carousel id="my-carousel" width={width} height={height}>
+      {Array.from({length: slideCount}, (x, i) => {
+        const v = colorIncrement * (i + 1);
+        return (
+          <div
+            style={{
+              backgroundColor: `rgb(${v}, 100, 100)`,
+              border: 'solid white 1px',
+              width: '100%',
+              height: '100%',
+            }}
+          ></div>
+        );
+      })}
+      <button slot="next-arrow">Next</button>
+      <button slot="prev-arrow">Prev</button>
+    </amp-base-carousel>
+  );
+};
+
 Default.storyName = 'default';

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -170,6 +170,7 @@ export const provideArrows = () => {
     color: 'white',
     width: '30px',
     height: '30px',
+    padding: '1px 6px',
   };
   const MyButton = (props) => {
     const {children} = props;
@@ -184,8 +185,8 @@ export const provideArrows = () => {
       controls={controls}
       style={{width, height}}
       outsetArrows={outsetArrows}
-      arrowPrev={<MyButton>←</MyButton>}
-      arrowNext={<MyButton>→</MyButton>}
+      arrowPrevAs={(props) => <MyButton {...props}>←</MyButton>}
+      arrowNextAs={(props) => <MyButton {...props}>→</MyButton>}
     >
       {['lightcoral', 'peachpuff', 'lavender'].map((color) => (
         <div style={{backgroundColor: color, width, height}}></div>

--- a/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/test/test-base-carousel.js
@@ -41,10 +41,18 @@ describes.sandboxed('BaseCarousel preact component', {}, () => {
   });
 
   it('should render custom Arrows when given', () => {
-    const arrowPrev = <div class="my-custom-arrow-prev">left</div>;
-    const arrowNext = <div class="my-custom-arrow-next">right</div>;
+    const arrowPrev = (props) => (
+      <div {...props} className="my-custom-arrow-prev">
+        left
+      </div>
+    );
+    const arrowNext = (props) => (
+      <div {...props} className="my-custom-arrow-next">
+        right
+      </div>
+    );
     const wrapper = mount(
-      <BaseCarousel arrowPrev={arrowPrev} arrowNext={arrowNext}>
+      <BaseCarousel arrowPrevAs={arrowPrev} arrowNextAs={arrowNext}>
         <div>slide 1</div>
         <div>slide 2</div>
         <div>slide 3</div>
@@ -52,8 +60,8 @@ describes.sandboxed('BaseCarousel preact component', {}, () => {
     );
     const arrows = wrapper.find('Arrow');
     expect(arrows).to.have.lengthOf(2);
-    expect(arrows.first().props().customArrow).to.equal(arrowPrev);
-    expect(arrows.last().props().customArrow).to.equal(arrowNext);
+    expect(arrows.first().props().as).to.equal(arrowPrev);
+    expect(arrows.last().props().as).to.equal(arrowNext);
   });
 
   it('should not loop by default', () => {

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
@@ -61,6 +61,24 @@ class AmpStreamGallery extends PreactBaseElement {
     );
     return super.isLayoutSupported(layout);
   }
+
+  /** @override */
+  updatePropsForRendering(props) {
+    if (props['arrowPrev']) {
+      const Comp = props['arrowPrev'];
+      props['arrowPrevAs'] = (props) => {
+        Comp.props = {...Comp.props, ...props};
+        return Comp;
+      };
+    }
+    if (props['arrowNext']) {
+      const Comp = props['arrowNext'];
+      props['arrowNextAs'] = (props) => {
+        Comp.props = {...Comp.props, ...props};
+        return Comp;
+      };
+    }
+  }
 }
 
 /**

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
@@ -21,6 +21,7 @@ import {CSS as GALLERY_CSS} from './stream-gallery.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Services} from '../../../src/services';
 import {StreamGallery} from './stream-gallery';
+import {cloneElement} from '../../../src/preact';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dict} from '../../../src/utils/object';
 import {dispatchCustomEvent} from '../../../src/dom';
@@ -64,19 +65,12 @@ class AmpStreamGallery extends PreactBaseElement {
 
   /** @override */
   updatePropsForRendering(props) {
-    if (props['arrowPrev']) {
-      const Comp = props['arrowPrev'];
-      props['arrowPrevAs'] = (props) => {
-        Comp.props = {...Comp.props, ...props};
-        return Comp;
-      };
+    const {arrowPrev, arrowNext} = props;
+    if (arrowPrev) {
+      props['arrowPrevAs'] = (props) => cloneElement(arrowPrev, props);
     }
-    if (props['arrowNext']) {
-      const Comp = props['arrowNext'];
-      props['arrowNextAs'] = (props) => {
-        Comp.props = {...Comp.props, ...props};
-        return Comp;
-      };
+    if (arrowNext) {
+      props['arrowNextAs'] = (props) => cloneElement(arrowNext, props);
     }
   }
 }

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
@@ -91,4 +91,30 @@ export const Default = () => {
   );
 };
 
+export const customArrows = () => {
+  const width = number('width', 400);
+  const height = number('height', 200);
+  const slideCount = number('slide count', 7, {min: 0, max: 99});
+  const colorIncrement = Math.floor(255 / (slideCount + 1));
+  return (
+    <amp-stream-gallery max-visible-count={3} width={width} height={height}>
+      {Array.from({length: slideCount}, (x, i) => {
+        const v = colorIncrement * (i + 1);
+        return (
+          <div
+            style={{
+              backgroundColor: `rgb(${v}, 100, 100)`,
+              border: 'solid white 1px',
+              width: '100%',
+              height: '100%',
+            }}
+          ></div>
+        );
+      })}
+      <button slot="next-arrow">Next</button>
+      <button slot="prev-arrow">Prev</button>
+    </amp-stream-gallery>
+  );
+};
+
 Default.storyName = 'default';

--- a/extensions/amp-stream-gallery/1.0/stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/stream-gallery.js
@@ -27,6 +27,7 @@ import {
   useState,
 } from '../../../src/preact';
 import {useStyles} from './stream-gallery.jss';
+import objstr from 'obj-str';
 
 const DEFAULT_VISIBLE_COUNT = 1;
 const OUTSET_ARROWS_WIDTH = 100;
@@ -118,9 +119,11 @@ function StreamGalleryWithRef(props, ref) {
       advanceCount={Math.floor(visibleCount)}
       arrowPrevAs={arrowPrevAs}
       arrowNextAs={arrowNextAs}
-      className={`${className ?? ''} ${classes.gallery} ${
-        extraSpace === 'around' ? classes.extraSpace : ''
-      }`}
+      className={objstr({
+        [className]: !!className,
+        [classes.gallery]: true,
+        [classes.extraSpace]: extraSpace === 'around',
+      })}
       outsetArrows={outsetArrows}
       snapAlign={slideAlign}
       ref={carouselRef}
@@ -145,10 +148,14 @@ function DefaultArrow({by, className, outsetArrows, ...rest}) {
   return (
     <div className={className}>
       <button
-        className={`${classes.arrow} ${
-          by < 0 ? classes.arrowPrev : classes.arrowNext
-        } ${outsetArrows ? classes.outsetArrow : classes.insetArrow}`}
         aria-hidden="true"
+        className={objstr({
+          [classes.arrow]: true,
+          [classes.arrowPrev]: by < 0,
+          [classes.arrowNext]: by > 0,
+          [classes.outsetArrow]: outsetArrows,
+          [classes.insetArrow]: !outsetArrows,
+        })}
         {...rest}
       >
         <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/extensions/amp-stream-gallery/1.0/stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/stream-gallery.js
@@ -23,7 +23,6 @@ import {
   useCallback,
   useImperativeHandle,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from '../../../src/preact';
@@ -39,8 +38,8 @@ const OUTSET_ARROWS_WIDTH = 100;
  */
 function StreamGalleryWithRef(props, ref) {
   const {
-    arrowPrev: customArrowPrev,
-    arrowNext: customArrowNext,
+    arrowPrevAs = DefaultArrow,
+    arrowNextAs = DefaultArrow,
     children,
     className,
     extraSpace,
@@ -56,16 +55,6 @@ function StreamGalleryWithRef(props, ref) {
   const classes = useStyles();
   const carouselRef = useRef(null);
   const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT);
-  const arrowPrev = useMemo(
-    () =>
-      customArrowPrev ?? <DefaultArrow by={-1} outsetArrows={outsetArrows} />,
-    [customArrowPrev, outsetArrows]
-  );
-  const arrowNext = useMemo(
-    () =>
-      customArrowNext ?? <DefaultArrow by={1} outsetArrows={outsetArrows} />,
-    [customArrowNext, outsetArrows]
-  );
 
   const measure = useCallback(
     (containerWidth) =>
@@ -127,8 +116,8 @@ function StreamGalleryWithRef(props, ref) {
   return (
     <BaseCarousel
       advanceCount={Math.floor(visibleCount)}
-      arrowPrev={arrowPrev}
-      arrowNext={arrowNext}
+      arrowPrevAs={arrowPrevAs}
+      arrowNextAs={arrowNextAs}
       className={`${className ?? ''} ${classes.gallery} ${
         extraSpace === 'around' ? classes.extraSpace : ''
       }`}
@@ -151,28 +140,31 @@ export {StreamGallery};
  * @param {!StreamGalleryDef.ArrowProps} props
  * @return {PreactDef.Renderable}
  */
-function DefaultArrow({advance, by, outsetArrows, ...rest}) {
+function DefaultArrow({by, className, outsetArrows, ...rest}) {
   const classes = useStyles();
   return (
-    <button
-      onClick={() => advance(by)}
-      className={`${classes.arrow} ${
-        by < 0 ? classes.arrowPrev : classes.arrowNext
-      } ${outsetArrows ? classes.outsetArrow : classes.insetArrow}`}
-      aria-hidden="true"
-      {...rest}
-    >
-      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path
-          d={by < 0 ? 'M14,7.4 L9.4,12 L14,16.6' : 'M10,7.4 L14.6,12 L10,16.6'}
-          fill="none"
-          stroke="#000"
-          stroke-width="2"
-          stroke-linejoin="round"
-          stroke-linecap="round"
-        />
-      </svg>
-    </button>
+    <div className={className}>
+      <button
+        className={`${classes.arrow} ${
+          by < 0 ? classes.arrowPrev : classes.arrowNext
+        } ${outsetArrows ? classes.outsetArrow : classes.insetArrow}`}
+        aria-hidden="true"
+        {...rest}
+      >
+        <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path
+            d={
+              by < 0 ? 'M14,7.4 L9.4,12 L14,16.6' : 'M10,7.4 L14.6,12 L10,16.6'
+            }
+            fill="none"
+            stroke="#000"
+            stroke-width="2"
+            stroke-linejoin="round"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+    </div>
   );
 }
 

--- a/extensions/amp-stream-gallery/1.0/test/test-stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/test/test-stream-gallery.js
@@ -40,10 +40,18 @@ describes.sandboxed('StreamGallery preact component', {}, () => {
   });
 
   it('should render custom Arrows when given', () => {
-    const arrowPrev = <div class="my-custom-arrow-prev">left</div>;
-    const arrowNext = <div class="my-custom-arrow-next">right</div>;
+    const arrowPrev = (props) => (
+      <div {...props} className="my-custom-arrow-prev">
+        left
+      </div>
+    );
+    const arrowNext = (props) => (
+      <div {...props} className="my-custom-arrow-next">
+        right
+      </div>
+    );
     const wrapper = mount(
-      <StreamGallery arrowPrev={arrowPrev} arrowNext={arrowNext}>
+      <StreamGallery arrowPrevAs={arrowPrev} arrowNextAs={arrowNext}>
         <div>slide 1</div>
         <div>slide 2</div>
         <div>slide 3</div>
@@ -51,8 +59,8 @@ describes.sandboxed('StreamGallery preact component', {}, () => {
     );
     const arrows = wrapper.find('Arrow');
     expect(arrows).to.have.lengthOf(2);
-    expect(arrows.first().props().customArrow).to.equal(arrowPrev);
-    expect(arrows.last().props().customArrow).to.equal(arrowNext);
+    expect(arrows.first().props().as).to.equal(arrowPrev);
+    expect(arrows.last().props().as).to.equal(arrowNext);
   });
 
   it('should not loop by default', () => {


### PR DESCRIPTION
This PR changes the `arrowPrev` and `arrowNext` props to be `arrowPrevAs` and `arrowNextAs`, such that a custom navigational button is given as `() => <button></button>` as opposed to plain `<button></button>`. This is inline with the Lightbox custom close button introduced in #33105.

Note that all AMP elements that integrate with these `as` props have an intermediary layer where the prop is defined via `updatePropsForRendering`. This can be removed once we have a generic soln in PreactBaseElement, which will be introduced in a follow up PR.

Partial for #28284