### PR TITLE
🏗 Move directory management into `TransformCache`

### DIFF
--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -19,15 +19,10 @@ const path = require('path');
 const {TransformCache, batchedRead, md5} = require('./transform-cache');
 
 /**
- * Directory where the babel filecache lives.
- */
-const CACHE_DIR = path.resolve(__dirname, '..', '..', '.babel-cache');
-
-/**
  * Used to cache babel transforms done by esbuild.
- * @const {!TransformCache}
+ * @const {TransformCache}
  */
-const transformCache = new TransformCache(CACHE_DIR, '.js');
+let transformCache;
 
 /**
  * Creates a babel plugin for esbuild for the given caller. Optionally enables
@@ -44,6 +39,10 @@ function getEsbuildBabelPlugin(
   preSetup = () => {},
   postLoad = () => {}
 ) {
+  if (!transformCache) {
+    transformCache = new TransformCache('.babel-cache', '.js');
+  }
+
   function transformContents(contents, hash, babelOptions) {
     if (enableCache) {
       const cached = transformCache.get(hash);

--- a/build-system/common/transform-cache.js
+++ b/build-system/common/transform-cache.js
@@ -22,19 +22,19 @@ const path = require('path');
  * Cache for storing transformed files on both memory and on disk.
  */
 class TransformCache {
-  constructor(cacheDir, fileExtension) {
+  constructor(cacheName, fileExtension) {
     /** @type {string} */
     this.fileExtension = fileExtension;
 
     /** @type {string} */
-    this.cacheDir = cacheDir;
-    fs.ensureDirSync(cacheDir);
+    this.cacheDir = path.resolve(__dirname, '..', '..', cacheName);
+    fs.ensureDirSync(this.cacheDir);
 
     /** @type {Map<string, Promise<Buffer|string>>} */
     this.transformMap = new Map();
 
     /** @type {Set<string>} */
-    this.fsCache = new Set(fs.readdirSync(cacheDir));
+    this.fsCache = new Set(fs.readdirSync(this.cacheDir));
   }
 
   /**

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -79,13 +79,11 @@ function getEnvironmentHash() {
   return environmentHash;
 }
 
-const CACHE_DIR = path.join(__dirname, '..', '..', '..', '.css-cache');
-
 /**
  * Used to cache css transforms done by postcss.
- * @const {!TransformCache}
+ * @const {TransformCache}
  */
-const transformCache = new TransformCache(CACHE_DIR, '.css');
+let transformCache;
 
 /**
  * @typedef {{css: string, warnings: string[]}}:
@@ -130,6 +128,9 @@ async function jsifyCssAsync(filename) {
  * @return {Promise<CssTransformResultDef>}
  */
 async function transformCss(contents, hash, opt_filename) {
+  if (!transformCache) {
+    transformCache = new TransformCache('.css-cache', '.css');
+  }
   const cached = transformCache.get(hash);
   if (cached) {
     return JSON.parse((await cached).toString());


### PR DESCRIPTION
This is a pending item that was discussed in https://github.com/ampproject/amphtml/pull/33313#discussion_r603598002. In addition to moving directory management into `TransformCache`, this PR lazily instantiates the cache on first use. Doing it at the global scope during module load will slow down all `amp` tasks, even unrelated ones.