### PR TITLE
amp-script: sandboxed implies nodom

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -345,7 +345,7 @@ amp-autocomplete > textarea,
 /**
  * amp-script[nodom] is an element with no UI, similar to amp-analytics.
  */
-amp-script[nodom] {
+amp-script[nodom], amp-script[sandboxed] {
   /* Fixed to make position independent of page other elements. */
   position: fixed !important;
   top: 0 !important;

--- a/examples/amp-script/example.sandboxed.amp.html
+++ b/examples/amp-script/example.sandboxed.amp.html
@@ -27,8 +27,6 @@
 <body>
   <h1>Example: Demo</h1>
   <!-- Note: sandboxed amp-script do not require CSP hashes. -->
-  <amp-script sandboxed layout=container src="/examples/amp-script/amp-script-demo.js">
-    <button id="hello">Insert Hello World!</button>
-  </amp-script>
+  <amp-script sandboxed layout=container src="/examples/amp-script/export-functions.js"></amp-script>
 </body>
 </html>

--- a/examples/amp-script/export-functions.js
+++ b/examples/amp-script/export-functions.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+exportFunction('getData', () => ({data: true}));

--- a/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
+++ b/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
@@ -672,13 +672,8 @@ describes.realWin('UI loaded in frame by amp-ima-video', {}, (env) => {
     imaVideoObj.setVideoPlayerForTesting(getVideoPlayerMock());
     imaVideoObj.setContentCompleteForTesting(true);
     // expect a subset of controls to be hidden / displayed during ad
-    const {
-      controlsDiv,
-      playPauseDiv,
-      timeDiv,
-      muteUnmuteDiv,
-      fullscreenDiv,
-    } = imaVideoObj.getPropertiesForTesting();
+    const {controlsDiv, playPauseDiv, timeDiv, muteUnmuteDiv, fullscreenDiv} =
+      imaVideoObj.getPropertiesForTesting();
     expect(controlsDiv).not.to.be.null;
     expect(playPauseDiv).not.to.be.null;
     expect(timeDiv).not.to.be.null;

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -125,7 +125,7 @@ export class AmpScript extends AMP.BaseElement {
     /**
      * If true, signals that worker-dom should activate sandboxed mode.
      * In this mode the Worker lives in its own crossorigin iframe, creating
-     * a strong security boundary.
+     * a strong security boundary. It also forces nodom mode.
      *
      * @private {boolean}
      */
@@ -139,8 +139,8 @@ export class AmpScript extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.nodom_ = this.element.hasAttribute('nodom');
     this.sandboxed_ = this.element.hasAttribute('sandboxed');
+    this.nodom_ = this.element.hasAttribute('nodom') || this.sandboxed_;
     this.development_ =
       this.element.hasAttribute('data-ampdevmode') ||
       this.element.ownerDocument.documentElement.hasAttribute(

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -140,7 +140,7 @@ export class AmpScript extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.sandboxed_ = this.element.hasAttribute('sandboxed');
-    this.nodom_ = this.element.hasAttribute('nodom') || this.sandboxed_;
+    this.nodom_ = this.sandboxed_ || this.element.hasAttribute('nodom');
     this.development_ =
       this.element.hasAttribute('data-ampdevmode') ||
       this.element.ownerDocument.documentElement.hasAttribute(

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -16,6 +16,7 @@
 
 import {BrowserController} from '../../../../../testing/test-helper';
 import {poll as classicPoll} from '../../../../../testing/iframe';
+import {expect} from 'chai';
 
 const TIMEOUT = 10000;
 
@@ -186,12 +187,7 @@ describes.sandboxed
     describes.integration(
       'sandboxed',
       {
-        body: `
-      <amp-script sandboxed src="/examples/amp-script/amp-script-demo.js">
-        <button id="hello">Insert Hello World!</button>
-        <button id="long">Long task</button>
-      </amp-script>
-    `,
+        body: `<amp-script sandboxed src="/examples/amp-script/export-functions.js"></amp-script>`,
         extensions: ['amp-script'],
       },
       (env) => {
@@ -201,24 +197,10 @@ describes.sandboxed
           element = doc.querySelector('amp-script');
         });
 
-        it('should say "hello world"', function* () {
-          yield poll('<amp-script> to be hydrated', () =>
-            element.classList.contains('i-amphtml-hydrated')
-          );
-          const impl = yield element.getImpl();
-
-          // Give event listeners in hydration a moment to attach.
-          yield browser.wait(100);
-
-          env.sandbox
-            .stub(impl.getUserActivation(), 'isActive')
-            .callsFake(() => true);
-          browser.click('button#hello');
-
-          yield poll('mutations applied', () => {
-            const h1 = doc.querySelector('h1');
-            return h1 && h1.textContent == 'Hello World!';
-          });
+        it('should let you call functions on it', async () => {
+          const impl = await element.getImpl(true);
+          const result = await impl.callFunction('getData');
+          expect(result).deep.equal({data: true});
         });
       }
     );

--- a/extensions/amp-script/0.1/test/integration/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/integration/test-amp-script.js
@@ -16,7 +16,6 @@
 
 import {BrowserController} from '../../../../../testing/test-helper';
 import {poll as classicPoll} from '../../../../../testing/iframe';
-import {expect} from 'chai';
 
 const TIMEOUT = 10000;
 


### PR DESCRIPTION
**summary**
There are complications that could arise when trying to use `sandboxed` amp-script without nodom.

- Any exported functions used would hang until the amp-script was close enough to viewport to be laid out.
- Potential unpleasant ramifications for allowing 3p scripts to have control over part of the DOM.

This PR skirts the whole issue for now by forcing `nodom` for any amp-script using sandboxed mode, and we can revisit this later. It is easier to loosen restrictions than to lock them down.