### PR TITLE
🏗 Drop support for python 3.5 now that it has reached EOL

### DIFF
--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -220,7 +220,7 @@ function checkPythonVersion() {
   // Python 3.6+ are still supported
   // https://devguide.python.org/#status-of-python-branches
   const recommendedVersion = '2.7 or 3.6+';
-  const recommendedVersionRegex = /^2\.7|^3\.[6-9]/;
+  const recommendedVersionRegex = /^2\.7|^3\.(?:[6-9]|1\d)/;
 
   // Python2 prints its version to stderr (fixed in Python 3.4)
   // See: https://bugs.python.org/issue18338

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -217,10 +217,10 @@ function logNpmVersion() {
  */
 function checkPythonVersion() {
   // Python 2.7 is EOL but still supported
-  // Python 3.5+ are still supported (TODO: deprecate 3.5 on 2020-09-13)
+  // Python 3.6+ are still supported
   // https://devguide.python.org/#status-of-python-branches
-  const recommendedVersion = '2.7 or 3.5+';
-  const recommendedVersionRegex = /^2\.7|^3\.[5-9]/;
+  const recommendedVersion = '2.7 or 3.6+';
+  const recommendedVersionRegex = /^2\.7|^3\.[6-9]/;
 
   // Python2 prints its version to stderr (fixed in Python 3.4)
   // See: https://bugs.python.org/issue18338


### PR DESCRIPTION
Python 3.5 reached EOL a few months ago: https://devguide.python.org/#status-of-python-branches

This PR changes AMP's list of supported versions to 2.7 (legacy support still works) and 3.6+. Developers with other versions of python on their machines will see a warning during `npm install`, but devtools will all continue to work normally.

**Obligatory xkcd:** ([link](https://xkcd.com/1987/))

![](https://imgs.xkcd.com/comics/python_environment_2x.png)
