### PR TITLE
Add validation rules for amp-lightbox:1.0

### DIFF
--- a/extensions/amp-lightbox/1.0/test/validator-amp-lightbox.html
+++ b/extensions/amp-lightbox/1.0/test/validator-amp-lightbox.html
@@ -1,0 +1,53 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests for the amp-lightbox tag. See the inline comments.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-1.0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <!-- Valid -->
+  <amp-lightbox id="lb-0" layout="nodisplay">
+
+  <!-- Invalid: layout must be nodisplay. -->
+  <amp-lightbox width="512" height="360"></amp-lightbox>
+
+  <!-- Valid -->
+  <amp-lightbox id="lb-2" layout="nodisplay" animation="fade-in">
+  </amp-lightbox>
+
+  <!-- Valid -->
+  <amp-lightbox id="lb-3" layout="nodisplay" animation="fly-in-bottom">
+  </amp-lightbox>
+
+  <!-- Valid -->
+  <amp-lightbox id="lb-4" layout="nodisplay" animation="fly-in-top">
+  </amp-lightbox>
+
+  <!-- Invalid: invalid `animation` value -->
+  <amp-lightbox id="lb-5" layout="nodisplay" animation="xmas-lights">
+  </amp-lightbox>
+</body>
+</html>

--- a/extensions/amp-lightbox/1.0/test/validator-amp-lightbox.out
+++ b/extensions/amp-lightbox/1.0/test/validator-amp-lightbox.out
@@ -1,0 +1,58 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests for the amp-lightbox tag. See the inline comments.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-1.0.js"></script>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <amp-lightbox id="lb-0" layout="nodisplay">
+|
+|    <!-- Invalid: layout must be nodisplay. -->
+|    <amp-lightbox width="512" height="360"></amp-lightbox>
+>>   ^~~~~~~~~
+amp-lightbox/1.0/test/validator-amp-lightbox.html:35:2 The implied layout 'FIXED' is not supported by tag 'amp-lightbox'. (see https://amp.dev/documentation/components/amp-lightbox)
+|
+|    <!-- Valid -->
+|    <amp-lightbox id="lb-2" layout="nodisplay" animation="fade-in">
+|    </amp-lightbox>
+|
+|    <!-- Valid -->
+|    <amp-lightbox id="lb-3" layout="nodisplay" animation="fly-in-bottom">
+|    </amp-lightbox>
+|
+|    <!-- Valid -->
+|    <amp-lightbox id="lb-4" layout="nodisplay" animation="fly-in-top">
+|    </amp-lightbox>
+|
+|    <!-- Invalid: invalid `animation` value -->
+|    <amp-lightbox id="lb-5" layout="nodisplay" animation="xmas-lights">
+>>   ^~~~~~~~~
+amp-lightbox/1.0/test/validator-amp-lightbox.html:50:2 The attribute 'animation' in tag 'amp-lightbox' is set to the invalid value 'xmas-lights'. (see https://amp.dev/documentation/components/amp-lightbox)
+|    </amp-lightbox>
+|  </body>
+|  </html>

--- a/extensions/amp-lightbox/1.0/test/validator-amp4ads-lightbox.html
+++ b/extensions/amp-lightbox/1.0/test/validator-amp4ads-lightbox.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Format is set to A4A.
+-->
+<!doctype html>
+<html ⚡4ads>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp4ads-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+  <!-- Invalid: importing disallowed version in the ads format. -->
+  <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-1.0.js"></script>
+</head>
+<body>
+  <!-- Valid use with close-button despite importing the wrong version. -->
+  <amp-lightbox layout="nodisplay" close-button>
+  </amp-lightbox>
+
+  <!-- Invalid: close-button not present. -->
+  <amp-lightbox layout="nodisplay">
+  </amp-lightbox>
+
+  <!-- Invalid: scrollable present. -->
+  <amp-lightbox layout="nodisplay" close-button scrollable>
+  </amp-lightbox>
+</body>
+</html>

--- a/extensions/amp-lightbox/1.0/test/validator-amp4ads-lightbox.out
+++ b/extensions/amp-lightbox/1.0/test/validator-amp4ads-lightbox.out
@@ -1,0 +1,50 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Format is set to A4A.
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|    <!-- Invalid: importing disallowed version in the ads format. -->
+|    <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-1.0.js"></script>
+>>   ^~~~~~~~~
+amp-lightbox/1.0/test/validator-amp4ads-lightbox.html:28:2 The attribute 'src' in tag 'SCRIPT[custom-element=amp-lightbox] (AMP4ADS)' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-lightbox-1.0.js'. (see https://amp.dev/documentation/components/amp-lightbox)
+|  </head>
+|  <body>
+|    <!-- Valid use with close-button despite importing the wrong version. -->
+|    <amp-lightbox layout="nodisplay" close-button>
+|    </amp-lightbox>
+|
+|    <!-- Invalid: close-button not present. -->
+|    <amp-lightbox layout="nodisplay">
+>>   ^~~~~~~~~
+amp-lightbox/1.0/test/validator-amp4ads-lightbox.html:36:2 The mandatory attribute 'close-button' is missing in tag 'amp-lightbox'. (see https://amp.dev/documentation/components/amp-lightbox)
+|    </amp-lightbox>
+|
+|    <!-- Invalid: scrollable present. -->
+|    <amp-lightbox layout="nodisplay" close-button scrollable>
+>>   ^~~~~~~~~
+amp-lightbox/1.0/test/validator-amp4ads-lightbox.html:40:2 The attribute 'scrollable' may not appear in tag 'amp-lightbox'. (see https://amp.dev/documentation/components/amp-lightbox)
+|    </amp-lightbox>
+|  </body>
+|  </html>

--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -14,11 +14,26 @@
 # limitations under the license.
 #
 
-tags: {  # amp-lightbox
+tags: {  # amp-lightbox 1.0
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-lightbox 1.0"
+  excludes: "amp-lightbox 0.1"
   extension_spec: {
     name: "amp-lightbox"
+    version_name: "v1.0"
+    version: "1.0"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-lightbox 0.1 and latest
+  html_format: AMP
+  tag_name: "SCRIPT"
+  satisfies: "amp-lightbox 0.1"
+  excludes: "amp-lightbox 1.0"
+  extension_spec: {
+    name: "amp-lightbox"
+    version_name: "v0.1"
     version: "0.1"
     version: "latest"
     requires_usage: EXEMPTED
@@ -32,6 +47,7 @@ tags: {  # amp-lightbox
   spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4ADS)"
   extension_spec: {
     name: "amp-lightbox"
+    version_name: "v0.1"
     version: "0.1"
     version: "latest"
   }
@@ -43,6 +59,7 @@ tags: {  # amp-lightbox
   spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4EMAIL)"
   extension_spec: {
     name: "amp-lightbox"
+    version_name: "v0.1"
     version: "0.1"
     version: "latest"
   }
@@ -56,7 +73,13 @@ tags: {  # <amp-lightbox>
   tag_name: "AMP-LIGHTBOX"
   requires_extension: "amp-lightbox"
   attrs: {
-    name: "animate-in"
+    name: "animate-in" # 0.1 only
+    value_casei: "fade-in"
+    value_casei: "fly-in-bottom"
+    value_casei: "fly-in-top"
+  }
+  attrs: {
+    name: "animation" # 1.0 only
     value_casei: "fade-in"
     value_casei: "fly-in-bottom"
     value_casei: "fly-in-top"
@@ -64,7 +87,7 @@ tags: {  # <amp-lightbox>
   attrs: { name: "controls" }
   attrs: { name: "from" }
   attrs: {
-    name: "scrollable"
+    name: "scrollable" # 0.1 only
     disabled_by: "amp4email"
   }
   # <amp-bind>


### PR DESCRIPTION
Notes: 

- `bento-lightbox` experiment is still active, so this PR does not "launch" the component, only widens the pool for experimental usage and feedback to include valid AMP documents on the web.
- This PR preserves `controls` and `from` attr from 0.1 but there is currently no indication their purpose, so there is reason to assume they are unsupported in 1.0.

Partial for #31052