### PR TITLE
✨ [amp-accordion] Error when amp-accordion 0.1 is used with amp-bind on the expanded attribute

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -155,6 +155,14 @@ class AmpAccordion extends AMP.BaseElement {
         // for details.
       });
 
+      userAssert(
+        !section.hasAttribute('[expanded]') &&
+          !section.hasAttribute('data-amp-bind-expanded'),
+        'The "expanded" attribute cannot be used with amp-bind. ' +
+          'Found in: %s',
+        this.element
+      );
+
       const isExpanded = section.hasAttribute('expanded');
       header.classList.add('i-amphtml-accordion-header');
       if (!header.hasAttribute('role')) {

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -158,7 +158,8 @@ class AmpAccordion extends AMP.BaseElement {
       userAssert(
         !section.hasAttribute('[expanded]') &&
           !section.hasAttribute('data-amp-bind-expanded'),
-        'The "expanded" attribute cannot be used with amp-bind. ' +
+        'The "expanded" attribute cannot be used with amp-bind in version ' +
+          '0.1 of amp-accordion. Please bind to [data-expand] instead. ' +
           'Found in: %s',
         this.element
       );

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -25,6 +25,7 @@ import {
   tryFocus,
   whenUpgradedToCustomElement,
 } from '../../../../src/dom';
+import {htmlFor} from '../../../../src/static-template';
 import {poll} from '../../../../testing/iframe';
 
 describes.realWin(
@@ -844,6 +845,34 @@ describes.realWin(
       expect(header2.getAttribute('id')).to.equal(
         content2.getAttribute('aria-labelledby')
       );
+    });
+
+    it('should throw an error when amp-bind used with expanded attribute ', async () => {
+      const errors = [];
+      const consoleError = console.error;
+      console.error = (msg) => {
+        errors.push(msg);
+      };
+
+      const html = htmlFor(win.document);
+      const accordion = html`
+        <amp-accordion animate>
+          <section [expanded]="section1">
+            <h2>Section 1</h2>
+            <div>Puppies are cute.</div>
+          </section>
+        </amp-accordion>
+      `;
+      doc.body.appendChild(accordion);
+
+      try {
+        await accordion.buildInternal();
+      } catch (expected) {
+        expect(errors.length).to.equal(1);
+        expect(errors[0]).to.include('The "expanded" attribute');
+      }
+
+      console.error = consoleError;
     });
   }
 );

--- a/extensions/amp-accordion/0.1/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/0.1/test/test-amp-accordion.js
@@ -865,13 +865,12 @@ describes.realWin(
       `;
       doc.body.appendChild(accordion);
 
-      try {
-        await accordion.buildInternal();
-      } catch (expected) {
-        expect(errors.length).to.equal(1);
-        expect(errors[0]).to.include('The "expanded" attribute');
-      }
+      await accordion.buildInternal().catch((err) => {
+        expect(err.message).to.include('The "expanded" attribute');
+      });
 
+      expect(errors.length).to.equal(1);
+      expect(errors[0]).to.include('The "expanded" attribute');
       console.error = consoleError;
     });
   }


### PR DESCRIPTION
`0.1 amp-accordion` should not support `amp-bind` on the `expanded` attribute.

This is related to: https://github.com/ampproject/amphtml/pull/33493

Validator is currently unable to distinguish between `0.1` and `1.0` for attributes using `amp-bind` so we must throw an error to protect against improper usage.