### PR TITLE
🐛 [amp-carousel 0.1] Stop jittery slides on scroll

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.css
+++ b/extensions/amp-carousel/0.1/amp-carousel.css
@@ -199,11 +199,11 @@ amp-carousel[i-amphtml-carousel-hide-buttons] .amp-carousel-button-next {
 }
 
 .i-amphtml-slidescroll-no-snap.i-amphtml-slides-container {
-  scroll-snap-type: none !important;
+  scroll-snap-type: none;
 }
 
 .i-amphtml-slidescroll-no-snap .i-amphtml-slide-item {
-  scroll-snap-align: none !important;
+  scroll-snap-align: none;
 }
 
 .i-amphtml-slidescroll-no-snap.i-amphtml-slides-container.i-amphtml-no-scroll {

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -1364,6 +1364,44 @@ describes.realWin(
       });
     });
 
+    describe('Snap Styling', () => {
+      let platform;
+
+      beforeEach(() => {
+        platform = Services.platformFor(win);
+      });
+
+      it('shoud add disabled CSS snap class for iOS 10.3', async () => {
+        env.sandbox.stub(platform, 'isIos').returns(true);
+        env.sandbox.stub(platform, 'getIosVersionString').returns('10.3');
+        const el = await getAmpSlideScroll(false, 3);
+        const slidesContainer = el.querySelector('.i-amphtml-slides-container');
+        expect(
+          slidesContainer.classList.contains('i-amphtml-slidescroll-no-snap')
+        ).to.be.true;
+      });
+
+      it('shoud not contain disabled snap class for non iOS 10.3', async () => {
+        env.sandbox.stub(platform, 'isIos').returns(true);
+        env.sandbox.stub(platform, 'getIosVersionString').returns('10.4');
+        const el = await getAmpSlideScroll(false, 3);
+        const slidesContainer = el.querySelector('.i-amphtml-slides-container');
+        expect(
+          slidesContainer.classList.contains('i-amphtml-slidescroll-no-snap')
+        ).to.be.false;
+      });
+
+      it('shoud add disabled CSS snap class for for non iOS', async () => {
+        env.sandbox.stub(platform, 'isIos').returns(false);
+        env.sandbox.stub(platform, 'getIosVersionString').returns('10.4');
+        const el = await getAmpSlideScroll(false, 3);
+        const slidesContainer = el.querySelector('.i-amphtml-slides-container');
+        expect(
+          slidesContainer.classList.contains('i-amphtml-slidescroll-no-snap')
+        ).to.be.true;
+      });
+    });
+
     describe('button titles', () => {
       function getNextTitle(el) {
         return el


### PR DESCRIPTION
Closes #33540

Seems like before the scroll snapping was still being applied even though it shouldn't have been. Strange bug with `!important` in Safari. 

Before:

https://user-images.githubusercontent.com/30711678/113770415-f440fe80-96d6-11eb-8e2b-0611c8786b72.mov


After: 

https://user-images.githubusercontent.com/30711678/113770353-e3908880-96d6-11eb-8546-92d2125a1969.mov
