### PR TITLE
🐛 Fix "story-ad-click" trigger.

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-shared.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-shared.css
@@ -22,6 +22,4 @@
   display: flex !important;
   flex-direction: column !important;
   align-items: center !important;
-  height: 100% !important;
-  width: 100% !important;
 }

--- a/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
@@ -249,6 +249,7 @@ export function createCta(doc, buttonFitter, container, uiMetadata) {
       'div',
       dict({
         'class': 'i-amphtml-story-ad-link-root',
+        'role': 'button',
       })
     );
 

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-page.js
@@ -550,6 +550,8 @@ describes.realWin('story-ad-page', {amp: true}, (env) => {
       cta.target = '_self';
       cta.click();
 
+      // In real world the shadow host element will be the click target.
+      expect(cta.parentElement.getAttribute('role')).to.equal('button');
       await macroTask();
       expect(fireEventStub).to.be.calledWithExactly(
         pageElement,


### PR DESCRIPTION
This regression was introduced when I moved the button into shadow DOM. When a listener is fired in the parent dom, the `event.target` will be the shadow host, not the actual element. This causes amp-story to swallow the click, as it thinks it should be a page navigation.

Setting the `role="button"` on the shadow host tells the amp-story to let the click flow through. Also resizes the host so that actual navigation clicks will navigate.