### PR TITLE
🏗 Fix dependency extraction while watching JS entry points

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -30,7 +30,6 @@ const {
   VERSION: internalRuntimeVersion,
 } = require('../compile/internal-version');
 const {applyConfig, removeConfig} = require('./prepend-global/index.js');
-const {batchedRead} = require('../common/transform-cache');
 const {closureCompile} = require('../compile/compile');
 const {getEsbuildBabelPlugin} = require('../common/esbuild-babel');
 const {green, red, cyan} = require('kleur/colors');
@@ -647,7 +646,7 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
 
   if (options.watch) {
     watchedEntryPoints.add(entryPoint);
-    const deps = await getDependencies(entryPoint);
+    const deps = await getDependencies(entryPoint, options);
     const watchFunc = async () => {
       await doCompileJs({...options, continueOnError: true});
     };
@@ -827,31 +826,24 @@ function mkdirSync(path) {
 }
 
 /**
- * Returns the list of dependencies for a given JS entrypoint.
+ * Returns the list of dependencies for a given JS entrypoint by having esbuild
+ * generate a metafile for it. Uses the set of babel plugins that would've been
+ * used to compile the entrypoint.
+ *
  * @param {string} entryPoint
+ * @param {!Object} options
  * @return {Promise<Array<string>>}
  */
-async function getDependencies(entryPoint) {
-  const stripImportAssertionPlugin = {
-    name: 'stripImportAssertion',
-    setup(build) {
-      build.onLoad({filter: /\.[cm]?js$/, namespace: ''}, async (file) => {
-        const filename = file.path;
-        const contents = (await batchedRead(filename)).contents.toString();
-        const stripped = contents.replace(/assert {type: 'json'}/g, '');
-        return {contents: stripped};
-      });
-    },
-  };
-
+async function getDependencies(entryPoint, options) {
+  const caller = options.minify ? 'minified' : 'unminified';
+  const babelPlugin = getEsbuildBabelPlugin(caller, /* enableCache */ true);
   const result = await esbuild.build({
     entryPoints: [entryPoint],
     bundle: true,
     write: false,
     metafile: true,
-    plugins: [stripImportAssertionPlugin],
+    plugins: [babelPlugin],
   });
-
   return Object.keys(result.metafile?.inputs);
 }
 


### PR DESCRIPTION
#33840 introduced a way to extract the dependencies of JS entry points so that the watcher could intelligently react to code changes. This broke in situations when an extension contained JSX, because `getDependencies()` wasn't using all the plugins required to parse and transform the source code.

![image](https://user-images.githubusercontent.com/26553114/115065624-59a5a400-9ebc-11eb-9e81-ed8deefd5d1b.png)

This PR makes `getDependencies()` use the exact set of plugins that would've been used by `esbuild` during normal compilation. With this, watching extensions containing JSX code is fixed, and future changes to the set of babel plugins used during compilation will automatically get picked up by `getDependencies()`.

![image](https://user-images.githubusercontent.com/26553114/115065889-c02ac200-9ebc-11eb-8c03-d36cab08eed0.png)

Addresses https://github.com/ampproject/amphtml/pull/33873#issuecomment-821327849
Implements https://github.com/ampproject/amphtml/pull/33873#issuecomment-821334930