### PR TITLE
🏗 Print relative path of task file while running `amp` tasks

### DIFF
--- a/build-system/tasks/amp-task-runner.js
+++ b/build-system/tasks/amp-task-runner.js
@@ -22,6 +22,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const commander = require('commander');
 const fs = require('fs-extra');
+const os = require('os');
 const path = require('path');
 const {
   updatePackages,
@@ -62,7 +63,7 @@ function startAtRepoRoot() {
   const repoRoot = path.resolve(__dirname, '..', '..');
   if (repoRoot != process.cwd()) {
     process.chdir(repoRoot);
-    log('Working directory changed to', magenta('amphtml'));
+    log('Working directory changed to', magenta(path.basename(repoRoot)));
   }
 }
 
@@ -87,7 +88,8 @@ async function maybeUpdateSubpackages(taskSourceFilePath) {
  * @return {Promise<void>}
  */
 async function runTask(taskName, taskSourceFilePath, taskFunc) {
-  log('Using task file', magenta(path.join('amphtml', 'amp.js')));
+  const taskFile = path.relative(os.homedir(), 'amp.js');
+  log('Using task file', magenta(taskFile));
   const start = Date.now();
   try {
     log(`Starting '${cyan(taskName)}'...`);


### PR DESCRIPTION
The `gulp` task runner begins by printing the full path of `gulpfile.js` relative to the OS home dir. During the switch to the `amp` task runner, we initially set out to replicate this behavior, but ended up logging a hard-coded `amphtml/amp.js` instead. (See https://github.com/ampproject/amphtml/pull/33315#discussion_r596238113)

However, as pointed out by @antiphoton, this can be very confusing to developers who maintain multiple local copies of the `amphtml` repo in different directories. As a result, this PR goes back to explicitly logging the path of the task file relative to the OS home dir. With this, variations in the task file path are properly captured.

**Before:**

![image](https://user-images.githubusercontent.com/26553114/114106719-6a8f5d80-989d-11eb-9a67-d6b3e113155b.png)

**After (main local repo):**

![image](https://user-images.githubusercontent.com/26553114/114106826-9f9bb000-989d-11eb-8fcd-fe66e60b89b0.png)

**After (duplicate local repo - type 1):**

![image](https://user-images.githubusercontent.com/26553114/114106899-cfe34e80-989d-11eb-9fd9-f568e0e722cf.png)

**After (duplicate local repo - type 2):**

![image](https://user-images.githubusercontent.com/26553114/114107350-d1614680-989e-11eb-94aa-7b81f115b6cb.png)

