### PR TITLE
🏗 Update AMP's CI config to work on the `main` branch

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -25,14 +25,14 @@ RED() { echo -e "\n\033[0;31m$1\033[0m"; }
 YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-# Push builds are only run against master and amp-release branches.
-if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+# Push builds are only run against the main branch and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "main" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
   echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
   exit 0
 fi
 
 # Check if the PR branch contains the most recent revision the CircleCI config.
-CONFIG_REV=`git rev-list master -1 -- .circleci/config.yml`
+CONFIG_REV=`git rev-list main -1 -- .circleci/config.yml`
 (set -x && git merge-base --is-ancestor $CONFIG_REV $CIRCLE_SHA1) || err=$?
 
 if [[ "$err" -ne "0" ]]; then
@@ -46,23 +46,23 @@ if [[ "$err" -ne "0" ]]; then
   echo "   ⤷ It can be found towards the bottom of the PR, after the list of checks."
   echo -e "\n"
 
-  echo "2. Pull the latest commits from $(CYAN "master") and re-push the PR branch."
+  echo "2. Pull the latest commits from $(CYAN "main") and re-push the PR branch."
   echo "   ⤷ Follow these steps:"
   echo ""
-  echo "      $(CYAN "git checkout master")"
+  echo "      $(CYAN "git checkout main")"
   echo "      $(CYAN "git pull")"
   echo "      $(CYAN "git checkout <PR branch>")"
-  echo "      $(CYAN "git merge master")"
+  echo "      $(CYAN "git merge main")"
   echo "      $(CYAN "git push origin")"
   echo -e "\n"
 
-  echo "3. Rebase on $(CYAN "master") and re-push the PR branch."
+  echo "3. Rebase on $(CYAN "main") and re-push the PR branch."
   echo "   ⤷ Follow these steps:"
   echo ""
-  echo "      $(CYAN "git checkout master")"
+  echo "      $(CYAN "git checkout main")"
   echo "      $(CYAN "git pull")"
   echo "      $(CYAN "git checkout <PR branch>")"
-  echo "      $(CYAN "git rebase master")"
+  echo "      $(CYAN "git rebase main")"
   echo "      $(CYAN "git push origin --force")"
   echo -e "\n"
   exit 1

--- a/.circleci/compute_merge_commit.sh
+++ b/.circleci/compute_merge_commit.sh
@@ -23,7 +23,7 @@ err=0
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
 
 # Try to determine the PR number.
-curl -sS https://raw.githubusercontent.com/ampproject/amphtml/master/.circleci/get_pr_number.sh | bash
+curl -sS https://raw.githubusercontent.com/ampproject/amphtml/main/.circleci/get_pr_number.sh | bash
 if [[ -f "$BASH_ENV" ]]; then
   source $BASH_ENV
 fi
@@ -34,8 +34,8 @@ if [[ -z "$PR_NUMBER" ]]; then
 fi
 
 # GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for
-# every PR branch that can be cleanly merged to master. For more details, see:
-# https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662
+# every PR branch that can be cleanly merged to the main branch. For more
+# details, see: https://discuss.circleci.com/t/show-test-results-for-prospective-merge-of-a-github-pr/1662
 MERGE_BRANCH="refs/pull/$PR_NUMBER/merge"
 echo $(GREEN "Computing merge SHA of $MERGE_BRANCH...")
 CIRCLE_MERGE_SHA="$(git ls-remote https://github.com/ampproject/amphtml.git "$MERGE_BRANCH" | awk '{print $1}')"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ push_builds_only: &push_builds_only
   filters:
     branches:
       only:
-        - master
+        - main
         - /^amp-release-.*$/
 
 executors:
@@ -100,7 +100,7 @@ jobs:
     steps:
       - run:
           name: 'Compute Merge Commit'
-          command: curl -sS https://raw.githubusercontent.com/ampproject/amphtml/master/.circleci/compute_merge_commit.sh | bash
+          command: curl -sS https://raw.githubusercontent.com/ampproject/amphtml/main/.circleci/compute_merge_commit.sh | bash
       - save_merge_commit
   'Checks':
     executor:

--- a/.circleci/fail_fast.sh
+++ b/.circleci/fail_fast.sh
@@ -25,7 +25,7 @@ YELLOW() { echo -e "\n\033[0;33m$1\033[0m"; }
 # For push builds, continue in spite of failures so that other jobs like
 # bundle-size and visual-diff can establish their baselines for this commit.
 # Without this, our custom bots will not be able to function correctly.
-if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+if [[ "$CIRCLE_BRANCH" == "main" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
   echo $(YELLOW "Not canceling build in spite of failures because $CIRCLE_BRANCH is not a PR branch.")
   exit 0
 fi

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the license.
 
-# This script fetches the merge commit of a PR branch with master to make sure
-# PRs are tested against all the latest changes on CircleCI.
+# This script fetches the merge commit of a PR branch with the main branch to
+# make sure PRs are tested against all the latest changes on CircleCI.
 
 set -e
 err=0
@@ -51,9 +51,9 @@ echo $(GREEN "Fetching merge commit $CIRCLECI_MERGE_COMMIT...")
 # If a clean merge is not possible, do not proceed with the build. GitHub's UI
 # will show an error indicating there was a merge conflict.
 if [[ "$err" -ne "0" ]]; then
-  echo $(RED "Detected a merge conflict between $CIRCLE_BRANCH and master.")
+  echo $(RED "Detected a merge conflict between $CIRCLE_BRANCH and the main branch.")
   echo $(RED "Please rebase your PR branch.")
   exit $err
 fi
 
-echo $(GREEN "Successfully fetched merge commit of $CIRCLE_BRANCH with master.")
+echo $(GREEN "Successfully fetched merge commit of $CIRCLE_BRANCH with the main branch.")

--- a/.circleci/get_pr_number.sh
+++ b/.circleci/get_pr_number.sh
@@ -23,8 +23,8 @@ err=0
 GREEN() { echo -e "\n\033[0;32m$1\033[0m"; }
 YELLOW() { echo -e "\n\033[0;33m$1\033[0m"; }
 
-# Push builds are only run against master and amp-release branches.
-if [[ "$CIRCLE_BRANCH" == "master" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+# Push builds are only run against the main branch and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "main" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
   echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
   # Warn if the build is linked to a PR on a different repo (known CircleCI bug).
   if [[ -n "$CIRCLE_PULL_REQUEST" && ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then

--- a/.github/workflows/create-design-review-issue.yml
+++ b/.github/workflows/create-design-review-issue.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - name: Create Design Review Issue
         run: |
-          wget -q -O - "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/master/.github/workflows/create-design-review-issue.js" | node
+          wget -q -O - "https://raw.githubusercontent.com/ampproject/amphtml/main/.github/workflows/create-design-review-issue.js" | node
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -2,10 +2,10 @@ name: GitHub Actions
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -16,7 +16,7 @@
     "<details>",
     "<summary>How to resolve breaking changes</summary>",
     "This PR may introduce breaking changes that require manual intervention. In such cases, you will need to check out this branch, fix the cause of the breakage, and commit the fix to ensure a green CI build. To check out and update this PR, follow the steps below:",
-    "```sh\n# Check out the PR branch (these steps are from GitHub)\ngit checkout -b renovate-bot-{{{branchName}}} master\ngit pull https://github.com/renovate-bot/amphtml.git {{{branchName}}}\n\n# Directly make fixes and commit them\namp lint --fix # For lint errors in JS files\namp prettify --fix # For prettier errors in non-JS files\n# Edit source code in case of new compiler warnings / errors\n\n# Push the changes to the branch\ngit push git@github.com:renovate-bot/amphtml.git renovate-bot-{{{branchName}}}:{{{branchName}}}\n```",
+    "```sh\n# Check out the PR branch (these steps are from GitHub)\ngit checkout -b renovate-bot-{{{branchName}}} main\ngit pull https://github.com/renovate-bot/amphtml.git {{{branchName}}}\n\n# Directly make fixes and commit them\namp lint --fix # For lint errors in JS files\namp prettify --fix # For prettier errors in non-JS files\n# Edit source code in case of new compiler warnings / errors\n\n# Push the changes to the branch\ngit push git@github.com:renovate-bot/amphtml.git renovate-bot-{{{branchName}}}:{{{branchName}}}\n```",
     "</details>"
   ],
 

--- a/build-system/common/main-branch.js
+++ b/build-system/common/main-branch.js
@@ -15,10 +15,9 @@
  */
 
 /**
- * TODO(rsimha, #32195): Change this to main when branch is renamed, and delete
- * this file once the dust settles.
+ * TODO(rsimha, #32195): Delete this file once the dust settles.
  */
-const mainBranch = 'master';
+const mainBranch = 'main';
 
 module.exports = {
   mainBranch,

--- a/build-system/server/app-index/header-links.js
+++ b/build-system/server/app-index/header-links.js
@@ -37,7 +37,7 @@ module.exports = [
   {
     'name': 'CircleCI',
     'href':
-      'https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master',
+      'https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=main',
   },
   {
     'name': 'Percy',


### PR DESCRIPTION
This PR will need to be force-merged immediately after the branch is renamed. (Until then, CI is expected to fail.)

In anticipation of this change, all CI code in `build-system/` was refactored in #33535. This PR modifies exactly one source of truth in that directory (see code below). Once the dust settles, we can delete `main-branch.js`.

https://github.com/ampproject/amphtml/blob/702f2798967f7e01ecd06145c6f438695a38d638/build-system/common/main-branch.js#L21

**Next steps:**

- Once the branch is renamed, all visitors to the `amphtml` repo will see a notification like this:

![unnamed](https://user-images.githubusercontent.com/26553114/113951794-49b60200-97e2-11eb-920e-8c4238fb27c9.png)

- For those who use `upstream` to refer to `ampproject/amphtml` and `origin` to refer to their fork, here are distilled instructions that will work (to be run after the rename is done):

```sh
# Start at the repo root directory
git checkout master
git branch -m master main
git config -e
# Change master to main in the config
# Carry on
```

Partial fix for #32195