### PR TITLE
✨ Extend preventDefault() from keypress to click

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -304,9 +304,24 @@ export class ActionService {
       // TODO(dvoytenko): if needed, also configure touch-based tap, e.g. for
       // fast-click.
       this.root_.addEventListener('click', (event) => {
-        if (!event.defaultPrevented) {
-          const element = dev().assertElement(event.target);
-          this.trigger(element, name, event, ActionTrust.HIGH);
+        const {key, target} = event;
+        const element = dev().assertElement(event.target);
+        const role = element.getAttribute('role');
+        const isTapEventRole =
+          role && hasOwn(TAPPABLE_ARIA_ROLES, role.toLowerCase());
+        if (!event.defaultPrevented && isTapEventRole) {
+          this.trigger(
+            element,
+            name,
+            event,
+            ActionTrust.HIGH
+          );
+          // Only if the element has an action do we prevent the default.
+          // In the absence of an action, e.g. on="[event].method", we do not
+          // want to stop default behavior.
+          if (hasAction) {
+            event.preventDefault();
+          }
         }
       });
       this.root_.addEventListener('keydown', (event) => {


### PR DESCRIPTION
Resolves #33625 one way.

/cc @westonruter @milindmore22

If preventing the default action is a good feature on keypress, this PR suggests implementing it for click events too.

Note: This is a desperate attempt to pay back to AMP-WP off WP since implementing AMP compat into the intended product is compromised (▲Please don’t link that issue).