### PR TITLE
♻️ Enable Storybook's a11y addon the current way

### DIFF
--- a/build-system/tasks/make-extension/bento/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
+++ b/build-system/tasks/make-extension/bento/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
@@ -15,13 +15,12 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'amp-__component_name_hyphenated__-__component_version_snakecase__',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/build-system/tasks/make-extension/bento/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
+++ b/build-system/tasks/make-extension/bento/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
@@ -16,13 +16,12 @@
 
 import * as Preact from '../../../../src/preact';
 import {__component_name_pascalcase__} from '../component'
-import {withA11y} from '@storybook/addon-a11y';
 import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: '__component_name_pascalcase__',
   component: __component_name_pascalcase__,
-  decorators: [withKnobs, withA11y],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/build-system/tasks/storybook/amp-env/main.js
+++ b/build-system/tasks/storybook/amp-env/main.js
@@ -22,8 +22,8 @@ module.exports = {
   addons: [
     // TODO(alanorozco): AMP previews are loaded inside an iframe, so the a11y
     // addon is not able to inspect the tree inside it. Its results are incorrect,
-    // since it checks this wrapper iframe. Enable this eventually, once we find a
-    // way to inspect the iframe's tree.
+    // since it only checks the structure of the outer iframe element.
+    // Enable this once we find a way to inspect the iframe document's tree.
     // '@storybook/addon-a11y',
     '@storybook/addon-viewport',
     '@storybook/addon-knobs',

--- a/build-system/tasks/storybook/amp-env/main.js
+++ b/build-system/tasks/storybook/amp-env/main.js
@@ -20,7 +20,11 @@ module.exports = {
     '../../../../extensions/**/*.*/storybook/*.amp.js',
   ],
   addons: [
-    '@storybook/addon-a11y',
+    // TODO(alanorozco): AMP previews are loaded inside an iframe, so the a11y
+    // addon is not able to inspect the tree inside it. Its results are incorrect,
+    // since it checks this wrapper iframe. Enable this eventually, once we find a
+    // way to inspect the iframe's tree.
+    // '@storybook/addon-a11y',
     '@storybook/addon-viewport',
     '@storybook/addon-knobs',
     '@ampproject/storybook-addon',

--- a/build-system/tasks/storybook/preact-env/main.js
+++ b/build-system/tasks/storybook/preact-env/main.js
@@ -20,7 +20,7 @@ module.exports = {
     '../../../../extensions/**/*.*/storybook/!(*.amp).js',
   ],
   addons: [
-    '@storybook/addon-a11y/register',
+    '@storybook/addon-a11y',
     '@storybook/addon-viewport/register',
     '@storybook/addon-knobs/register',
   ],

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1147,6 +1147,8 @@ const forbiddenTermsSrcInclusive = {
     message:
       'Instead of fancy-log, use the logging functions in build-system/common/logging.js.',
   },
+  'withA11y':
+    'The Storybook decorator "withA11y" has been deprecated. You may simply remove it, since the a11y addon is now globally configured.',
 };
 
 /**

--- a/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
+++ b/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../src/preact';
 import {number, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: '0/amp-layout with aspect ratio CSS',
-  decorators: [withA11y, withKnobs, withAmp],
+  decorators: [withKnobs, withAmp],
   parameters: {
     experiments: ['layout-aspect-ratio-css'],
   },

--- a/builtins/storybook/amp-layout.amp.js
+++ b/builtins/storybook/amp-layout.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../src/preact';
 import {number, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: '0/amp-layout',
-  decorators: [withA11y, withKnobs, withAmp],
+  decorators: [withKnobs, withAmp],
 };
 
 export const responsive = () => {

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-accordion-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-accordion', version: '1.0'}],

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -22,12 +22,11 @@ import {
   AccordionSection,
 } from '../component';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'Accordion',
   component: Accordion,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 /**

--- a/extensions/amp-accordion/1.0/storybook/Bind.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Bind.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-accordion-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -16,14 +16,13 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, number, select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 const ORIENTATIONS = ['horizontal', 'vertical'];
 
 export default {
   title: 'amp-base-carousel-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -17,7 +17,6 @@
 import * as Preact from '../../../../src/preact';
 import {BaseCarousel} from '../base-carousel';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 const CONTROLS = ['auto', 'always', 'never'];
 const SNAP_ALIGN = ['start', 'center'];
@@ -26,7 +25,7 @@ const ORIENTATIONS = ['horizontal', 'vertical'];
 export default {
   title: 'BaseCarousel',
   component: BaseCarousel,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 /**

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, date, select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-date-countdown-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.js
@@ -17,12 +17,11 @@
 import * as Preact from '../../../../src/preact';
 import {DateCountdown} from '../component';
 import {boolean, date, select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'DateCountdown',
   component: DateCountdown,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const LOCALE_CONFIGURATIONS = [

--- a/extensions/amp-date-display/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-display/1.0/storybook/Basic.amp.js
@@ -16,7 +16,6 @@
 
 import * as Preact from '../../../../src/preact';
 import {date, select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 const DISPLAY_IN_OPTIONS = ['utc', 'local'];
@@ -24,7 +23,7 @@ const LOCALES = ['en-US', 'en-GB', 'fr', 'ru', 'ar', 'he', 'ja'];
 
 export default {
   title: 'amp-date-display-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-date-display/1.0/storybook/Basic.js
+++ b/extensions/amp-date-display/1.0/storybook/Basic.js
@@ -17,12 +17,11 @@
 import * as Preact from '../../../../src/preact';
 import {DateDisplay} from '../component';
 import {date, select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'DateDisplay',
   component: DateDisplay,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const DISPLAY_IN_OPTIONS = ['utc', 'local'];

--- a/extensions/amp-fit-text/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-fit-text-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-fit-text', version: '1.0'}],

--- a/extensions/amp-fit-text/1.0/storybook/Basic.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.js
@@ -17,12 +17,11 @@
 import * as Preact from '../../../../src/preact';
 import {FitText} from '../component';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'FitText',
   component: FitText,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/extensions/amp-iframe/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-iframe/0.1/storybook/Basic.amp.js
@@ -15,13 +15,12 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'amp-iframe',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-iframe', version: '0.1'}],

--- a/extensions/amp-image-slider/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-image-slider/0.1/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'Image Slider',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-image-slider', version: 0.1}],

--- a/extensions/amp-inline-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-inline-gallery/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-inline-gallery-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-inline-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-inline-gallery/1.0/storybook/Basic.js
@@ -20,12 +20,11 @@ import {InlineGallery} from '../component';
 import {Pagination} from '../pagination';
 import {Thumbnails} from '../thumbnails';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'InlineGallery',
   component: InlineGallery,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/extensions/amp-instagram/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/0.1/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-instagram-0_1',
-  decorators: [withA11y, withKnobs, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-instagram', version: '0.1'}],

--- a/extensions/amp-instagram/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-instagram-1_0',
-  decorators: [withA11y, withKnobs, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-instagram/1.0/storybook/Basic.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.js
@@ -23,12 +23,11 @@ import {
 } from '../../../amp-accordion/1.0/component';
 import {Instagram} from '../component';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'Instagram',
   component: Instagram,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
@@ -17,13 +17,12 @@
 import * as Preact from '../../../../src/preact';
 import {BaseCarousel} from '../../../amp-base-carousel/1.0/base-carousel';
 import {LightboxGalleryProvider, WithLightbox} from '../component';
-import {withA11y} from '@storybook/addon-a11y';
 import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'LightboxGallery',
   component: LightboxGalleryProvider,
-  decorators: [withKnobs, withA11y],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-lightbox-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-lightbox', version: '1.0'}],

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -18,12 +18,11 @@ import * as Preact from '../../../../src/preact';
 import {Lightbox} from '../component';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {useRef} from '../../../../src/preact';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'Lightbox',
   component: Lightbox,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 /**

--- a/extensions/amp-render/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-render/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-render-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-render/1.0/storybook/Basic.js
+++ b/extensions/amp-render/1.0/storybook/Basic.js
@@ -16,13 +16,12 @@
 
 import * as Preact from '../../../../src/preact';
 import {Render} from '../component';
-import {withA11y} from '@storybook/addon-a11y';
 import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'Render',
   component: Render,
-  decorators: [withKnobs, withA11y],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/extensions/amp-selector/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-selector-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-selector', version: '1.0'}],

--- a/extensions/amp-selector/1.0/storybook/Basic.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.js
@@ -18,11 +18,10 @@ import * as Preact from '../../../../src/preact';
 import {Option, Selector} from '../component';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {useState} from '../../../../src/preact';
-import {withA11y} from '@storybook/addon-a11y';
 export default {
   title: 'Selector',
   component: Selector,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const imgStyle = {

--- a/extensions/amp-sidebar/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/0.1/storybook/Basic.amp.js
@@ -17,13 +17,12 @@
 // To do: how to add CSS
 //import '!style-loader!css-loader!./Basic-styles.css';
 import * as Preact from '../../../../src/preact';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'amp-sidebar-0_1',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-sidebar', version: 0.1}],

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -23,12 +23,11 @@ import {
   text,
   withKnobs,
 } from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-sidebar-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-sidebar', version: '1.0'}],

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -17,12 +17,11 @@
 import * as Preact from '../../../../src/preact';
 import {Sidebar, SidebarToolbar} from '../component';
 import {boolean, color, select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'Sidebar',
   component: Sidebar,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 /**

--- a/extensions/amp-social-share/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/0.1/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-social-share-0_1',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-social-share', version: 0.1}],

--- a/extensions/amp-social-share/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-social-share-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-social-share', version: '1.0'}],

--- a/extensions/amp-social-share/1.0/storybook/Basic.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.js
@@ -17,12 +17,11 @@
 import * as Preact from '../../../../src/preact';
 import {SocialShare} from '../social-share';
 import {color, object, select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'SocialShare',
   component: SocialShare,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
@@ -16,14 +16,13 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 const CONTROLS = ['auto', 'always', 'never'];
 
 export default {
   title: 'amp-stream-gallery-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-stream-gallery', version: '1.0'}],

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.js
@@ -17,14 +17,13 @@
 import * as Preact from '../../../../src/preact';
 import {StreamGallery} from '../stream-gallery';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 const CONTROLS = ['auto', 'always', 'never'];
 
 export default {
   title: 'StreamGallery',
   component: StreamGallery,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 /**

--- a/extensions/amp-timeago/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-timeago/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {date, number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-timeago-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-timeago', version: '1.0'}],

--- a/extensions/amp-timeago/1.0/storybook/Basic.js
+++ b/extensions/amp-timeago/1.0/storybook/Basic.js
@@ -17,12 +17,11 @@
 import * as Preact from '../../../../src/preact';
 import {Timeago} from '../component';
 import {date, number, select, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'Timeago',
   component: Timeago,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const LOCALES = [

--- a/extensions/amp-twitter/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/0.1/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-twitter-0_1',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-twitter/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-twitter-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [

--- a/extensions/amp-twitter/1.0/storybook/Basic.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.js
@@ -16,13 +16,12 @@
 
 import * as Preact from '../../../../src/preact';
 import {Twitter} from '../component';
-import {withA11y} from '@storybook/addon-a11y';
 import {withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'Twitter',
   component: Twitter,
-  decorators: [withKnobs, withA11y],
+  decorators: [withKnobs],
 };
 
 export const _default = () => {

--- a/extensions/amp-video/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, number, object, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-video-1_0',
-  decorators: [withA11y, withKnobs, withAmp],
+  decorators: [withKnobs, withAmp],
   parameters: {
     extensions: [
       {name: 'amp-video', version: '1.0'},

--- a/extensions/amp-video/1.0/storybook/Basic.js
+++ b/extensions/amp-video/1.0/storybook/Basic.js
@@ -23,12 +23,11 @@ import {
 } from '../../../amp-accordion/1.0/component';
 import {VideoWrapper} from '../video-wrapper';
 import {boolean, number, object, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'Video Wrapper',
   component: VideoWrapper,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const VideoTagPlayer = ({i}) => {

--- a/extensions/amp-video/1.0/storybook/VideoIframe.js
+++ b/extensions/amp-video/1.0/storybook/VideoIframe.js
@@ -25,12 +25,11 @@ import {VideoWrapper} from '../video-wrapper';
 import {boolean, text, withKnobs} from '@storybook/addon-knobs';
 import {createCustomEvent} from '../../../../src/event-helper';
 import {useCallback} from '../../../../src/preact';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'VideoIframe',
   component: VideoIframe,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const AmpVideoIframeLike = ({unloadOnPause, ...rest}) => {

--- a/extensions/amp-youtube/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/0.1/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-youtube-0_1',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
 
   parameters: {
     extensions: [{name: 'amp-youtube', version: 0.1}],

--- a/extensions/amp-youtube/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-youtube-1_0',
-  decorators: [withKnobs, withA11y, withAmp],
+  decorators: [withKnobs, withAmp],
   parameters: {
     extensions: [
       {name: 'amp-youtube', version: '1.0'},

--- a/extensions/amp-youtube/1.0/storybook/Basic.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.js
@@ -24,12 +24,11 @@ import {
 import {Youtube} from '../component';
 import {boolean, number, object, text, withKnobs} from '@storybook/addon-knobs';
 import {useRef, useState} from '../../../../src/preact';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: 'YouTube',
   component: Youtube,
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const VIDEOID = 'IAvf-rkzNck';

--- a/src/preact/storybook/Context.js
+++ b/src/preact/storybook/Context.js
@@ -18,11 +18,9 @@ import * as Preact from '../';
 import {WithAmpContext, useAmpContext, useLoading} from '../context';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 
-import {withA11y} from '@storybook/addon-a11y';
-
 export default {
   title: '0/Context',
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 const IMG_SRC =

--- a/src/preact/storybook/Wrappers.js
+++ b/src/preact/storybook/Wrappers.js
@@ -17,11 +17,10 @@
 import * as Preact from '../';
 import {ContainWrapper, Wrapper} from '../component';
 import {boolean, object, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 
 export default {
   title: '0/Wrappers',
-  decorators: [withA11y, withKnobs],
+  decorators: [withKnobs],
 };
 
 export const wrapper = () => {


### PR DESCRIPTION
[The `withA11y` decorator has been deprecated.](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#removed-witha11y-decorator)

We should instead set up the addon globally, by excluding `/register` from its configured module name.
