### PR TITLE
Fix amp-ad a4a example server

### DIFF
--- a/build-system/server/new-server/router.js
+++ b/build-system/server/new-server/router.js
@@ -29,6 +29,10 @@ router.get('/examples/*.html', async (req, res) => {
     );
   }
   res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  if (req.query.__amp_source_origin) {
+    res.setHeader('Access-Control-Allow-Origin', req.query.__amp_source_origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
   res.end(transformedHTML);
 });
 


### PR DESCRIPTION
We are getting CORS failures on a4a envelope since ads are served from a different domain intentionally (ads.localhost vs localhost).