### PR TITLE
amp-script: fix long task start/end order for within the same macrotask

### DIFF
--- a/extensions/amp-script/0.1/user-activation-tracker.js
+++ b/extensions/amp-script/0.1/user-activation-tracker.js
@@ -100,13 +100,13 @@ export class UserActivationTracker {
       return;
     }
     this.inLongTask_ = true;
-    promise
-      .catch(() => {})
-      .then(() => {
-        this.inLongTask_ = false;
-        // Add additional "activity window" after a long task is done.
-        this.lastActivationTime_ = Date.now();
-      });
+
+    const longTaskComplete = () => {
+      this.inLongTask_ = false;
+      // Add additional "activity window" after a long task is done.
+      this.lastActivationTime_ = Date.now();
+    };
+    promise.then(longTaskComplete, longTaskComplete);
   }
 
   /**

--- a/extensions/amp-script/0.1/user-activation-tracker.js
+++ b/extensions/amp-script/0.1/user-activation-tracker.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {devAssert} from '../../../src/log';
+
 export const ACTIVATION_TIMEOUT = 5000; // 5 seconds.
 
 const ACTIVATION_EVENTS = [
@@ -99,6 +101,10 @@ export class UserActivationTracker {
     if (!this.isActive()) {
       return;
     }
+    devAssert(
+      !this.inLongTask_,
+      'Should not expand while a longTask is already ongoing.'
+    );
     this.inLongTask_ = true;
 
     const longTaskComplete = () => {


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amp.dev/issues/4879, https://github.com/ampproject/amphtml/issues/30548

The activity tracker relies on careful ordering of `longTask` events. We need it to be a sequence of START --> END --> START --> END.

The `.catch` call ended up delaying the `LONG_TASK_END` event by an extra microtask, which was just enough to make it occur after a 2nd start event.

**before**
<img width="839" alt="Screen Shot 2021-04-06 at 12 16 46 PM" src="https://user-images.githubusercontent.com/4656974/113746010-d4f4a200-96d3-11eb-8515-edc1738d31bc.png">

**after**
<img width="842" alt="Screen Shot 2021-04-06 at 12 17 37 PM" src="https://user-images.githubusercontent.com/4656974/113746043-df16a080-96d3-11eb-9f94-6d72bb8cec40.png">

**note**: a more robust but larger fix would either be: (a) start/end counter (so order doesn't matter), or (b) the `longTask` fn gets called with a "type" for start/end (avoids promises)