### PR TITLE
🚮 Remove notion of a lite viewer

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -904,7 +904,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   isAutoplaySupported_() {
     VideoUtils.resetIsAutoplaySupported();
-    return VideoUtils.isAutoplaySupported(this.win, getMode(this.win).lite);
+    return VideoUtils.isAutoplaySupported(this.win);
   }
 
   /**

--- a/extensions/amp-vimeo/0.1/amp-vimeo.js
+++ b/extensions/amp-vimeo/0.1/amp-vimeo.js
@@ -29,7 +29,6 @@ import {
 import {dict} from '../../../src/core/types/object';
 import {dispatchCustomEvent, removeElement} from '../../../src/dom';
 import {getData, listen} from '../../../src/event-helper';
-import {getMode} from '../../../src/mode';
 import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl';
 import {isLayoutSizeDefined} from '../../../src/layout';
 import {once} from '../../../src/core/types/function';
@@ -197,8 +196,7 @@ class AmpVimeo extends AMP.BaseElement {
     if (!this.element.hasAttribute(VideoAttributes.AUTOPLAY)) {
       return Promise.resolve(false);
     }
-    const {win} = this;
-    return VideoUtils.isAutoplaySupported(win, getMode(win).lite);
+    return VideoUtils.isAutoplaySupported(this.win);
   }
 
   /**

--- a/src/mode-object.js
+++ b/src/mode-object.js
@@ -28,7 +28,6 @@ export function getModeObject(opt_win) {
     development: getMode(opt_win).development,
     esm: IS_ESM,
     minified: getMode(opt_win).minified,
-    lite: getMode(opt_win).lite,
     test: getMode(opt_win).test,
     log: getMode(opt_win).log,
     version: getMode(opt_win).version,

--- a/src/mode.js
+++ b/src/mode.js
@@ -79,8 +79,6 @@ function getMode_(win) {
     win.location['originalHash'] || win.location.hash
   );
 
-  const searchQuery = parseQueryString_(win.location.search);
-
   if (!rtvVersion) {
     rtvVersion = getRtvVersion(win);
   }
@@ -105,9 +103,6 @@ function getMode_(win) {
     // amp-geo override
     geoOverride: hashQuery['amp-geo'],
     minified: IS_MINIFIED,
-    // Whether document is in an amp-lite viewer. It signal that the user
-    // would prefer to use less bandwidth.
-    lite: searchQuery['amp_lite'] != undefined,
     test: runningTests,
     log: hashQuery['log'],
     version: internalRuntimeVersion(),

--- a/src/mode.js
+++ b/src/mode.js
@@ -22,7 +22,6 @@ import {parseQueryString_} from './url-parse-query-string';
  *   localDev: boolean,
  *   development: boolean,
  *   minified: boolean,
- *   lite: boolean,
  *   test: boolean,
  *   examiner: boolean,
  *   log: (string|undefined),

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -459,7 +459,8 @@ class VideoEntry {
 
     // eslint-disable-next-line jsdoc/require-returns
     /** @private @const {function(): !Promise<boolean>} */
-    this.isAutoplaySupported_ = () => VideoUtils.isAutoplaySupported(this.win);
+    this.isAutoplaySupported_ = () =>
+      VideoUtils.isAutoplaySupported(this.ampdoc_.win);
 
     /** @private @const {function(): !AnalyticsPercentageTracker} */
     this.getAnalyticsPercentageTracker_ = once(

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -43,7 +43,6 @@ import {createViewportObserver} from '../viewport-observer';
 import {dev, devAssert, user, userAssert} from '../log';
 import {dict, map} from '../core/types/object';
 import {dispatchCustomEvent, removeElement} from '../dom';
-import {getMode} from '../mode';
 import {installAutoplayStylesForDoc} from './video/install-autoplay-styles';
 import {isFiniteNumber} from '../types';
 import {measureIntersection} from '../utils/intersection';

--- a/src/service/video-manager-impl.js
+++ b/src/service/video-manager-impl.js
@@ -459,10 +459,7 @@ class VideoEntry {
 
     // eslint-disable-next-line jsdoc/require-returns
     /** @private @const {function(): !Promise<boolean>} */
-    this.supportsAutoplay_ = () => {
-      const {win} = this.ampdoc_;
-      return VideoUtils.isAutoplaySupported(win, getMode(win).lite);
-    };
+    this.isAutoplaySupported_ = () => VideoUtils.isAutoplaySupported(this.win);
 
     /** @private @const {function(): !AnalyticsPercentageTracker} */
     this.getAnalyticsPercentageTracker_ = once(
@@ -783,10 +780,10 @@ class VideoEntry {
     if (!this.ampdoc_.isVisible()) {
       return;
     }
-    this.supportsAutoplay_().then((supportsAutoplay) => {
+    this.isAutoplaySupported_().then((isAutoplaySupported) => {
       const canAutoplay = this.hasAutoplay && !this.userInteracted();
 
-      if (canAutoplay && supportsAutoplay) {
+      if (canAutoplay && isAutoplaySupported) {
         this.autoplayLoadedVideoVisibilityChanged_();
       } else {
         this.nonAutoplayLoadedVideoVisibilityChanged_();
@@ -808,8 +805,8 @@ class VideoEntry {
       this.video.hideControls();
     }
 
-    this.supportsAutoplay_().then((supportsAutoplay) => {
-      if (!supportsAutoplay && this.video.isInteractive()) {
+    this.isAutoplaySupported_().then((isAutoplaySupported) => {
+      if (!isAutoplaySupported && this.video.isInteractive()) {
         // Autoplay is not supported, show the controls so user can manually
         // initiate playback.
         this.video.showControls();
@@ -997,7 +994,7 @@ class VideoEntry {
    */
   getAnalyticsDetails() {
     const {video} = this;
-    const supportsAutoplay = this.supportsAutoplay_();
+    const supportsAutoplay = this.isAutoplaySupported_();
     const intersection = measureIntersection(video.element);
     return Promise.all([supportsAutoplay, intersection]).then((responses) => {
       const supportsAutoplay = /** @type {boolean} */ (responses[0]);

--- a/src/utils/video.js
+++ b/src/utils/video.js
@@ -19,15 +19,9 @@ import {setStyles} from '../style';
 
 /**
  * @param {!Window} win
- * @param {boolean} isLiteViewer
  * @return {!Promise<boolean>}
  */
-function isAutoplaySupportedImpl(win, isLiteViewer) {
-  // We do not support autoplay in amp-lite viewer regardless of platform.
-  if (isLiteViewer) {
-    return Promise.resolve(false);
-  }
-
+function isAutoplaySupportedImpl(win) {
   // To detect autoplay, we create a video element and call play on it, if
   // `paused` is true after `play()` call, autoplay is supported. Although
   // this is unintuitive, it works across browsers and is currently the lightest
@@ -90,14 +84,13 @@ export class VideoUtils {
    * when autoplay has been disabled by the user.
    *
    * @param {!Window} win
-   * @param {boolean} isLiteViewer
    * @return {!Promise<boolean>}
    */
-  static isAutoplaySupported(win, isLiteViewer) {
+  static isAutoplaySupported(win) {
     if (!isAutoplaySupported) {
       setIsAutoplaySupported();
     }
-    return isAutoplaySupported(win, isLiteViewer);
+    return isAutoplaySupported(win);
   }
 
   /** @visibleForTesting */

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -282,10 +282,8 @@ describe
   .configure()
   .ifChrome()
   .run('Autoplay support', () => {
-    const supportsAutoplay = VideoUtils.isAutoplaySupported; // for line length
     let win;
     let video;
-    let isLite;
     let createElementSpy;
     let setAttributeSpy;
     let playStub;
@@ -315,8 +313,6 @@ describe
 
       win = {document: doc};
 
-      isLite = false;
-
       createElementSpy = window.sandbox.spy(doc, 'createElement');
       setAttributeSpy = window.sandbox.spy(video, 'setAttribute');
       playStub = window.sandbox.stub(video, 'play');
@@ -329,7 +325,7 @@ describe
     });
 
     it('should create an invisible test video element', () => {
-      return supportsAutoplay(win, isLite).then(() => {
+      return VideoUtils.isAutoplaySupported(win).then(() => {
         expect(video.style.position).to.equal('fixed');
         expect(video.style.top).to.equal('0');
         expect(video.style.width).to.equal('0');
@@ -355,7 +351,7 @@ describe
 
     it('should return false if `paused` is true after `play()` call', () => {
       video.paused = true;
-      return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
+      return VideoUtils.isAutoplaySupported(win).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.false;
         expect(playStub.called).to.be.true;
         expect(createElementSpy.called).to.be.true;
@@ -364,7 +360,7 @@ describe
 
     it('should return true if `paused` is false after `play()` call', () => {
       video.paused = false;
-      return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
+      return VideoUtils.isAutoplaySupported(win).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.true;
         expect(playStub.called).to.be.true;
         expect(createElementSpy.called).to.be.true;
@@ -374,7 +370,7 @@ describe
     it('should suppress errors if detection play call throws', () => {
       playStub.throws();
       video.paused = true;
-      return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
+      return VideoUtils.isAutoplaySupported(win).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.false;
         expect(playStub.called).to.be.true;
         expect(createElementSpy.called).to.be.true;
@@ -387,17 +383,10 @@ describe
       );
       playStub.returns(p);
       video.paused = true;
-      return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
+      return VideoUtils.isAutoplaySupported(win).then((supportsAutoplay) => {
         expect(supportsAutoplay).to.be.false;
         expect(playStub.called).to.be.true;
         expect(createElementSpy.called).to.be.true;
-      });
-    });
-
-    it('should be false when in amp-lite mode', () => {
-      isLite = true;
-      return supportsAutoplay(win, isLite).then((supportsAutoplay) => {
-        expect(supportsAutoplay).to.be.false;
       });
     });
   });

--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -33,7 +33,7 @@ import {toggleExperiment} from '../../src/experiments';
 function skipIfAutoplayUnsupported(win) {
   VideoUtils.resetIsAutoplaySupported();
 
-  return VideoUtils.isAutoplaySupported(win, false).then((isSupported) => {
+  return VideoUtils.isAutoplaySupported(win).then((isSupported) => {
     if (isSupported) {
       return;
     }

--- a/test/unit/test-mode.js
+++ b/test/unit/test-mode.js
@@ -29,28 +29,6 @@ describe('getMode', () => {
     return win;
   }
 
-  it('CDN - lite mode on', () => {
-    const url =
-      'https://cdn.ampproject.org/v/www.example.com/amp.html?amp_js_v=5&amp_lite#origin=https://www.google.com';
-    expect(getMode(getWin(url)).lite).to.be.true;
-  });
-
-  it('CDN - lite mode off', () => {
-    const url =
-      'https://cdn.ampproject.org/v/www.example.com/amp.html?amp_js_v=5#origin=https://www.google.com';
-    expect(getMode(getWin(url)).lite).to.be.false;
-  });
-
-  it('Origin - lite mode on', () => {
-    const url = 'https://www.example.com/amp.html?amp_lite';
-    expect(getMode(getWin(url)).lite).to.be.true;
-  });
-
-  it('Origin - lite mode off', () => {
-    const url = 'https://www.example.com/amp.html';
-    expect(getMode(getWin(url)).lite).to.be.false;
-  });
-
   it('should support different html formats for development', () => {
     let url = 'https://www.amp-site.org#development=1';
     expect(getMode(getWin(url)).development).to.be.true;


### PR DESCRIPTION
We would previously allow viewers to opt-in to a "lite" document by setting the query parameter `amp_lite`.

In practice, this signal was used sparingly—only to disable video autoplay.

Since viewers almost never ask for a lite document, we remove this notion.
