### PR TITLE
🐛 added support for iframePing to load trk.js

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/taboola.json
+++ b/extensions/amp-analytics/0.1/vendors/taboola.json
@@ -8,7 +8,8 @@
   "triggers": {
     "pageview": {
       "on": "visible",
-      "request": "loadamptrkhtml"
+      "request": "loadamptrkhtml",
+      "iframePing": true
     }
   },
   "transport": {


### PR DESCRIPTION
@micajuine-ho I think I messed up with the merging. I created a new branch anyway which is probably the right thing to do. This pull request is to fix the bug in #32803. Found an issue where our trk.js was not getting loaded and after debugging found out it is because of missing "iframePing":true. Can you please take a look at the change to fix that. We need this to be resolved, since we have customers waiting for this fix. Thanks