### PR TITLE
🏗 Extract `PERCY_TOKEN` before skipping the check

### DIFF
--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -19,6 +19,7 @@
  * @fileoverview Script that builds the nomodule AMP runtime during CI.
  */
 
+const atob = require('atob');
 const {
   abortTimedJob,
   skipDependentJobs,
@@ -72,6 +73,7 @@ async function prBuildWorkflow() {
     // Special case for visual diffs - Percy is a required check and must pass,
     // but we just called `skipDependentJobs` so the Visual Diffs job will not
     // run. Instead, we create an empty, passing check on Percy here.
+    process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
     timedExecOrDie('amp visual-diff --empty');
 
     skipDependentJobs(


### PR DESCRIPTION
Without this, the check cannot be skipped. See https://app.circleci.com/pipelines/github/ampproject/amphtml/6229/workflows/0d129b3f-f949-42df-bb67-e2ec2dbdbc69/jobs/88512/parallel-runs/0/steps/0-111

Addresses https://github.com/ampproject/amphtml/pull/33620#discussion_r608918755
