### PR TITLE
♻️ Use isString helper in runtime where possible

### DIFF
--- a/src/3p-frame-messaging.js
+++ b/src/3p-frame-messaging.js
@@ -17,6 +17,7 @@
 import {dev, devAssert} from './log';
 import {dict} from './core/types/object';
 import {internalListenImplementation} from './event-helper-listen';
+import {isString} from './core/types';
 import {parseJson} from './json';
 
 /** @const */
@@ -135,7 +136,7 @@ export function deserializeMessage(message) {
  */
 export function isAmpMessage(message) {
   return (
-    typeof message == 'string' &&
+    isString(message) &&
     message.indexOf(AMP_MESSAGE_PREFIX) == 0 &&
     message.indexOf('{') != -1
   );

--- a/src/base-template.js
+++ b/src/base-template.js
@@ -16,6 +16,7 @@
 
 import {Services} from './services';
 import {dev} from './log';
+import {isString} from './core/types';
 
 /**
  * The interface that is implemented by all templates.
@@ -122,7 +123,7 @@ export class BaseTemplate {
   unwrapChildren(root) {
     const children = [];
     this.visitChildren_(root, (c) => {
-      if (typeof c == 'string') {
+      if (isString(c)) {
         const element = this.win.document.createElement('div');
         element.textContent = c;
         children.push(element);

--- a/src/config.js
+++ b/src/config.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {isString} from './core/types';
+
 /**
  * Allows for runtime configuration. Internally, the runtime should
  * use the src/config.js module for various constants. We can use the
@@ -24,12 +26,12 @@
 const env = self.AMP_CONFIG || {};
 
 const thirdPartyFrameRegex =
-  (typeof env['thirdPartyFrameRegex'] == 'string'
+  (isString(env['thirdPartyFrameRegex'])
     ? new RegExp(env['thirdPartyFrameRegex'])
     : env['thirdPartyFrameRegex']) || /^d-\d+\.ampproject\.net$/;
 
 const cdnProxyRegex =
-  (typeof env['cdnProxyRegex'] == 'string'
+  (isString(env['cdnProxyRegex'])
     ? new RegExp(env['cdnProxyRegex'])
     : env['cdnProxyRegex']) ||
   /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org$/;

--- a/src/core/types/string.js
+++ b/src/core/types/string.js
@@ -168,7 +168,7 @@ export function trimStart(str) {
  * @return {!Promise<string>}
  */
 export function asyncStringReplace(str, regex, replacer) {
-  if (typeof replacer === 'string') {
+  if (isString(replacer)) {
     return Promise.resolve(str.replace(regex, replacer));
   }
   const stringBuilder = [];
@@ -217,5 +217,5 @@ export function padStart(s, targetLength, padString) {
  * @return {boolean}
  */
 export function isString(s) {
-  return typeof s == 'string';
+  return isString(s);
 }

--- a/src/core/types/string.js
+++ b/src/core/types/string.js
@@ -217,5 +217,5 @@ export function padStart(s, targetLength, padString) {
  * @return {boolean}
  */
 export function isString(s) {
-  return isString(s);
+  return typeof s == 'string';
 }

--- a/src/curve.js
+++ b/src/curve.js
@@ -17,6 +17,7 @@
 // Imported just for the side effect of getting the `types` it exports into
 // the type system during compile time.
 import './time';
+import {isString} from './core/types';
 
 /**
  * A CurveDef is a function that returns a normtime value (0 to 1) for another
@@ -291,7 +292,7 @@ export function getCurve(curve) {
   if (!curve) {
     return null;
   }
-  if (typeof curve == 'string') {
+  if (isString(curve)) {
     // If the curve is a custom cubic-bezier curve
     if (curve.indexOf('cubic-bezier') != -1) {
       const match = curve.match(/cubic-bezier\((.+)\)/);

--- a/src/error.js
+++ b/src/error.js
@@ -29,6 +29,7 @@ import {exponentialBackoff} from './exponential-backoff';
 import {getMode} from './mode';
 import {isLoadErrorMessage} from './event-helper';
 import {isProxyOrigin} from './url';
+import {isString} from './core/types';
 import {makeBodyVisibleRecovery} from './style-installer';
 import {triggerAnalyticsEvent} from './analytics';
 import {urls} from './config';
@@ -244,10 +245,10 @@ export function isCancellation(errorOrMessage) {
   if (!errorOrMessage) {
     return false;
   }
-  if (typeof errorOrMessage == 'string') {
+  if (isString(errorOrMessage)) {
     return errorOrMessage.startsWith(CANCELLED);
   }
-  if (typeof errorOrMessage.message == 'string') {
+  if (isString(errorOrMessage.message)) {
     return errorOrMessage.message.startsWith(CANCELLED);
   }
   return false;
@@ -269,10 +270,10 @@ export function isBlockedByConsent(errorOrMessage) {
   if (!errorOrMessage) {
     return false;
   }
-  if (typeof errorOrMessage == 'string') {
+  if (isString(errorOrMessage)) {
     return errorOrMessage.startsWith(BLOCK_BY_CONSENT);
   }
-  if (typeof errorOrMessage.message == 'string') {
+  if (isString(errorOrMessage.message)) {
     return errorOrMessage.message.startsWith(BLOCK_BY_CONSENT);
   }
   return false;

--- a/src/get-html.js
+++ b/src/get-html.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {isString} from './core/types';
+
 /** @type {!Array<string>} */
 const excludedTags = ['script', 'style'];
 
@@ -81,7 +83,7 @@ function appendToResult(node, attrs, result) {
   while (stack.length > 0) {
     node = stack.pop();
 
-    if (typeof node === 'string') {
+    if (isString(node)) {
       result.push(node);
     } else if (node.nodeType === Node.TEXT_NODE) {
       result.push(node.textContent);

--- a/src/iframe-helper.js
+++ b/src/iframe-helper.js
@@ -19,6 +19,7 @@ import {deserializeMessage, isAmpMessage} from './3p-frame-messaging';
 import {dev, devAssert} from './log';
 import {dict} from './core/types/object';
 import {getData} from './event-helper';
+import {isString} from './core/types';
 import {parseUrlDeprecated} from './url';
 import {remove} from './core/types/array';
 import {setStyle} from './style';
@@ -334,7 +335,7 @@ export function listenFor(
  */
 export function listenForOncePromise(iframe, typeOfMessages, opt_is3P) {
   const unlistenList = [];
-  if (typeof typeOfMessages == 'string') {
+  if (isString(typeOfMessages)) {
     typeOfMessages = [typeOfMessages];
   }
   return new Promise((resolve) => {
@@ -421,7 +422,7 @@ function getSentinel_(iframe, opt_is3P) {
  * @visibleForTesting
  */
 export function parseIfNeeded(data) {
-  if (typeof data == 'string') {
+  if (isString(data)) {
     if (data.charAt(0) == '{') {
       data =
         tryParseJson(data, (e) => {

--- a/src/iframe-video.js
+++ b/src/iframe-video.js
@@ -18,7 +18,7 @@ import {VideoEvents} from './video-interface';
 import {dev} from './log';
 import {dispatchCustomEvent} from './dom';
 import {htmlFor} from './static-template';
-import {isArray, isObject} from './core/types';
+import {isArray, isObject, isString} from './core/types';
 
 import {tryParseJson} from './json';
 
@@ -42,7 +42,7 @@ export function originMatches(event, iframe, host) {
   if (!iframe || event.source != iframe.contentWindow) {
     return false;
   }
-  if (typeof host === 'string') {
+  if (isString(host)) {
     return host == event.origin;
   }
   return host.test(event.origin);

--- a/src/layout.js
+++ b/src/layout.js
@@ -23,6 +23,7 @@ import {dev, devAssert, userAssert} from './log';
 import {htmlFor} from './static-template';
 import {isExperimentOn} from './experiments';
 import {isFiniteNumber, toWin} from './types';
+import {isString} from './core/types';
 import {setStyle, setStyles, toggle} from './style';
 
 import {transparentPng} from './utils/img';
@@ -177,7 +178,7 @@ export function isLayoutSizeFixed(layout) {
  * @return {boolean}
  */
 export function isInternalElement(tag) {
-  const tagName = typeof tag == 'string' ? tag : tag.tagName;
+  const tagName = isString(tag) ? tag : tag.tagName;
   return tagName && tagName.toLowerCase().startsWith('i-');
 }
 

--- a/src/log.js
+++ b/src/log.js
@@ -21,7 +21,7 @@ import {
 import {findIndex, isArray} from './core/types/array';
 import {getMode} from './mode';
 import {internalRuntimeVersion} from './internal-version';
-import {isEnumValue} from './core/types';
+import {isEnumValue, isString} from './core/types';
 import {once} from './utils/function';
 import {pureDevAssert, pureUserAssert} from './core/assert';
 import {urls} from './config';
@@ -246,7 +246,7 @@ export class Log {
       const args = this.maybeExpandMessageArgs_(messages);
       // Prefix console message with "[tag]".
       const prefix = `[${tag}]`;
-      if (typeof args[0] === 'string') {
+      if (isString(args[0])) {
         // Prepend string to avoid breaking string substitutions e.g. %s.
         args[0] = prefix + ' ' + args[0];
       } else {
@@ -448,7 +448,7 @@ export class Log {
   assertString(shouldBeString, opt_message) {
     this.assertType_(
       shouldBeString,
-      typeof shouldBeString == 'string',
+      isString(shouldBeString),
       'String expected',
       opt_message
     );

--- a/src/mediasession-helper.js
+++ b/src/mediasession-helper.js
@@ -15,7 +15,7 @@
  */
 import {Services} from './services';
 import {devAssert, userAssert} from './log';
-import {isArray, isObject} from './core/types';
+import {isArray, isObject, isString} from './core/types';
 
 import {tryParseJson} from './json';
 
@@ -79,19 +79,19 @@ export function parseSchemaImage(doc) {
   }
 
   // Image definition in schema could be one of :
-  if (typeof schemaJson['image'] === 'string') {
+  if (isString(schemaJson['image'])) {
     // 1. "image": "http://..",
     return schemaJson['image'];
   } else if (
     schemaJson['image']['@list'] &&
-    typeof schemaJson['image']['@list'][0] === 'string'
+    isString(schemaJson['image']['@list'][0])
   ) {
     // 2. "image": {.., "@list": ["http://.."], ..}
     return schemaJson['image']['@list'][0];
-  } else if (typeof schemaJson['image']['url'] === 'string') {
+  } else if (isString(schemaJson['image']['url'])) {
     // 3. "image": {.., "url": "http://..", ..}
     return schemaJson['image']['url'];
-  } else if (typeof schemaJson['image'][0] === 'string') {
+  } else if (isString(schemaJson['image'][0])) {
     // 4. "image": ["http://.. "]
     return schemaJson['image'][0];
   } else {

--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -27,7 +27,7 @@ import {dev, user} from './log';
 import {disposeServicesForDoc, getServicePromiseOrNullForDoc} from './service';
 import {getMode} from './mode';
 import {installStylesForDoc} from './style-installer';
-import {isArray, isObject} from './core/types';
+import {isArray, isObject, isString} from './core/types';
 
 import {parseExtensionUrl} from './service/extension-script';
 import {parseUrlDeprecated} from './url';
@@ -190,7 +190,7 @@ export class MultidocManager {
         if (!bind) {
           return Promise.reject('amp-bind is not available in this document');
         }
-        if (typeof state === 'string') {
+        if (isString(state)) {
           return bind.setStateWithExpression(
             /** @type {string} */ (state),
             /** @type {!JsonObject} */ ({})

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -47,6 +47,7 @@ import {getDate} from '../utils/date';
 import {getMode} from '../mode';
 import {hydrate, render} from './index';
 import {installShadowStyle} from '../shadow-embed';
+import {isString} from '../core/types';
 import {sequentialIdGenerator} from '../utils/id-generator';
 import {toArray} from '../core/types/array';
 
@@ -165,7 +166,7 @@ const HAS_MEDIA = (def) => !!def.media;
  * @param {!AmpElementPropDef} def
  * @return {boolean}
  */
-const HAS_SELECTOR = (def) => typeof def === 'string' || !!def.selector;
+const HAS_SELECTOR = (def) => isString(def) || !!def.selector;
 
 /**
  * @param {!AmpElementPropDef} def
@@ -1213,7 +1214,7 @@ function matchChild(element, defs) {
   // TODO: a little slow to do this repeatedly.
   for (const match in defs) {
     const def = defs[match];
-    const selector = typeof def == 'string' ? def : def.selector;
+    const selector = isString(def) ? def : def.selector;
     if (matches(element, selector)) {
       return match;
     }

--- a/src/service/cid-impl.js
+++ b/src/service/cid-impl.js
@@ -33,8 +33,9 @@ import {getCookie, setCookie} from '../cookies';
 import {getCryptoRandomBytesArray} from '../utils/bytes';
 import {getServiceForDoc, registerServiceBuilderForDoc} from '../service';
 import {getSourceOrigin, isProxyOrigin, parseUrlDeprecated} from '../url';
-import {isExperimentOn} from '../../src/experiments';
+import {isExperimentOn} from '../experiments';
 import {isIframed} from '../dom';
+import {isString} from '../core/types';
 import {parseJson, tryParseJson} from '../json';
 import {tryResolve} from '../utils/promise';
 
@@ -725,7 +726,7 @@ function getEntropy(win) {
  */
 export function getRandomString64(win) {
   const entropy = getEntropy(win);
-  if (typeof entropy == 'string') {
+  if (isString(entropy)) {
     return Services.cryptoFor(win).sha384Base64(entropy);
   } else {
     // If our entropy is a pure random number, we can just directly turn it

--- a/src/service/crypto-impl.js
+++ b/src/service/crypto-impl.js
@@ -18,6 +18,7 @@ import {Services} from '../services';
 import {base64UrlEncodeFromBytes} from '../utils/base64';
 import {dev, devAssert, user} from '../log';
 import {getService, registerServiceBuilder} from '../service';
+import {isString} from '../core/types';
 import {stringToBytes, utf8Encode} from '../utils/bytes';
 
 /** @const {string} */
@@ -72,7 +73,7 @@ export class Crypto {
    * @throws {!Error} when input string contains chars out of range [0,255]
    */
   sha384(input) {
-    if (typeof input === 'string') {
+    if (isString(input)) {
       input = stringToBytes(input);
     }
 

--- a/src/service/real-time-config/real-time-config-impl.js
+++ b/src/service/real-time-config/real-time-config-impl.js
@@ -18,7 +18,7 @@ import {RTC_VENDORS} from './callout-vendors';
 import {Services} from '../../services';
 import {dev, user, userAssert} from '../../log';
 import {getMode} from '../../mode';
-import {isArray, isObject} from '../../core/types';
+import {isArray, isObject, isString} from '../../core/types';
 import {isCancellation} from '../../error';
 
 import {registerServiceBuilderForDoc} from '../../service';
@@ -322,7 +322,7 @@ export class RealTimeConfigManager {
       if (isObject(urlObj)) {
         url = urlObj.url;
         errorReportingUrl = urlObj.errorReportingUrl;
-      } else if (typeof urlObj == 'string') {
+      } else if (isString(urlObj)) {
         url = urlObj;
       } else {
         dev().warn(TAG, `Invalid url: ${urlObj}`);

--- a/src/service/timer-impl.js
+++ b/src/service/timer-impl.js
@@ -15,6 +15,7 @@
  */
 
 import {getMode} from '../mode';
+import {isString} from '../core/types';
 import {
   registerServiceBuilder,
   registerServiceBuilderInEmbedWin,
@@ -104,7 +105,7 @@ export class Timer {
    * @param {number|string|null} timeoutId
    */
   cancel(timeoutId) {
-    if (typeof timeoutId == 'string') {
+    if (isString(timeoutId)) {
       this.canceled_[timeoutId] = true;
       return;
     }

--- a/src/service/url-expander/expander.js
+++ b/src/service/url-expander/expander.js
@@ -15,8 +15,8 @@
  */
 
 import {hasOwn} from '../../core/types/object';
+import {isString, trimStart} from '../../core/types/string';
 import {rethrowAsync, user} from '../../log';
-import {trimStart} from '../../core/types/string';
 import {tryResolve} from '../../utils/promise';
 
 /** @private @const {string} */
@@ -428,7 +428,7 @@ export class Expander {
         user().error(TAG, 'ignoring async macro resolution');
         result = '';
       } else if (
-        typeof value === 'string' ||
+        isString(value) ||
         typeof value === 'number' ||
         typeof value === 'boolean'
       ) {

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -45,6 +45,7 @@ import {WindowInterface} from '../window-interface';
 import {getTrackImpressionPromise} from '../impression.js';
 import {hasOwn} from '../core/types/object';
 import {internalRuntimeVersion} from '../internal-version';
+import {isString} from '../core/types/types';
 
 /** @private @const {string} */
 const TAG = 'UrlReplacements';
@@ -307,7 +308,7 @@ export class GlobalVariableSource extends VariableSource {
             // TODO: replace with "filter" when it's in place. #2198
             const cookieName = opt_cookieName || scope;
             if (cid && cookieName == '_ga') {
-              if (typeof cid === 'string') {
+              if (isString(cid)) {
                 cid = extractClientIdFromGaCookie(cid);
               } else {
                 // TODO(@jridgewell, #11120): remove once #11120 is figured out.
@@ -706,7 +707,7 @@ export class GlobalVariableSource extends VariableSource {
       'The first argument to FRAGMENT_PARAM, the fragment string ' +
         'param is required'
     );
-    userAssert(typeof param == 'string', 'param should be a string');
+    userAssert(isString(param), 'param should be a string');
     const hash = this.ampdoc.win.location['originalHash'];
     const params = parseQueryString(hash);
     return params[param] === undefined ? defaultValue : params[param];

--- a/src/service/url-replacements-impl.js
+++ b/src/service/url-replacements-impl.js
@@ -45,7 +45,7 @@ import {WindowInterface} from '../window-interface';
 import {getTrackImpressionPromise} from '../impression.js';
 import {hasOwn} from '../core/types/object';
 import {internalRuntimeVersion} from '../internal-version';
-import {isString} from '../core/types/types';
+import {isString} from '../core/types';
 
 /** @private @const {string} */
 const TAG = 'UrlReplacements';

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -15,7 +15,7 @@
  */
 
 import {dict} from './core/types/object';
-import {isArray} from './core/types';
+import {isArray, isString} from './core/types';
 import {toStructuredCloneable} from './utils/xhr-utils';
 import {userAssert} from './log';
 
@@ -120,7 +120,7 @@ export class SsrTemplateHelper {
     let renderTemplatePromise;
     if (this.isEnabled()) {
       userAssert(
-        typeof data['html'] === 'string',
+        isString(data['html']),
         'Server side html response must be defined'
       );
       renderTemplatePromise = this.assertTrustedViewer(element).then(() => {

--- a/src/style.js
+++ b/src/style.js
@@ -16,6 +16,7 @@
 
 // Note: loaded by 3p system. Cannot rely on babel polyfills.
 import {dev, devAssert} from './log';
+import {isString} from './core/types';
 import {map} from './core/types/object';
 
 /** @type {Object<string, string>} */
@@ -273,7 +274,7 @@ export function deg(value) {
  * @return {string}
  */
 export function translateX(value) {
-  if (typeof value == 'string') {
+  if (isString(value)) {
     return `translateX(${value})`;
   }
   return `translateX(${px(value)})`;

--- a/src/transition.js
+++ b/src/transition.js
@@ -17,6 +17,7 @@
 import * as st from './style';
 import {assertNotDisplay, setStyle} from './style';
 import {getCurve} from './curve';
+import {isString} from './core/types';
 
 export const NOOP = function (unusedTime) {
   return null;
@@ -50,7 +51,7 @@ export function concat(transitions, opt_delimiter = ' ') {
     for (let i = 0; i < transitions.length; i++) {
       const tr = transitions[i];
       const result = tr(time, complete);
-      if (typeof result == 'string') {
+      if (isString(result)) {
         results.push(result);
       }
     }
@@ -143,7 +144,7 @@ export function px(transition) {
 export function translateX(transition) {
   return (time) => {
     const res = transition(time);
-    if (typeof res == 'string') {
+    if (isString(res)) {
       return `translateX(${res})`;
     }
     return `translateX(${res}px)`;
@@ -158,7 +159,7 @@ export function translateX(transition) {
 export function translateY(transition) {
   return (time) => {
     const res = transition(time);
-    if (typeof res == 'string') {
+    if (isString(res)) {
       return `translateY(${res})`;
     }
     return `translateY(${res}px)`;

--- a/src/url.js
+++ b/src/url.js
@@ -18,7 +18,7 @@ import {LruCache} from './utils/lru-cache';
 import {dict, hasOwn} from './core/types/object';
 import {endsWith} from './core/types/string';
 import {getMode} from './mode';
-import {isArray} from './core/types';
+import {isArray, isString} from './core/types';
 import {parseQueryString_} from './url-parse-query-string';
 import {tryDecodeUriComponent_} from './url-try-decode-uri-component';
 import {urls} from './config';
@@ -291,7 +291,7 @@ export function serializeQueryString(params) {
  * @return {boolean}
  */
 export function isSecureUrlDeprecated(url) {
-  if (typeof url == 'string') {
+  if (isString(url)) {
     url = parseUrlDeprecated(url);
   }
   return (
@@ -400,7 +400,7 @@ export function getFragment(url) {
  * @return {boolean}
  */
 export function isProxyOrigin(url) {
-  if (typeof url == 'string') {
+  if (isString(url)) {
     url = parseUrlDeprecated(url);
   }
   return urls.cdnProxyRegex.test(url.origin);
@@ -414,7 +414,7 @@ export function isProxyOrigin(url) {
  * @return {?string}
  */
 export function getProxyServingType(url) {
-  if (typeof url == 'string') {
+  if (isString(url)) {
     url = parseUrlDeprecated(url);
   }
   if (!isProxyOrigin(url)) {
@@ -430,7 +430,7 @@ export function getProxyServingType(url) {
  * @return {boolean}
  */
 export function isLocalhostOrigin(url) {
-  if (typeof url == 'string') {
+  if (isString(url)) {
     url = parseUrlDeprecated(url);
   }
   return urls.localhostRegex.test(url.origin);
@@ -446,7 +446,7 @@ export function isProtocolValid(url) {
   if (!url) {
     return true;
   }
-  if (typeof url == 'string') {
+  if (isString(url)) {
     url = parseUrlDeprecated(url);
   }
   return !INVALID_PROTOCOLS.includes(url.protocol);
@@ -521,7 +521,7 @@ export function removeParamsFromSearch(urlSearch, paramName) {
  * @return {string}
  */
 export function getSourceUrl(url) {
-  if (typeof url == 'string') {
+  if (isString(url)) {
     url = parseUrlDeprecated(url);
   }
 
@@ -574,7 +574,7 @@ export function getSourceOrigin(url) {
  * @return {string}
  */
 export function resolveRelativeUrl(relativeUrlString, baseUrl) {
-  if (typeof baseUrl == 'string') {
+  if (isString(baseUrl)) {
     baseUrl = parseUrlDeprecated(baseUrl);
   }
   if (IS_ESM || typeof URL == 'function') {
@@ -591,7 +591,7 @@ export function resolveRelativeUrl(relativeUrlString, baseUrl) {
  * @private @visibleForTesting
  */
 export function resolveRelativeUrlFallback_(relativeUrlString, baseUrl) {
-  if (typeof baseUrl == 'string') {
+  if (isString(baseUrl)) {
     baseUrl = parseUrlDeprecated(baseUrl);
   }
   relativeUrlString = relativeUrlString.replace(/\\/g, '/');

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -18,6 +18,7 @@ import {
   pureDevAssert as devAssert,
   pureUserAssert as userAssert,
 } from '../core/assert';
+import {isString} from '../core/types';
 
 /**
  * Parses the date using the `Date.parse()` rules. Additionally supports the
@@ -50,7 +51,7 @@ export function getDate(value) {
   if (typeof value == 'number') {
     return value;
   }
-  if (typeof value == 'string') {
+  if (isString(value)) {
     return parseDate(value);
   }
   // Must be a `Date` object.

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../services';
 import {devAssert, user, userAssert} from '../log';
-import {dict, isArray, isObject, isString, map} from '../core/types/object';
+import {dict, map} from '../core/types/object';
 import {fromIterator} from '../core/types/array';
 import {
   getCorsUrl,
@@ -26,6 +26,7 @@ import {
   serializeQueryString,
 } from '../url';
 import {getMode} from '../mode';
+import {isArray, isObject, isString} from '../core/types';
 
 import {isExperimentOn} from '../experiments';
 import {isFormDataWrapper} from '../form-data-wrapper';

--- a/src/utils/xhr-utils.js
+++ b/src/utils/xhr-utils.js
@@ -16,8 +16,8 @@
 
 import {Services} from '../services';
 import {devAssert, user, userAssert} from '../log';
-import {dict, isObject, map} from '../core/types/object';
-import {fromIterator, isArray} from '../core/types/array';
+import {dict, isArray, isObject, isString, map} from '../core/types/object';
+import {fromIterator} from '../core/types/array';
 import {
   getCorsUrl,
   getWinOrigin,
@@ -248,7 +248,7 @@ export function getViewerInterceptResponse(win, ampdocSingle, input, init) {
  * @return {string}
  */
 export function setupInput(win, input, init) {
-  devAssert(typeof input == 'string', 'Only URL supported: %s', input);
+  devAssert(isString(input), 'Only URL supported: %s', input);
   if (init.ampCors !== false) {
     input = getCorsUrl(win, input);
   }


### PR DESCRIPTION
`"string"==typeof x` (length 18) appears ~25 times in `v0.js`; using this helper reduces all of those to a function call. Reduces real bundle size by ~0.30KB, though difference is negligible after compression.