### PR TITLE
❄️ test-amp-iframe: Fix consent message races

### DIFF
--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -30,6 +30,7 @@ import {macroTask} from '../../../../testing/yield';
 import {poll} from '../../../../testing/iframe';
 import {toggleExperiment} from '../../../../src/experiments';
 import {user} from '../../../../src/log';
+import {whenCalled} from '../../../../testing/test-helper.js';
 
 /** @const {number} */
 const IFRAME_MESSAGE_TIMEOUT = 50;
@@ -968,7 +969,7 @@ describes.realWin(
         });
 
         impl = await element.getImpl();
-        env.sandbox.stub(impl, 'sendConsentDataToIframe_');
+        env.sandbox.spy(impl, 'sendConsentDataToIframe_');
 
         await waitForAmpIframeLayoutPromise(doc, element);
 
@@ -998,7 +999,9 @@ describes.realWin(
           '*'
         );
 
-        await macroTask();
+        await whenCalled(impl.sendConsentDataToIframe_);
+
+        // Ensure listener only triggers once by waiting for event queue to flush
         await macroTask();
 
         expect(
@@ -1030,6 +1033,9 @@ describes.realWin(
           '*'
         );
 
+        await whenCalled(impl.sendConsentDataToIframe_);
+
+        // Ensure listener only triggers once by waiting for event queue to flush
         await macroTask();
 
         expect(


### PR DESCRIPTION
Tests 'is sent' and 'is sent with empty fields when consent service not
available' used one or two calls of `await macroTask()` before checking
whether the `MessageType.SEND_CONSENT_DATA` listener triggered
`sendConsentDataToIframe_` successfully. These tests were failing due to
a race condition:

      consent-data message
        ✗ is sent
    AssertionError: expected stub to have been called exactly once, but
    it was called 0 times

        ✗ is sent with empty fields when consent service not available
    AssertionError: expected stub to have been called exactly once, but
    it was called 0 times

Wait for `sendConsentDataToIframe_` to be called at least once, then allow
another event queue to flush before verifying listener handled message
exactly once.