### PR TITLE
build-system: use metafile for smarter watching

### DIFF
--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -69,7 +69,7 @@ async function lazyBuild(url, matcher, bundles, buildFunc, next) {
   const match = url.match(matcher);
   if (match && match.length == 2) {
     const name = maybeGetUnminifiedName(bundles, match[1]);
-    const bundle = bundles[name];
+    const bundle = bundles[name]; 
     if (bundle) {
       await build(bundles, name, buildFunc);
     }

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -69,7 +69,7 @@ async function lazyBuild(url, matcher, bundles, buildFunc, next) {
   const match = url.match(matcher);
   if (match && match.length == 2) {
     const name = maybeGetUnminifiedName(bundles, match[1]);
-    const bundle = bundles[name]; 
+    const bundle = bundles[name];
     if (bundle) {
       await build(bundles, name, buildFunc);
     }

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -486,7 +486,7 @@ async function buildExtension(
 
   await compileJison(path.join(extDir, '**', '*.jison'));
   if (name === 'amp-bind') {
-    await doBuildJs(jsBundles, 'ww.max.js', {...options, watch: false});
+    await doBuildJs(jsBundles, 'ww.max.js', options);
   }
   if (options.npm) {
     await buildNpmBinaires(extDir, options);

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -23,12 +23,14 @@ const {
   extensionAliasBundles,
   extensionBundles,
   verifyExtensionBundles,
+  jsBundles,
 } = require('../compile/bundles.config');
 const {
   maybeToEsmName,
   compileJs,
   compileJsWithEsbuild,
   mkdirSync,
+  doBuildJs,
 } = require('./helpers');
 const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
 const {compileJison} = require('./compile-jison');
@@ -482,6 +484,9 @@ async function buildExtension(
   }
 
   await compileJison(path.join(extDir, '**', '*.jison'));
+  if (name === 'amp-bind') {
+    await doBuildJs(jsBundles, 'ww.max.js', {...options, watch: false});
+  }
   if (options.npm) {
     await buildNpmBinaires(extDir, options);
   }

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -23,7 +23,6 @@ const {
   extensionAliasBundles,
   extensionBundles,
   verifyExtensionBundles,
-  jsBundles,
 } = require('../compile/bundles.config');
 const {
   maybeToEsmName,
@@ -33,13 +32,12 @@ const {
 } = require('./helpers');
 const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
 const {compileJison} = require('./compile-jison');
-const {endBuildStep, watchDebounceDelay, doBuildJs} = require('./helpers');
+const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {green, red, cyan} = require('kleur/colors');
 const {isCiBuild} = require('../common/ci');
 const {jsifyCssAsync} = require('./css/jsify-css');
 const {log} = require('../common/logging');
 const {parse: pathParse} = require('path');
-const {removeFromClosureBabelCache} = require('../compile/pre-closure-babel');
 const {watch} = require('chokidar');
 
 /**
@@ -399,8 +397,7 @@ async function doBuildExtension(extensions, extension, options) {
 }
 
 /**
- * Watches the contents of an extension directory. When a file in the given path
- * changes, the extension is rebuilt.
+ * Watches for non-JS changes within an extensions directory to trigger recompilation.
  *
  * @param {string} extDir
  * @param {string} name
@@ -409,24 +406,29 @@ async function doBuildExtension(extensions, extension, options) {
  * @param {boolean} hasCss
  * @param {?Object} options
  */
-function watchExtension(extDir, name, version, latestVersion, hasCss, options) {
+async function watchExtension(
+  extDir,
+  name,
+  version,
+  latestVersion,
+  hasCss,
+  options
+) {
   function watchFunc() {
-    if (options.minify) {
-      removeFromClosureBabelCache(extDir);
-    }
-
-    const bundleComplete = buildExtension(
-      name,
-      version,
-      latestVersion,
-      hasCss,
-      {...options, continueOnError: true}
-    );
-    if (options.onWatchBuild) {
-      options.onWatchBuild(bundleComplete);
-    }
+    buildExtension(name, version, latestVersion, hasCss, {
+      ...options,
+      continueOnError: true,
+      isRebuild: true,
+      watch: false,
+    });
   }
-  watch(`${extDir}/**/*`).on('change', debounce(watchFunc, watchDebounceDelay));
+
+  const cssDeps = `${extDir}/**/*.css`;
+  const jisonDeps = `${extDir}/**/*.jison`;
+  watch([cssDeps, jisonDeps]).on(
+    'change',
+    debounce(watchFunc, watchDebounceDelay)
+  );
 }
 
 /**
@@ -464,18 +466,12 @@ async function buildExtension(
   }
   const extDir = 'extensions/' + name + '/' + version;
 
-  // Use a separate watcher for extensions to copy / inline CSS and compile JS
-  // instead of relying on the watchers used by compileUnminifiedJs and
-  // compileMinifiedJs, which only recompile JS.
+  // Use a separate watcher for css and jison compilation.
+  // The watcher within compileJs recompiles the JS.
   if (options.watch) {
-    options.watch = false;
-    watchExtension(extDir, name, version, latestVersion, hasCss, options);
-    // When an ad network extension is being watched, also watch amp-a4a.
-    if (name.match(/amp-ad-network-.*-impl/)) {
-      const a4aPath = `extensions/amp-a4a/${version}`;
-      watchExtension(a4aPath, name, version, latestVersion, hasCss, options);
-    }
+    await watchExtension(extDir, name, version, latestVersion, hasCss, options);
   }
+
   if (hasCss) {
     mkdirSync('build');
     mkdirSync('build/css');
@@ -486,9 +482,6 @@ async function buildExtension(
   }
 
   await compileJison(path.join(extDir, '**', '*.jison'));
-  if (name === 'amp-bind') {
-    await doBuildJs(jsBundles, 'ww.max.js', options);
-  }
   if (options.npm) {
     await buildNpmBinaires(extDir, options);
   }
@@ -498,6 +491,11 @@ async function buildExtension(
   if (name === 'amp-analytics') {
     await analyticsVendorConfigs(options);
   }
+
+  if (options.isRebuild) {
+    return;
+  }
+
   await buildExtensionJs(extDir, name, version, latestVersion, options);
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -20,21 +20,22 @@ const fs = require('fs-extra');
 const path = require('path');
 const wrappers = require('../compile/compile-wrappers');
 const {
+  compileJs,
+  compileJsWithEsbuild,
+  doBuildJs,
+  endBuildStep,
+  maybeToEsmName,
+  mkdirSync,
+  watchDebounceDelay,
+} = require('./helpers');
+const {
   extensionAliasBundles,
   extensionBundles,
   verifyExtensionBundles,
   jsBundles,
 } = require('../compile/bundles.config');
-const {
-  maybeToEsmName,
-  compileJs,
-  compileJsWithEsbuild,
-  mkdirSync,
-  doBuildJs,
-} = require('./helpers');
 const {analyticsVendorConfigs} = require('./analytics-vendor-configs');
 const {compileJison} = require('./compile-jison');
-const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {green, red, cyan} = require('kleur/colors');
 const {isCiBuild} = require('../common/ci');
 const {jsifyCssAsync} = require('./css/jsify-css');

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -39,7 +39,7 @@ const {jsBundles} = require('../compile/bundles.config');
 const {log, logLocalDev} = require('../common/logging');
 const {removeFromClosureBabelCache} = require('../compile/pre-closure-babel');
 const {thirdPartyFrames} = require('../test-configs/config');
-const {watch: fileWatch, watch} = require('chokidar');
+const {watch} = require('chokidar');
 
 /** @type {Remapping.default} */
 const remapping = /** @type {*} */ (Remapping);
@@ -134,7 +134,7 @@ async function bootstrapThirdPartyFrames(options) {
       const watchFunc = async () => {
         await thirdPartyBootstrap(frameObject.max, frameObject.min, options);
       };
-      fileWatch(frameObject.max).on(
+      watch(frameObject.max).on(
         'change',
         debounce(watchFunc, watchDebounceDelay)
       );
@@ -636,7 +636,7 @@ async function minifyWithTerser(destDir, destFilename, options) {
 async function compileJs(srcDir, srcFilename, destDir, options) {
   options = options || {};
 
-  async function compile(modifiedFile) {
+  async function doCompileJs(modifiedFile) {
     if (options.minified && modifiedFile) {
       removeFromClosureBabelCache(modifiedFile);
     }
@@ -653,10 +653,10 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
   if (options.watch) {
     const entryPoint = path.join(srcDir, srcFilename);
     const deps = await getDependencies(entryPoint);
-    watch(deps).on('change', debounce(compile, watchDebounceDelay));
+    watch(deps).on('change', debounce(doCompileJs, watchDebounceDelay));
   }
 
-  await compile();
+  await doCompileJs();
 }
 
 /**
@@ -857,7 +857,6 @@ module.exports = {
   compileJsWithEsbuild,
   doBuildJs,
   endBuildStep,
-  getDependencies,
   compileUnminifiedJs,
   maybePrintCoverageMessage,
   maybeToEsmName,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -646,6 +646,7 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
     if (options.onWatchBuild) {
       options.onWatchBuild(buildResult);
     }
+    await buildResult;
   }
 
   if (options.watch) {
@@ -654,7 +655,7 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
     watch(deps).on('change', debounce(compile, watchDebounceDelay));
   }
 
-  compile();
+  await compile();
 }
 
 /**


### PR DESCRIPTION
**summary**
Fixes: https://github.com/ampproject/amphtml/issues/33664

- Uses `esbuild` metafiles for perfectly determining JS dependencies of an extension (or runtime).
- Utilizes this function for all JS. Even the less used runtime have watch modes that now work as expected.
- Creates a new esbuild plugin for stripping import assertions

**testing**
For both `amp` and `amp --compiled`:
- Modify `amp.js` --> v0 should be rebuilt
- Modify `install-alp.js`+ one other alp dependency --> alp should be rebuild.
- Modify amp-story-player-entrypoint --> amp-story-player should be rebuild.
- Load an amp-bind example, modify a ww.js dep --> ww.js should be rebuilt, only once.
- Load an amp-bind example, modify a `jison` file --> jison should be recompiled (as well as ww.js)
- Load an amp network extension, modify a4a --> the network extensions should also be rebuilt