### PR TITLE
♻️ Move contextprops from src/core to src/context

### DIFF
--- a/extensions/amp-accordion/1.0/test/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test/test-amp-accordion.js
@@ -16,7 +16,7 @@
 import '../amp-accordion';
 import {ActionInvocation} from '../../../../src/service/action-impl';
 import {ActionTrust} from '../../../../src/core/constants/action-constants';
-import {CanRender} from '../../../../src/core/contextprops';
+import {CanRender} from '../../../../src/context/contextprops';
 import {htmlFor} from '../../../../src/static-template';
 import {subscribe, unsubscribe} from '../../../../src/context';
 import {toggleExperiment} from '../../../../src/experiments';

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -53,7 +53,6 @@ module.exports = {
       'files': [
         './preact/base-element.js',
         './preact/slot.js',
-        './core/contextprops.js',
         './context/node.js',
         // TEMPORARY, follow tracking issue #33631
         './preact/component/3p-frame.js',

--- a/src/context/contextprops.js
+++ b/src/context/contextprops.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import {Loading, reducer as loadingReducer} from './loading-instructions';
-import {contextProp} from '../context';
+import {Loading, reducer as loadingReducer} from '../core/loading-instructions';
+import {contextProp} from './prop';
 
 /**
  * Defines whether a DOM subtree can be currently seen by the user. A subtree

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -17,7 +17,7 @@
 import * as Preact from './index';
 import {ActionTrust} from '../core/constants/action-constants';
 import {AmpEvents} from '../core/constants/amp-events';
-import {CanPlay, CanRender, LoadingProp} from '../core/contextprops';
+import {CanPlay, CanRender, LoadingProp} from '../context/contextprops';
 import {Deferred} from '../core/data-structures/promise';
 import {Layout, isLayoutSizeDefined} from '../layout';
 import {Loading} from '../core/loading-instructions';

--- a/src/preact/slot.js
+++ b/src/preact/slot.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from './index';
-import {CanPlay, CanRender, LoadingProp} from '../core/contextprops';
+import {CanPlay, CanRender, LoadingProp} from '../context/contextprops';
 import {Loading} from '../core/loading-instructions';
 import {pureDevAssert as devAssert} from '../core/assert';
 import {

--- a/test/unit/context/test-contextprops.js
+++ b/test/unit/context/test-contextprops.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import {CanPlay, CanRender, LoadingProp} from '../../../src/core/contextprops';
+import {
+  CanPlay,
+  CanRender,
+  LoadingProp,
+} from '../../../src/context/contextprops';
 
 describes.sandboxed('contextprops - common props', {}, () => {
   describe('CanRender', () => {

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../src/preact/index';
-import {CanRender} from '../../../src/core/contextprops';
+import {CanRender} from '../../../src/context/contextprops';
 import {
   PreactBaseElement,
   whenUpgraded,

--- a/test/unit/preact/test-slot.js
+++ b/test/unit/preact/test-slot.js
@@ -16,7 +16,11 @@
 
 import * as Preact from '../../../src/preact/index';
 import * as fakeTimers from '@sinonjs/fake-timers';
-import {CanPlay, CanRender, LoadingProp} from '../../../src/core/contextprops';
+import {
+  CanPlay,
+  CanRender,
+  LoadingProp,
+} from '../../../src/context/contextprops';
 import {Slot, useSlotContext} from '../../../src/preact/slot';
 import {WithAmpContext} from '../../../src/preact/context';
 import {createElementWithAttributes} from '../../../src/dom';


### PR DESCRIPTION
This seems to be directly tied into `src/context`, so this move seemed to make sense to me. It also untangles one cross-dependency from `src/core/contextprops` into `src/context`

Somewhat related to #33631 