### PR TITLE
🐛 [no-signing] handle versioned extensions correctly

### DIFF
--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -75,8 +75,18 @@ const EXTENSION_ALLOWLIST = map({
   'amp-video': true,
 });
 
+/**
+ * Escape any regex chars from given string.
+ * https://developer.cdn.mozilla.net/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+ * @param {string} string
+ * @return {string}
+ */
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
 const EXTENSION_URL_PREFIX = new RegExp(
-  '^' + urls.cdn.replace(/\./g, '\\.') + '/(rtv/\\d*/)?v0/'
+  '^' + escapeRegExp(urls.cdn) + '/(rtv/\\d+/)?v0/'
 );
 
 /**

--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -76,7 +76,7 @@ const EXTENSION_ALLOWLIST = map({
 });
 
 const EXTENSION_URL_PREFIX = new RegExp(
-  urls.cdn.replace(/\./g, '\\.') + '/v0/'
+  '^' + urls.cdn.replace(/\./g, '\\.') + '/(rtv/\\d*/)?v0/'
 );
 
 /**

--- a/extensions/amp-a4a/0.1/test/test-head-validation.js
+++ b/extensions/amp-a4a/0.1/test/test-head-validation.js
@@ -79,6 +79,39 @@ describes.realWin('head validation', {amp: true}, (env) => {
       expect(preloadStub.secondCall).calledWith('amp-video');
     });
 
+    it('registers extensions with RTV', () => {
+      const preloadStub = env.sandbox.stub(
+        Services.extensionsFor(env.win),
+        'preloadExtension'
+      );
+      head.innerHTML = `
+        <script async custom-element="amp-analytics" src="https://cdn.ampproject.org/rtv/012104070150000/v0/amp-analytics-0.1.js"></script>
+      `;
+      const validated = processHead(env.win, adElement, head);
+      expect(validated.head.querySelector('script')).not.to.exist;
+      expect(validated.extensions).to.have.length(1);
+      expect(preloadStub).calledOnce;
+      expect(validated.extensions[0].extensionId).to.equal('amp-analytics');
+      expect(preloadStub.firstCall).calledWith('amp-analytics');
+    });
+
+    it('ignores v0 scripts (versioned & unversioned)', () => {
+      const preloadStub = env.sandbox.stub(
+        Services.extensionsFor(env.win),
+        'preloadExtension'
+      );
+      head.innerHTML = `
+        <script async src="https://cdn.ampproject.org/v0.js"></script>
+        <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+        <script async src="https://cdn.ampproject.org/rtv/012104070150000/v0.js"></script>
+        <script async src="https://cdn.ampproject.org/rtv/012104070150000/amp4ads-v0.js"></script>
+      `;
+      const validated = processHead(env.win, adElement, head);
+      expect(validated.head.querySelector('script')).not.to.exist;
+      expect(validated.extensions).to.have.length(0);
+      expect(preloadStub).not.to.be.called;
+    });
+
     it('removes non-allowlisted amp elements scripts', () => {
       const preloadStub = env.sandbox.stub(
         Services.extensionsFor(env.win),


### PR DESCRIPTION
The regex was excluding anything with a `rtv/1234` in the path.