### PR TITLE
🏗 Prevent Karma from hanging when a transformation error is encountered

### DIFF
--- a/build-system/tasks/report-test-status.js
+++ b/build-system/tasks/report-test-status.js
@@ -209,11 +209,12 @@ async function reportAllExpectedTests() {
 
 /**
  * Callback to the Karma.Server on('run_complete') event for simple test types.
+ * Optionally takes an object containing test results if they were run.
  *
- * @param {!Karma.TestResults} results
+ * @param {?Karma.TestResults} results
  */
 async function reportTestRunComplete(results) {
-  if (results.error) {
+  if (!results || results.error) {
     await reportTestErrored();
   } else {
     await reportTestFinished(results.success, results.failed);

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -20,7 +20,7 @@ const fs = require('fs');
 const path = require('path');
 const {green, yellow, cyan} = require('kleur/colors');
 const {isCiBuild} = require('../../common/ci');
-const {log} = require('../../common/logging');
+const {log, logWithoutTimestamp} = require('../../common/logging');
 const {maybePrintCoverageMessage} = require('../helpers');
 const {reportTestRunComplete} = require('../report-test-status');
 const {Server} = require('karma');
@@ -172,7 +172,7 @@ async function karmaBrowserComplete_(browser) {
  * @private
  */
 function karmaBrowserStart_() {
-  console./*OK*/ log('\n');
+  logWithoutTimestamp('\n');
   log(green('Done. Running tests...'));
 }
 

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -399,11 +399,9 @@ class RuntimeTestRunner {
     await stopServer();
     exitCtrlcHandler(this.env.get('handlerProcess'));
     if (this.exitCode != 0) {
-      log(
-        red('ERROR:'),
-        yellow(`Karma test failed with exit code ${this.exitCode}`)
-      );
-      process.exitCode = this.exitCode;
+      const message = `Karma test failed with exit code ${this.exitCode}`;
+      log(red('ERROR:'), yellow(message));
+      throw new Error(message);
     }
   }
 }


### PR DESCRIPTION
**PR Highlights:**
- Throws from `teardown()` immediately after a fatal error is detected (to ensure the task doesn't stall)
- Adds a check for a non-existent `results` object in `reportTestRunComplete()` (some fatal errors don't yield results)

With this, errors like the one in https://github.com/ampproject/amphtml/issues/30907#issue-732459832 will cleanly exit with an error message

![image](https://user-images.githubusercontent.com/26553114/115781295-31201d00-a388-11eb-9906-52e54a6d0a1d.png)

Fixes #30907
