### PR TITLE
🏗 Use unique filenames to signal graceful halt of CircleCI Jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
           at: /tmp
       - run:
           name: 'Maybe Gracefully Halt'
-          command: if [[ -f "/tmp/workspace/.CI_GRACEFULLY_HALT_*" ]]; then echo "Gracefully halting this job."; circleci-agent step halt; fi
+          command: if ls .CI_GRACEFULLY_HALT_* 1>/dev/null 2>&1; then echo "Gracefully halting this job."; circleci-agent step halt; fi
   setup_vm:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ commands:
           at: /tmp
       - run:
           name: 'Maybe Gracefully Halt'
-          command: if [[ -f "/tmp/workspace/.CI_GRACEFULLY_HALT" ]]; then echo "Gracefully halting this job."; circleci-agent step halt; fi
+          command: if [[ -f "/tmp/workspace/.CI_GRACEFULLY_HALT_*" ]]; then echo "Gracefully halting this job."; circleci-agent step halt; fi
   setup_vm:
     steps:
       - run:

--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -206,6 +206,15 @@ function circleciPrMergeCommit() {
 }
 
 /**
+ * Returns an identifier that is unique to each CircleCI job. This is different
+ * from the workflow ID, which is common across all jobs in a workflow.
+ * @return {string}
+ */
+function circleciBuildNumber() {
+  return isCircleci ? env('CIRCLE_BUILD_NUM') : '';
+}
+
+/**
  * Returns the repo slug for the ongoing build.
  * @return {string}
  */
@@ -235,6 +244,7 @@ module.exports = {
   ciPullRequestBranch,
   ciPullRequestSha,
   ciPushBranch,
+  circleciBuildNumber,
   circleciPrMergeCommit,
   ciRepoSlug,
   isCiBuild,

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 const {
   ciBuildSha,
   ciPullRequestSha,
+  circleciBuildNumber,
   isCiBuild,
   isCircleciBuild,
 } = require('../common/ci');
@@ -110,13 +111,20 @@ function printChangeSummary() {
 }
 
 /**
- * Signal to dependent jobs that they should be skipped.
+ * Signal to dependent jobs that they should be skipped. Uses an identifier that
+ * corresponds to the current job to eliminate conflicts if a parallel job also
+ * signals the same thing.
  *
  * Currently only relevant for CircleCI builds.
  */
 function signalGracefulHalt() {
   if (isCircleciBuild()) {
-    fs.closeSync(fs.openSync('/tmp/workspace/.CI_GRACEFULLY_HALT', 'w'));
+    fs.closeSync(
+      fs.openSync(
+        `/tmp/workspace/.CI_GRACEFULLY_HALT_${circleciBuildNumber()}`,
+        'w'
+      )
+    );
   }
 }
 


### PR DESCRIPTION
This prevents a conflict when more than one parallel job signals a graceful halt. For example, [here](https://app.circleci.com/pipelines/github/ampproject/amphtml/6244/workflows/5ddec186-f3d0-47da-9f0f-0decdadd4443/jobs/88781/parallel-runs/0/steps/0-101).

