### PR TITLE
♻️ [bento][amp-accordion] Update usage of imperativeHandle in amp side Shim

### DIFF
--- a/extensions/amp-accordion/1.0/base-element.js
+++ b/extensions/amp-accordion/1.0/base-element.js
@@ -27,11 +27,8 @@ import {devAssert} from '../../../src/log';
 import {dict, memo} from '../../../src/utils/object';
 import {forwardRef} from '../../../src/preact/compat';
 import {toArray} from '../../../src/core/types/array';
-import {
-  useImperativeHandle,
-  useLayoutEffect,
-  useRef,
-} from '../../../src/preact';
+import {useDOMHandle} from '../../../src/preact/component';
+import {useLayoutEffect, useRef} from '../../../src/preact';
 import {useSlotContext} from '../../../src/preact/slot';
 
 const SECTION_SHIM_PROP = '__AMP_S_SHIM';
@@ -219,7 +216,7 @@ function ContentShimWithRef(
   const contentRef = useRef();
   contentRef.current = contentElement;
   useSlotContext(contentRef);
-  useImperativeHandle(ref, () => contentElement, [contentElement]);
+  useDOMHandle(ref, contentElement);
   useLayoutEffect(() => {
     if (!contentElement) {
       return;

--- a/src/preact/component/dom-handle.js
+++ b/src/preact/component/dom-handle.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-export {ContainWrapper} from './contain';
-export {Wrapper} from './wrapper';
-export {useRenderer} from './renderer';
-export {useValueRef} from './value-ref';
-export {useDOMHandle} from './dom-handle';
+import {useImperativeHandle} from '../';
+
+/**
+ * @param {{current: (T|null)}} ref
+ * @param {T} node
+ * @template T
+ */
+export function useDOMHandle(ref, node) {
+  useImperativeHandle(ref, () => node, [node]);
+}


### PR DESCRIPTION
Adding `useDOMHandle` and replacing `useImperativeHandle` in `amp-accordion`.

This is a continuation from another PR that was accidentally deleted when moving github branches from `master` to `main`. https://github.com/ampproject/amphtml/pull/33499