### PR TITLE
🏗 Check forbidden terms in Markdown files

### DIFF
--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -130,7 +130,7 @@ const lintGlobs = [
  *  - forbidden terms: local/no-forbidden-terms
  */
 const presubmitGlobs = [
-  '**/*.{css,go}',
+  '**/*.{css,go,md}',
   '!{node_modules,build,dist,dist.tools,' +
     'dist.3p/[0-9]*,dist.3p/current,dist.3p/current-min}/**/*.*',
   '!out/**/*.*',

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -42,6 +42,17 @@ const realiasGetMode =
  *   checkInTestFolder?: (undefined|boolean),
  *   checkProse?: (undefined|boolean),
  * }}
+ * - message:
+ *   a message optionally displayed with a matching term
+ *
+ * - allowlist:
+ *   optional list of filepaths that are allowed to use a term
+ *
+ * - checkInTestFolder:
+ *   check term in files whose path includes /test/ (false by default)
+ *
+ * - checkProse:
+ *   check term in comments and documentation (.md) (false by default)
  */
 let ForbiddenTermDef;
 

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -40,7 +40,7 @@ const realiasGetMode =
  *   message?: (undefined|string),
  *   allowlist?: (undefined|Array<string>),
  *   checkInTestFolder?: (undefined|boolean),
- *   checkComments?: (undefined|boolean),
+ *   checkProse?: (undefined|boolean),
  * }}
  */
 let ForbiddenTermDef;
@@ -51,19 +51,19 @@ let ForbiddenTermDef;
  */
 const forbiddenTermsGlobal = {
   'DO NOT SUBMIT': {
-    checkComments: true,
+    checkProse: true,
   },
   'whitelist|white-list': {
     message: 'Please use the term allowlist instead',
-    checkComments: true,
+    checkProse: true,
   },
   'blacklist|black-list': {
     message: 'Please use the term denylist instead',
-    checkComments: true,
+    checkProse: true,
   },
   'grandfather|grandfathered': {
     message: 'Please use the term legacy instead',
-    checkComments: true,
+    checkProse: true,
   },
   '(^-amp-|\\W-amp-)': {
     message: 'Switch to new internal class form',
@@ -1200,7 +1200,7 @@ function matchForbiddenTerms(srcFile, contents, terms) {
         message,
         allowlist = null,
         checkInTestFolder = false,
-        checkComments = false,
+        checkProse = false,
       } =
         typeof messageOrDef === 'string'
           ? {message: messageOrDef}
@@ -1209,7 +1209,8 @@ function matchForbiddenTerms(srcFile, contents, terms) {
       // if needed but that might be too permissive.
       if (
         (Array.isArray(allowlist) && allowlist.indexOf(srcFile) != -1) ||
-        (isInTestFolder(srcFile) && !checkInTestFolder)
+        (isInTestFolder(srcFile) && !checkInTestFolder) ||
+        (srcFile.endsWith('.md') && !checkProse)
       ) {
         return [];
       }
@@ -1220,13 +1221,13 @@ function matchForbiddenTerms(srcFile, contents, terms) {
       // original term to get the possible fix value. This is ok as the
       // presubmit doesn't have to be blazing fast and this is most likely
       // negligible.
-      const regex = new RegExp(term, 'gm' + (checkComments ? 'i' : ''));
+      const regex = new RegExp(term, 'gm' + (checkProse ? 'i' : ''));
       let index = 0;
       let line = 1;
       let column = 0;
       const start = {line: -1, column: -1};
 
-      const subject = checkComments ? contents : contentsWithoutComments;
+      const subject = checkProse ? contents : contentsWithoutComments;
       let result;
       while ((result = regex.exec(subject))) {
         const [match] = result;

--- a/contributing/building-an-amp-extension.md
+++ b/contributing/building-an-amp-extension.md
@@ -515,7 +515,7 @@ HTML-native `img` tag which will be out of AMP resource management.
 Consider showing a loading indicator if your element is expected to take
 a long time to load (for example, loading a GIF, video or iframe). AMP
 has a built-in mechanism to show a loading indicator simply by
-whitelisting your element to show it. You can do that inside layout.js
+listing your element so it's allowed to show it. You can do that inside the `layout.js`
 file in the `LOADING_ELEMENTS_` object.
 
 ```javascript


### PR DESCRIPTION
- Adds `.md` files to the presubmit check glob.

- Replaces `checkComments` flag with `checkProse`, which causes a term to be matched in source, comments and Markdown documentation.
