### PR TITLE
📖  Use `default-jdk` for `amp validator --update_tests` instead of `openjdk-7-jre`

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -59,7 +59,7 @@ around the edges. Below are instructions for Linux Ubuntu 14.
 Install these packages using apt-get:
 
 -   `npm`
--   `openjdk-7-jre`
+-   `default-jdk`
 -   `protobuf-compiler`
 -   `python3`
 -   `python3-pip`


### PR DESCRIPTION
Looks like `openjdk-7-jre` [has been removed since Ubuntu 16.04](https://unix.stackexchange.com/a/475657).  Using the `default-jdk` package seems to have worked for me; not sure if there's complete compatibility or not (and my understanding is that it's intended to continually change in the future, so I'm not sure if there's a better approach).
