### PR TITLE
🚀🏗 Speed up minified compilation by caching pre-closure transforms

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@
 # Keep this list in sync with .gitignore, .prettierignore, and build-system/tasks/clean.js
 .babel-cache
 .css-cache
+.pre-closure-cache
 
 # Output directories
 # Keep this list in sync with .gitignore, .prettierignore, and build-system/tasks/clean.js
@@ -26,8 +27,7 @@ test/coverage-e2e
 validator/**/dist
 validator/export
 
-
-# Files and directories specifically ignored by eslint
+# Files and directories explicitly ignored by eslint
 build-system/babel-plugins/**/fixtures/**/*.js
 build-system/babel-plugins/**/fixtures/**/*.mjs
 build-system/server/app-index/test/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,23 +1,8 @@
-# OS level files
-.DS_Store
-.g4ignore
-*.swp
-*.swo
-
-# Development environment files
-**/node_modules
-npm-debug.log
-
-# Firebase directories
-.firebaserc
-.firebase
-firebase
-firebase.json
-
 # Local cache directories
 # Keep this list in sync with .eslintignore, .prettierignore, and build-system/tasks/clean.js
 .babel-cache
 .css-cache
+.pre-closure-cache
 
 # Output directories
 # Keep this list in sync with .eslintignore, .prettierignore, and build-system/tasks/clean.js
@@ -41,3 +26,19 @@ test/coverage
 test/coverage-e2e
 validator/**/dist
 validator/export
+
+# OS level files
+.DS_Store
+.g4ignore
+*.swp
+*.swo
+
+# Development environment files
+**/node_modules
+npm-debug.log
+
+# Firebase directories
+.firebaserc
+.firebase
+firebase
+firebase.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 # Keep this list in sync with .gitignore, .eslintignore, and build-system/tasks/clean.js
 .babel-cache
 .css-cache
+.pre-closure-cache
 
 # Output directories
 # Keep this list in sync with .gitignore, .eslintignore, and build-system/tasks/clean.js
@@ -26,7 +27,7 @@ test/coverage-e2e
 validator/**/dist
 validator/export
 
-# Files and directories specifically ignored by prettier
+# Files and directories explicitly ignored by prettier
 .github/ISSUE_TEMPLATE/**
 **/package*.json
 **/node_modules/**

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -56,7 +56,7 @@ function getEsbuildBabelPlugin(
       .then((result) => result.code);
 
     if (enableCache) {
-      await transformCache.set(hash, promise);
+      transformCache.set(hash, promise);
     }
 
     return promise.finally(postLoad);

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -43,7 +43,7 @@ function getEsbuildBabelPlugin(
     transformCache = new TransformCache('.babel-cache', '.js');
   }
 
-  function transformContents(contents, hash, babelOptions) {
+  async function transformContents(contents, hash, babelOptions) {
     if (enableCache) {
       const cached = transformCache.get(hash);
       if (cached) {
@@ -56,7 +56,7 @@ function getEsbuildBabelPlugin(
       .then((result) => result.code);
 
     if (enableCache) {
-      transformCache.set(hash, promise);
+      await transformCache.set(hash, promise);
     }
 
     return promise.finally(postLoad);

--- a/build-system/common/transform-cache.js
+++ b/build-system/common/transform-cache.js
@@ -64,16 +64,14 @@ class TransformCache {
   /**
    * @param {string} hash
    * @param {Promise<string>} transformPromise
-   * @return {Promise<void>}
    */
-  async set(hash, transformPromise) {
+  set(hash, transformPromise) {
     if (this.transformMap.has(hash)) {
       throw new Error('Read race: Attempting to transform a file twice.');
     }
     this.transformMap.set(hash, transformPromise);
     const filepath = path.join(this.cacheDir, hash) + this.fileExtension;
-    const contents = await transformPromise;
-    await fs.outputFile(filepath, contents);
+    transformPromise.then((contents) => fs.outputFile(filepath, contents));
   }
 }
 

--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -18,7 +18,7 @@
 const compiler = require('@ampproject/google-closure-compiler');
 const vinylFs = require('vinyl-fs');
 const {cyan, red, yellow} = require('kleur/colors');
-const {getBabelCacheDir} = require('./pre-closure-babel');
+const {getBabelOutputDir} = require('./pre-closure-babel');
 const {log, logWithoutTimestamp} = require('../common/logging');
 
 /**
@@ -29,13 +29,13 @@ const {log, logWithoutTimestamp} = require('../common/logging');
  */
 function logClosureCompilerError(message) {
   log(red('ERROR:'));
-  const babelCacheDir = `${getBabelCacheDir()}/`;
+  const babelOutputDir = `${getBabelOutputDir()}/`;
   const loggingPrefix = /^.*?gulp-google-closure-compiler.*?: /;
   const {highlight} = require('cli-highlight'); // Lazy-required to speed up task loading.
   const highlightedMessage = highlight(message, {ignoreIllegals: true});
   const formattedMessage = highlightedMessage
     .replace(loggingPrefix, '')
-    .replace(new RegExp(babelCacheDir, 'g'), '')
+    .replace(new RegExp(babelOutputDir, 'g'), '')
     .replace(/ ERROR /g, red(' ERROR '))
     .replace(/ WARNING /g, yellow(' WARNING '));
   logWithoutTimestamp(formattedMessage);
@@ -87,7 +87,7 @@ function initializeClosure(flags) {
 function runClosure(outputFilename, options, flags, srcFiles) {
   return new Promise((resolve, reject) => {
     vinylFs
-      .src(srcFiles, {base: getBabelCacheDir()})
+      .src(srcFiles, {base: getBabelOutputDir()})
       .pipe(initializeClosure(flags))
       .on('error', (err) => {
         const reason = handleClosureCompilerError(err, outputFilename, options);

--- a/build-system/compile/helpers.js
+++ b/build-system/compile/helpers.js
@@ -18,7 +18,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const path = require('path');
-const {getBabelCacheDir} = require('./pre-closure-babel');
+const {getBabelOutputDir} = require('./pre-closure-babel');
 const {VERSION: internalRuntimeVersion} = require('./internal-version');
 
 function getSourceMapBase(options) {
@@ -36,10 +36,10 @@ function getSourceMapBase(options) {
 }
 
 function updatePaths(sourcemaps) {
-  const babelCacheDir = getBabelCacheDir();
+  const babelOutputDir = getBabelOutputDir();
   sourcemaps.sources = sourcemaps.sources.map((source) =>
-    source.startsWith(babelCacheDir)
-      ? path.relative(babelCacheDir, source)
+    source.startsWith(babelOutputDir)
+      ? path.relative(babelOutputDir, source)
       : source
   );
   if (sourcemaps.file) {

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -119,7 +119,7 @@ async function preClosureBabel(file, outputFilename, options) {
           sourceFileName: path.relative(process.cwd(), file),
         })
         .then((result) => result?.code);
-      await transformCache.set(hash, transformPromise);
+      transformCache.set(hash, transformPromise);
       await fs.outputFile(transformedFile, await transformPromise);
       debug(CompilationLifecycles['pre-closure'], transformedFile);
     }

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -33,6 +33,7 @@ async function clean() {
     // Keep this list in sync with .gitignore, .eslintignore, and .prettierignore
     '.babel-cache',
     '.css-cache',
+    '.pre-closure-cache',
 
     // Output directories
     // Keep this list in sync with .gitignore, .eslintignore, and .prettierignore

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -137,7 +137,7 @@ async function transformCss(contents, hash, opt_filename) {
   }
 
   const transformed = transform(contents, opt_filename);
-  transformCache.set(
+  await transformCache.set(
     hash,
     transformed.then((r) => JSON.stringify(r))
   );

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -137,7 +137,7 @@ async function transformCss(contents, hash, opt_filename) {
   }
 
   const transformed = transform(contents, opt_filename);
-  await transformCache.set(
+  transformCache.set(
     hash,
     transformed.then((r) => JSON.stringify(r))
   );


### PR DESCRIPTION
**PR Highlights:**
- Builds on the excellent work done by @samouri to create `TransformCache` in #33314 and #33313
- Introduces a persistent on-disk cache `.pre-closure-cache` for pre-closure babel transforms
- Rewrites `preClosureBabel()` to use `TransformCache` to cache (and invalidate) babel output
- Repurposes the non-persistent `cacheDir` to `outputDir` (closure requires the original src tree structure)
- Updates `amp clean` to wipe out the cache directory
- Fixes assorted bugs that snuck in over time
	- Makes sure that `fs.outputFile()` completes in the `then()` block of `TransformCache.set()`
	- Removes unused `modifiedFile` param from `compileJs()`
    - Adds missing `continueOnError: true` while setting up `watch` in `compileJs()`

**Results:**
- First time compilation of `v0.js` gets a 2.5x speed up with a warm cache (babel is the long pole)
- Live recompilation of `v0.js` via watcher + lazy-builder gets a 2x speed up with a warm cache (babel is the long pole)
- Full compilation of all binaries gets a 1.2x speed up with a warm cache (closure is the long pole)

**Screenshots:**

🚂 **`amp dist --core_runtime_only` (cold cache)**

![image](https://user-images.githubusercontent.com/26553114/115053256-efd1ce00-9eac-11eb-969b-f41af6f59662.png)

🚄 **`amp dist --core_runtime_only` (warm cache)**

![image](https://user-images.githubusercontent.com/26553114/115053290-f9f3cc80-9eac-11eb-8ba7-1078ded985e0.png)

🚂 **`amp --compiled` (initial build with cold cache, rebuild with warm cache)**

![image](https://user-images.githubusercontent.com/26553114/114948804-c322a580-9e1d-11eb-812f-4c0278550eec.png)

🚄 **`amp --compiled` (initial build and rebuild with warm cache)**

![image](https://user-images.githubusercontent.com/26553114/114948831-cddd3a80-9e1d-11eb-95ef-e7808b9541b8.png)

🚂 **`amp dist --fortesting` (cold cache)**

![image](https://user-images.githubusercontent.com/26553114/114953044-88247000-9e25-11eb-85ad-32afd1d77125.png)
![image](https://user-images.githubusercontent.com/26553114/114953073-9bcfd680-9e25-11eb-92d6-28e7f4256db5.png)

🚄 **`amp dist --fortesting` (warm cache)**

![image](https://user-images.githubusercontent.com/26553114/114953112-b5711e00-9e25-11eb-9955-4babf421532c.png)
![image](https://user-images.githubusercontent.com/26553114/114953296-10a31080-9e26-11eb-9535-be0606b8c959.png)

🚄 **`amp --compiled` (faster error detection with warm cache)**

![image](https://user-images.githubusercontent.com/26553114/114955806-7c3bac80-9e2b-11eb-9721-2464dd4b170c.png)
