### PR TITLE
Add validation rules for amp-selector:1.0

### DIFF
--- a/extensions/amp-selector/1.0/test/validator-amp-selector.html
+++ b/extensions/amp-selector/1.0/test/validator-amp-selector.html
@@ -1,0 +1,72 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests amp-selector.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-1.0.js"></script>
+  <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+  <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+</head>
+<body>
+  <!-- Valid -->
+  <form action="/" method="get" target="_blank" id="form1">
+    <!-- <amp-selector> with the options as list elements -->
+    <amp-selector layout="container" name="single_image_select">
+      <ul>
+        <li><amp-img src="/img1.png" width=50 height=50 option="1"></amp-img></li>
+        <li><amp-img src="/img2.png" width=50 height=50 option="2"></amp-img></li>
+        <li option="na" selected>None of the Above</li>
+      </ul>
+    </amp-selector>
+    <!-- <amp-selector> with the options as images -->
+    <amp-selector layout="container" name="multi_image_select" multiple>
+      <amp-img src="/img1.png" width=50 height=50 option="1"></amp-img>
+      <amp-img src="/img2.png" width=50 height=50 option="2"></amp-img>
+      <amp-img src="/img3.png" width=50 height=50 option="3"></amp-img>
+    </amp-selector>
+    <!-- <amp-selector> with the options as carousel images -->
+    <amp-selector layout="container" name="multi_image_select_1" multiple>
+      <amp-carousel id="carousel-1" width=200 height=60 controls>
+        <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+        <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+        <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+        <amp-img src="/img4.png" width=80 height=60 option="d" disabled></amp-img>
+      </amp-carousel>
+    </amp-selector>
+    <!-- <amp-selector> with bindable attributes -->
+    <amp-selector layout="container" name="with_binding" [selected]="foo" [disabled]="bar">
+    </amp-selector>
+  </form>
+
+  <!-- <amp-selector> with the options as carousel images, outside a form -->
+  <amp-selector layout="container" name="multi_image_select_2" multiple form="form1">
+    <amp-carousel id="carousel-1" width=400 height=300 type=slides controls>
+      <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+      <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+      <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+      <amp-img src="/img4.png" width=80 height=60 option="d"></amp-img>
+    </amp-carousel>
+  </amp-selector>
+</body>

--- a/extensions/amp-selector/1.0/test/validator-amp-selector.out
+++ b/extensions/amp-selector/1.0/test/validator-amp-selector.out
@@ -1,0 +1,73 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests amp-selector.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-selector" src="https://cdn.ampproject.org/v0/amp-selector-1.0.js"></script>
+|    <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
+|    <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <form action="/" method="get" target="_blank" id="form1">
+|      <!-- <amp-selector> with the options as list elements -->
+|      <amp-selector layout="container" name="single_image_select">
+|        <ul>
+|          <li><amp-img src="/img1.png" width=50 height=50 option="1"></amp-img></li>
+|          <li><amp-img src="/img2.png" width=50 height=50 option="2"></amp-img></li>
+|          <li option="na" selected>None of the Above</li>
+|        </ul>
+|      </amp-selector>
+|      <!-- <amp-selector> with the options as images -->
+|      <amp-selector layout="container" name="multi_image_select" multiple>
+|        <amp-img src="/img1.png" width=50 height=50 option="1"></amp-img>
+|        <amp-img src="/img2.png" width=50 height=50 option="2"></amp-img>
+|        <amp-img src="/img3.png" width=50 height=50 option="3"></amp-img>
+|      </amp-selector>
+|      <!-- <amp-selector> with the options as carousel images -->
+|      <amp-selector layout="container" name="multi_image_select_1" multiple>
+|        <amp-carousel id="carousel-1" width=200 height=60 controls>
+|          <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+|          <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+|          <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+|          <amp-img src="/img4.png" width=80 height=60 option="d" disabled></amp-img>
+|        </amp-carousel>
+|      </amp-selector>
+|      <!-- <amp-selector> with bindable attributes -->
+|      <amp-selector layout="container" name="with_binding" [selected]="foo" [disabled]="bar">
+|      </amp-selector>
+|    </form>
+|
+|    <!-- <amp-selector> with the options as carousel images, outside a form -->
+|    <amp-selector layout="container" name="multi_image_select_2" multiple form="form1">
+|      <amp-carousel id="carousel-1" width=400 height=300 type=slides controls>
+|        <amp-img src="/img1.png" width=80 height=60 option="a"></amp-img>
+|        <amp-img src="/img2.png" width=80 height=60 option="b" selected></amp-img>
+|        <amp-img src="/img3.png" width=80 height=60 option="c"></amp-img>
+|        <amp-img src="/img4.png" width=80 height=60 option="d"></amp-img>
+|      </amp-carousel>
+|    </amp-selector>
+|  </body>

--- a/extensions/amp-selector/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/validator-amp-selector.protoascii
@@ -13,12 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the license.
 #
-tags: {
+tags: {  # amp-selector 1.0
+  html_format: AMP
+  tag_name: "SCRIPT"
+  satisfies: "amp-selector 1.0"
+  excludes: "amp-selector 0.1"
+  extension_spec: {
+    name: "amp-selector"
+    version_name: "v1.0"
+    version: "1.0"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-selector 0.1 and latest
   html_format: AMP
   html_format: AMP4ADS
   tag_name: "SCRIPT"
+  satisfies: "amp-selector 0.1"
+  excludes: "amp-selector 1.0"
   extension_spec: {
     name: "amp-selector"
+    version_name: "v0.1"
     version: "0.1"
     version: "latest"
     requires_usage: EXEMPTED
@@ -33,6 +48,7 @@ tags: {
   extension_spec: {
     name: "amp-selector"
     # AMP4EMAIL doesn't allow version: "latest".
+    version_name: "v0.1"
     version: "0.1"
     requires_usage: EXEMPTED
   }


### PR DESCRIPTION
`bento-selector` experiment is still active, so this PR does not "launch" the component, only widens the pool for experimental usage and feedback to include valid AMP documents on the web.

Partial for #28282