### PR TITLE
♿  [Story a11y] Make amp-twitter not tabbable if not on current page

### DIFF
--- a/examples/amp-story/show-tooltip.html
+++ b/examples/amp-story/show-tooltip.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <script async custom-element="amp-story"
-        src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-twitter" src="https://cdn.ampproject.org/v0/amp-twitter-0.1.js"></script>
     <title>My Story</title>
     <meta name="description" content="Get started with amp-story">
 
@@ -55,6 +55,15 @@
           </div>
 
           <a href="https://www.google.com"  show-tooltip="auto" style="position:absolute; bottom:15px;"><span>This is a link in the bottom 20% of grid-layer using [show-tooltip]="auto"</span></a>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="twitter">
+        <amp-story-grid-layer>
+          <amp-twitter width="375" height="472"
+             layout="responsive"
+             data-tweetid="638793490521001985" interactive>
+          </amp-twitter>
         </amp-story-grid-layer>
       </amp-story-page>
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -112,7 +112,7 @@ export const Selectors = {
   ALL_PLAYBACK_MEDIA:
     '> audio, amp-story-grid-layer audio, amp-story-grid-layer video',
   ALL_VIDEO: 'amp-story-grid-layer video',
-  ALL_TABBABLE: 'a',
+  ALL_TABBABLE: 'a, amp-twitter > iframe',
 };
 
 /** @private @const {string} */


### PR DESCRIPTION
Closes #31747
Relates to #32498

Twitter component can be focused with tabbing when outside the page. Adding the iframe to the tabindex logic will set `tabindex="-1"` on the iframe when the component is being initialized.

Does this work? Yes, the iframe is picked up by `toggleTabbableElements_` and sets `tabindex="-1"` on the iframe if it's on an active story. Since amp-twitter doesn't support a custom `tabindex` set by the creator, we don't need to worry about the iframe not being loaded when the `initializeTabbableElements` function is ran.