### PR TITLE
✨ [Amp story] [Page attachments] [inline] Add contrast protection

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -257,6 +257,7 @@
 }
 
 [href].i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment {
+  /* Outlink attachments do not need the linear gradient. */
   background: none !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -241,18 +241,12 @@
 .i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment {
   --i-amphtml-outlink-cta-background-color: white !important;
   --i-amphtml-outlink-cta-text-color: black !important;
-}
-
-[theme="dark"].i-amphtml-story-page-open-attachment {
-  --i-amphtml-outlink-cta-background-color: black !important;
-  --i-amphtml-outlink-cta-text-color: white !important;
-}
-
-.i-amphtml-story-page-open-attachment.i-amphtml-amp-story-page-attachment-ui-v2 {
   background: linear-gradient(0, rgba(0, 0, 0, 0.30), transparent) !important;
 }
 
 [theme="dark"].i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment {
+  --i-amphtml-outlink-cta-background-color: black !important;
+  --i-amphtml-outlink-cta-text-color: white !important;
   background: linear-gradient(0, rgba(255, 255, 255, 0.30), transparent) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -238,7 +238,7 @@
 }
 
 /** For amp-story-outlink-page-attachment-v2 experiment elements. */
-.i-amphtml-story-page-open-attachment {
+.i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment {
   --i-amphtml-outlink-cta-background-color: white !important;
   --i-amphtml-outlink-cta-text-color: black !important;
 }
@@ -252,8 +252,12 @@
   background: linear-gradient(0, rgba(0, 0, 0, 0.30), transparent) !important;
 }
 
-[theme="dark"].i-amphtml-story-page-open-attachment.i-amphtml-amp-story-page-attachment-ui-v2 {
+[theme="dark"].i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment {
   background: linear-gradient(0, rgba(255, 255, 255, 0.30), transparent) !important;
+}
+
+.i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment.i-amphtml-story-page-open-attachment-outlink {
+  background: none !important;
 }
 
 .i-amphtml-story-outlink-page-attachment-arrow {

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -249,7 +249,11 @@
 }
 
 .i-amphtml-story-page-open-attachment.i-amphtml-amp-story-page-attachment-ui-v2 {
-  background: none !important;
+  background: linear-gradient(0, rgba(0, 0, 0, 0.30), transparent) !important;
+}
+
+[theme="dark"].i-amphtml-story-page-open-attachment.i-amphtml-amp-story-page-attachment-ui-v2 {
+  background: linear-gradient(0, rgba(255, 255, 255, 0.30), transparent) !important;
 }
 
 .i-amphtml-story-outlink-page-attachment-arrow {

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -256,7 +256,7 @@
   background: linear-gradient(0, rgba(255, 255, 255, 0.30), transparent) !important;
 }
 
-.i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment.i-amphtml-story-page-open-attachment-outlink {
+[href].i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment {
   background: none !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -70,7 +70,7 @@ export const buildOpenInlineAttachmentElement = (element) =>
  */
 const buildOpenOutlinkAttachmentElement = (element) =>
   htmlFor(element)`
-     <a class="i-amphtml-story-page-open-attachment i-amphtml-amp-story-page-attachment-ui-v2"
+     <a class="i-amphtml-story-page-open-attachment i-amphtml-story-page-open-attachment-outlink i-amphtml-amp-story-page-attachment-ui-v2"
          role="button">
        <span class="i-amphtml-story-outlink-page-attachment-arrow">
          <span class="i-amphtml-story-outlink-page-open-attachment-bar-left"></span>
@@ -113,6 +113,11 @@ export const renderPageAttachmentUI = (win, pageEl, attachmentEl) => {
  */
 const renderDefaultPageAttachmentUI = (win, pageEl, attachmentEl) => {
   const openAttachmentEl = buildOpenDefaultAttachmentElement(pageEl);
+  if (isPageAttachmentUiV2ExperimentOn(win)) {
+    openAttachmentEl.classList.add(
+      '.i-amphtml-amp-story-page-attachment-ui-v2'
+    );
+  }
   // If the attachment is a link, copy href to the element so it can be previewed on hover and long press.
   const attachmentHref = attachmentEl.getAttribute('href');
   if (attachmentHref) {

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -70,7 +70,7 @@ export const buildOpenInlineAttachmentElement = (element) =>
  */
 const buildOpenOutlinkAttachmentElement = (element) =>
   htmlFor(element)`
-     <a class="i-amphtml-story-page-open-attachment i-amphtml-story-page-open-attachment-outlink i-amphtml-amp-story-page-attachment-ui-v2"
+     <a class="i-amphtml-story-page-open-attachment i-amphtml-amp-story-page-attachment-ui-v2"
          role="button">
        <span class="i-amphtml-story-outlink-page-attachment-arrow">
          <span class="i-amphtml-story-outlink-page-open-attachment-bar-left"></span>


### PR DESCRIPTION
Context / Fixes #33913

Add contrast protection for inline attachments.

<img width="380" alt="Screen Shot 2021-04-21 at 3 36 44 PM" src="https://user-images.githubusercontent.com/3860311/115610837-64df4200-a2b7-11eb-8409-ce484f384e72.png">

[demo](https://philipbell-stamp-ui.web.app/examples/amp-story/attachment.html)

The theming for "no image pre-tap dark theme" will be added in #32767