### PR TITLE
📖 Update `amphtml` docs to reference `main` instead of `master`

### DIFF
--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -83,8 +83,8 @@ const setupMeasurement = (page) =>
   });
 
 /**
- * Intecepts requests for default extensions made by runtime,
- * and returns cached version (master and local).
+ * Intecepts requests for default extensions made by runtime and returns a
+ * cached version.
  * @param {Request} interceptedRequest
  * @param {string} version
  * @return {!Promise<boolean>}

--- a/build-system/tasks/performance/rewrite-script-tags.js
+++ b/build-system/tasks/performance/rewrite-script-tags.js
@@ -90,8 +90,8 @@ async function useRemoteScripts(url) {
 }
 
 /**
- * Download local and master version of default extension that
- * are not explicility stated by script tags in the HTML.
+ * Download default extensions that are not explicility stated by script tags in
+ * the HTML.
  * @return {Promise}
  */
 async function downloadDefaultExtensions() {

--- a/contributing/DEVELOPING.md
+++ b/contributing/DEVELOPING.md
@@ -90,7 +90,7 @@ We also recommend scanning the [spec](../spec/). The non-element part should hel
 
 ## Builds and releases
 
--   The [AMP Build On-duty](build-on-duty.md) helps ensure that AMP's builds remain green (i.e. everything builds and all of the tests pass). If you run into issues with builds that seem unrelated to your changes see if the issue is present on [CircleCI](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master) and send a message to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack ([sign up for Slack](https://bit.ly/amp-slack-signup)).
+-   The [AMP Build On-duty](build-on-duty.md) helps ensure that AMP's builds remain green (i.e. everything builds and all of the tests pass). If you run into issues with builds that seem unrelated to your changes see if the issue is present on [CircleCI](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=main) and send a message to the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack ([sign up for Slack](https://bit.ly/amp-slack-signup)).
 -   Understanding the [AMP release process](release-schedule.md) is useful for understanding when a change in AMP will make it into production and what to do if things go wrong during the rollout of a change.
 
 ### Opting in to pre-release channels

--- a/contributing/TESTING.md
+++ b/contributing/TESTING.md
@@ -244,7 +244,7 @@ For testing documents on arbitrary URLs with your current local version of the A
 
 ## Visual Diff Tests
 
-In addition to building the AMP runtime and running `amp [unit|integration]`, the automatic test run on CircleCI includes a set of visual diff tests to make sure a new commit to `master` does not result in unintended changes to how pages are rendered. The tests load a few well-known pages in a browser and compare the results with known good versions of the same pages.
+In addition to building the AMP runtime and running `amp [unit|integration]`, the automatic test run on CircleCI includes a set of visual diff tests to make sure a new commit to `main` does not result in unintended changes to how pages are rendered. The tests load a few well-known pages in a browser and compare the results with known good versions of the same pages.
 
 The technology stack used is:
 

--- a/contributing/build-on-duty.md
+++ b/contributing/build-on-duty.md
@@ -1,6 +1,6 @@
 # AMP Build On-Duty
 
-The AMP build on-duty is responsible for ensuring that the [master build](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master) remains green. The AMP build on-duty responsibility rotates between members of the community.
+The AMP build on-duty is responsible for ensuring that the [main branch build](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=main) remains green. The AMP build on-duty responsibility rotates between members of the community.
 
 Make sure you are a member of the [#contributing](https://amphtml.slack.com/messages/C9HRJ1GPN) channel on Slack while you are build on-duty.
 
@@ -9,7 +9,7 @@ Make sure you are a member of the [#contributing](https://amphtml.slack.com/mess
 
 ## Build On-Duty Tasks
 
-1. Ensure the [master build](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=master) remains green. Your goal is to keep the build from being red for more than an hour.
+1. Ensure the [main branch build](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=main) remains green. Your goal is to keep the build from being red for more than an hour.
     1. Note that yellow builds are in the process of being created/tested so you do not need to do anything special with them.
     2. Keep an eye out for emails sent to an address starting with amp-build-on-duty. **You are encouraged to set up a filter so that these emails will stand out to you.**
     3. You will need to investigate whether a red build is due to a flake or due to a real issue.

--- a/contributing/getting-started-e2e.md
+++ b/contributing/getting-started-e2e.md
@@ -162,11 +162,11 @@ git remote add upstream git@github.com:ampproject/amphtml.git
 
 Now run `git remote -v` again and notice that you have set up your upstream alias.
 
-Each branch of your local Git repository can track a branch of a remote repository. Right now, your local `master` branch is tracking `origin/master`, which corresponds to the `master` branch of your GitHub fork. You don't actually want this, though; the upstream `master` branch is constantly being updated, and your fork's `master` branch will rapidly become outdated. Instead, it's best to make your local `master` branch track the upstream `master` branch. You can do this like so:
+Each branch of your local Git repository can track a branch of a remote repository. Right now, your local `main` branch is tracking `origin/main`, which corresponds to the `main` branch of your GitHub fork. You don't actually want this, though; the upstream `main` branch is constantly being updated, and your fork's `main` branch will rapidly become outdated. Instead, it's best to make your local `main` branch track the upstream `main` branch. You can do this like so:
 
 ```sh
-git fetch upstream master
-git branch -u upstream/master master
+git fetch upstream main
+git branch -u upstream/main main
 ```
 
 # Building AMP and starting a local server
@@ -233,17 +233,17 @@ You may have noticed that the files in your local repository are editable which 
 
 Branches let you work on multiple different things in your repository in parallel. For example you can have one branch where you're fixing a bug, another branch where you're implementing a new feature and yet another branch where you're just doing some exploratory work. These branches co-exist in the same repository so there's no need to go through the forking and cloning steps described earlier every time you want to make a change.
 
-By default you'll have a branch named _master_. You can see this if you run the command `git branch` which lists the branches in your local repository.
+By default you'll have a branch named _main_. You can see this if you run the command `git branch` which lists the branches in your local repository.
 
-Although you could do work on the master branch, most people choose to leave the master branch unchanged and create other branches to actually do work in. Creating a branch is easy; simply run:
+Although you could do work on the main branch, most people choose to leave the main branch unchanged and create other branches to actually do work in. Creating a branch is easy; simply run:
 
 ```sh
-git checkout -b <branch_name> master
+git checkout -b <branch_name> main
 ```
 
-This will move you to the new branch, which uses `master` as its start point, meaning that it will start out containing the same files as `master`. You can then start working in the new branch.
+This will move you to the new branch, which uses `main` as its start point, meaning that it will start out containing the same files as `main`. You can then start working in the new branch.
 
-(You can use a different branch as a start point, like if you want to make one branch based on another. Generally, though, you want `master` as your start point. If you omit the start point, Git will use whichever branch you're currently on.)
+(You can use a different branch as a start point, like if you want to make one branch based on another. Generally, though, you want `main` as your start point. If you omit the start point, Git will use whichever branch you're currently on.)
 
 Whenever you want to move to a different branch, run the checkout command:
 
@@ -263,11 +263,11 @@ Note that currently the branch you just created only exists in your local reposi
 
 Since your local repository is just a copy of the amphtml repository it can quickly become out of date if other people make changes to the amphtml repository. Before you start making changes you'll want to make sure you have the latest version of the code; you'll also want to do this periodically during development, before sending your code for review, etc.
 
-In the workflow we will be using you'll go to the master branch on your local repository and pull the latest changes in from the remote amphtml repository's master branch. (Remember that you set up the alias _upstream_ to refer to the remote amphtml repository, and you set your local `master` branch to track `upstream/master`.)
+In the workflow we will be using you'll go to the main branch on your local repository and pull the latest changes in from the remote amphtml repository's main branch. (Remember that you set up the alias _upstream_ to refer to the remote amphtml repository, and you set your local `main` branch to track `upstream/main`.)
 
 ```sh
-# make sure you are in your local repo's master branch
-git checkout master
+# make sure you are in your local repo's main branch
+git checkout main
 
 # pull in the latest changes from the remote amphtml repository
 git pull
@@ -275,17 +275,17 @@ git pull
 
 If there have been any changes you'll see the details of what changed, otherwise you'll see a message like `Already up-to-date`.
 
-After running that `git pull` command your local master branch has the latest files, but your other local branches won't get automatically updated. To get a local branch in sync:
+After running that `git pull` command your local main branch has the latest files, but your other local branches won't get automatically updated. To get a local branch in sync:
 
 ```sh
 # go to the branch you want to sync
 git checkout <branch name>
 
-# bring the latest changes from your master branch into this branch
-git merge master
+# bring the latest changes from your main branch into this branch
+git merge main
 ```
 
-Since you just ran the `git pull` in your master branch it has the latest changes from the remote amphtml repository so running `git merge master` in your other branch effectively brings the latest changes from the remote amphtml repository to this other branch.
+Since you just ran the `git pull` in your main branch it has the latest changes from the remote amphtml repository so running `git merge main` in your other branch effectively brings the latest changes from the remote amphtml repository to this other branch.
 
 If there are changes that conflict with changes on your branch (e.g. someone modified a file that you're working on) you'll be prompted to resolve them at this point.
 
@@ -338,7 +338,7 @@ Since you're done with changes to that file, go ahead and create a commit:
 git commit -m "<a brief description of your commit>"
 ```
 
-Now run `git status` again, and you'll see the message `nothing to commit` and `your branch is ahead of 'origin/master' by 1 commit`.
+Now run `git status` again, and you'll see the message `nothing to commit` and `your branch is ahead of 'origin/main' by 1 commit`.
 
 Note that you can optionally skip using `git add` commands and just use the `git commit -a` flag to say "add all of the modified/deleted files to this commit," e.g.
 
@@ -467,10 +467,10 @@ Up to this point you've been making changes in a branch on your local repository
 Before pushing your changes, make sure you have the latest changes in the amphtml repository on your branch by running the commands we described above:
 
 ```sh
-git checkout master
+git checkout main
 git pull
 git checkout <branch name>
-git merge master
+git merge main
 ```
 
 Now push your changes to `origin` (the alias for your GitHub fork):
@@ -515,7 +515,7 @@ Once your code is ready for a review, go to [https://github.com/ampproject/ampht
 On the "Open a pull request" page, you will see dropdowns at the top indicating the proposed merge. It will look something like:
 
 ```sh
-amproject/amphtml / master … <username>/amphtml / <branch name>
+amproject/amphtml / main … <username>/amphtml / <branch name>
 ```
 
 Below this are text boxes where you can provide a title and description for your pull request. Please follow the guidelines in the template for providing a good title and description.
@@ -561,8 +561,8 @@ Creating, deleting and moving between branches in Git is cheap. Reusing branches
 GitHub offers a convenient "Delete branch" button on the PR page after the changes in your branch have been merged into the amphtml repository. You can click this button to delete your branch in the GitHub fork if you prefer, but you will also want to delete the branch in your local repository:
 
 ```sh
-# go back to the master branch
-git checkout master
+# go back to the main branch
+git checkout main
 
 # delete the branch in your local repository
 git branch -D <branch name>

--- a/contributing/getting-started-quick.md
+++ b/contributing/getting-started-quick.md
@@ -49,14 +49,14 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 8. Fetch data from the `upstream` remote:
 
     ```shell
-    git fetch upstream master
+    git fetch upstream main
     ```
 
-9. Set up your local `master` branch to track `upstream/master` instead of `origin/master` (which will rapidly become
+9. Set up your local `main` branch to track `upstream/main` instead of `origin/main` (which will rapidly become
    outdated).
 
     ```shell
-    git branch -u upstream/master master
+    git branch -u upstream/main main
     ```
 
 ## Branch (do this each time you want a new branch)
@@ -64,7 +64,7 @@ This Quick Start guide is the TL;DR version of the longer [end-to-end guide](get
 Create and go to the branch:
 
 ```shell
-git checkout -b <branch name> master
+git checkout -b <branch name> main
 ```
 
 ## Build AMP & run a local server
@@ -97,10 +97,10 @@ git checkout -b <branch name> master
 
 ## Pull the latest changes
 
-1.  Check out the master branch: `git checkout master`
+1.  Check out the main branch: `git checkout main`
 2.  Pull the latest changes: `git pull`
 3.  Check out your branch: `git checkout <branch name>`
-4.  Merge the changes to your branch: `git merge master`
+4.  Merge the changes to your branch: `git merge main`
 
     **Note**: You may need to resolve conflicting changes at this point.
 
@@ -125,7 +125,7 @@ git checkout -b <branch name> master
 
 ## Delete your branch after your changes are merged (optional)
 
-1.  Go to the master branch: `git checkout master`
+1.  Go to the main branch: `git checkout main`
 2.  Delete your local branch: `git branch -D <branch name>`
 3.  Delete the corresponding GitHub fork branch: `git push -d origin <branch name>`
 

--- a/contributing/git_helpers.sh
+++ b/contributing/git_helpers.sh
@@ -10,7 +10,7 @@ git_track() {
       echo "You must specify the name of the branch to create."
       return
   fi
-  git branch --track $1 origin/master
+  git branch --track $1 origin/main
   echo "Checking out $1"
   git checkout $1
 }
@@ -24,31 +24,31 @@ git_delete_branch() {
       echo "You must specify the name of the branch to delete."
       return
   fi
-  git checkout master
+  git checkout main
   git branch -D $1
   echo "Deleted local branch $1"
   git push origin --delete $1
   echo "Deleted remote branch origin:$1 (if it existed)"
 }
 
-# Syncs your local master branch to the HEAD of the "upstream" repository,
-# then pushes the updates to your remote master branch and the local
+# Syncs your local main branch to the HEAD of the "upstream" repository,
+# then pushes the updates to your remote main branch and the local
 # branch you ran this command from.
 git_sync() {
   local branch_name=$(git symbolic-ref -q HEAD)
   branch_name=${branch_name##refs/heads/}
   branch_name=${branch_name:-HEAD}
-  echo "Checking out your master branch"
-  git checkout master
-  echo "Updating your local master branch with the latest changes (pulling upstream/master)"
-  git pull --rebase upstream master
+  echo "Checking out your main branch"
+  git checkout main
+  echo "Updating your local main branch with the latest changes (pulling upstream/main)"
+  git pull --rebase upstream main
   git rebase -i
-  echo "Updating your remote repository with the latest changes (pushing origin/master)"
-  git push origin master -f
+  echo "Updating your remote repository with the latest changes (pushing origin/main)"
+  git push origin main -f
   echo "Checking out $branch_name"
   git checkout $branch_name
   echo "Updating your local $branch_name branch"
-  git rebase master
+  git rebase main
 }
 
 # Pushes your changes from the current branch to your remote repository.

--- a/contributing/release-schedule.md
+++ b/contributing/release-schedule.md
@@ -17,7 +17,7 @@
     -   [Detailed schedule](#detailed-schedule)
     -   [Release Freezes](#release-freezes)
 
-A new release of AMP is pushed to all AMP pages every week on Tuesday. **Once a change in AMP is merged into the master branch of the amphtml repository, it will typically take 1-2 weeks for the change to be live for all users.**
+A new release of AMP is pushed to all AMP pages every week on Tuesday. **Once a change in AMP is merged into the main branch of the amphtml repository, it will typically take 1-2 weeks for the change to be live for all users.**
 
 The [AMPHTML Validator](https://github.com/ampproject/amphtml/tree/master/validator#amp-html--validator) has it's own [Release Schedule](validator-release-schedule.md)
 

--- a/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-permission-dialog.js
@@ -104,7 +104,7 @@ describes.realWin(
       });
     });
 
-    // TODO(jasonpang): This fails on master under headless Chrome.
+    // TODO(jasonpang): This fails during CI under headless Chrome.
     it.skip('should request notification permissions, when opened as popup', () => {
       return setupPermissionDialogFrame().then(() => {
         env.sandbox
@@ -121,7 +121,7 @@ describes.realWin(
       });
     });
 
-    // TODO(jasonpang): This fails on master under headless Chrome.
+    // TODO(jasonpang): This fails during CI under headless Chrome.
     it.skip('should request notification permissions when redirected', () => {
       return setupPermissionDialogFrame().then(() => {
         env.sandbox
@@ -142,7 +142,7 @@ describes.realWin(
       });
     });
 
-    // TODO(jasonpang): This fails on master under headless Chrome.
+    // TODO(jasonpang): This fails during CI under headless Chrome.
     it.skip('should redirect back to original site, when redirected', () => {
       let spy = null;
       return setupPermissionDialogFrame()

--- a/extensions/amp-web-push/0.1/test/test-web-push-service.js
+++ b/extensions/amp-web-push/0.1/test/test-web-push-service.js
@@ -244,7 +244,7 @@ describes.realWin(
       });
     });
 
-    // TODO(jasonpang): This fails on master under headless Chrome.
+    // TODO(jasonpang): This fails during CI under headless Chrome.
     it.skip('should receive reply from helper iframe for permission query', () => {
       return setupHelperIframe()
         .then(() => {


### PR DESCRIPTION
The branch rename was done earlier today. This PR updates all our docs and a couple of code comments.

Partial fix for #32195