### PR TITLE
Add validation rules for amp-instagram:1.0

### DIFF
--- a/extensions/amp-instagram/1.0/test/validator-amp-instagram.html
+++ b/extensions/amp-instagram/1.0/test/validator-amp-instagram.html
@@ -1,0 +1,91 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Instagram examples</title>
+  <link rel="canonical" href="amps.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-1.0.js"></script>
+  <style amp-custom>
+    body {
+      background-color: white;
+      padding: 20px;
+    }
+
+    amp-instagram [overflow] {
+      position: absolute;
+      bottom: 0;
+      text-align: center;
+      background: #444;
+      color: white;
+      padding: 5px;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+
+
+  <h2>Instagram</h2>
+
+  <amp-instagram
+      data-shortcode="fBwFP"
+      width="381"
+      height="381"
+      layout="responsive">
+  </amp-instagram>
+
+  <h2>Instagram with Frame</h2>
+  <amp-instagram
+      data-shortcode="BR3g5NDBvBu"
+      data-default-framing
+      width="500"
+      height="500"
+      layout="responsive">
+  </amp-instagram>
+
+  <h2>Instagram with Frame, Caption and Overflow Element</h2>
+  <amp-instagram
+      data-shortcode="BR3g5NDBvBu"
+      data-captioned
+      data-default-framing
+      width="500"
+      height="500"
+      layout="responsive">
+      <div overflow>Show Caption</div>
+  </amp-instagram>
+
+  <h2>Instagram Default Layout</h2>
+  <amp-instagram
+      data-shortcode="fBwFP"
+      width="381"
+      height="381">
+  </amp-instagram>
+
+  <h3>Instagram Video</h3>
+  <amp-instagram data-shortcode="ftMW4rmDM_"
+                 width="300"
+                 height="300"
+                 layout="responsive">
+  </amp-instagram>
+
+</body>
+</html>

--- a/extensions/amp-instagram/1.0/test/validator-amp-instagram.out
+++ b/extensions/amp-instagram/1.0/test/validator-amp-instagram.out
@@ -1,0 +1,92 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <title>Instagram examples</title>
+|    <link rel="canonical" href="amps.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <link href='https://fonts.googleapis.com/css?family=Questrial' rel='stylesheet' type='text/css'>
+|    <script async custom-element="amp-instagram" src="https://cdn.ampproject.org/v0/amp-instagram-1.0.js"></script>
+|    <style amp-custom>
+|      body {
+|        background-color: white;
+|        padding: 20px;
+|      }
+|
+|      amp-instagram [overflow] {
+|        position: absolute;
+|        bottom: 0;
+|        text-align: center;
+|        background: #444;
+|        color: white;
+|        padding: 5px;
+|      }
+|    </style>
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|
+|
+|
+|    <h2>Instagram</h2>
+|
+|    <amp-instagram
+|        data-shortcode="fBwFP"
+|        width="381"
+|        height="381"
+|        layout="responsive">
+|    </amp-instagram>
+|
+|    <h2>Instagram with Frame</h2>
+|    <amp-instagram
+|        data-shortcode="BR3g5NDBvBu"
+|        data-default-framing
+|        width="500"
+|        height="500"
+|        layout="responsive">
+|    </amp-instagram>
+|
+|    <h2>Instagram with Frame, Caption and Overflow Element</h2>
+|    <amp-instagram
+|        data-shortcode="BR3g5NDBvBu"
+|        data-captioned
+|        data-default-framing
+|        width="500"
+|        height="500"
+|        layout="responsive">
+|        <div overflow>Show Caption</div>
+|    </amp-instagram>
+|
+|    <h2>Instagram Default Layout</h2>
+|    <amp-instagram
+|        data-shortcode="fBwFP"
+|        width="381"
+|        height="381">
+|    </amp-instagram>
+|
+|    <h3>Instagram Video</h3>
+|    <amp-instagram data-shortcode="ftMW4rmDM_"
+|                   width="300"
+|                   height="300"
+|                   layout="responsive">
+|    </amp-instagram>
+|
+|  </body>
+|  </html>

--- a/extensions/amp-instagram/validator-amp-instagram.protoascii
+++ b/extensions/amp-instagram/validator-amp-instagram.protoascii
@@ -14,11 +14,26 @@
 # limitations under the license.
 #
 
-tags: {  # amp-instagram
+tags: {  # amp-instagram 1.0
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-instagram 1.0"
+  excludes: "amp-instagram 0.1"
   extension_spec: {
     name: "amp-instagram"
+    version_name: "v1.0"
+    version: "1.0"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-instagram 0.1 and latest
+  html_format: AMP
+  tag_name: "SCRIPT"
+  satisfies: "amp-instagram 0.1"
+  excludes: "amp-instagram 1.0"
+  extension_spec: {
+    name: "amp-instagram"
+    version_name: "v0.1"
     version: "0.1"
     version: "latest"
     requires_usage: EXEMPTED


### PR DESCRIPTION
Note: `bento-instagram` experiment is still active, so this PR does not "launch" the component, only widens the pool for experimental usage and feedback to include valid AMP documents on the web.

Partial for #30172