### PR TITLE
📖 Support newlines for amp-script meta hashes

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -573,10 +573,8 @@ export class AmpScriptService {
     // Query the meta tag once per document.
     const allowedHashes = ampdoc.getMetaByName('amp-script-src');
     if (allowedHashes) {
-      this.sources_ = allowedHashes
-        .split(' ')
-        .map((s) => s.trim())
-        .filter((s) => s.length);
+      // Allow newlines between hashes for readability/diffs
+      this.sources_ = allowedHashes.split(/\s+/).filter(Boolean);
     }
 
     /** @private @const {!../../../src/service/crypto-impl.Crypto} */

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -107,6 +107,8 @@ You can also include your JavaScript inline, in a `script` tag. You must:
 
 [tip type="default"]
 For security reasons, `amp-script` elements with a `script` or cross-origin `src` attribute require a [script hash](#calculating-the-script-hash) in a `<meta name="amp-script-src" content="...">` tag. Also, same-origin `src` files must have [`Content-Type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type): `application/javascript` or `text/javascript`.
+
+If you are including multiple `amp-script` elements which require a [script hash](#calculating-the-script-hash), they should be included as a whitespace-delimited list in a single `<meta name="amp-script-src" content="...">` tag (see [examples/amp-script/example.amp.html](https://github.com/ampproject/amphtml/blob/main/examples/amp-script/example.amp.html) for an example with multiple script hashes).
 [/tip]
 
 ### How does it work?

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -108,7 +108,7 @@ You can also include your JavaScript inline, in a `script` tag. You must:
 [tip type="default"]
 For security reasons, `amp-script` elements with a `script` or cross-origin `src` attribute require a [script hash](#calculating-the-script-hash) in a `<meta name="amp-script-src" content="...">` tag. Also, same-origin `src` files must have [`Content-Type`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type): `application/javascript` or `text/javascript`.
 
-If you are including multiple `amp-script` elements which require a [script hash](#calculating-the-script-hash), they should be included as a whitespace-delimited list in a single `<meta name="amp-script-src" content="...">` tag (see [examples/amp-script/example.amp.html](https://github.com/ampproject/amphtml/blob/main/examples/amp-script/example.amp.html) for an example with multiple script hashes).
+If your page contains multiple `amp-script` elements, each requiring a [script hash](#calculating-the-script-hash), include each as a whitespace-delimited list in a single `<meta name="amp-script-src" content="...">` tag (see [examples/amp-script/example.amp.html](https://github.com/ampproject/amphtml/blob/main/examples/amp-script/example.amp.html) for an example with multiple script hashes).
 [/tip]
 
 ### How does it work?

--- a/test/fixtures/e2e/amp-script/basic.amp.html
+++ b/test/fixtures/e2e/amp-script/basic.amp.html
@@ -4,7 +4,10 @@
   <meta charset="utf-8">
   <link rel="canonical" href="self.html" />
   <meta name="viewport" content="width=device-width,minimum-scale=1">
-  <meta name="amp-script-src" content="sha384-bW-_HMkVMBmO47rFOYGO7-P-VXShwCOrZ25J2lRfcMyh5YoMYIGMBshG0pm6GlWW sha384-DP5URoE0rQ4CsfiB7KeMTr4ePLGDIEYK04htqx2_VzA0Glzf0VQ9otDwkTyeWACf">
+  <meta name="amp-script-src" content="
+    sha384-bW-_HMkVMBmO47rFOYGO7-P-VXShwCOrZ25J2lRfcMyh5YoMYIGMBshG0pm6GlWW
+    sha384-DP5URoE0rQ4CsfiB7KeMTr4ePLGDIEYK04htqx2_VzA0Glzf0VQ9otDwkTyeWACf
+  ">
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
   <script async custom-template="amp-script" src="https://cdn.ampproject.org/v0/amp-script-0.1.js"></script>


### PR DESCRIPTION
Related to https://github.com/ampproject/amphtml/issues/33402

Publishers wanting to use multiple inline amp-scripts in a page require multiple source SHAs. The current parsing logic expects them to be a space-delimited list in a single meta tag, but this is undocumented and non-obvious. This PR:
- [x] adds documentation describing supported formats
- [x] adds support for newlines in the meta attribute value for better publisher diffs/readability