### PR TITLE
Minor fix: auto-lightbox: check image's loading state after async measurement

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -438,13 +438,13 @@ export function apply(ampdoc, element) {
 export function runCandidates(ampdoc, candidates) {
   return candidates.map((candidate) =>
     whenLoaded(candidate).then(() => {
-      // <amp-img> will change the img's src inline data on unlayout and remove
-      // it from DOM, but a LOAD_END event would still be triggered afterwards.
-      if (candidate.signals().get(CommonSignals.UNLOAD)) {
-        return;
-      }
       return measureIntersectionNoRoot(candidate).then(
         ({boundingClientRect}) => {
+          // <amp-img> will change the img's src inline data on unlayout and
+          // remove it from DOM.
+          if (!candidate.signals().get(CommonSignals.LOAD_END)) {
+            return;
+          }
           const {width, height} = boundingClientRect;
           if (!Criteria.meetsAll(candidate, width, height)) {
             return;

--- a/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test/test-amp-auto-lightbox.js
@@ -517,10 +517,16 @@ describes.realWin(
         const signals = new Signals();
         img.signals = () => signals;
 
-        signals.signal(CommonSignals.UNLOAD);
         signals.signal(CommonSignals.LOAD_END);
 
-        const elected = await Promise.all(runCandidates(env.ampdoc, [img]));
+        const candidatePromise = Promise.all(runCandidates(env.ampdoc, [img]));
+
+        // Skip microtask and reset LOAD_END to emulate unloading in the middle
+        // of the candidate's measurement.
+        await new Promise((resolve) => resolve());
+        signals.reset(CommonSignals.LOAD_END);
+
+        const elected = await candidatePromise;
         expect(elected[0]).to.be.undefined;
       });
 


### PR DESCRIPTION
Partial for #31540.
Fixes https://github.com/ampproject/error-reporting/issues/79.
