### PR TITLE
✨ Holdback experiment for disallowing amp-auto-ad from inserting ads above the viewport

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -17,5 +17,6 @@
   "amp-consent-granular-consent": 1,
   "amp-cid-backup": 1,
   "3p-vendor-split": 0.1,
-  "story-ad-placements": 0.01
+  "story-ad-placements": 0.01,
+  "auto-ads-no-insertion-above": 0.2
 }

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -20,6 +20,7 @@ import {
   cloneLayoutMarginsChangeDef,
 } from '../../../src/layout-rect';
 import {Services} from '../../../src/services';
+import {addExperimentIdToElement} from '../../../ads/google/a4a/traffic-experiments';
 import {
   closestAncestorElementBySelector,
   createElementWithAttributes,
@@ -28,6 +29,11 @@ import {
 } from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/core/types/object';
+import {
+  getExperimentBranch,
+  isExperimentOn,
+  randomlySelectUnsetExperiments,
+} from '../../../src/experiments';
 import {measurePageLayoutBox} from '../../../src/utils/page-layout-box';
 
 /** @const */
@@ -194,8 +200,29 @@ export class Placement {
    */
   placeAd(baseAttributes, sizing, adTracker, isResponsiveEnabled) {
     return this.getEstimatedPosition().then((yPosition) => {
-      // TODO(powerivq@) Remove this after fixing ad resizing
-      if (this.ampdoc.win./*OK*/ scrollY > yPosition) {
+      // TODO(powerivq@) Remove this after finishing the experiment
+      const controlBranch = '31060868';
+      const expBranch = '31060869';
+      const holdbackExp = isExperimentOn(
+        this.ampdoc.win,
+        'auto-ads-no-insertion-above'
+      );
+      if (holdbackExp) {
+        const expInfoList = /** @type {!Array<!../../../experiments.ExperimentInfo>} */ ([
+          {
+            experimentId: 'auto-ads-no-insertion-above',
+            isTrafficEligible: () => true,
+            branches: [controlBranch, expBranch],
+          },
+        ]);
+        randomlySelectUnsetExperiments(this.ampdoc.win, expInfoList);
+      }
+      if (
+        (!holdbackExp ||
+          getExperimentBranch(this.ampdoc.win, 'auto-ads-no-insertion-above') ==
+            expBranch) &&
+        this.ampdoc.win./*OK*/ scrollY > yPosition
+      ) {
         this.state_ = PlacementState.UNUSED;
         return this.state_;
       }
@@ -211,6 +238,12 @@ export class Placement {
         this.adElement_ = shouldUseFullWidthResponsive
           ? this.createFullWidthResponsiveAdElement_(baseAttributes)
           : this.createAdElement_(baseAttributes, sizing.width);
+        if (holdbackExp) {
+          addExperimentIdToElement(
+            getExperimentBranch(this.ampdoc.win, 'auto-ads-no-insertion-above'),
+            this.getAdElement()
+          );
+        }
 
         this.injector_(this.anchorElement_, this.getAdElement());
 


### PR DESCRIPTION
In order to see the revenue impact of doing so.

The change is necessary to prevent CLS on pages using amp-auto-ads. This experiment will only emit eid if the ad is created using amp-auto-ads, not through any other means.