### PR TITLE
🏗 Update CircleCI base docker image from 12/2020 to 4/2021

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ push_builds_only: &push_builds_only
 executors:
   amphtml-docker-small-executor:
     docker:
-      - image: cimg/base:2020.12
+      - image: cimg/base:2021.04
     resource_class: small
   amphtml-medium-executor:
     machine:


### PR DESCRIPTION
There seems to have been a temporary blip with the old image. For example, [these logs](https://app.circleci.com/pipelines/github/ampproject/amphtml/6957/workflows/1db0388e-0be1-4411-abc1-534ab9bff66e/jobs/100978).

![image](https://user-images.githubusercontent.com/26553114/114920004-f7cf3680-9df6-11eb-9af5-c3d58506fa54.png)

This PR switches to the new [April 2021 image](https://circleci.com/developer/images/image/cimg/base). 

![image](https://user-images.githubusercontent.com/26553114/114920104-103f5100-9df7-11eb-805d-11259c69c020.png)

