### PR TITLE
🚮 Remove server logic for amp-story 0.1

### DIFF
--- a/build-system/server/app-utils.js
+++ b/build-system/server/app-utils.js
@@ -85,19 +85,11 @@ const isRtvMode = (serveMode) => {
  * @param {string} file
  * @param {string=} hostName
  * @param {boolean=} inabox
- * @param {boolean=} storyV1
  * @return {string}
  */
-const replaceUrls = (mode, file, hostName, inabox, storyV1) => {
+const replaceUrls = (mode, file, hostName, inabox) => {
   hostName = hostName || '';
   if (mode == 'default') {
-    // TODO:(ccordry) remove this when story 0.1 is deprecated
-    if (storyV1) {
-      file = file.replace(
-        /https:\/\/cdn\.ampproject\.org\/v0\/amp-story-0\.1\.js/g,
-        hostName + '/dist/v0/amp-story-1.0.max.js'
-      );
-    }
     file = file.replace(
       /https:\/\/cdn\.ampproject\.org\/v0\.js/g,
       hostName + '/dist/amp.js'

--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -522,8 +522,6 @@ function proxyToAmpProxy(req, res, mode) {
       // <base> href pointing to the proxy, so that images, etc. still work.
       .replace('<head>', '<head><base href="https://cdn.ampproject.org/">');
     const inabox = req.query['inabox'];
-    // TODO(ccordry): Remove this when story v01 is depricated.
-    const storyV1 = req.query['story_v'] === '1';
     const urlPrefix = getUrlPrefix(req);
     if (req.query['mraid']) {
       body = body
@@ -546,7 +544,7 @@ function proxyToAmpProxy(req, res, mode) {
             ' </script>'
         );
     }
-    body = replaceUrls(mode, body, urlPrefix, inabox, storyV1);
+    body = replaceUrls(mode, body, urlPrefix, inabox);
     if (inabox) {
       // Allow CORS requests for A4A.
       const origin = req.headers.origin || urlPrefix;

--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -59,14 +59,7 @@ async function replace(filePath) {
   const data = await fs.readFile(filePath, 'utf8');
   const hostName = getBaseUrl();
   const inabox = false;
-  const storyV1 = true;
-  const result = replaceUrlsAppUtil(
-    'compiled',
-    data,
-    hostName,
-    inabox,
-    storyV1
-  );
+  const result = replaceUrlsAppUtil('compiled', data, hostName, inabox);
 
   await fs.writeFile(filePath, result, 'utf8');
 }

--- a/test/manual/video-caching.amp.html
+++ b/test/manual/video-caching.amp.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story"
-        src="https://cdn.ampproject.org/v0/amp-story-0.1.js"></script>
+        src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
     <script async custom-element="amp-video"
         src="https://cdn.ampproject.org/v0/amp-video-0.1.js"></script>
     <title>Hello, amp-story</title>


### PR DESCRIPTION
The local server contains logic to replace references to `amp-story-0.1.js` to `-1.0.js`. This removes that logic since `0.1` is no longer shipped.

I've confirmed that this repository no longer references `amp-story-0.1.js` and that it does not use the `story_v` query parameter referenced in a changed server route.
