### PR TITLE
🐛 [Story outlink] Use linker on swipe up

### DIFF
--- a/examples/amp-story/analytics.html
+++ b/examples/amp-story/analytics.html
@@ -149,6 +149,7 @@
         <amp-story-cta-layer>
           <a href="https://google.com">CTA link</a>
         </amp-story-cta-layer>
+        <amp-story-page-attachment layout="nodisplay" href="https://google.com"></amp-story-page-attachment>
       </amp-story-page>
 
       <amp-story-page id="p4" style="background-color: grey">

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -27,6 +27,7 @@ import {getState} from '../../../src/history';
 import {htmlFor} from '../../../src/static-template';
 import {isPageAttachmentUiV2ExperimentOn} from './amp-story-open-page-attachment';
 import {toggle} from '../../../src/style';
+import {triggerClickFromLightDom} from './utils';
 
 /** @const {string} */
 const DARK_THEME_CLASS = 'i-amphtml-story-draggable-drawer-theme-dark';
@@ -292,10 +293,10 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       // amp-story-page-attachment.css). The navigation itself will take some
       // time, depending on the target and network conditions.
       this.win.setTimeout(() => {
-        this.element.parentElement
+        const clickTarget = this.element.parentElement
           .querySelector('.i-amphtml-story-page-open-attachment-host')
-          .shadowRoot.querySelector('a.i-amphtml-story-page-open-attachment')
-          .click();
+          .shadowRoot.querySelector('a.i-amphtml-story-page-open-attachment');
+        triggerClickFromLightDom(clickTarget, this.element);
       }, 50);
     });
   }


### PR DESCRIPTION
Closes #33860

Outlinks are clicked inside a shadow dom, so the linker doesn't get triggered.
Fix: Replace the `.click()` with `triggerClickFromLightDom`, a utility function that clones the anchor tag and adds it into the light dom, so that the linker can catch the navigation event and append the `linker` queryParam.

Tested on swipe up and click, both work with the linker.