### PR TITLE
🏗 Omit files / dirs in `.gitignore` during invalid whitespace checks

### DIFF
--- a/build-system/tasks/check-invalid-whitespaces.js
+++ b/build-system/tasks/check-invalid-whitespaces.js
@@ -45,7 +45,11 @@ function runCheck(filesToCheck) {
  * Checks multiple kinds of files for invalid whitespaces.
  */
 function checkInvalidWhitespaces() {
-  const filesToCheck = getFilesToCheck(invalidWhitespaceGlobs, {dot: true});
+  const filesToCheck = getFilesToCheck(
+    invalidWhitespaceGlobs,
+    {dot: true},
+    '.gitignore'
+  );
   if (filesToCheck.length == 0) {
     return;
   }


### PR DESCRIPTION
Forgot to do this in #33926 and #33927