### PR TITLE
🏗 Remove duplicate local var in task runner installer

### DIFF
--- a/build-system/task-runner/install-amp-task-runner.js
+++ b/build-system/task-runner/install-amp-task-runner.js
@@ -44,9 +44,8 @@ async function installAmpTaskRunner() {
     }
   }
   log(yellow('Installing'), cyan('amp'), yellow('task runner...'));
-  const runnerBinary = path.join(npmBinDir, 'amp');
-  await fs.remove(runnerBinary);
-  await fs.copy(ampCliRunner, runnerBinary);
+  await fs.remove(ampBinary);
+  await fs.copy(ampCliRunner, ampBinary);
   log(green('Installed'), cyan('amp'), green('task runner.\n'));
 }
 


### PR DESCRIPTION
The local var `runnerBinary` is now an exact duplicate of `ampBinary` on line 37, so we should remove it. Forgot to do this in #33787.
