### PR TITLE
♿ Remove preventDefault() from keypress events

### DIFF
--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -323,12 +323,6 @@ export class ActionService {
               event,
               ActionTrust.HIGH
             );
-            // Only if the element has an action do we prevent the default.
-            // In the absence of an action, e.g. on="[event].method", we do not
-            // want to stop default behavior.
-            if (hasAction) {
-              event.preventDefault();
-            }
           }
         }
       });


### PR DESCRIPTION
Resolves #33625 the initial way.

/cc @westonruter @milindmore22

Currently it is not possible to access a link by keypress when the ARIA role is tappable and an action is triggered on tap.