### PR TITLE
🐛🏗 Fix start references for multiple forbidden terms

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1235,13 +1235,13 @@ function matchForbiddenTerms(srcFile, contents, terms) {
       let index = 0;
       let line = 1;
       let column = 0;
-      const start = {line: -1, column: -1};
 
       const subject = checkProse ? contents : contentsWithoutComments;
       let result;
       while ((result = regex.exec(subject))) {
         const [match] = result;
 
+        const start = {line: -1, column: -1};
         for (index; index < result.index + match.length; index++) {
           if (index === result.index) {
             start.line = line;


### PR DESCRIPTION
One term is fine:
![image](https://user-images.githubusercontent.com/254946/115922844-43ef2c00-a432-11eb-962f-2603d51d7f2f.png)

Start references for multiple terms are overridden:
![image](https://user-images.githubusercontent.com/254946/115923022-7c8f0580-a432-11eb-8b7a-ba168bb66e2c.png)

**This change fixes it:**
![image](https://user-images.githubusercontent.com/254946/115922923-5a958300-a432-11eb-81d7-505b2241bf32.png)
