### PR TITLE
🏗 Ignore `build-system/dist`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ firebase
 firebase.json
 .firebase/
 src/purifier/dist
+build-system/dist
 build-system/server/new-server/transforms/dist
 build-system/tasks/performance/cache
 build-system/tasks/performance/results.json

--- a/build-system/tsconfig.json
+++ b/build-system/tsconfig.json
@@ -29,7 +29,7 @@
     "./tasks/coverage-map/*",
     "./tasks/create-golden-css/*",
     "./tasks/css/*",
-    "./tasks/e2e/*", // 253 remaining type errors.
+    "./tasks/e2e/*", // 152 remaining type errors.
     "./tasks/get-zindex/*",
     "./tasks/markdown-toc/*",
     // "./tasks/performance/*", // 35 remaining type errors.


### PR DESCRIPTION
This shows up as a local diff when you run `amp check-build-system`.

Bonus fix: Update comment with number of remaining errors in `build-system/tasks/e2e/`