### PR TITLE
♻️ Extract AmpScriptService.fetch into its own fn.

### DIFF
--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -325,9 +325,10 @@ export class Transport {
   /**
    * @param {!AmpDoc} ampdoc
    * @param {!RequestDef} request
+   * @return {!Promise}
    */
   static forwardRequestToAmpScript(ampdoc, request) {
-    Services.scriptForDocOrNull(ampdoc).then((ampScriptService) => {
+    return Services.scriptForDocOrNull(ampdoc).then((ampScriptService) => {
       ampScriptService.fetch(request.url, JSON.parse(request.payload));
     });
   }

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -329,6 +329,7 @@ export class Transport {
    */
   static forwardRequestToAmpScript(ampdoc, request) {
     return Services.scriptForDocOrNull(ampdoc).then((ampScriptService) => {
+      userAssert(ampScriptService, 'AMP-SCRIPT is not installed');
       ampScriptService.fetch(request.url, JSON.parse(request.payload));
     });
   }

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -19,6 +19,7 @@ import {ActionTrust} from '../../../../src/core/constants/action-constants';
 import {AmpDocService} from '../../../../src/service/ampdoc-impl';
 import {AmpEvents} from '../../../../src/core/constants/amp-events';
 import {AmpList} from '../amp-list';
+import {AmpScriptService} from '../../../amp-script/0.1/amp-script';
 import {Deferred} from '../../../../src/core/data-structures/promise';
 import {Services} from '../../../../src/services';
 import {
@@ -1008,12 +1009,14 @@ describes.repeated(
             });
           });
 
-          describe('Using amp-script: protocol', () => {
+          describe.only('Using amp-script: protocol', () => {
             let ampScriptEl;
             beforeEach(() => {
               resetExperimentTogglesForTesting(win);
 
-              env.sandbox.stub(Services, 'scriptForDocOrNull');
+              env.sandbox
+                .stub(Services, 'scriptForDocOrNull')
+                .returns(Promise.resolve(new AmpScriptService(env.ampdoc)));
               ampScriptEl = document.createElement('amp-script');
               ampScriptEl.setAttribute('id', 'example');
               doc.body.appendChild(ampScriptEl);

--- a/extensions/amp-list/0.1/test/test-amp-list.js
+++ b/extensions/amp-list/0.1/test/test-amp-list.js
@@ -1009,7 +1009,7 @@ describes.repeated(
             });
           });
 
-          describe.only('Using amp-script: protocol', () => {
+          describe('Using amp-script: protocol', () => {
             let ampScriptEl;
             beforeEach(() => {
               resetExperimentTogglesForTesting(win);

--- a/extensions/amp-render/1.0/amp-render.js
+++ b/extensions/amp-render/1.0/amp-render.js
@@ -18,14 +18,14 @@ import {BaseElement} from './base-element';
 import {Services} from '../../../src/services';
 import {batchFetchJsonFor} from '../../../src/batched-json';
 import {dev, user, userAssert} from '../../../src/log';
-import {dict} from '../../../src/core/types/object';
+import {dict} from '../../../src/utils/object';
+import {isAmpScriptUri} from '../../../src/url';
 import {isExperimentOn} from '../../../src/experiments';
 
 /** @const {string} */
 const TAG = 'amp-render';
 
 const AMP_STATE_URI_SCHEME = 'amp-state:';
-const AMP_SCRIPT_URI_SCHEME = 'amp-script:';
 
 /**
  * Returns true if element's src points to amp-state.
@@ -33,13 +33,6 @@ const AMP_SCRIPT_URI_SCHEME = 'amp-script:';
  * @return {boolean}
  */
 const isAmpStateSrc = (src) => src && src.startsWith(AMP_STATE_URI_SCHEME);
-
-/**
- * Returns true if element's src points to an amp-script function.
- * @param {?string} src
- * @return {boolean}
- */
-const isAmpScriptSrc = (src) => src && src.startsWith(AMP_SCRIPT_URI_SCHEME);
 
 /**
  * Gets the json from an "amp-state:" uri. For example, src="amp-state:json.path".
@@ -75,45 +68,6 @@ const getAmpStateJson = (element, src) => {
 };
 
 /**
- * Gets the json from an amp-script uri.
- * TODO: this is similar to the implementation in amp-list. Move it
- * to a common file and import it.
- *
- * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
- * @param {string} src
- * @return {Promise<!JsonObject>}
- */
-function getAmpScriptJson(ampdoc, src) {
-  return Promise.resolve()
-    .then(() => {
-      const args = src.slice('amp-script:'.length).split('.');
-      userAssert(
-        args.length === 2 && args[0].length > 0 && args[1].length > 0,
-        '[amp-render]: "amp-script" URIs must be of the format "scriptId.functionIdentifier".'
-      );
-
-      const ampScriptId = args[0];
-      const fnIdentifier = args[1];
-      const ampScriptEl = ampdoc.getElementById(ampScriptId);
-      userAssert(
-        ampScriptEl && ampScriptEl.tagName === 'AMP-SCRIPT',
-        `[amp-render]: could not find <amp-script> with script set to ${ampScriptId}`
-      );
-
-      return ampScriptEl.getImpl().then((impl) => {
-        return impl.callFunction(fnIdentifier);
-      });
-    })
-    .then((json) => {
-      userAssert(
-        json !== undefined,
-        `[amp-render] ${src} must return json, but instead returned: ${typeof json}`
-      );
-      return json;
-    });
-}
-
-/**
  * Returns a function to fetch json from remote url, amp-state or
  * amp-script.
  *
@@ -129,8 +83,11 @@ export const getJsonFn = (element) => {
   if (isAmpStateSrc(src)) {
     return (src) => getAmpStateJson(element, src);
   }
-  if (isAmpScriptSrc(src)) {
-    return (src) => getAmpScriptJson(element.getAmpDoc(), src);
+  if (isAmpScriptUri(src)) {
+    return (src) =>
+      Services.scriptForDocOrNull(element).then((ampScriptService) =>
+        ampScriptService.fetch(src)
+      );
   }
   return () => batchFetchJsonFor(element.getAmpDoc(), element);
 };
@@ -164,7 +121,7 @@ export class AmpRender extends BaseElement {
       // variable `canRefresh`. See https://github.com/ampproject/amphtml/pull/33776#discussion_r614087734
       // for more context. This approach may be better if src does not mutate often. But the alternative might
       // be better if src mutatates often and component user does not use `refresh` action.
-      if (!src?.length || isAmpStateSrc(src) || isAmpScriptSrc(src)) {
+      if (!src?.length || isAmpStateSrc(src) || isAmpScriptUri(src)) {
         return;
       }
       api.refresh();

--- a/extensions/amp-render/1.0/amp-render.js
+++ b/extensions/amp-render/1.0/amp-render.js
@@ -18,7 +18,7 @@ import {BaseElement} from './base-element';
 import {Services} from '../../../src/services';
 import {batchFetchJsonFor} from '../../../src/batched-json';
 import {dev, user, userAssert} from '../../../src/log';
-import {dict} from '../../../src/utils/object';
+import {dict} from '../../../src/core/types/object';
 import {isAmpScriptUri} from '../../../src/url';
 import {isExperimentOn} from '../../../src/experiments';
 

--- a/extensions/amp-render/1.0/amp-render.js
+++ b/extensions/amp-render/1.0/amp-render.js
@@ -85,9 +85,10 @@ export const getJsonFn = (element) => {
   }
   if (isAmpScriptUri(src)) {
     return (src) =>
-      Services.scriptForDocOrNull(element).then((ampScriptService) =>
-        ampScriptService.fetch(src)
-      );
+      Services.scriptForDocOrNull(element).then((ampScriptService) => {
+        userAssert(ampScriptService, 'AMP-SCRIPT is not installed');
+        return ampScriptService.fetch(src);
+      });
   }
   return () => batchFetchJsonFor(element.getAmpDoc(), element);
 };

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -650,7 +650,7 @@ export class AmpScriptService {
     return ampScriptEl
       .getImpl()
       .then((impl) =>
-        impl.callFunction.apply(impl, [].concat(fnIdentifier).concat(args))
+        impl.callFunction.apply(impl, [fnIdentifier].concat(args))
       );
   }
 }

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -36,6 +36,9 @@ import {utf8Encode} from '../../../src/utils/bytes';
 /** @const {string} */
 const TAG = 'amp-script';
 
+/** @const {string} */
+const SERVICE_TAG = 'amp-script-service';
+
 /**
  * @typedef {{
  *   terminate: function():void,
@@ -208,15 +211,15 @@ export class AmpScript extends AMP.BaseElement {
     return this.userActivation_;
   }
 
-  // * @param {Array<*>} args
-
   /**
    * Calls the specified function on this amp-script's worker-dom instance.
+   * Accepts variable number of args to pass along to the underlying worker.
    *
-   * @param {string} unused - function identifier
+   * @param {string} unusedFnId - function identifier
+   * @param {...*} unusedFnArgs
    * @return {!Promise<*>}
    */
-  callFunction(unused /*, ...args */) {
+  callFunction(unusedFnId, unusedFnArgs) {
     return this.initialize_.promise.then(() => {
       return this.workerDom_.callFunction.apply(this.workerDom_, arguments);
     });
@@ -564,6 +567,9 @@ export class AmpScriptService {
    * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
    */
   constructor(ampdoc) {
+    /** @private {!../../../src/service/ampdoc-impl.AmpDoc}  */
+    this.ampdoc_ = ampdoc;
+
     /** @private {number} */
     this.cumulativeSize_ = 0;
 
@@ -598,7 +604,7 @@ export class AmpScriptService {
         // TODO(#24266): Refactor to %s interpolation when error string
         // extraction is ready.
         throw user().createError(
-          TAG,
+          SERVICE_TAG,
           `Script hash not found or incorrect for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">. ` +
             'See https://amp.dev/documentation/components/amp-script/#script-hash.'
         );
@@ -615,6 +621,38 @@ export class AmpScriptService {
   sizeLimitExceeded(size) {
     this.cumulativeSize_ += size;
     return this.cumulativeSize_ > MAX_TOTAL_SCRIPT_SIZE;
+  }
+
+  /**
+   * Fetches an amp-script URI by finding the associated amp-script and
+   * calling the specified function.
+   *
+   * Note: the amp-script URI does not yet support function args,
+   *       even though worker-dom's callFunction does. Therefore we allow it
+   *       via extra args.
+   *
+   * @param {string} uri
+   * @param {...*} unusedArgs
+   * @return {Promise<*>}
+   */
+  fetch(uri, unusedArgs) {
+    const uriParts = uri.slice('amp-script:'.length).split('.');
+    userAssert(
+      uriParts.length === 2 && uriParts[0].length > 0 && uriParts[1].length > 0,
+      `[${SERVICE_TAG}]: "amp-script" URIs must be of the format "scriptId.functionIdentifier".`
+    );
+
+    const ampScriptId = uriParts[0];
+    const fnIdentifier = uriParts[1];
+    const ampScriptEl = this.ampdoc_.getElementById(ampScriptId);
+    userAssert(
+      ampScriptEl && ampScriptEl.tagName === 'AMP-SCRIPT',
+      `[${SERVICE_TAG}]: could not find <amp-script> with script set to ${ampScriptId}`
+    );
+    const args = Array.prototype.slice.call(arguments, 1);
+    return ampScriptEl
+      .getImpl()
+      .then((impl) => impl.callFunction([].concat(fnIdentifier).concat(args)));
   }
 }
 
@@ -879,6 +917,6 @@ export class SanitizerImpl {
 }
 
 AMP.extension(TAG, '0.1', function (AMP) {
-  AMP.registerServiceForDoc(TAG, AmpScriptService);
+  AMP.registerServiceForDoc(SERVICE_TAG, AmpScriptService);
   AMP.registerElement(TAG, AmpScript, CSS);
 });

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -36,9 +36,6 @@ import {utf8Encode} from '../../../src/utils/bytes';
 /** @const {string} */
 const TAG = 'amp-script';
 
-/** @const {string} */
-const SERVICE_TAG = 'amp-script-service';
-
 /**
  * @typedef {{
  *   terminate: function():void,
@@ -604,7 +601,7 @@ export class AmpScriptService {
         // TODO(#24266): Refactor to %s interpolation when error string
         // extraction is ready.
         throw user().createError(
-          SERVICE_TAG,
+          TAG,
           `Script hash not found or incorrect for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">. ` +
             'See https://amp.dev/documentation/components/amp-script/#script-hash.'
         );
@@ -639,7 +636,7 @@ export class AmpScriptService {
     const uriParts = uri.slice('amp-script:'.length).split('.');
     userAssert(
       uriParts.length === 2 && uriParts[0].length > 0 && uriParts[1].length > 0,
-      `[${SERVICE_TAG}]: "amp-script" URIs must be of the format "scriptId.functionIdentifier".`
+      `[${TAG}]: "amp-script" URIs must be of the format "scriptId.functionIdentifier".`
     );
 
     const ampScriptId = uriParts[0];
@@ -647,7 +644,7 @@ export class AmpScriptService {
     const ampScriptEl = this.ampdoc_.getElementById(ampScriptId);
     userAssert(
       ampScriptEl && ampScriptEl.tagName === 'AMP-SCRIPT',
-      `[${SERVICE_TAG}]: could not find <amp-script> with script set to ${ampScriptId}`
+      `[${TAG}]: could not find <amp-script> with script set to ${ampScriptId}`
     );
     const args = Array.prototype.slice.call(arguments, 1);
     return ampScriptEl
@@ -917,6 +914,6 @@ export class SanitizerImpl {
 }
 
 AMP.extension(TAG, '0.1', function (AMP) {
-  AMP.registerServiceForDoc(SERVICE_TAG, AmpScriptService);
+  AMP.registerServiceForDoc(TAG, AmpScriptService);
   AMP.registerElement(TAG, AmpScript, CSS);
 });

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -649,7 +649,9 @@ export class AmpScriptService {
     const args = Array.prototype.slice.call(arguments, 1);
     return ampScriptEl
       .getImpl()
-      .then((impl) => impl.callFunction([].concat(fnIdentifier).concat(args)));
+      .then((impl) =>
+        impl.callFunction.apply(impl, [].concat(fnIdentifier).concat(args))
+      );
   }
 }
 

--- a/src/services.js
+++ b/src/services.js
@@ -212,7 +212,7 @@ export class Services {
   static scriptForDocOrNull(element) {
     return /** @type {!Promise<?../extensions/amp-script/0.1/amp-script.AmpScriptService>} */ (getElementServiceIfAvailableForDocInEmbedScope(
       element,
-      'amp-script-service',
+      'amp-script',
       'amp-script'
     ));
   }

--- a/src/services.js
+++ b/src/services.js
@@ -212,7 +212,7 @@ export class Services {
   static scriptForDocOrNull(element) {
     return /** @type {!Promise<?../extensions/amp-script/0.1/amp-script.AmpScriptService>} */ (getElementServiceIfAvailableForDocInEmbedScope(
       element,
-      'amp-script',
+      'amp-script-service',
       'amp-script'
     ));
   }

--- a/src/url.js
+++ b/src/url.js
@@ -407,6 +407,14 @@ export function isProxyOrigin(url) {
 }
 
 /**
+ * @param {string} uri
+ * @return {boolean}
+ */
+export function isAmpScriptUri(uri) {
+  return uri.startsWith('amp-script:');
+}
+
+/**
  * For proxy-origin URLs, returns the serving type. Otherwise, returns null.
  * E.g., 'https://amp-com.cdn.ampproject.org/a/s/amp.com/amp_document.html'
  * returns 'a'.


### PR DESCRIPTION
**summary**
Partial for https://github.com/ampproject/amphtml/issues/33581

Now that `amp-script.callFunction` is used in 4 places (a4a rtc, analytics, amp-list, amp-render), it is worth extracting the common logic at callsites into `AmpScriptService`.

Notes
- I corrected the jsdoc for var args functions `callFunction` and `fetch`
- Centralized logic the call logic into `amp-script.js.AmpScriptService`

TIL: do not export things from files that call `AMP.extension`.


**size diff**
```
dist/v0/amp-list-0.1.mjs: Δ -0.07KB
dist/v0/amp-list-0.1.js: Δ -0.10KB
dist/v0/amp-render-1.0.mjs: Δ -0.18KB
dist/v0/amp-render-1.0.js: Δ -0.14KB
dist/v0/amp-script-0.1.mjs: Δ +0.15KB
dist/v0/amp-script-0.1.js: Δ +0.16KB
dist/v0/amp-analytics-0.1.mjs: Δ -0.08KB
dist/v0/amp-analytics-0.1.js: Δ -0.01KB
```