### PR TITLE
Ensure no error is displayed when publishers correctly disable slot for refresh with data attribute.

### DIFF
--- a/extensions/amp-a4a/0.1/refresh-manager.js
+++ b/extensions/amp-a4a/0.1/refresh-manager.js
@@ -80,6 +80,9 @@ export function getPublisherSpecifiedRefreshInterval(element, unusedWin) {
  * @return {?number}
  */
 function checkAndSanitizeRefreshInterval(refreshInterval) {
+  if (refreshInterval === 'false') {
+    return null;
+  }
   const refreshIntervalNum = Number(refreshInterval);
   if (isNaN(refreshIntervalNum) || refreshIntervalNum < MIN_REFRESH_INTERVAL) {
     user().warn(

--- a/extensions/amp-a4a/0.1/test/test-refresh.js
+++ b/extensions/amp-a4a/0.1/test/test-refresh.js
@@ -70,6 +70,17 @@ describe('refresh', () => {
       ).to.be.null;
     });
 
+    it('should get null refreshInterval when disabled via data attr', () => {
+      mockA4a.element.setAttribute(DATA_ATTR_NAME, false);
+      expect(
+        getPublisherSpecifiedRefreshInterval(
+          mockA4a.element,
+          window,
+          'doubleclick'
+        )
+      ).to.be.null;
+    });
+
     it('should get refreshInterval from slot', () => {
       expect(
         getPublisherSpecifiedRefreshInterval(


### PR DESCRIPTION
This should bring into alignment refresh on/off behavior as specified in [the docs](https://github.com/ampproject/amphtml/blob/master/extensions/amp-ad-network-doubleclick-impl/refresh.md ).

(This is a duplicate of PR#33646. That PR was broken due to pulling in a bunch of unrelated changes. Not sure what happened, but likely due to my AMP environment rusting over from not using it in a while.)