### PR TITLE
🚀 Early exit for SSR AMP Image 

### DIFF
--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -191,8 +191,7 @@ export class AmpImg extends BaseElement {
     // fallback to stop from nested fallback abuse.
     this.allowImgLoadFallback_ = !this.element.hasAttribute('fallback');
 
-    // For inabox SSR, image will have been written directly to DOM so no need
-    // to recreate.  Calling appendChild again will have no effect.
+    // For SSR, image will have been written directly to DOM so no need to recreate.
     if (this.element.hasAttribute('i-amphtml-ssr')) {
       this.img_ = scopedQuerySelector(this.element, '> img:not([placeholder])');
       return this.img_;

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -195,6 +195,7 @@ export class AmpImg extends BaseElement {
     // to recreate.  Calling appendChild again will have no effect.
     if (this.element.hasAttribute('i-amphtml-ssr')) {
       this.img_ = scopedQuerySelector(this.element, '> img:not([placeholder])');
+      return this.img_;
     }
     this.img_ = this.img_ || new Image();
     this.img_.setAttribute('decoding', 'async');

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -192,9 +192,9 @@ export class AmpImg extends BaseElement {
     this.allowImgLoadFallback_ = !this.element.hasAttribute('fallback');
 
     // For SSR, image will have been written directly to DOM so no need to recreate.
-    if (this.element.hasAttribute('i-amphtml-ssr')) {
+    const serverRendered = this.element.hasAttribute('i-amphtml-ssr');
+    if (serverRendered) {
       this.img_ = scopedQuerySelector(this.element, '> img:not([placeholder])');
-      return this.img_;
     }
     this.img_ = this.img_ || new Image();
     this.img_.setAttribute('decoding', 'async');
@@ -224,7 +224,9 @@ export class AmpImg extends BaseElement {
     this.applyFillContent(this.img_, true);
     propagateObjectFitStyles(this.element, this.img_);
 
-    this.element.appendChild(this.img_);
+    if (!serverRendered) {
+      this.element.appendChild(this.img_);
+    }
     return this.img_;
   }
 

--- a/test/unit/test-amp-img-v1.js
+++ b/test/unit/test-amp-img-v1.js
@@ -440,9 +440,14 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
      *     placeholder attribute.
      * @param {boolean} addBlurClass Whether the child should have the
      *     class that allows it to be a blurred placeholder.
+     * @param {boolean} serverRendered If the image is server rendered.
      * @return {AmpImg} An amp-img object potentially with a blurry placeholder
      */
-    function getImgWithBlur(addPlaceholder, addBlurClass) {
+    function getImgWithBlur(
+      addPlaceholder,
+      addBlurClass,
+      serverRendered = false
+    ) {
       const el = createImg({
         src: '/examples/img/sample.jpg',
         id: 'img1',
@@ -462,6 +467,12 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
         img.classList.add('i-amphtml-blurry-placeholder');
       }
       el.appendChild(img);
+      if (serverRendered) {
+        const serverRenderedImg = doc.createElement('img');
+        serverRenderedImg.setAttribute('src', '/examples/img/sample.jpg');
+        el.appendChild(serverRenderedImg);
+        el.setAttribute('i-amphtml-ssr', '');
+      }
       doc.body.appendChild(el);
       return el;
     }
@@ -506,7 +517,6 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
 
     it('does not interfere with SSR img creation', async () => {
       const ampImg = getImgWithBlur(true, true);
-      ampImg.setAttribute('i-amphtml-ssr', '');
       await ampImg.build();
 
       expect(ampImg.querySelector('img[src*="sample.jpg"]')).to.exist;

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -588,7 +588,6 @@ describes.sandboxed('amp-img', {}, (env) => {
       impl.buildCallback();
       impl.layoutCallback();
 
-      // debugger;
       expect(ampImg.querySelector('img[src*="sample.jpg"]')).to.exist;
       expect(ampImg.querySelector('img[src*="image/svg+xml"]')).to.exist;
     });

--- a/test/unit/test-amp-img.js
+++ b/test/unit/test-amp-img.js
@@ -535,10 +535,10 @@ describes.sandboxed('amp-img', {}, (env) => {
       el.appendChild(img);
       el.getResources = () => Services.resourcesForDoc(document);
       if (serverRendered) {
-        el.setAttribute('i-amphtml-ssr', '');
         const serverRenderedImg = document.createElement('img');
         serverRenderedImg.setAttribute('src', '/examples/img/sample.jpg');
         el.appendChild(serverRenderedImg);
+        el.setAttribute('i-amphtml-ssr', '');
       }
       const impl = new AmpImg(el);
       impl.togglePlaceholder = sandbox.stub();
@@ -588,7 +588,8 @@ describes.sandboxed('amp-img', {}, (env) => {
       impl.buildCallback();
       impl.layoutCallback();
 
-      // expect(ampImg.querySelector('img[src*="sample.jpg"]')).to.exist;
+      // debugger;
+      expect(ampImg.querySelector('img[src*="sample.jpg"]')).to.exist;
       expect(ampImg.querySelector('img[src*="image/svg+xml"]')).to.exist;
     });
 


### PR DESCRIPTION
Avoid late LCP for attaching the same node again during hydration.

