### PR TITLE
♻️ Hoist associatedElement extraction out of core

### DIFF
--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -68,19 +68,12 @@ function assertion(
     const subValue = arguments[i++];
     const nextConstant = splitMessage.shift();
 
-    // If an element is provided, add it to the error object
-    if (!firstElement && subValue?.tagName) {
-      // Here we want the actual element
-      firstElement = subValue;
-    }
-
     message += elementStringOrPassThru(subValue) + nextConstant;
     messageArray.push(subValue, nextConstant.trim());
   }
 
   const error = new Error(message);
   error.messageArray = messageArray.filter((x) => x !== '');
-  error.associatedElement = firstElement;
   throw error;
 }
 

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -57,7 +57,6 @@ function assertion(
   // const messageArgs = Array.prototype.slice.call(arguments, 3);
   // Index at which message args start
   let i = 3;
-  let firstElement;
 
   // Substitute provided values into format string in message
   const splitMessage = opt_message.split('%s');

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -19,6 +19,7 @@ import {
   elementStringOrPassThru,
 } from './error-message-helpers';
 import {isMinifiedMode} from './minified-mode';
+import {remove} from './types/array';
 
 /**
  * Throws an error if the second argument isn't trueish.
@@ -72,7 +73,7 @@ function assertion(
   }
 
   const error = new Error(message);
-  error.messageArray = messageArray.filter((x) => x !== '');
+  error.messageArray = remove(messageArray, (x) => x !== '');
   throw error;
 }
 

--- a/src/error.js
+++ b/src/error.js
@@ -611,10 +611,7 @@ export function getErrorReportData(
   data['exps'] = exps.join(',');
 
   if (error) {
-    const tagName = error.associatedElement
-      ? error.associatedElement.tagName
-      : 'u'; // Unknown
-    data['el'] = tagName;
+    data['el'] = error.associatedElement?.tagName || 'u'; // Unknown
 
     if (error.args) {
       data['args'] = JSON.stringify(error.args);

--- a/src/log.js
+++ b/src/log.js
@@ -541,9 +541,9 @@ export class Log {
   prepareError_(error) {
     error = duplicateErrorIfNecessary(error);
 
-    // error.associatedElement is used to add the i-amphtml-error class; in
-    // `#development=1`` mode, it also adds `i-amphtml-element-error` to the
-    // element and sets the `error-message`` attribute.
+    // `associatedElement` is used to add the i-amphtml-error class; in
+    // `#development=1` mode, it also adds `i-amphtml-element-error` to the
+    // element and sets the `error-message` attribute.
     error.associatedElement = error.messageArray?.find((item) => item?.tagName);
     if (this.suffix_) {
       if (!error.message) {

--- a/src/log.js
+++ b/src/log.js
@@ -18,9 +18,9 @@ import {
   USER_ERROR_SENTINEL,
   elementStringOrPassThru,
 } from './core/error-message-helpers';
+import {findIndex, isArray} from './core/types/array';
 import {getMode} from './mode';
 import {internalRuntimeVersion} from './internal-version';
-import {isArray} from './core/types/array';
 import {isEnumValue} from './types';
 import {once} from './utils/function';
 import {pureDevAssert, pureUserAssert} from './core/assert';
@@ -544,7 +544,12 @@ export class Log {
     // `associatedElement` is used to add the i-amphtml-error class; in
     // `#development=1` mode, it also adds `i-amphtml-element-error` to the
     // element and sets the `error-message` attribute.
-    error.associatedElement = error.messageArray?.find((item) => item?.tagName);
+    if (error.messageArray) {
+      const elIndex = findIndex(error.messageArray, (item) => item?.tagName);
+      if (elIndex > -1) {
+        error.associatedElement = error.messageArray[elIndex];
+      }
+    }
     if (this.suffix_) {
       if (!error.message) {
         error.message = this.suffix_;

--- a/src/log.js
+++ b/src/log.js
@@ -540,6 +540,11 @@ export class Log {
    */
   prepareError_(error) {
     error = duplicateErrorIfNecessary(error);
+
+    // error.associatedElement is used to add the i-amphtml-error class; in
+    // `#development=1`` mode, it also adds `i-amphtml-element-error` to the
+    // element and sets the `error-message`` attribute.
+    error.associatedElement = error.messageArray?.find((item) => item?.tagName);
     if (this.suffix_) {
       if (!error.message) {
         error.message = this.suffix_;

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -862,8 +862,7 @@ export class Resource {
         'currently: ',
         this.state_
       );
-      err.associatedElement = this.element;
-      reportError(err);
+      reportError(err, this.element);
       return Promise.reject(err);
     }
 

--- a/test/unit/test-assert.js
+++ b/test/unit/test-assert.js
@@ -73,7 +73,6 @@ describes.sandboxed('assertions', {}, () => {
     }
 
     expect(error.toString()).to.match(/div#testId a 2 b 3/);
-    expect(error.associatedElement).to.equal(div);
     expect(error.messageArray).to.deep.equal([div, 'a', 2, 'b', 3]);
   });
 });

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -383,7 +383,7 @@ describe('Logging', () => {
         error = e;
       }
       expect(error).to.be.instanceof(Error);
-      expect(error.associatedElement).to.equal(div);
+      expect(error.messageArray[0]).to.equal(div);
     });
 
     it('should recognize asserts', () => {


### PR DESCRIPTION
Currently core assertion code picks out the first element in the message array and assigns it to `error.associatedElement`. This is only used in two places and only by AMP code. This PR hoists that logic up into `prepareError` in `src/log`

Part of https://github.com/ampproject/amphtml/issues/33631