### PR TITLE
🏗 Make `amp` and `gulp` execute the correct repo-local task runner

### DIFF
--- a/amp.js
+++ b/amp.js
@@ -18,7 +18,7 @@
 const {
   createTask,
   finalizeRunner,
-} = require('./build-system/tasks/amp-task-runner');
+} = require('./build-system/task-runner/amp-task-runner');
 
 /**
  * All the AMP tasks. Keep this list alphabetized.

--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -114,7 +114,8 @@ async function runTask(taskName, taskSourceFilePath, taskFunc) {
  * @param {string} taskSourceFileName
  */
 function createTask(taskName, taskFuncName, taskSourceFileName) {
-  const taskSourceFilePath = path.join(__dirname, taskSourceFileName);
+  const tasksDir = path.join(__dirname, '..', 'tasks');
+  const taskSourceFilePath = path.join(tasksDir, taskSourceFileName);
   const isInvokedTask = argv._.includes(taskName); // `amp <task>`
   const isDefaultTask =
     argv._.length === 0 && taskName == 'default' && !isHelpTask; // `amp`

--- a/build-system/task-runner/cli-runner.js
+++ b/build-system/task-runner/cli-runner.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview This is the amphtml CLI runner executable that is installed to
+ * the global node directory. It invokes the repo-local `amp` or `gulp` runner,
+ * and makes it possible for multiple local repo copies to share one globally
+ * installed runner executable.
+ */
+
+const childProcess = require('child_process');
+const path = require('path');
+
+/**
+ * Returns the current git repo's root directory if we are inside one.
+ * @return {string|undefined}
+ */
+function getRepoRoot() {
+  const repoRootCmd = 'git rev-parse --show-toplevel';
+  const spawnOptions = {
+    shell: process.platform == 'win32' ? 'cmd' : '/bin/bash',
+    encoding: 'utf-8',
+  };
+  const result = childProcess.spawnSync(repoRootCmd, spawnOptions);
+  return result.status == 0 ? result.stdout.trim() : undefined;
+}
+
+/**
+ * Invokes the repo-local runner if we are inside a git repository. The runner
+ * target is set to either `amp.js` or gulp-deprecated.js` at install time.
+ */
+function invokeRunner() {
+  const repoRoot = getRepoRoot();
+  if (repoRoot) {
+    require(path.join(repoRoot, '__RUNNER_TARGET__'));
+  } else {
+    console.log('\x1b[31mERROR:\x1b[0m Not inside a git repo');
+  }
+}
+
+invokeRunner();

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -127,6 +127,7 @@ const forbiddenTermsGlobal = {
     allowlist: [
       'build-system/common/check-package-manager.js',
       'build-system/common/logging.js',
+      'build-system/task-runner/cli-runner.js',
       'src/purifier/noop.js',
       'validator/js/engine/validator-in-browser.js',
       'validator/js/engine/validator.js',

--- a/gulp-deprecated.js
+++ b/gulp-deprecated.js
@@ -17,7 +17,7 @@
 
 const {
   printGulpDeprecationNotice,
-} = require('./build-system/tasks/amp-task-runner');
+} = require('./build-system/task-runner/amp-task-runner');
 
 /**
  * Print a deprecation notice and fall back to the amp task runner.

--- a/package.json
+++ b/package.json
@@ -10,12 +10,9 @@
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git"
   },
-  "bin": {
-    "amp": "./amp.js"
-  },
   "scripts": {
     "preinstall": "node build-system/common/check-package-manager.js",
-    "postinstall": "node build-system/common/install-task-runner.js"
+    "postinstall": "node build-system/task-runner/install-task-runner.js"
   },
   "dependencies": {
     "@ampproject/animations": "0.2.2",


### PR DESCRIPTION
**Background:**
- The `amp` / `gulp` commands are hard-coded symlinks to `amp.js` / `gulp-deprecated.js` in the local `amphtml` repo.
- While this works for a single local repo, it breaks down when there are two repo copies in different directories.
- Running a task in the second directory redirects to the first due to the hard-coded symlink, as reported by @antiphoton.

**PR Highlights:**
- Replaces hard-coded symlinks with global wrapper scripts that load the correct repo-local task runner.
- Ensures that the scripts gracefully error out when invoked from outside a `git` directory.
- Seamlessly updates any previously installed symlinks during `npm install`.
- Continues to detect and respect globally installed `gulp-cli` / `gulp` (prints a warning and exits).
- Consolidates all task runner code in `build-system/task-runner/`.

**Screenshots:**

**Before (wrong repo directory):**

![image](https://user-images.githubusercontent.com/26553114/114128274-020aa580-98ca-11eb-9a43-ec02c09b3643.png)

**After (correct repo directory):**

![image](https://user-images.githubusercontent.com/26553114/114128303-12228500-98ca-11eb-9219-3f27ea75615f.png)

**`npm install` (first time):**

![image](https://user-images.githubusercontent.com/26553114/114136388-9bd94f00-98d8-11eb-9833-dc1c614d1a45.png)

**`npm install` (subsequent time):**

![image](https://user-images.githubusercontent.com/26553114/114136445-b1e70f80-98d8-11eb-9c10-793f61c07ed5.png)


Follow up to #33315 and #33726