### PR TITLE
🏗 Run the `bundle-size` check on pure production code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
       - fail_fast
   'Bundle Size':
     executor:
-      name: amphtml-medium-executor
+      name: amphtml-xlarge-executor
     steps:
       - setup_vm
       - run:
@@ -277,8 +277,7 @@ workflows:
       - 'Bundle Size':
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build'
-            - 'Module Build'
+            - 'Compute Merge Commit'
       - 'Validator Tests':
           <<: *push_and_pr_builds
           requires:

--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -19,34 +19,26 @@
  * @fileoverview Script that runs the bundle-size checks during CI.
  */
 
-const {
-  downloadModuleOutput,
-  downloadNomoduleOutput,
-  printSkipMessage,
-  timedExecOrDie,
-} = require('./utils');
 const {buildTargetsInclude, Targets} = require('./build-targets');
+const {printSkipMessage, timedExecOrDie} = require('./utils');
 const {runCiJob} = require('./ci-job');
 
 const jobName = 'bundle-size.js';
 
 function pushBuildWorkflow() {
-  downloadNomoduleOutput();
-  downloadModuleOutput();
+  timedExecOrDie('amp dist --noconfig --esm');
+  timedExecOrDie('amp dist --noconfig');
   timedExecOrDie('amp bundle-size --on_push_build');
 }
 
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME)) {
-    downloadNomoduleOutput();
-    downloadModuleOutput();
+    timedExecOrDie('amp dist --noconfig --esm');
+    timedExecOrDie('amp dist --noconfig');
     timedExecOrDie('amp bundle-size --on_pr_build');
   } else {
     timedExecOrDie('amp bundle-size --on_skipped_build');
-    printSkipMessage(
-      jobName,
-      'this PR does not affect the runtime or flag configs'
-    );
+    printSkipMessage(jobName, 'this PR does not affect the runtime');
   }
 }
 


### PR DESCRIPTION
With this, we should no longer have any size fluctuations due to code that would have normally been DCE'd in production builds.

**Notes:**
- The `Bundle Size` job now does its own builds (using an XLarge VM), and doesn't wait for test binaries to be built
- Total CI round trip time remains unchanged (because there are other longer-running jobs)
- The bundle-size [check run](https://github.com/ampproject/amphtml/pull/33659/checks?check_run_id=2281134449) shows a small decrease (because we're no longer counting DCE-able code)

Fixes #33657
Fixes #33658
