### PR TITLE
✨ amp-script: allow 3p scripts without csp hash if sandboxed

### DIFF
--- a/3p/amp-script-proxy-iframe.js
+++ b/3p/amp-script-proxy-iframe.js
@@ -1,0 +1,59 @@
+/**
+ * See `worker-dom` for the iframe proxy contract.
+ */ 
+const MESSAGE_TYPES = {
+  ready: 'iframe-ready',
+  init: 'init-worker',
+  onmessage: 'onmessage',
+  onerror: 'onerror',
+  onmessageerror: 'onmessageerror',
+  postMessage: 'postMessage',
+};
+
+let parentOrigin = '*';
+
+function send(type, message) {
+  if (type !== MESSAGE_TYPES.ready && parentOrigin === '*') {
+    throw new Error('Broadcast banned except for iframe-ready message.');
+  }
+  parent.postMessage({type, message}, parentOrigin);
+}
+
+function listen(type, handler) {
+  window.addEventListener('message', (event) => {
+    if (event.source !== parent) {
+      return;
+    }
+    parentOrigin = event.origin;
+
+    if (event.data.type === type) {
+      handler(event.data);
+    }
+  });
+}
+
+// Send initialization.
+send(MESSAGE_TYPES.ready);
+
+let worker = null;
+// Listen for Worker Init.
+listen(MESSAGE_TYPES.init, ({code}) => {
+  if (worker) {
+    return;
+  }
+  worker = new Worker(URL.createObjectURL(new Blob([code])));
+
+  // Proxy messages Worker to parent Window.
+  worker.onmessage = (e) => send(MESSAGE_TYPES.onmessage, e.data);
+  worker.onmessageerror = (e) => send(MESSAGE_TYPES.onmessageerror, e.data);
+  worker.onerror = (e) =>
+    send(MESSAGE_TYPES.onerror, {
+      lineno: e.lineno,
+      colno: e.colno,
+      message: e.message,
+      filename: e.filename,
+    });
+
+  // Proxy message from parent Window to Worker.
+  listen(MESSAGE_TYPES.postMessage, ({message}) => worker.postMessage(message));
+});

--- a/3p/amp-script-proxy-iframe.js
+++ b/3p/amp-script-proxy-iframe.js
@@ -1,7 +1,27 @@
 /**
- * See `worker-dom` for the iframe proxy contract.
- */ 
-const MESSAGE_TYPES = {
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * See IframeWorker within `worker-dom` for the iframe proxy contract.
+ */
+
+/**
+ * @enum {string}
+ */
+const MESSAGE_TYPE = {
   ready: 'iframe-ready',
   init: 'init-worker',
   onmessage: 'onmessage',
@@ -12,13 +32,22 @@ const MESSAGE_TYPES = {
 
 let parentOrigin = '*';
 
+/**
+ * @param {MessageType} type
+ * @param {*} message
+ */
 function send(type, message) {
-  if (type !== MESSAGE_TYPES.ready && parentOrigin === '*') {
+  if (type !== MESSAGE_TYPE.ready && parentOrigin === '*') {
     throw new Error('Broadcast banned except for iframe-ready message.');
   }
-  parent.postMessage({type, message}, parentOrigin);
+  parent./*OK*/ postMessage({type, message}, parentOrigin);
 }
 
+/**
+ *
+ * @param {MessageType} type
+ * @param {*} handler
+ */
 function listen(type, handler) {
   window.addEventListener('message', (event) => {
     if (event.source !== parent) {
@@ -33,21 +62,21 @@ function listen(type, handler) {
 }
 
 // Send initialization.
-send(MESSAGE_TYPES.ready);
+send(MESSAGE_TYPE.ready);
 
 let worker = null;
 // Listen for Worker Init.
-listen(MESSAGE_TYPES.init, ({code}) => {
+listen(MESSAGE_TYPE.init, ({code}) => {
   if (worker) {
     return;
   }
   worker = new Worker(URL.createObjectURL(new Blob([code])));
 
   // Proxy messages Worker to parent Window.
-  worker.onmessage = (e) => send(MESSAGE_TYPES.onmessage, e.data);
-  worker.onmessageerror = (e) => send(MESSAGE_TYPES.onmessageerror, e.data);
+  worker.onmessage = (e) => send(MESSAGE_TYPE.onmessage, e.data);
+  worker.onmessageerror = (e) => send(MESSAGE_TYPE.onmessageerror, e.data);
   worker.onerror = (e) =>
-    send(MESSAGE_TYPES.onerror, {
+    send(MESSAGE_TYPE.onerror, {
       lineno: e.lineno,
       colno: e.colno,
       message: e.message,
@@ -55,5 +84,7 @@ listen(MESSAGE_TYPES.init, ({code}) => {
     });
 
   // Proxy message from parent Window to Worker.
-  listen(MESSAGE_TYPES.postMessage, ({message}) => worker.postMessage(message));
+  listen(MESSAGE_TYPE./*OK*/ postMessage, ({message}) =>
+    worker./*OK*/ postMessage(message)
+  );
 });

--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -88,6 +88,17 @@ exports.jsBundles = {
       includePolyfills: false,
     },
   },
+  'amp-script-proxy-iframe.js': {
+    srcDir: './3p/',
+    srcFilename: 'amp-script-proxy-iframe.js',
+    destDir: './dist.3p/current',
+    minifiedDestDir: './dist.3p/' + internalRuntimeVersion,
+    options: {
+      minifiedName: 'amp-script-proxy-iframe.js',
+      includePolyfills: false,
+      include3pDirectories: true,
+    },
+  },
   'iframe-transport-client-lib.js': {
     srcDir: './3p/',
     srcFilename: 'iframe-transport-client-lib.js',

--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -95,8 +95,8 @@ exports.jsBundles = {
     minifiedDestDir: './dist.3p/' + internalRuntimeVersion,
     options: {
       minifiedName: 'amp-script-proxy-iframe.js',
-      includePolyfills: false,
       include3pDirectories: true,
+      includePolyfills: false,
     },
   },
   'iframe-transport-client-lib.js': {

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -294,7 +294,7 @@ async function postBuildWebPushPublisherFilesVersion() {
       await fs.outputFile(`dist/v0/${fileName}.html`, minifiedHtml);
     }
   }
-} 
+}
 
 /**
  * Precompilation steps required to build experiment js binaries.

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -294,7 +294,7 @@ async function postBuildWebPushPublisherFilesVersion() {
       await fs.outputFile(`dist/v0/${fileName}.html`, minifiedHtml);
     }
   }
-}
+} 
 
 /**
  * Precompilation steps required to build experiment js binaries.

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -686,10 +686,22 @@ async function buildExtensionJs(extDir, name, version, latestVersion, options) {
     copyWorkerDomResources(version);
 
     // Create the proxy iframe for sandboxed worker.
-    await doBuildJs(jsBundles, 'amp-script-proxy-iframe.js', options);
-    const proxyScript = await fs.readFile('dist.3p/amp-script-proxy-iframe.js');
+    await doBuildJs(jsBundles, 'amp-script-proxy-iframe.js', {});
+    const dist3pDir = path.join(
+      __dirname,
+      '..',
+      '..',
+      'dist.3p',
+      `current${options.minified ? '-min' : ''}`
+    );
+    const proxyScript = await fs.readFile(
+      path.join(dist3pDir, 'amp-script-proxy-iframe.js')
+    );
     const proxyIframe = `<html><script>${proxyScript}</script></html>`;
-    await fs.outputFile('dist.3p/amp-script-proxy-iframe.html', proxyIframe);
+    await fs.outputFile(
+      path.join(dist3pDir, 'amp-script-proxy-iframe.html'),
+      proxyIframe
+    );
   }
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -701,8 +701,9 @@ async function buildSandboxedProxyIframe(minify) {
     'dist.3p',
     minify ? `${internalRuntimeVersion}` : 'current'
   );
+  const fileExt = argv.esm ? '.mjs' : '.js';
   const proxyScript = await fs.readFile(
-    path.join(dist3pDir, 'amp-script-proxy-iframe.js')
+    path.join(dist3pDir, 'amp-script-proxy-iframe' + fileExt)
   );
   const proxyIframe = `<html><script>${proxyScript}</script></html>`;
   await fs.outputFile(

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -684,6 +684,12 @@ async function buildExtensionJs(extDir, name, version, latestVersion, options) {
 
   if (name === 'amp-script') {
     copyWorkerDomResources(version);
+
+    // Create the proxy iframe for sandboxed worker.
+    await doBuildJs(jsBundles, 'amp-script-proxy-iframe.js', options);
+    const proxyScript = await fs.readFile('dist.3p/amp-script-proxy-iframe.js');
+    const proxyIframe = `<html><script>${proxyScript}</script></html>`;
+    await fs.outputFile('dist.3p/amp-script-proxy-iframe.html', proxyIframe);
   }
 }
 

--- a/examples/amp-script/example.sandboxed.amp.html
+++ b/examples/amp-script/example.sandboxed.amp.html
@@ -6,7 +6,6 @@
   <meta name="viewport" content="width=device-width,minimum-scale=1">
   <!-- Token for "amp-script" experiment on "http://localhost:8000" that expires on 1/1/2030. -->
   <meta name="amp-experiment-token" content="AAAAAFd7Im9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMCIsImV4cGVyaW1lbnQiOiJhbXAtc2NyaXB0IiwiZXhwaXJhdGlvbiI6MTg5NjEzNDQwMDAwMH08Wb1WA4ZcsTLNK1pxwXdmfYUlv4ybtfIMw3yS66dZhsJl11JYrTanag4ZlAr4sfBRTVmQfKLsiJq/JJHdrpRzT9M6EQD/JYos1SlohtQiK2YfhvXgN7zot3WBuFkqoxSiyvX/l23UYKSo2ebNTnMDFhI+yrX8uc9BblbYniRtQGXBPktjJUIgavEBS5t45bgbPNutNvAreYGlz7na4lImrpnNa8K28Ow4hqOxcqqdFoHD9hlwtKlpydJQpEmtM+S+jdDLKWq6JtC+HoUSovuitrqkioJ4cfuVkFqtoaKWPLXSOwoc5UJl3zNjlTjvQ/Gnk33NdWs6/FtZbxCq+lWe">
-  <!-- CSP-like hashes for amp-script [src] or inline scripts. -->
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <style amp-custom>
     h1 {
@@ -27,6 +26,7 @@
 </head>
 <body>
   <h1>Example: Demo</h1>
+  <!-- Note: sandboxed amp-script do not require CSP hashes. -->
   <amp-script sandboxed layout=container src="/examples/amp-script/amp-script-demo.js">
     <button id="hello">Insert Hello World!</button>
   </amp-script> 

--- a/examples/amp-script/example.sandboxed.amp.html
+++ b/examples/amp-script/example.sandboxed.amp.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="self.html" />
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <!-- Token for "amp-script" experiment on "http://localhost:8000" that expires on 1/1/2030. -->
+  <meta name="amp-experiment-token" content="AAAAAFd7Im9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODAwMCIsImV4cGVyaW1lbnQiOiJhbXAtc2NyaXB0IiwiZXhwaXJhdGlvbiI6MTg5NjEzNDQwMDAwMH08Wb1WA4ZcsTLNK1pxwXdmfYUlv4ybtfIMw3yS66dZhsJl11JYrTanag4ZlAr4sfBRTVmQfKLsiJq/JJHdrpRzT9M6EQD/JYos1SlohtQiK2YfhvXgN7zot3WBuFkqoxSiyvX/l23UYKSo2ebNTnMDFhI+yrX8uc9BblbYniRtQGXBPktjJUIgavEBS5t45bgbPNutNvAreYGlz7na4lImrpnNa8K28Ow4hqOxcqqdFoHD9hlwtKlpydJQpEmtM+S+jdDLKWq6JtC+HoUSovuitrqkioJ4cfuVkFqtoaKWPLXSOwoc5UJl3zNjlTjvQ/Gnk33NdWs6/FtZbxCq+lWe">
+  <!-- CSP-like hashes for amp-script [src] or inline scripts. -->
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    h1 {
+      font-size: 1.2em;
+    }
+    button, input {
+      border: solid 1px black;
+    }
+    amp-script {
+      border: dotted 1px orangered;
+      margin: 5px;
+      padding: 5px;
+    }
+  </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>
+  <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+</head>
+<body>
+  <h1>Example: Demo</h1>
+  <amp-script sandboxed layout=container src="/examples/amp-script/amp-script-demo.js">
+    <button id="hello">Insert Hello World!</button>
+  </amp-script> 
+</body>
+</html>

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -282,6 +282,15 @@ export class AmpScript extends AMP.BaseElement {
 
     const sandbox = this.element.getAttribute('sandbox') || '';
     const sandboxTokens = sandbox.split(' ').map((s) => s.trim());
+    let iframeUrl;
+    if (getMode().localDev) {
+      const folder = getMode().minified ? 'current-min' : 'current';
+      iframeUrl = `/dist.3p/${folder}/amp-script-proxy-iframe.html`;
+    } else {
+      iframeUrl = `${urls.thirdParty}${
+        getMode().rtvVersion
+      }/amp-script-proxy-iframe.html`;
+    }
 
     // @see src/main-thread/configuration.WorkerDOMConfiguration in worker-dom.
     const config = {
@@ -302,13 +311,7 @@ export class AmpScript extends AMP.BaseElement {
       onReceiveMessage: (data) => {
         dev().info(TAG, 'From worker:', data);
       },
-      sandbox: this.sandboxed_ && {
-        iframeUrl: getMode().localDev
-          ? '/dist.3p/current/amp-script-proxy-iframe.html'
-          : `${urls.thirdParty}${
-              getMode().rtvVersion
-            }/amp-script-proxy-iframe.html`,
-      },
+      sandbox: this.sandboxed_ && {iframeUrl},
     };
 
     // Create worker and hydrate.

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -387,7 +387,7 @@ export class AmpScript extends AMP.BaseElement {
           id
         );
         const text = local.textContent;
-        if (this.development_) {
+        if (this.development_ || this.sandboxed_) {
           return Promise.resolve(text);
         } else {
           return this.service_.checkSha384(text, debugId).then(() => text);

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -287,8 +287,8 @@ export class AmpScript extends AMP.BaseElement {
       const folder = getMode().minified ? 'current-min' : 'current';
       iframeUrl = `/dist.3p/${folder}/amp-script-proxy-iframe.html`;
     } else {
-      iframeUrl = `${urls.thirdParty}${
-        getMode().rtvVersion
+      iframeUrl = `${urls.thirdParty}/${
+        getMode().version
       }/amp-script-proxy-iframe.html`;
     }
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -30,6 +30,7 @@ import {getMode} from '../../../src/mode';
 import {getService, registerServiceBuilder} from '../../../src/service';
 import {rewriteAttributeValue} from '../../../src/url-rewrite';
 import {tryParseJson} from '../../../src/json';
+import {urls} from '../../../src/config';
 import {utf8Encode} from '../../../src/utils/bytes';
 
 /** @const {string} */
@@ -304,7 +305,7 @@ export class AmpScript extends AMP.BaseElement {
       sandbox: this.sandboxed_ && {
         iframeUrl: getMode().localDev
           ? '/dist.3p/current/amp-script-proxy-iframe.html'
-          : `https://3p.ampproject.net/${
+          : `${urls.thirdParty}${
               getMode().rtvVersion
             }/amp-script-proxy-iframe.html`,
       },

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -302,8 +302,11 @@ export class AmpScript extends AMP.BaseElement {
         dev().info(TAG, 'From worker:', data);
       },
       sandbox: this.sandboxed_ && {
-        // QQQQ: Must get the correct RTVed version of this HTML.
-        iframeUrl: 'cdn.ampproject.net/TODO/amp-script-proxy-iframe.html',
+        iframeUrl: getMode().localDev
+          ? '/dist.3p/current/amp-script-proxy-iframe.html'
+          : `https://3p.ampproject.net/${
+              getMode().rtvVersion
+            }/amp-script-proxy-iframe.html`,
       },
     };
 

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -120,6 +120,15 @@ export class AmpScript extends AMP.BaseElement {
      * @private {boolean}
      */
     this.nodom_ = false;
+
+    /**
+     * If true, signals that worker-dom should activate sandboxed mode.
+     * In this mode the Worker lives in its own crossorigin iframe, creating
+     * a strong security boundary.
+     *
+     * @private {boolean}
+     */
+    this.sandboxed_ = false;
   }
 
   /** @override */
@@ -130,6 +139,7 @@ export class AmpScript extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.nodom_ = this.element.hasAttribute('nodom');
+    this.sandboxed_ = this.element.hasAttribute('sandboxed');
     this.development_ =
       this.element.hasAttribute('data-ampdevmode') ||
       this.element.ownerDocument.documentElement.hasAttribute(
@@ -290,6 +300,10 @@ export class AmpScript extends AMP.BaseElement {
       },
       onReceiveMessage: (data) => {
         dev().info(TAG, 'From worker:', data);
+      },
+      sandbox: this.sandboxed_ && {
+        // QQQQ: Must get the correct RTVed version of this HTML.
+        iframeUrl: 'cdn.ampproject.net/TODO/amp-script-proxy-iframe.html',
       },
     };
 

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -184,6 +184,46 @@ describe
     );
 
     describes.integration(
+      'sandboxed',
+      {
+        body: `
+      <amp-script sandboxed src="/examples/amp-script/amp-script-demo.js">
+        <button id="hello">Insert Hello World!</button>
+        <button id="long">Long task</button>
+      </amp-script>
+    `,
+        extensions: ['amp-script'],
+      },
+      (env) => {
+        beforeEach(() => {
+          browser = new BrowserController(env.win);
+          doc = env.win.document;
+          element = doc.querySelector('amp-script');
+        });
+
+        it('should say "hello world"', function* () {
+          yield poll('<amp-script> to be hydrated', () =>
+            element.classList.contains('i-amphtml-hydrated')
+          );
+          const impl = yield element.getImpl();
+
+          // Give event listeners in hydration a moment to attach.
+          yield browser.wait(100);
+
+          env.sandbox
+            .stub(impl.getUserActivation(), 'isActive')
+            .callsFake(() => true);
+          browser.click('button#hello');
+
+          yield poll('mutations applied', () => {
+            const h1 = doc.querySelector('h1');
+            return h1 && h1.textContent == 'Hello World!';
+          });
+        });
+      }
+    );
+
+    describes.integration(
       'defined-layout',
       {
         body: `

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -198,11 +198,9 @@ tags: {  # <amp-script>
       also_requires_attr: "script"
     }
   }
-  attrs: {
-    name: "nodom"
-    value: ""
-  }
+  attrs: { name: "nodom" }
   attrs: { name: "sandbox" }
+  attrs: { name: "sandboxed" }
   attrs: {
     name: "script"
     mandatory_oneof: "['script', 'src']"

--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -198,9 +198,15 @@ tags: {  # <amp-script>
       also_requires_attr: "script"
     }
   }
-  attrs: { name: "nodom" }
+  attrs: { 
+    name: "nodom" 
+    value: ""
+  }
+  attrs: { 
+    name: "sandboxed" 
+    value: ""
+  }
   attrs: { name: "sandbox" }
-  attrs: { name: "sandboxed" }
   attrs: {
     name: "script"
     mandatory_oneof: "['script', 'src']"


### PR DESCRIPTION
**summary**
Fixes: https://github.com/ampproject/amphtml/issues/30193. The relevant `worker-dom` changes are here: https://github.com/ampproject/worker-dom/pull/1042.

- Creates a new binary in `dist.3p` called `amp-script-proxy-iframe.js`
- Creates the `sandboxed` attribute for `<amp-script>` and allows it in the validator. When present, csp is ignored.
- 🍝  integration test