### PR TITLE
🏗 Check dot files and directories for invalid whitespaces

### DIFF
--- a/.circleci/maybe_gracefully_halt.sh
+++ b/.circleci/maybe_gracefully_halt.sh
@@ -32,7 +32,7 @@ fi
 if [[ $CIRCLE_JOB == Experiment* ]]; then
   # Extract the experiment name from the job name in `config.yml`.
   EXP=$(echo $CIRCLE_JOB | awk '{print $2}')
-  
+
   # Extract the commit SHA. For PR jobs, this is written to .CIRCLECI_MERGE_COMMIT.
   if [[ -f /tmp/restored-workspace/.CIRCLECI_MERGE_COMMIT ]]; then
     COMMIT_SHA="$(cat /tmp/restored-workspace/.CIRCLECI_MERGE_COMMIT)"
@@ -58,4 +58,4 @@ if [[ $CIRCLE_JOB == Experiment* ]]; then
     circleci-agent step halt
     exit 0
   fi
-fi  
+fi

--- a/build-system/tasks/check-invalid-whitespaces.js
+++ b/build-system/tasks/check-invalid-whitespaces.js
@@ -45,7 +45,7 @@ function runCheck(filesToCheck) {
  * Checks multiple kinds of files for invalid whitespaces.
  */
 function checkInvalidWhitespaces() {
-  const filesToCheck = getFilesToCheck(invalidWhitespaceGlobs);
+  const filesToCheck = getFilesToCheck(invalidWhitespaceGlobs, {dot: true});
   if (filesToCheck.length == 0) {
     return;
   }


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/26553114/115473441-bc26d900-a209-11eb-9399-9affe208bc05.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/115473471-c3e67d80-a209-11eb-810f-1f0991d8507d.png)

**Reference:** https://github.com/mrmlnc/fast-glob#dot

Follow up to #33926