### PR TITLE
🏗  Optimize `dist` when only a subset of binaries need to be built

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -146,10 +146,17 @@ async function doDist(extraArgs = {}) {
   }
   await buildExtensions(options);
 
-  if (!argv.core_runtime_only) {
+  // Steps that are to be run only during a full `amp dist`.
+  if (
+    !argv.core_runtime_only &&
+    !argv.extensions &&
+    !argv.extensions_from &&
+    !argv.noextensions
+  ) {
     await buildVendorConfigs(options);
     await formatExtractedMessages();
   }
+
   if (!argv.watch) {
     exitCtrlcHandler(handlerProcess);
   }

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -135,7 +135,7 @@ async function doDist(extraArgs = {}) {
   printDistHelp(options);
   await runPreDistSteps(options);
 
-  // Steps that use closure compiler. Small ones before large (parallel) ones.
+  // These steps use closure compiler. Small ones before large (parallel) ones.
   if (argv.core_runtime_only) {
     await compileCoreRuntime(options);
   } else {
@@ -144,9 +144,11 @@ async function doDist(extraArgs = {}) {
     await buildWebPushPublisherFiles();
     await compileAllJs(options);
   }
+
+  // This step internally parses the various extension* flags.
   await buildExtensions(options);
 
-  // Steps that are to be run only during a full `amp dist`.
+  // This step is to be run only during a full `amp dist`.
   if (
     !argv.core_runtime_only &&
     !argv.extensions &&
@@ -154,6 +156,10 @@ async function doDist(extraArgs = {}) {
     !argv.noextensions
   ) {
     await buildVendorConfigs(options);
+  }
+
+  // This step is required no matter which extensions are built.
+  if (!argv.core_runtime_only) {
     await formatExtractedMessages();
   }
 

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -158,10 +158,8 @@ async function doDist(extraArgs = {}) {
     await buildVendorConfigs(options);
   }
 
-  // This step is required no matter which extensions are built.
-  if (!argv.core_runtime_only) {
-    await formatExtractedMessages();
-  }
+  // This step is required no matter which binaries are built.
+  await formatExtractedMessages();
 
   if (!argv.watch) {
     exitCtrlcHandler(handlerProcess);


### PR DESCRIPTION
With this PR, we no longer build ~300 ad vendors when only a subset of extensions / runtime binaries are built. This only takes effect during local development and doesn't affect CI or releases.