### PR TITLE
[amp-story-auto-analytics] Add default linker

### DIFF
--- a/examples/amp-story/auto-analytics.html
+++ b/examples/amp-story/auto-analytics.html
@@ -62,7 +62,7 @@
       <amp-story-page id="p3">
         <amp-story-grid-layer template="vertical">
           <h1>Page Three</h1>
-          <a href="google.com">click me</a>
+          <a href="https://google.com">click me</a>
         </amp-story-grid-layer>
         <amp-story-cta-layer>
           <a>click me</a>

--- a/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
+++ b/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
@@ -64,12 +64,17 @@ export const buildGtagConfig = (gtagId) => ({
     },
   },
   'linkers': {
-    'enabled': true,
-    'proxyOnly': false,
-    'linker': {
+    'ampStoryAutoAnalyticsLinker': {
       'ids': {
-        'cid': 'CLIENT_ID(cid)',
+        'cid': '${clientId}',
       },
+      'enabled': true,
+      'proxyOnly': false,
+    },
+  },
+  'cookies': {
+    'ampStoryAutoAnalyticsCookies': {
+      'value': 'LINKER_PARAM(ampStoryAutoAnalyticsLinker, cid)',
     },
   },
 });

--- a/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
+++ b/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
@@ -64,13 +64,12 @@ export const buildGtagConfig = (gtagId) => ({
     },
   },
   'linkers': {
-    'linker1': {
-      'enabled': true,
-      'proxyOnly': false,
-      'destinationDomains': ['google.com', 'localhost'],
+    'enabled': true,
+    'proxyOnly': false,
+    'destinationDomains': ['google.com'],
+    'linker': {
       'ids': {
-        'cid': 'CLIENT_ID(_ga)',
-        'uid': 'QUERY_PARAM(uid)',
+        'cid': 'CLIENT_ID(cid)',
       },
     },
   },

--- a/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
+++ b/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
@@ -66,7 +66,6 @@ export const buildGtagConfig = (gtagId) => ({
   'linkers': {
     'enabled': true,
     'proxyOnly': false,
-    'destinationDomains': ['google.com'],
     'linker': {
       'ids': {
         'cid': 'CLIENT_ID(cid)',

--- a/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
+++ b/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
@@ -21,11 +21,6 @@
 export const buildGtagConfig = (gtagId) => ({
   'vars': {
     'gtag_id': gtagId,
-    'config': {
-      [gtagId]: {
-        'groups': 'default',
-      },
-    },
   },
   'triggers': {
     'storyPageCount': {
@@ -65,6 +60,17 @@ export const buildGtagConfig = (gtagId) => ({
       },
       'storySpec': {
         'repeat': false,
+      },
+    },
+  },
+  'linkers': {
+    'linker1': {
+      'enabled': true,
+      'proxyOnly': false,
+      'destinationDomains': ['google.com', 'localhost'],
+      'ids': {
+        'cid': 'CLIENT_ID(_ga)',
+        'uid': 'QUERY_PARAM(uid)',
       },
     },
   },

--- a/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
+++ b/extensions/amp-story-auto-analytics/0.1/auto-analytics-configs.js
@@ -33,6 +33,7 @@ export const buildGtagConfig = (gtagId) => ({
         'send_to': [gtagId],
       },
       'storySpec': {
+        // Makes sure the event is only fired once.
         'repeat': false,
       },
     },
@@ -46,6 +47,7 @@ export const buildGtagConfig = (gtagId) => ({
         'send_to': [gtagId],
       },
       'storySpec': {
+        // Makes sure the event is only fired once.
         'repeat': false,
       },
     },
@@ -59,21 +61,28 @@ export const buildGtagConfig = (gtagId) => ({
         'send_to': [gtagId],
       },
       'storySpec': {
+        // Makes sure the event is only fired once.
         'repeat': false,
       },
     },
   },
+  // Linkers stitch sessions between cache and origin together using cid.
   'linkers': {
     'ampStoryAutoAnalyticsLinker': {
       'ids': {
         'cid': '${clientId}',
       },
       'enabled': true,
+      // Makes sure URL is decorated from origin to cache. (Default is cache to
+      // origin only).
       'proxyOnly': false,
     },
   },
+  // CookieWriter config is used to extract the url params and store them into
+  // cookies.
   'cookies': {
     'ampStoryAutoAnalyticsCookies': {
+      // Reads URL linker params and stores them as cookies.
       'value': 'LINKER_PARAM(ampStoryAutoAnalyticsLinker, cid)',
     },
   },

--- a/extensions/amp-story-auto-analytics/0.1/test/test-amp-story-auto-analytics.js
+++ b/extensions/amp-story-auto-analytics/0.1/test/test-amp-story-auto-analytics.js
@@ -54,10 +54,43 @@ describes.realWin(
         .exist;
     });
 
-    it('should add linker support by default', async () => {
+    it('should add linker config', async () => {
       await autoAnalyticsEl.whenBuilt();
+      const config = {
+        'linkers': {
+          'ampStoryAutoAnalyticsLinker': {
+            'ids': {
+              'cid': '${clientId}',
+            },
+            'enabled': true,
+            'proxyOnly': false,
+          },
+        },
+      };
+
+      const strConfig = JSON.stringify(config);
+      const configContents = strConfig.substr(1, strConfig.length - 2);
+
       expect(autoAnalyticsEl.querySelector('script').textContent).to.contain(
-        '"linkers":{"enabled":true,"proxyOnly":false,"linker":{"ids":{"cid":"CLIENT_ID(cid)"}}}'
+        configContents
+      );
+    });
+
+    it('should add cookieWriter config', async () => {
+      await autoAnalyticsEl.whenBuilt();
+      const config = {
+        'cookies': {
+          'ampStoryAutoAnalyticsCookies': {
+            'value': 'LINKER_PARAM(ampStoryAutoAnalyticsLinker, cid)',
+          },
+        },
+      };
+
+      const strConfig = JSON.stringify(config);
+      const configContents = strConfig.substr(1, strConfig.length - 2);
+
+      expect(autoAnalyticsEl.querySelector('script').textContent).to.contain(
+        configContents
       );
     });
   }

--- a/extensions/amp-story-auto-analytics/0.1/test/test-amp-story-auto-analytics.js
+++ b/extensions/amp-story-auto-analytics/0.1/test/test-amp-story-auto-analytics.js
@@ -53,5 +53,12 @@ describes.realWin(
       expect(autoAnalyticsEl.querySelector('amp-analytics[type="gtag"]')).to
         .exist;
     });
+
+    it('should add linker support by default', async () => {
+      await autoAnalyticsEl.whenBuilt();
+      expect(autoAnalyticsEl.querySelector('script').textContent).to.contain(
+        '"linkers":{"enabled":true,"proxyOnly":false,"linker":{"ids":{"cid":"CLIENT_ID(cid)"}}}'
+      );
+    });
   }
 );


### PR DESCRIPTION
Closes #33463

Having `'groups': 'default'` overrides the `linker` configuration (if provided) and does not decorate URLs. 

The only way I was able to get the URLs decorated is by removing the `groups` property and specifying `destinationDomains`. which we would need to open an API for at the `<amp-story-auto-analytics>` component level.

<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE1: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.
> NOTE2: To ensure that all PR checks are triggered, make sure you've authenticated with the services listed in the one-time setup instructions at https://github.com/ampproject/amphtml/blob/main/contributing/getting-started-quick.md#one-time-setup (see last step).

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
