### PR TITLE
[bento][amp-accordion] Accordion storybook issue

### DIFF
--- a/extensions/amp-accordion/1.0/storybook/Bind.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Bind.amp.js
@@ -49,7 +49,7 @@ export const withAmpBind = () => {
           <h2>Section 2</h2>
           <div>Kittens are furry.</div>
         </section>
-        <section expanded data-amp-bind-expanded="section3">
+        <section data-amp-bind-expanded="section3">
           <h2>Section 3</h2>
           <div>Elephants have great memory.</div>
         </section>


### PR DESCRIPTION
Apparently the accordion does not like having the `expanded` attribute when `amp-bind` is used

This issue seems to be isolated to Storybook.  Tried it out on a test page and the issue does not occur

Issue for tracking storybook: https://github.com/ampproject/amphtml/issues/33679