### PR TITLE
Bump worker-dom, update iframe-worker-proxy

### DIFF
--- a/3p/amp-script-proxy-iframe.js
+++ b/3p/amp-script-proxy-iframe.js
@@ -22,7 +22,8 @@
  * @enum {string}
  */
 const MESSAGE_TYPE = {
-  ready: 'iframe-ready',
+  iframeReady: 'iframe-ready',
+  workerReady: 'worker-ready',
   init: 'init-worker',
   onmessage: 'onmessage',
   onerror: 'onerror',
@@ -37,7 +38,7 @@ let parentOrigin = '*';
  * @param {*} message
  */
 function send(type, message) {
-  if (type !== MESSAGE_TYPE.ready && parentOrigin === '*') {
+  if (type !== MESSAGE_TYPE.iframeReady && parentOrigin === '*') {
     throw new Error('Broadcast banned except for iframe-ready message.');
   }
   parent./*OK*/ postMessage({type, message}, parentOrigin);
@@ -62,7 +63,7 @@ function listen(type, handler) {
 }
 
 // Send initialization.
-send(MESSAGE_TYPE.ready);
+send(MESSAGE_TYPE.iframeReady);
 
 let worker = null;
 // Listen for Worker Init.
@@ -87,4 +88,6 @@ listen(MESSAGE_TYPE.init, ({code}) => {
   listen(MESSAGE_TYPE./*OK*/ postMessage, ({message}) =>
     worker./*OK*/ postMessage(message)
   );
+
+  send(MESSAGE_TYPE.workerReady);
 });

--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -15,7 +15,7 @@
   <h1>PROTOCOL ADAPTERS</h1>
 
   <h3>basic example</h3>
-  <amp-script id="fns" script="local-script" nodom data-ampdevmode></amp-script>
+  <amp-script id="fns" script="local-script" nodom sandboxed></amp-script>
   <script type="text/plain" target="amp-script" id="local-script">
     function fetchData() {
       const items = [{name: 'apple'}, {name: 'banana'}, {name: 'pear'}];

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,9 +105,9 @@
       "integrity": "sha512-oOlju4AQkgel/h4h8ZPRk0xIsE1xtFsn2IAvFOAB6GTa8IXLp+XNDzAUKKU/HpJbrbh/c+AUjYvcKds+c7C+uQ=="
     },
     "@ampproject/worker-dom": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.29.1.tgz",
-      "integrity": "sha512-7blaPY3xLQVwm+EMvk0XBFKoE3YuILeRd+5xoAfVeh5FwoK4YD3kcmc41W7QzPvm5kVXohIZalSPJpOG7Yxe2A=="
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.29.2.tgz",
+      "integrity": "sha512-S5vSbR6XJrZXZ5bMxBVjEP6uwfyb8VGSXwrRa3Tsn+aHIA/6MT7Y3uZYTIKRJEZTJWdyeCj0l4/bmi6JZf93FQ=="
     },
     "@babel/code-frame": {
       "version": "7.12.13",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.7.2",
     "@ampproject/viewer-messaging": "1.1.2",
-    "@ampproject/worker-dom": "0.29.1",
+    "@ampproject/worker-dom": "0.29.2",
     "@webcomponents/webcomponentsjs": "2.5.0",
     "dompurify": "2.2.6",
     "google-closure-library": "20210202.0.0",


### PR DESCRIPTION
**summary**
Fixes a bug in `<amp-script>` sandboxed mode where the upgrade completes before the underlying iframe/worker is actually ready to receive messages.

- Bumps `worker-dom` verison.
- Updates the iframe to send the new `worker-ready` message
- Modified the `amp-list` "protocol adapters" example to use a sandboxed amp-script, demonstrating the fix (would not have worked before PR)

~Blocked on https://github.com/ampproject/worker-dom/pull/1047~