### PR TITLE
♻️ Extra type assertions into core

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -574,7 +574,7 @@ const forbiddenTermsGlobal = {
   '/\\*\\* @type \\{\\!Element\\} \\*/': {
     message: 'Use assertElement instead of casting to !Element.',
     allowlist: [
-      'src/log.js', // Has actual implementation of assertElement.
+      'src/core/assert.js', // Has actual implementation of assertElement.
       'src/polyfills/custom-elements.js',
       'ads/google/imaVideo.js', // Required until #22277 is fixed.
       '3p/twitter.js', // Runs in a 3p window context, so cannot import log.js.

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -54,32 +54,22 @@ function assertion(
   const messageArgs = isArray(opt_messageArray)
     ? opt_messageArray
     : // opt_messageArray instead contains the message format string; everything
-      // after that belongs to the actual messageArray.
+      // after that is a format argument.
       Array.prototype.slice.call(arguments, 2);
-  let messageFmt = messageArgs[0];
 
   // Include the sentinel string if provided and not already present
-  if (sentinel && !messageFmt.includes(sentinel)) {
-    messageFmt += sentinel;
+  if (sentinel && !messageArgs[0].includes(sentinel)) {
+    messageArgs[0] += sentinel;
   }
 
   // Substitute provided values into format string in message
-  const splitMessage = messageFmt.split('%s');
-  let message = splitMessage.shift();
-
-  const messageArray = [];
-  // Index at which message args start
   let i = 1;
-  while (splitMessage.length) {
-    const subValue = messageArgs[i++];
-    const nextConstant = splitMessage.shift();
-
-    message += elementStringOrPassThru(subValue) + nextConstant;
-    messageArray.push(subValue, nextConstant.trim());
-  }
+  const message = messageArgs[0].replace(/%s/g, () =>
+    elementStringOrPassThru(messageArgs[i++])
+  );
 
   const error = new Error(message);
-  error.messageArray = remove(messageArray, (x) => x !== '');
+  error.messageArray = messageArgs.slice(0, i);
   throw error;
 }
 

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -75,7 +75,6 @@ export function baseAssert(
  * default. An interpolation token is added at the end to include the `subject`.
  * @param {!function} assertFn underlying assertion function to call
  * @param {*} subject
- * @param {*} assertion
  * @param shouldBeTruthy
  * @param {string} defaultMessage
  * @param {!Array|string=} opt_message
@@ -311,3 +310,46 @@ export function pureDevAssert(
     opt_9
   );
 }
+
+/**
+ * Given an assertion function, produces the type assertion variants. Allows
+ * AMP Log to use its own wrapped assertion method.
+ * @param {!function} assertFn
+//  * @return {!Object}
+//  */
+// export function typeAssertions(assertFn) {
+//   return {
+//     assertElement: baseAssertElement.bind(null, assertFn),
+//     assertString: baseAssertString.bind(null, assertFn),
+//     assertNumber: baseAssertNumber.bind(null, assertFn),
+//     assertArray: baseAssertArray.bind(null, assertFn),
+//     assertBoolean: baseAssertBoolean.bind(null, assertFn),
+//   };
+// }
+
+// /**
+//  * Creates a set of assertions using the provided sentinel string, if any.
+//  * @param {string|undefined} sentinel
+//  * @return {!Object}
+//  */
+// function Assertions(sentinel) {
+//   const assert = baseAssert.bind(null, sentinel);
+//   return {assert, ...typeAssertions(assert)};
+// }
+
+export const userAsserts = {
+  assert: pureUserAssert,
+  assertElement: baseAssertElement.bind(null, pureUserAssert),
+  assertString: baseAssertString.bind(null, pureUserAssert),
+  assertNumber: baseAssertNumber.bind(null, pureUserAssert),
+  assertArray: baseAssertArray.bind(null, pureUserAssert),
+  assertBoolean: baseAssertBoolean.bind(null, pureUserAssert),
+};
+export const devAsserts = {
+  assert: pureUserAssert,
+  assertElement: baseAssertElement.bind(null, pureUserAssert),
+  assertString: baseAssertString.bind(null, pureUserAssert),
+  assertNumber: baseAssertNumber.bind(null, pureUserAssert),
+  assertArray: baseAssertArray.bind(null, pureUserAssert),
+  assertBoolean: baseAssertBoolean.bind(null, pureUserAssert),
+};

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -114,13 +114,13 @@ function baseAssertType_(
  * @closurePrimitive {asserts.matchesReturn}
  */
 export function baseAssertElement(assertFn, shouldBeElement, opt_message) {
-  return baseAssertType_(
+  return /** @type {!Element} */ (baseAssertType_(
     assertFn,
     shouldBeElement,
     shouldBeElement?.nodeType == 1,
     'Element expected',
     opt_message
-  );
+  ));
 }
 
 /**

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -18,7 +18,7 @@ import {
   USER_ERROR_SENTINEL,
   elementStringOrPassThru,
 } from './error-message-helpers';
-import {isArray, remove} from './types/array';
+import {isArray} from './types/array';
 import {isMinifiedMode} from './minified-mode';
 
 /**

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -37,7 +37,6 @@ import {isMinifiedMode} from './minified-mode';
  * @param {string} opt_message
  * @param {...*} var_args Arguments substituted into %s in the message
  * @return {T}
- * @template {T}
  * @throws {Error} when shouldBeTruthy is not truthy.
  * @closurePrimitive {asserts.truthy}
  */
@@ -84,7 +83,6 @@ export function baseAssert(
  * @param {string} defaultMessage
  * @param {Array|string=} opt_message
  * @return {T}
- * @template {T}
  * @private
  */
 function baseAssertType_(

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -38,7 +38,7 @@ import {isMinifiedMode} from './minified-mode';
  * @return {T}
  * @throws {Error} when shouldBeTruthy is not truthy.
  */
-function assertion(
+export function baseAssert(
   sentinel,
   shouldBeTruthy,
   opt_message = 'Assertion failed',
@@ -99,7 +99,7 @@ export function pureUserAssert(
   opt_8,
   opt_9
 ) {
-  return assertion(
+  return baseAssert(
     USER_ERROR_SENTINEL,
     shouldBeTruthy,
     opt_message,
@@ -159,7 +159,7 @@ export function pureDevAssert(
       .log('__devAssert_sentinel__');
   }
 
-  return assertion(
+  return baseAssert(
     null,
     shouldBeTruthy,
     opt_message,

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -19,6 +19,7 @@ import {
   elementStringOrPassThru,
 } from './error-message-helpers';
 import {isArray} from './types/array';
+import {isEnumValue} from './types/enum';
 import {isMinifiedMode} from './minified-mode';
 
 /**
@@ -216,6 +217,32 @@ export function baseAssertBoolean(assertFn, shouldBeBoolean, opt_message) {
 }
 
 /**
+ * Asserts and returns the enum value. If the enum doesn't contain such a
+ * value, the error is thrown.
+ *
+ * @param {!AssertionFunction} assertFn
+ * @param {*} shouldBeEnum
+ * @param {T} shouldBeEnum
+ * @param {!Object<T>} enumObj
+ * @param {string=} opt_enumName
+ * @return {T}
+ * @closurePrimitive {asserts.matchesReturn}
+ */
+export function baseAssertEnumValue(
+  assertFn,
+  shouldBeEnum,
+  enumObj,
+  opt_enumName = 'enum'
+) {
+  return baseAssertType_(
+    assertFn,
+    shouldBeEnum,
+    isEnumValue(enumObj, shouldBeEnum),
+    `Unknown ${opt_enumName} value: "${shouldBeEnum}"`
+  );
+}
+
+/**
  * Throws a user error if the first argument isn't trueish. Mirrors userAssert
  * in src/log.js.
  * @param {T} shouldBeTruthy
@@ -329,12 +356,14 @@ export const userAsserts = {
   assertNumber: baseAssertNumber.bind(null, pureUserAssert),
   assertArray: baseAssertArray.bind(null, pureUserAssert),
   assertBoolean: baseAssertBoolean.bind(null, pureUserAssert),
+  assertEnum: baseAssertEnumValue.bind(null, pureUserAssert),
 };
 export const devAsserts = {
-  assert: pureUserAssert,
-  assertElement: baseAssertElement.bind(null, pureUserAssert),
-  assertString: baseAssertString.bind(null, pureUserAssert),
-  assertNumber: baseAssertNumber.bind(null, pureUserAssert),
-  assertArray: baseAssertArray.bind(null, pureUserAssert),
-  assertBoolean: baseAssertBoolean.bind(null, pureUserAssert),
+  assert: pureDevAssert,
+  assertElement: baseAssertElement.bind(null, pureDevAssert),
+  assertString: baseAssertString.bind(null, pureDevAssert),
+  assertNumber: baseAssertNumber.bind(null, pureDevAssert),
+  assertArray: baseAssertArray.bind(null, pureDevAssert),
+  assertBoolean: baseAssertBoolean.bind(null, pureDevAssert),
+  assertEnum: baseAssertEnumValue.bind(null, pureDevAssert),
 };

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -35,7 +35,6 @@ import {isMinifiedMode} from './minified-mode';
  * @param {string} sentinel
  * @param {T} shouldBeTruthy
  * @param {string} opt_message
- * @param opt_messageArray
  * @param {...*} var_args Arguments substituted into %s in the message
  * @return {T}
  * @throws {Error} when shouldBeTruthy is not truthy.
@@ -43,19 +42,16 @@ import {isMinifiedMode} from './minified-mode';
 function assertion(
   sentinel,
   shouldBeTruthy,
-  opt_messageArray = 'Assertion failed',
+  opt_message = 'Assertion failed',
   var_args
 ) {
   if (shouldBeTruthy) {
     return shouldBeTruthy;
   }
 
-  // TODO(#33631): Eventually allow only the array format
-  const messageArgs = isArray(opt_messageArray)
-    ? opt_messageArray
-    : // opt_messageArray instead contains the message format string; everything
-      // after that is a format argument.
-      Array.prototype.slice.call(arguments, 2);
+  // opt_message instead contains the message format string; everything after it
+  // is a format argument.
+  const messageArgs = Array.prototype.slice.call(arguments, 2);
 
   // Include the sentinel string if provided and not already present
   if (sentinel && !messageArgs[0].includes(sentinel)) {

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -18,7 +18,6 @@ import {
   USER_ERROR_SENTINEL,
   elementStringOrPassThru,
 } from './error-message-helpers';
-import {isArray} from './types/array';
 import {isMinifiedMode} from './minified-mode';
 
 /**

--- a/src/error-reporting.js
+++ b/src/error-reporting.js
@@ -206,7 +206,8 @@ export function reportError(error, opt_associatedElement) {
         // This outputs a log message where non-string values are preserved but
         // appear  inline
         const prettyMessageArray = error.messageArray[0]
-          .split(/(?<=%s)|(?=%s)/) // Split at each %s, leave them in the array
+          .split(/(%s)/) // Split at each %s, leave them in the array
+          .filter((s) => s !== '')
           .map((substr) =>
             substr == '%s' ? error.messageArray[i++] : substr.trim()
           );

--- a/src/error-reporting.js
+++ b/src/error-reporting.js
@@ -202,7 +202,15 @@ export function reportError(error, opt_associatedElement) {
     ) {
       const output = console.error || console.log;
       if (error.messageArray) {
-        output.apply(console, error.messageArray);
+        let i = 1;
+        // This outputs a log message where non-string values are preserved but
+        // appear  inline
+        const prettyMessageArray = error.messageArray[0]
+          .split(/(?<=%s)|(?=%s)/) // Split at each %s, leave them in the array
+          .map((substr) =>
+            substr == '%s' ? error.messageArray[i++] : substr.trim()
+          );
+        output.apply(console, prettyMessageArray);
       } else {
         if (element) {
           output.call(console, error.message, element);

--- a/src/log.js
+++ b/src/log.js
@@ -189,12 +189,87 @@ export class Log {
         });
     });
 
+    // Provide the AMP assertion function, including prepareError_ and error
+    // reporting calls, to each of the derived assertion helpers.
     const assertFn = this.assert.bind(this);
     const wrap = (typeAssertFn) => typeAssertFn.bind(null, assertFn);
+    /**
+     * Throws an error if the first argument isn't an Element.
+     *
+     * For more details see `assert`.
+     *
+     * @function
+     * @param {!AssertionFunction} assertFn
+     * @param {*} shouldBeElement
+     * @param {Array|string=} opt_message The assertion message
+     * @return {!Element} The value of shouldBeTrueish.
+     * @throws {Error} when shouldBeElement is not an Element
+     * @closurePrimitive {asserts.matchesReturn}
+     */
     this.assertElement = wrap(baseAssertElement);
+
+    /**
+     * Throws an error if the first argument isn't a string. The string can
+     * be empty.
+     *
+     * For more details see `assert`.
+     *
+     * @function
+     * @param {!AssertionFunction} assertFn
+     * @param {*} shouldBeString
+     * @param {Array|string=} opt_message The assertion message
+     * @return {string} The string value. Can be an empty string.
+     * @throws {Error} when shouldBeString is not an String
+     * @closurePrimitive {asserts.matchesReturn}
+     */
     this.assertString = wrap(baseAssertString);
+
+    /**
+     * Throws an error if the first argument isn't a number. The allowed values
+     * include `0` and `NaN`.
+     *
+     * For more details see `assert`.
+     *
+     * @function
+     * @param {!AssertionFunction} assertFn
+     * @param {*} shouldBeNumber
+     * @param {Array|string=} opt_message The assertion message
+     * @return {number} The number value. The allowed values include `0`
+     *   and `NaN`.
+     * @throws {Error} when shouldBeNumber is not an Number
+     * @closurePrimitive {asserts.matchesReturn}
+     */
     this.assertNumber = wrap(baseAssertNumber);
+
+    /**
+     * Throws an error if the first argument is not an array.
+     * The array can be empty.
+     *
+     * For more details see `assert`.
+     *
+     * @function
+     * @param {!AssertionFunction} assertFn
+     * @param {*} shouldBeArray
+     * @param {Array|string=} opt_message The assertion message
+     * @return {!Array} The array value
+     * @throws {Error} when shouldBeArray is not an Array
+     * @closurePrimitive {asserts.matchesReturn}
+     */
     this.assertArray = wrap(baseAssertArray);
+
+    /**
+     * Throws an error if the first argument isn't a boolean.
+     *
+     * For more details see `assert`.
+     *
+     * @function
+     * @param {!AssertionFunction} assertFn
+     * @param {*} shouldBeBoolean
+     * @param {Array|string=} opt_message The assertion message
+     * @return {boolean} The boolean value.
+     * @throws {Error} when shouldBeBoolean is not an Boolean
+     * @closurePrimitive {asserts.matchesReturn}
+     */
     this.assertBoolean = wrap(baseAssertBoolean);
   }
 

--- a/src/log.js
+++ b/src/log.js
@@ -23,6 +23,7 @@ import {
   baseAssertArray,
   baseAssertBoolean,
   baseAssertElement,
+  baseAssertEnumValue,
   baseAssertNumber,
   baseAssertString,
 } from './core/assert';
@@ -271,6 +272,7 @@ export class Log {
      * @closurePrimitive {asserts.matchesReturn}
      */
     this.assertBoolean = wrap(baseAssertBoolean);
+    this.assertEnumValue = wrap(baseAssertEnumValue);
   }
 
   /**
@@ -496,24 +498,6 @@ export class Log {
       self.__AMP_REPORT_ERROR(e);
       throw e;
     }
-  }
-
-  /**
-   * Asserts and returns the enum value. If the enum doesn't contain such a
-   * value, the error is thrown.
-   *
-   * @param {!Object<T>} enumObj
-   * @param {string} s
-   * @param {string=} opt_enumName
-   * @return {T}
-   * @template T
-   * @closurePrimitive {asserts.matchesReturn}
-   */
-  assertEnumValue(enumObj, s, opt_enumName) {
-    if (isEnumValue(enumObj, s)) {
-      return s;
-    }
-    this.assert(false, 'Unknown %s value: "%s"', opt_enumName || 'enum', s);
   }
 
   /**

--- a/src/log.js
+++ b/src/log.js
@@ -190,11 +190,12 @@ export class Log {
     });
 
     const assertFn = this.assert.bind(this);
-    this.assertElement = baseAssertElement.bind(null, assertFn);
-    this.assertString = baseAssertString.bind(null, assertFn);
-    this.assertNumber = baseAssertNumber.bind(null, assertFn);
-    this.assertArray = baseAssertArray.bind(null, assertFn);
-    this.assertBoolean = baseAssertBoolean.bind(null, assertFn);
+    const wrap = (typeAssertFn) => typeAssertFn.bind(null, assertFn);
+    this.assertElement = wrap(baseAssertElement);
+    this.assertString = wrap(baseAssertString);
+    this.assertNumber = wrap(baseAssertNumber);
+    this.assertArray = wrap(baseAssertArray);
+    this.assertBoolean = wrap(baseAssertBoolean);
   }
 
   /**

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -41,7 +41,7 @@ import {
   parseBooleanAttribute,
 } from '../dom';
 import {dashToCamelCase} from '../core/types/string';
-import {devAssert} from '../log';
+import {pureDevAssert as devAssert} from '../core/assert';
 import {dict, hasOwn, map} from '../core/types/object';
 import {getDate} from '../utils/date';
 import {getMode} from '../mode';

--- a/test/unit/core/test-assert.js
+++ b/test/unit/core/test-assert.js
@@ -73,6 +73,6 @@ describes.sandboxed('assertions', {}, () => {
     }
 
     expect(error.toString()).to.match(/div#testId a 2 b 3/);
-    expect(error.messageArray).to.deep.equal([div, 'a', 2, 'b', 3]);
+    expect(error.messageArray).to.deep.equal(['%s a %s b %s', div, 2, 3]);
   });
 });

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -371,7 +371,7 @@ describe('Logging', () => {
       }
       expect(error).to.be.instanceof(Error);
       expect(error.message).to.equal('1 a 2 b 3' + USER_ERROR_SENTINEL);
-      expect(error.messageArray).to.deep.equal([1, 'a', 2, 'b', 3]);
+      expect(error.messageArray).to.deep.equal(['%s a %s b %s', 1, 2, 3]);
     });
 
     it('should add element and assert info', () => {
@@ -383,7 +383,7 @@ describe('Logging', () => {
         error = e;
       }
       expect(error).to.be.instanceof(Error);
-      expect(error.messageArray[0]).to.equal(div);
+      expect(error.messageArray[1]).to.equal(div);
     });
 
     it('should recognize asserts', () => {

--- a/test/unit/utils/test-enum.js
+++ b/test/unit/utils/test-enum.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {isEnumValue} from '../../../src/core/types/enum';
+
+describe('isEnumValue', () => {
+  /** @enum {string} */
+  const enumObj = {
+    X: 'x',
+    Y: 'y',
+    Z: 'z',
+  };
+
+  it('should return true for valid enum values', () => {
+    ['x', 'y', 'z'].forEach((value) => {
+      expect(isEnumValue(enumObj, value), 'enum value = ' + value).to.be.true;
+    });
+  });
+
+  it('should return false for non-enum values', () => {
+    [
+      'a',
+      'X',
+      'Z',
+      {'x': 'x'},
+      ['y'],
+      null,
+      undefined,
+      [],
+      /x/,
+      /y/,
+      42,
+    ].forEach((value) => {
+      expect(isEnumValue(enumObj, value), 'enum value = ' + value).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Moves type assertions into core (which `log.js` uses) and move fancy-log-message-generation out of `core/assert` and into `src/error` where it's used.