### PR TITLE
🏗 Rework html-template lint rule for helper constant

### DIFF
--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -215,8 +215,7 @@ function create(context) {
           context
             .getSourceCode()
             .getText(quasi)
-            .replace(/^`([^\s])/gm, '` $1')
-            .replace(/([^\s])`$/gm, '$1 `')
+            .replace(/^(`)([^\s])|([^\s])(`)$/gm, '$1$3 $2$4')
         );
       },
     });

--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -211,10 +211,10 @@ function create(context) {
         // wrapped in whitespace.
         const {quasi} = node;
         const quasiText = context.getSourceCode().getText(quasi);
-        if (!/^`[\s\n]+/.test(quasiText)) {
+        if (!/^`[\s\n]/.test(quasiText)) {
           yield fixer.replaceTextRange([quasi.start, quasi.start + 1], '` ');
         }
-        if (!/[\s\n]+`$/.test(quasiText)) {
+        if (!/[\s\n]`$/.test(quasiText)) {
           yield fixer.replaceTextRange([quasi.end - 1, quasi.end], ' `');
         }
       },

--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -210,13 +210,14 @@ function create(context) {
         // Prettier formats this in a silly way unless the quasi's content is
         // wrapped in whitespace.
         const {quasi} = node;
-        const quasiText = context.getSourceCode().getText(quasi);
-        if (!/^`[\s\n]/.test(quasiText)) {
-          yield fixer.replaceTextRange([quasi.start, quasi.start + 1], '` ');
-        }
-        if (!/[\s\n]`$/.test(quasiText)) {
-          yield fixer.replaceTextRange([quasi.end - 1, quasi.end], ' `');
-        }
+        yield fixer.replaceText(
+          quasi,
+          context
+            .getSourceCode()
+            .getText(quasi)
+            .replace(/^`([^\s])/gm, '` $1')
+            .replace(/([^\s])`$/gm, '$1 `')
+        );
       },
     });
   }

--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -207,15 +207,15 @@ function create(context) {
         // htmlFor(...)`...` to html`...`
         yield fixer.replaceText(node.tag, helperConstName);
 
-        // Prettier formats this in a silly way unless the quasi's content
-        // starts and ends with newlines.
+        // Prettier formats this in a silly way unless the quasi's content is
+        // wrapped in whitespace.
         const {quasi} = node;
         const quasiText = context.getSourceCode().getText(quasi);
-        if (!/^`\s*\n/.test(quasiText)) {
-          yield fixer.replaceTextRange([quasi.start, quasi.start + 1], '`\n');
+        if (!/^`[\s\n]+/.test(quasiText)) {
+          yield fixer.replaceTextRange([quasi.start, quasi.start + 1], '` ');
         }
-        if (!/\n\s*`$/.test(quasiText)) {
-          yield fixer.replaceTextRange([quasi.end - 1, quasi.end], '\n`');
+        if (!/[\s\n]+`$/.test(quasiText)) {
+          yield fixer.replaceTextRange([quasi.end - 1, quasi.end], ' `');
         }
       },
     });

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -235,12 +235,18 @@ class AmpBridPlayer extends AMP.BaseElement {
 
     const {partnerID_: partnerID, feedID_: feedID} = this;
 
-    const placeholder = htmlFor(element)`
-      <amp-img referrerpolicy=origin layout=fill placeholder>
-        <amp-img referrerpolicy=origin layout=fill fallback
-            src="https://cdn.brid.tv/live/default/defaultSnapshot.png">
+    const html = htmlFor(element);
+    const placeholder = html`
+      <amp-img referrerpolicy="origin" layout="fill" placeholder>
+        <amp-img
+          referrerpolicy="origin"
+          layout="fill"
+          fallback
+          src="https://cdn.brid.tv/live/default/defaultSnapshot.png"
+        >
         </amp-img>
-      </amp-img>`;
+      </amp-img>
+    `;
 
     this.propagateAttributes(['aria-label'], placeholder);
     this.applyFillContent(placeholder);

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -512,18 +512,22 @@ export class ConsentUI {
     toggle(placeholder, false);
     placeholder.classList.add(consentUiClasses.placeholder);
 
-    const loadingSpinner = htmlFor(placeholder)`
+    const html = htmlFor(placeholder);
+    const loadingSpinner = html`
       <svg viewBox="0 0 40 40">
         <defs>
           <linearGradient id="grad">
             <stop stop-color="rgb(105, 105, 105)"></stop>
-            <stop offset="100%"
-            stop-color="rgb(105, 105, 105)"
-            stop-opacity="0"></stop>
+            <stop
+              offset="100%"
+              stop-color="rgb(105, 105, 105)"
+              stop-opacity="0"
+            ></stop>
           </linearGradient>
         </defs>
         <path d="M11,4.4 A18,18, 0,1,0, 38,20" stroke="url(#grad)"></path>
-      </svg>`;
+      </svg>
+    `;
 
     placeholder.appendChild(loadingSpinner);
     return placeholder;

--- a/extensions/amp-date-picker/0.1/test/integration/test-integration-dates-attributes.js
+++ b/extensions/amp-date-picker/0.1/test/integration/test-integration-dates-attributes.js
@@ -48,26 +48,28 @@ config.run('amp-date-picker', function () {
           now: new Date('2018-01-01T08:00:00Z'),
         });
 
-        document.body.appendChild(htmlFor(document)`
-      <div>
-        <input id="today-explicit-date">
-        <amp-date-picker
-          layout="fixed-height"
-          height="360"
-          id="today-explicit"
-          date="2018-01-01"
-          input-selector="#today-explicit-date"
-        ></amp-date-picker>
+        const html = htmlFor(document);
+        document.body.appendChild(html`
+          <div>
+            <input id="today-explicit-date" />
+            <amp-date-picker
+              layout="fixed-height"
+              height="360"
+              id="today-explicit"
+              date="2018-01-01"
+              input-selector="#today-explicit-date"
+            ></amp-date-picker>
 
-        <input id="today-duration-date">
-        <amp-date-picker
-          layout="fixed-height"
-          height="360"
-          id="today-duration"
-          date="P0D"
-          input-selector="#today-duration-date"
-        ></amp-date-picker>
-      </div>`);
+            <input id="today-duration-date" />
+            <amp-date-picker
+              layout="fixed-height"
+              height="360"
+              id="today-duration"
+              date="P0D"
+              input-selector="#today-duration-date"
+            ></amp-date-picker>
+          </div>
+        `);
       });
 
       after(() => {

--- a/extensions/amp-date-picker/0.1/test/integration/test-integration-maximum-nights.js
+++ b/extensions/amp-date-picker/0.1/test/integration/test-integration-maximum-nights.js
@@ -48,18 +48,20 @@ config.run('amp-date-picker', function () {
           now: new Date('2018-01-01T08:00:00Z'),
         });
 
-        doc.body.appendChild(htmlFor(doc)`
-      <div>
-        <amp-date-picker
-          layout="fixed-height"
-          height="360"
-          type="range"
-          id="picker"
-          min="0"
-          date="2018-01-01"
-          maximum-nights="3"
-        ></amp-date-picker>
-      </div>`);
+        const html = htmlFor(doc);
+        doc.body.appendChild(html`
+          <div>
+            <amp-date-picker
+              layout="fixed-height"
+              height="360"
+              type="range"
+              id="picker"
+              min="0"
+              date="2018-01-01"
+              maximum-nights="3"
+            ></amp-date-picker>
+          </div>
+        `);
         const picker = doc.getElementById('picker');
         const impl = await picker.getImpl(false);
         await impl.buildCallback();

--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -209,10 +209,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         return this.getAmpDoc().whenFirstVisible();
       })
       .then(() => {
-        this.container_ = htmlFor(/** @type {!Document} */ (this.doc_))`
-        <div class="i-amphtml-lbg">
-          <div class="i-amphtml-lbg-mask"></div>
-        </div>`;
+        const html = htmlFor(/** @type {!Document} */ (this.doc_));
+        this.container_ = html`
+          <div class="i-amphtml-lbg">
+            <div class="i-amphtml-lbg-mask"></div>
+          </div>
+        `;
         this.mask_ = this.container_.querySelector('.i-amphtml-lbg-mask');
         this.element.appendChild(this.container_);
         this.manager_.maybeInit();
@@ -238,8 +240,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   buildOverlay_() {
-    this.overlay_ = htmlFor(this.doc_)`
-      <div class="i-amphtml-lbg-overlay"></div>`;
+    const html = htmlFor(this.doc_);
+    this.overlay_ = html` <div class="i-amphtml-lbg-overlay"></div> `;
     const descriptionBoxElement = this.buildDescriptionBox_();
     const controlsElement = this.buildControls_();
     this.mutateElement(() => {
@@ -309,8 +311,10 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       let slide = clonedNode;
       if (ELIGIBLE_TAP_TAGS[clonedNode.tagName]) {
         const container = this.doc_.createElement('div');
-        const imageViewer = htmlFor(this.doc_)`
-          <amp-image-viewer layout="fill"></amp-image-viewer>`;
+        const html = htmlFor(this.doc_);
+        const imageViewer = html`
+          <amp-image-viewer layout="fill"></amp-image-viewer>
+        `;
         // Copy any data attributes from the cloneNode to the new slide
         // container. For example. when cloning carousel slides, we want to
         // carry over data-slide-id.
@@ -392,7 +396,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
         return this.manager_.getElementsForLightboxGroup(lightboxGroupId);
       })
       .then((list) => {
-        this.carousel_ = htmlFor(this.doc_)`
+        const html = htmlFor(this.doc_);
+        this.carousel_ = html`
           <amp-carousel type="slides" layout="fill" loop="true"></amp-carousel>
         `;
         this.carousel_.setAttribute('amp-lightbox-group', lightboxGroupId);
@@ -1262,8 +1267,8 @@ export class AmpLightboxGallery extends AMP.BaseElement {
       this.updateVideoThumbnails_();
     } else {
       // Build gallery
-      this.gallery_ = htmlFor(/** @type {!Document} */ (this.doc_))`
-      <div class="i-amphtml-lbg-gallery"></div>`;
+      const html = htmlFor(/** @type {!Document} */ (this.doc_));
+      this.gallery_ = html` <div class="i-amphtml-lbg-gallery"></div> `;
       this.gallery_.setAttribute(
         'amp-lightbox-group',
         this.currentLightboxGroupId_
@@ -1360,10 +1365,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
    * @private
    */
   createThumbnailElement_(thumbnailObj) {
-    const element = htmlFor(/** @type {!Document} */ (this.doc_))`
-    <div class="i-amphtml-lbg-gallery-thumbnail">
-      <img class="i-amphtml-lbg-gallery-thumbnail-img"></img>
-    </div>`;
+    const html = htmlFor(/** @type {!Document} */ (this.doc_));
+    const element = html`
+      <div class="i-amphtml-lbg-gallery-thumbnail">
+        <img class="i-amphtml-lbg-gallery-thumbnail-img" />
+      </div>
+    `;
     const imgElement = childElementByTag(element, 'img');
 
     if (thumbnailObj.srcset) {
@@ -1374,10 +1381,12 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     element.appendChild(imgElement);
 
     if (VIDEO_TAGS[thumbnailObj.element.tagName]) {
-      const timestampDiv = htmlFor(/** @type {!Document} */ (this.doc_))`
-      <div class="i-amphtml-lbg-thumbnail-timestamp-container">
-        <span class="i-amphtml-lbg-thumbnail-play-icon"></span>
-      <div>`;
+      const timestampDiv = html`
+        <div class="i-amphtml-lbg-thumbnail-timestamp-container">
+          <span class="i-amphtml-lbg-thumbnail-play-icon"></span>
+          <div></div>
+        </div>
+      `;
 
       thumbnailObj.timestampPromise.then((ts) => {
         // Many video players (e.g. amp-youtube) that don't support this API

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-caption.js
@@ -36,13 +36,17 @@ export class LightboxCaption {
    * @return {!LightboxCaption} A LightboxCaption instance.
    */
   static build(doc, measureMutateElement) {
-    const el = htmlFor(doc)`
+    const html = htmlFor(doc);
+    const el = html`
       <div class="i-amphtml-lbg-caption">
         <div class="i-amphtml-lbg-caption-scroll">
-          <div class="i-amphtml-lbg-caption-text amp-lightbox-gallery-caption"></div>
+          <div
+            class="i-amphtml-lbg-caption-text amp-lightbox-gallery-caption"
+          ></div>
         </div>
         <div class="i-amphtml-lbg-caption-mask"></div>
-      </div>`;
+      </div>
+    `;
     return new LightboxCaption(
       el,
       dev().assertElement(el.querySelector('.i-amphtml-lbg-caption-scroll')),

--- a/extensions/amp-lightbox-gallery/0.1/lightbox-controls.js
+++ b/extensions/amp-lightbox-gallery/0.1/lightbox-controls.js
@@ -44,36 +44,43 @@ export class LightboxControls {
    */
   static build(win, doc, measureMutateElement) {
     // TODO(aghassemi): i18n and customization. See https://git.io/v6JWu
-    const el = htmlFor(doc)`
+    const html = htmlFor(doc);
+    const el = html`
       <div class="i-amphtml-lbg-controls">
         <div class="i-amphtml-lbg-top-bar">
-          <div role="button"
-              class="i-amphtml-lbg-button "
-              data-action="close"
-              aria-label="Close">
-          </div>
-          <div role="button"
-              class="i-amphtml-lbg-button"
-              data-action="gallery"
-              aria-label="Gallery">
-          </div>
-          <div role="button"
-              class="i-amphtml-lbg-button"
-              data-action="slides"
-              aria-label="Content">
-          </div>
-        </div>
-        <div role="button"
+          <div
+            role="button"
+            class="i-amphtml-lbg-button "
+            data-action="close"
+            aria-label="Close"
+          ></div>
+          <div
+            role="button"
             class="i-amphtml-lbg-button"
-            data-action="prev"
-            aria-label="Content">
-        </div>
-        <div role="button"
+            data-action="gallery"
+            aria-label="Gallery"
+          ></div>
+          <div
+            role="button"
             class="i-amphtml-lbg-button"
-            data-action="next"
-            aria-label="Content">
+            data-action="slides"
+            aria-label="Content"
+          ></div>
         </div>
-      </div>`;
+        <div
+          role="button"
+          class="i-amphtml-lbg-button"
+          data-action="prev"
+          aria-label="Content"
+        ></div>
+        <div
+          role="button"
+          class="i-amphtml-lbg-button"
+          data-action="next"
+          aria-label="Content"
+        ></div>
+      </div>
+    `;
 
     const input = Services.inputFor(win);
     if (!input.isMouseDetected()) {

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -88,12 +88,14 @@ const DEFAULT_ANIMATION = 'fade-in';
  * @return {!Element}
  */
 function renderCloseButtonHeader(ctx) {
-  return htmlFor(ctx)`
-    <i-amphtml-ad-close-header role=button tabindex=0 aria-label="Close Ad">
+  const html = htmlFor(ctx);
+  return html`
+    <i-amphtml-ad-close-header role="button" tabindex="0" aria-label="Close Ad">
       <div>Ad</div>
       <i-amphtml-ad-close-button class="amp-ad-close-button">
       </i-amphtml-ad-close-button>
-    </i-amphtml-ad-close-header>`;
+    </i-amphtml-ad-close-header>
+  `;
 }
 
 class AmpLightbox extends AMP.BaseElement {

--- a/extensions/amp-list/0.1/service/load-more-service.js
+++ b/extensions/amp-list/0.1/service/load-more-service.js
@@ -61,9 +61,12 @@ export class LoadMoreService {
     if (this.loadMoreButton_) {
       this.loadMoreButton_.classList.add('amp-visible');
     } else {
-      this.loadMoreButton_ = htmlFor(this.ampListElement_)`
-        <amp-list-load-more load-more-button
-          class="amp-visible i-amphtml-default-ui">
+      const html = htmlFor(this.ampListElement_);
+      this.loadMoreButton_ = html`
+        <amp-list-load-more
+          load-more-button
+          class="amp-visible i-amphtml-default-ui"
+        >
           <button load-more-clickable class="i-amphtml-list-load-more-button">
             <label>See More</label>
           </button>
@@ -89,7 +92,8 @@ export class LoadMoreService {
     );
 
     if (!this.loadMoreLoadingElement_) {
-      this.loadMoreLoadingElement_ = htmlFor(this.ampListElement_)`
+      const html = htmlFor(this.ampListElement_);
+      this.loadMoreLoadingElement_ = html`
         <amp-list-load-more load-more-loading class="i-amphtml-default-ui">
           <div class="i-amphtml-list-load-more-spinner"></div>
         </amp-list-load-more>
@@ -143,12 +147,14 @@ export class LoadMoreService {
     );
 
     if (!this.loadMoreFailedElement_) {
-      this.loadMoreFailedElement_ = htmlFor(this.ampListElement_)`
+      const html = htmlFor(this.ampListElement_);
+      this.loadMoreFailedElement_ = html`
         <amp-list-load-more load-more-failed class="i-amphtml-default-ui">
           <div class="i-amphtml-list-load-more-message">
             Unable to Load More
           </div>
-          <button load-more-clickable
+          <button
+            load-more-clickable
             class="i-amphtml-list-load-more-button
                   i-amphtml-list-load-more-button-has-icon
                   i-amphtml-list-load-more-button-small"

--- a/extensions/amp-mega-menu/0.1/test/test-amp-mega-menu.js
+++ b/extensions/amp-mega-menu/0.1/test/test-amp-mega-menu.js
@@ -41,7 +41,8 @@ describes.realWin(
       const element = doc.createElement('amp-mega-menu');
       element.setAttribute('layout', 'fixed-height');
       element.setAttribute('height', '10');
-      const nav = htmlFor(doc)`
+      const html = htmlFor(doc);
+      const nav = html`
         <nav>
           <ul>
             <li>

--- a/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/test/test-amp-nested-menu.js
@@ -51,7 +51,8 @@ describes.realWin(
       doc.body.appendChild(element);
 
       [1, 2, 3, 4].forEach((i) => {
-        const item = htmlFor(doc)`
+        const html = htmlFor(doc);
+        const item = html`
           <li>
             <button amp-nested-submenu-open></button>
             <div amp-nested-submenu>

--- a/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/test/test-amp-pan-zoom.js
@@ -46,20 +46,20 @@ describes.realWin(
      * @param {Object} opt_attributes
      */
     function getPanZoom(opt_attributes) {
-      el = htmlFor(doc)`
-      <amp-pan-zoom layout="fixed" width ="300" height="400">
-      </amp-pan-zoom>
-    `;
+      const html = htmlFor(doc);
+      el = html`
+        <amp-pan-zoom layout="fixed" width="300" height="400"> </amp-pan-zoom>
+      `;
 
       for (const key in opt_attributes) {
         el.setAttribute(key, opt_attributes[key]);
       }
 
-      svg = htmlFor(doc)`
-      <svg width="100" height="100">
-        <rect width="100" height="100" fill="#95B3D7"></rect>
-      </svg>
-    `;
+      svg = html`
+        <svg width="100" height="100">
+          <rect width="100" height="100" fill="#95B3D7"></rect>
+        </svg>
+      `;
 
       el.appendChild(svg);
       doc.body.appendChild(el);

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -62,7 +62,9 @@ const MIN_WEBGL_DISTANCE = 2;
  * @param {!Element} element
  * @return {!Element}
  */
-const buildActivateButtonTemplate = (element) => htmlFor(element)`
+const buildActivateButtonTemplate = (element) => {
+  const html = htmlFor(element);
+  return html`
     <button class="i-amphtml-story-360-activate-button" role="button">
       <span class="i-amphtml-story-360-activate-text"></span>
       <span class="i-amphtml-story-360-activate-button-icon"
@@ -98,6 +100,7 @@ const buildActivateButtonTemplate = (element) => htmlFor(element)`
       </span>
     </button>
   `;
+};
 
 /**
  * Generates the template for the gyroscope feature discovery animation.
@@ -108,12 +111,15 @@ const buildActivateButtonTemplate = (element) => htmlFor(element)`
  * @param {!Element} element
  * @return {!Element}
  */
-const buildDiscoveryTemplate = (element) => htmlFor(element)`
+const buildDiscoveryTemplate = (element) => {
+  const html = htmlFor(element);
+  return html`
     <div class="i-amphtml-story-360-discovery" aria-live="polite">
       <div class="i-amphtml-story-360-discovery-animation"></div>
       <span class="i-amphtml-story-360-discovery-text"></span>
     </div>
   `;
+};
 
 /**
  * @param {number} deg

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-debug.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-debug.js
@@ -177,10 +177,11 @@ export class AmpStoryDevToolsTabDebug extends AMP.BaseElement {
   buildDebugTitle_(errorCount) {
     const statusIcon = buildStatusIcon(this.element, errorCount == 0);
     statusIcon.classList.add('i-amphtml-story-dev-tools-log-status-icon');
-    const title = htmlFor(
-      this.element
-    )`<div class="i-amphtml-story-dev-tools-log-status-title"></div>`;
-    const statusText = htmlFor(this.element)`<span></span>`;
+    const html = htmlFor(this.element);
+    const title = html`
+      <div class="i-amphtml-story-dev-tools-log-status-title"></div>
+    `;
+    const statusText = html` <span></span> `;
     statusText.textContent = errorCount
       ? `Failed - ${errorCount} errors`
       : 'Passed';

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -427,9 +427,10 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
     this.storyUrl_ = this.element.getAttribute('data-story-url');
     this.element.classList.add('i-amphtml-story-dev-tools-tab');
 
-    this.devicesContainer_ = htmlFor(
-      this.element
-    )`<div class="i-amphtml-story-dev-tools-devices-container"></div>`;
+    const html = htmlFor(this.element);
+    this.devicesContainer_ = html`
+      <div class="i-amphtml-story-dev-tools-devices-container"></div>
+    `;
     this.element.appendChild(this.devicesContainer_);
 
     const chipListContainer = this.element.ownerDocument.createElement('div');

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -46,15 +46,17 @@ export const Type = {
  * @return {!Element}
  */
 const getBlockingTemplate = (element) => {
-  return htmlFor(element)`
-      <div class="i-amphtml-story-access-overflow">
-        <div class="i-amphtml-story-access-container">
-          <div class="i-amphtml-story-access-header">
-            <div class="i-amphtml-story-access-logo"></div>
-          </div>
-          <div class="i-amphtml-story-access-content"></div>
+  const html = htmlFor(element);
+  return html`
+    <div class="i-amphtml-story-access-overflow">
+      <div class="i-amphtml-story-access-container">
+        <div class="i-amphtml-story-access-header">
+          <div class="i-amphtml-story-access-logo"></div>
         </div>
-      </div>`;
+        <div class="i-amphtml-story-access-content"></div>
+      </div>
+    </div>
+  `;
 };
 
 /**
@@ -63,16 +65,18 @@ const getBlockingTemplate = (element) => {
  * @return {!Element}
  */
 const getNotificationTemplate = (element) => {
-  return htmlFor(element)`
-      <div class="i-amphtml-story-access-overflow">
-        <div class="i-amphtml-story-access-container">
-          <div class="i-amphtml-story-access-content">
-            <span class="i-amphtml-story-access-close-button" role="button">
-              &times;
-            </span>
-          </div>
+  const html = htmlFor(element);
+  return html`
+    <div class="i-amphtml-story-access-overflow">
+      <div class="i-amphtml-story-access-container">
+        <div class="i-amphtml-story-access-content">
+          <span class="i-amphtml-story-access-close-button" role="button">
+            &times;
+          </span>
         </div>
-      </div>`;
+      </div>
+    </div>
+  `;
 };
 
 /**

--- a/extensions/amp-story/1.0/amp-story-affiliate-link.js
+++ b/extensions/amp-story/1.0/amp-story-affiliate-link.js
@@ -132,14 +132,16 @@ export class AmpStoryAffiliateLink {
    * @private
    */
   addIconElement_() {
-    const iconEl = htmlFor(this.element_)`
+    const html = htmlFor(this.element_);
+    const iconEl = html`
       <div class="i-amphtml-story-affiliate-link-circle">
         <i class="i-amphtml-story-affiliate-link-icon"></i>
         <div class="i-amphtml-story-reset i-amphtml-hidden">
           <span class="i-amphtml-story-affiliate-link-text" hidden></span>
           <i class="i-amphtml-story-affiliate-link-launch" hidden></i>
         </div>
-      </div>`;
+      </div>
+    `;
     this.element_.appendChild(iconEl);
   }
 
@@ -173,8 +175,10 @@ export class AmpStoryAffiliateLink {
    * @private
    */
   addPulseElement_() {
-    const pulseEl = htmlFor(this.element_)`
-      <div class="i-amphtml-story-affiliate-link-pulse"></div>`;
+    const html = htmlFor(this.element_);
+    const pulseEl = html`
+      <div class="i-amphtml-story-affiliate-link-pulse"></div>
+    `;
     this.element_.appendChild(pulseEl);
   }
 }

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -50,12 +50,14 @@ export const DrawerState = {
  * @return {!Element}
  */
 const getTemplateEl = (element) => {
-  return htmlFor(element)`
+  const html = htmlFor(element);
+  return html`
     <div class="i-amphtml-story-draggable-drawer">
       <div class="i-amphtml-story-draggable-drawer-container">
         <div class="i-amphtml-story-draggable-drawer-content"></div>
       </div>
-    </div>`;
+    </div>
+  `;
 };
 
 /**
@@ -64,8 +66,8 @@ const getTemplateEl = (element) => {
  * @return {!Element}
  */
 const getHeaderEl = (element) => {
-  return htmlFor(element)`
-    <div class="i-amphtml-story-draggable-drawer-header"></div>`;
+  const html = htmlFor(element);
+  return html` <div class="i-amphtml-story-draggable-drawer-header"></div> `;
 };
 
 /**

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -216,10 +216,20 @@ export const EMBED_ID_ATTRIBUTE_NAME = 'i-amphtml-embed-id';
  * @param {!Element} element
  * @return {!Element}
  */
-const buildExpandedViewOverlay = (element) => htmlFor(element)`
-    <div class="i-amphtml-story-expanded-view-overflow i-amphtml-story-system-reset">
-      <button class="i-amphtml-expanded-view-close-button" aria-label="close" role="button"></button>
-    </div>`;
+const buildExpandedViewOverlay = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <div
+      class="i-amphtml-story-expanded-view-overflow i-amphtml-story-system-reset"
+    >
+      <button
+        class="i-amphtml-expanded-view-close-button"
+        aria-label="close"
+        role="button"
+      ></button>
+    </div>
+  `;
+};
 
 /**
  * Updates embed's corresponding <style> element with embedData.

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -35,49 +35,71 @@ const AttachmentTheme = {
  * @param {!Element} element
  * @return {!Element}
  */
-export const buildOpenDefaultAttachmentElement = (element) =>
-  htmlFor(element)`
-    <a class="
+export const buildOpenDefaultAttachmentElement = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <a
+      class="
         i-amphtml-story-page-open-attachment i-amphtml-story-system-reset"
-        role="button">
+      role="button"
+    >
       <span class="i-amphtml-story-page-open-attachment-icon">
         <span class="i-amphtml-story-page-open-attachment-bar-left"></span>
         <span class="i-amphtml-story-page-open-attachment-bar-right"></span>
       </span>
       <span class="i-amphtml-story-page-open-attachment-label"></span>
-    </a>`;
+    </a>
+  `;
+};
 
 /**
  * @param {!Element} element
  * @return {!Element}
  */
-export const buildOpenInlineAttachmentElement = (element) =>
-  htmlFor(element)`
-    <a class="
+export const buildOpenInlineAttachmentElement = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <a
+      class="
         i-amphtml-story-page-open-attachment i-amphtml-story-system-reset"
-        role="button">
+      role="button"
+    >
       <div class="i-amphtml-story-inline-page-attachment-chip">
         <div class="i-amphtml-story-inline-page-attachment-img"></div>
         <div class="i-amphtml-story-inline-page-attachment-arrow"></div>
       </div>
-    </a>`;
+    </a>
+  `;
+};
 
 /**
  * @param {!Element} element
  * @return {!Element}
  */
-const buildOpenOutlinkAttachmentElement = (element) =>
-  htmlFor(element)`
-     <a class="i-amphtml-story-page-open-attachment"
-         role="button">
-       <span class="i-amphtml-story-outlink-page-attachment-arrow">
-         <span class="i-amphtml-story-outlink-page-open-attachment-bar-left"></span>
-         <span class="i-amphtml-story-outlink-page-open-attachment-bar-right"></span>
-       </span>
-       <div class="i-amphtml-story-outlink-page-attachment-outlink-chip" ref="chipEl">
-        <div class="i-amphtml-story-outlink-page-attachment-label" ref="ctaLabelEl"></div>
-       </div>
-     </a>`;
+const buildOpenOutlinkAttachmentElement = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <a class="i-amphtml-story-page-open-attachment" role="button">
+      <span class="i-amphtml-story-outlink-page-attachment-arrow">
+        <span
+          class="i-amphtml-story-outlink-page-open-attachment-bar-left"
+        ></span>
+        <span
+          class="i-amphtml-story-outlink-page-open-attachment-bar-right"
+        ></span>
+      </span>
+      <div
+        class="i-amphtml-story-outlink-page-attachment-outlink-chip"
+        ref="chipEl"
+      >
+        <div
+          class="i-amphtml-story-outlink-page-attachment-label"
+          ref="ctaLabelEl"
+        ></div>
+      </div>
+    </a>
+  `;
+};
 
 /**
  * Determines which open attachment UI to render.

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -108,14 +108,19 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    * @private
    */
   buildInline_() {
-    const closeButtonEl = htmlFor(this.element)`
-          <button class="i-amphtml-story-page-attachment-close-button" aria-label="close"
-              role="button">
-          </button>`;
+    const html = htmlFor(this.element);
+    const closeButtonEl = html`
+      <button
+        class="i-amphtml-story-page-attachment-close-button"
+        aria-label="close"
+        role="button"
+      ></button>
+    `;
     const localizationService = getLocalizationService(devAssert(this.element));
 
-    const titleEl = htmlFor(this.element)`
-    <span class="i-amphtml-story-page-attachment-title"></span>`;
+    const titleEl = html`
+      <span class="i-amphtml-story-page-attachment-title"></span>
+    `;
 
     if (localizationService) {
       const localizedCloseString = localizationService.getLocalizedString(
@@ -130,8 +135,11 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     if (isPageAttachmentUiV2ExperimentOn(this.win)) {
       const titleAndCloseWrapperEl = this.headerEl_.appendChild(
-        htmlFor(this.element)`
-            <div class="i-amphtml-story-draggable-drawer-header-title-and-close"></div>`
+        html`
+          <div
+            class="i-amphtml-story-draggable-drawer-header-title-and-close"
+          ></div>
+        `
       );
       titleAndCloseWrapperEl.appendChild(closeButtonEl);
       titleAndCloseWrapperEl.appendChild(titleEl);
@@ -166,11 +174,13 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     );
     this.element.classList.add('i-amphtml-story-page-attachment-remote');
     // Use an anchor element to make this a real link in vertical rendering.
-    const link = htmlFor(this.element)`
-    <a class="i-amphtml-story-page-attachment-remote-content" target="_blank">
-      <span class="i-amphtml-story-page-attachment-remote-title"></span>
-      <span class="i-amphtml-story-page-attachment-remote-icon"></span>
-    </a>`;
+    const html = htmlFor(this.element);
+    const link = html`
+      <a class="i-amphtml-story-page-attachment-remote-content" target="_blank">
+        <span class="i-amphtml-story-page-attachment-remote-title"></span>
+        <span class="i-amphtml-story-page-attachment-remote-icon"></span>
+      </a>
+    `;
     link.setAttribute('href', this.element.getAttribute('href'));
     this.contentEl_.appendChild(link);
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -147,23 +147,32 @@ const VIDEO_PREVIEW_AUTO_ADVANCE_DURATION = '5s';
  * @param {!Element} element
  * @return {!Element}
  */
-const buildPlayMessageElement = (element) =>
-  htmlFor(element)`
-      <button role="button" class="i-amphtml-story-page-play-button i-amphtml-story-system-reset">
-        <span class="i-amphtml-story-page-play-label"></span>
-        <span class='i-amphtml-story-page-play-icon'></span>
-      </button>`;
+const buildPlayMessageElement = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <button
+      role="button"
+      class="i-amphtml-story-page-play-button i-amphtml-story-system-reset"
+    >
+      <span class="i-amphtml-story-page-play-label"></span>
+      <span class="i-amphtml-story-page-play-icon"></span>
+    </button>
+  `;
+};
 
 /**
  * @param {!Element} element
  * @return {!Element}
  */
-const buildErrorMessageElement = (element) =>
-  htmlFor(element)`
-      <div class="i-amphtml-story-page-error i-amphtml-story-system-reset">
-        <span class="i-amphtml-story-page-error-label"></span>
-        <span class='i-amphtml-story-page-error-icon'></span>
-      </div>`;
+const buildErrorMessageElement = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <div class="i-amphtml-story-page-error i-amphtml-story-system-reset">
+      <span class="i-amphtml-story-page-error-label"></span>
+      <span class="i-amphtml-story-page-error-icon"></span>
+    </div>
+  `;
+};
 
 /**
  * amp-story-page states.

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -47,14 +47,24 @@ export const VISIBLE_CLASS = 'i-amphtml-story-share-menu-visible';
  * @return {!Element}
  */
 const getTemplate = (element) => {
-  return htmlFor(element)`
-    <div class="i-amphtml-story-share-menu i-amphtml-story-system-reset" aria-hidden="true" role="alert">
+  const html = htmlFor(element);
+  return html`
+    <div
+      class="i-amphtml-story-share-menu i-amphtml-story-system-reset"
+      aria-hidden="true"
+      role="alert"
+    >
       <div class="i-amphtml-story-share-menu-container">
-        <button class="i-amphtml-story-share-menu-close-button" aria-label="close" role="button">
+        <button
+          class="i-amphtml-story-share-menu-close-button"
+          aria-label="close"
+          role="button"
+        >
           &times;
         </button>
       </div>
-    </div>`;
+    </div>
+  `;
 };
 
 /**
@@ -63,7 +73,8 @@ const getTemplate = (element) => {
  * @return {!Element}
  */
 const getAmpSocialSystemShareTemplate = (element) => {
-  return htmlFor(element)`<amp-social-share type="system"></amp-social-share>`;
+  const html = htmlFor(element);
+  return html` <amp-social-share type="system"></amp-social-share> `;
 };
 
 /**

--- a/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
+++ b/extensions/amp-story/1.0/amp-story-viewport-warning-layer.js
@@ -43,9 +43,12 @@ const RESIZE_THROTTLE_MS = 300;
  * @return {!Element}
  */
 const getTemplate = (element) => {
-  return htmlFor(element)`
-    <div class="
-        i-amphtml-story-no-rotation-overlay i-amphtml-story-system-reset">
+  const html = htmlFor(element);
+  return html`
+    <div
+      class="
+        i-amphtml-story-no-rotation-overlay i-amphtml-story-system-reset"
+    >
       <div class="i-amphtml-overlay-container">
         <div class="i-amphtml-story-overlay-icon"></div>
         <div class="i-amphtml-story-overlay-text"></div>

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -78,11 +78,14 @@ const ForwardButtonStates = {
  * @param {!Element} element
  * @return {!Element}
  */
-const buildPaginationButton = (element) =>
-  htmlFor(element)`
-      <div class="i-amphtml-story-button-container">
-        <button class="i-amphtml-story-button-move"></button>
-      </div>`;
+const buildPaginationButton = (element) => {
+  const html = htmlFor(element);
+  return html`
+    <div class="i-amphtml-story-button-container">
+      <button class="i-amphtml-story-button-move"></button>
+    </div>
+  `;
+};
 
 /**
  * @param {!Element} hoverEl

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -750,7 +750,8 @@ export class AmpVideo extends AMP.BaseElement {
     if (element.querySelector('i-amphtml-poster')) {
       return;
     }
-    const poster = htmlFor(element)`<i-amphtml-poster></i-amphtml-poster>`;
+    const html = htmlFor(element);
+    const poster = html` <i-amphtml-poster></i-amphtml-poster> `;
     const src = element.getAttribute('poster');
     setInitialDisplay(poster, 'block');
     setStyles(poster, {

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -470,7 +470,8 @@ class AmpYoutube extends AMP.BaseElement {
     }
 
     const {element: el} = this;
-    const imgPlaceholder = htmlFor(el)`<img placeholder referrerpolicy=origin>`;
+    const html = htmlFor(el);
+    const imgPlaceholder = html` <img placeholder referrerpolicy="origin" /> `;
     const videoid = dev().assertString(this.videoid_);
 
     setStyles(imgPlaceholder, {

--- a/src/iframe-video.js
+++ b/src/iframe-video.js
@@ -77,9 +77,8 @@ export function redispatch(element, event, events) {
  */
 export function createFrameFor(video, src, opt_name, opt_sandbox) {
   const {element} = video;
-  const frame = htmlFor(
-    element
-  )`<iframe frameborder=0 allowfullscreen></iframe>`;
+  const html = htmlFor(element);
+  const frame = html` <iframe frameborder="0" allowfullscreen></iframe> `;
 
   if (opt_name) {
     frame.setAttribute('name', opt_name);

--- a/src/layout.js
+++ b/src/layout.js
@@ -536,11 +536,17 @@ export function applyStaticLayout(element, fixIeIntrinsic = false) {
     // Intrinsic uses an svg inside the sizer element rather than the padding
     // trick Note a naked svg won't work becasue other thing expect the
     // i-amphtml-sizer element
-    const sizer = htmlFor(element)`
+    const html = htmlFor(element);
+    const sizer = html`
       <i-amphtml-sizer class="i-amphtml-sizer" slot="i-amphtml-svc">
-        <img alt="" role="presentation" aria-hidden="true"
-             class="i-amphtml-intrinsic-sizer" />
-      </i-amphtml-sizer>`;
+        <img
+          alt=""
+          role="presentation"
+          aria-hidden="true"
+          class="i-amphtml-intrinsic-sizer"
+        />
+      </i-amphtml-sizer>
+    `;
     const intrinsicSizer = sizer.firstElementChild;
     intrinsicSizer.setAttribute(
       'src',

--- a/src/preconnect.js
+++ b/src/preconnect.js
@@ -240,8 +240,8 @@ export class PreconnectService {
    * @private
    */
   performPreload_(url) {
-    const preload = htmlFor(this.document_)`
-        <link rel="preload" referrerpolicy="origin" />`;
+    const html = htmlFor(this.document_);
+    const preload = html` <link rel="preload" referrerpolicy="origin" /> `;
     preload.setAttribute('href', url);
     // Do not set 'as' attribute to correct value for now, for 2 reasons
     // - document value is not yet supported and dropped

--- a/src/service/loading-indicator.js
+++ b/src/service/loading-indicator.js
@@ -133,10 +133,14 @@ export class LoadingIndicatorImpl {
       startTime
     );
 
-    const container = htmlFor(this.ampdoc_.win.document)`
-        <div slot="i-amphtml-svc" class="i-amphtml-svc i-amphtml-loading-container i-amphtml-fill-content
-            amp-hidden"></div>
-      `;
+    const html = htmlFor(this.ampdoc_.win.document);
+    const container = html`
+      <div
+        slot="i-amphtml-svc"
+        class="i-amphtml-svc i-amphtml-loading-container i-amphtml-fill-content
+            amp-hidden"
+      ></div>
+    `;
     container.appendChild(loader);
     element.appendChild(container);
 

--- a/test/unit/test-static-template.js
+++ b/test/unit/test-static-template.js
@@ -19,7 +19,8 @@ import {htmlFor, htmlRefs} from '../../src/static-template';
 describe('Static Template', () => {
   describe('html', () => {
     it('generates static html tree', () => {
-      const div = htmlFor(document)`<div attr="test"><p class="er"></p></div>`;
+      const html = htmlFor(document);
+      const div = html` <div attr="test"><p class="er"></p></div> `;
 
       expect(div.tagName).to.equal('DIV');
       expect(div.getAttribute('attr')).to.equal('test');
@@ -57,8 +58,11 @@ describe('Static Template', () => {
       let div = html` <div></div> `;
       expect(div.ownerDocument).to.equal(document);
 
-      div = htmlFor(iDoc)`<div></div>`;
-      expect(div.ownerDocument).to.equal(iDoc);
+      (() => {
+        const html = htmlFor(document);
+        div = html` <div></div> `;
+        expect(div.ownerDocument).to.equal(iDoc);
+      })();
 
       div = html` <div></div> `;
       expect(div.ownerDocument).to.equal(iDoc);
@@ -68,19 +72,31 @@ describe('Static Template', () => {
     });
 
     it('ignores text before first element', () => {
-      const div = htmlFor(document)`test<div></div>`;
+      const html = htmlFor(document);
+      const div = html`
+        test
+        <div></div>
+      `;
       expect(div.outerHTML).to.not.include('test');
     });
 
     it('ignores text after first element', () => {
-      const div = htmlFor(document)`<div></div>test`;
+      const html = htmlFor(document);
+      const div = html`
+        <div></div>
+        test
+      `;
       expect(div.outerHTML).to.not.include('test');
     });
 
     it('rejects multiple root elements', () => {
       expect(() => {
         allowConsoleError(() => {
-          htmlFor(document)`<div></div><div></div>`;
+          const html = htmlFor(document);
+          html`
+            <div></div>
+            <div></div>
+          `;
         });
       }).to.throw('template');
     });
@@ -88,7 +104,8 @@ describe('Static Template', () => {
     it('rejects non-existent root', () => {
       expect(() => {
         allowConsoleError(() => {
-          htmlFor(document)``;
+          const html = htmlFor(document);
+          html``;
         });
       }).to.throw('template');
     });
@@ -96,7 +113,8 @@ describe('Static Template', () => {
     it('rejects dynamic templates', () => {
       expect(() => {
         allowConsoleError(() => {
-          htmlFor(document)`<div>${'text'}</div>`;
+          const html = htmlFor(document);
+          html` <div>${'text'}</div> `;
         });
       }).to.throw('template');
     });
@@ -118,13 +136,15 @@ describe('Static Template', () => {
     });
 
     it('ignores element if it has ref attribute', () => {
-      const el = htmlFor(document)`<div ref="test"></div>`;
+      const html = htmlFor(document);
+      const el = html` <div ref="test"></div> `;
       const refs = htmlRefs(el);
       expect(refs).to.deep.equal({});
     });
 
     it('rejects empty ref attribute', () => {
-      const el = htmlFor(document)`<div><div ref=""></div></div>`;
+      const html = htmlFor(document);
+      const el = html` <div><div ref=""></div></div> `;
       expect(() => {
         allowConsoleError(() => {
           htmlRefs(el);
@@ -133,10 +153,13 @@ describe('Static Template', () => {
     });
 
     it('rejects duplicate ref attribute', () => {
-      const el = htmlFor(document)`<div>
-            <div ref="test"></div>
-            <div ref="test"</div>
-          </div>`;
+      const html = htmlFor(document);
+      const el = html`
+        <div>
+          <div ref="test"></div>
+          <div ref="test"></div>
+        </div>
+      `;
       expect(() => {
         allowConsoleError(() => {
           htmlRefs(el);


### PR DESCRIPTION
## Background

Different frameworks may use literals tagged as `html` to denote an HTML template.

When following this convention, tooling may:

- highlight the template's syntax (Github, editors)
- format it (`prettier`)
- enable tag completion inside it (VS Code [using an addon](https://marketplace.visualstudio.com/items?itemName=webreflection.literally-html))
- etc.

AMP employs HTML template literals similarly, where we use the tag factory `htmlFor()`. Tooling is enabled when the factory is assigned to a helper tag constant `html`, but disabled when using `htmlFor()` directly:

```js
htmlFor()`
<ul class="some-classname"><li>Hello
</li></ul>`;

// vs

const html = htmlFor();
html`
  <ul class="some-classname">
    <li>Hello</li>
  </ul>
`;
```

## Change

**This change enforces the `html` helper constant syntax.** This way we always take advantage of tooling.

When using <code>htmlFor()\`...\`</code> directly, the linter can autofix to insert the helper constant. [You may try this out on AST Explorer.](https://astexplorer.net/#/gist/3aeff696d47c75d9338f94fa7af67a8a/7eb27b6b6091c4e7369562647fc000058b294c9d)

![html-template-autofix](https://user-images.githubusercontent.com/254946/114245853-1b513780-9946-11eb-86ac-fe83bd10ccbe.gif)

#### Additionally:

- Static templates are now only checked when using the helper tag <code>html\`...`</code>, since we're guaranteeing that format.

- Refactors tree shape conditions into `eslint` selectors where it makes sense.

- Source updated to match lint rule.