### PR TITLE
[amp-story] 🐛 Add target="_top" to page attachment

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -41,7 +41,7 @@ export const buildOpenDefaultAttachmentElement = (element) =>
   htmlFor(element)`
     <a class="
         i-amphtml-story-page-open-attachment i-amphtml-story-system-reset"
-        role="button">
+        role="button" target="_top">
       <span class="i-amphtml-story-page-open-attachment-icon">
         <span class="i-amphtml-story-page-open-attachment-bar-left"></span>
         <span class="i-amphtml-story-page-open-attachment-bar-right"></span>

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -71,7 +71,7 @@ export const buildOpenInlineAttachmentElement = (element) =>
 const buildOpenOutlinkAttachmentElement = (element) =>
   htmlFor(element)`
      <a class="i-amphtml-story-page-open-attachment i-amphtml-amp-story-page-attachment-ui-v2"
-         role="button">
+         role="button" target="_top">
        <span class="i-amphtml-story-outlink-page-attachment-arrow">
          <span class="i-amphtml-story-outlink-page-open-attachment-bar-left"></span>
          <span class="i-amphtml-story-outlink-page-open-attachment-bar-right"></span>

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -643,7 +643,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     expect(openAttachmentEl).to.exist;
   });
 
-  it.only('page attachment should have target="top" to navigate in top window', async () => {
+  it('should build the open attachment UI with target="_top" to navigate in top window', async () => {
     const attachmentEl = win.document.createElement(
       'amp-story-page-attachment'
     );
@@ -657,25 +657,8 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     const openAttachmentEl = element.querySelector(
       '.i-amphtml-story-page-open-attachment'
     );
+
     expect(openAttachmentEl.getAttribute('target')).to.eql('_top');
-    expect(openAttachmentEl).to.exist;
-  });
-
-  it.only('should build the open attachment UI with target="_top"', async () => {
-    const attachmentEl = win.document.createElement(
-      'amp-story-page-attachment'
-    );
-    attachmentEl.setAttribute('layout', 'nodisplay');
-    element.appendChild(attachmentEl);
-
-    page.buildCallback();
-    await page.layoutCallback();
-    page.setState(PageState.PLAYING);
-
-    const openAttachmentEl = element.querySelector(
-      '.i-amphtml-story-page-open-attachment[target="_top]'
-    );
-    expect(openAttachmentEl).to.exist;
   });
 
   it('should build the inline page attachment UI with one image', async () => {

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -643,6 +643,41 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     expect(openAttachmentEl).to.exist;
   });
 
+  it.only('page attachment should have target="top" to navigate in top window', async () => {
+    const attachmentEl = win.document.createElement(
+      'amp-story-page-attachment'
+    );
+    attachmentEl.setAttribute('layout', 'nodisplay');
+    element.appendChild(attachmentEl);
+
+    page.buildCallback();
+    await page.layoutCallback();
+    page.setState(PageState.PLAYING);
+
+    const openAttachmentEl = element.querySelector(
+      '.i-amphtml-story-page-open-attachment'
+    );
+    expect(openAttachmentEl.getAttribute('target')).to.eql('_top');
+    expect(openAttachmentEl).to.exist;
+  });
+
+  it.only('should build the open attachment UI with target="_top"', async () => {
+    const attachmentEl = win.document.createElement(
+      'amp-story-page-attachment'
+    );
+    attachmentEl.setAttribute('layout', 'nodisplay');
+    element.appendChild(attachmentEl);
+
+    page.buildCallback();
+    await page.layoutCallback();
+    page.setState(PageState.PLAYING);
+
+    const openAttachmentEl = element.querySelector(
+      '.i-amphtml-story-page-open-attachment[target="_top]'
+    );
+    expect(openAttachmentEl).to.exist;
+  });
+
   it('should build the inline page attachment UI with one image', async () => {
     toggleExperiment(win, 'amp-story-page-attachment-ui-v2', true);
 

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -661,6 +661,26 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     expect(openAttachmentEl.getAttribute('target')).to.eql('_top');
   });
 
+  it('should build the new default outlink page attachment UI with target="_top" to navigate in top window', async () => {
+    toggleExperiment(win, 'amp-story-page-attachment-ui-v2', true);
+
+    const attachmentEl = win.document.createElement(
+      'amp-story-page-attachment'
+    );
+    attachmentEl.setAttribute('layout', 'nodisplay');
+    element.appendChild(attachmentEl);
+
+    page.buildCallback();
+    await page.layoutCallback();
+    page.setState(PageState.PLAYING);
+
+    const openAttachmentEl = element.querySelector(
+      '.i-amphtml-story-page-open-attachment'
+    );
+
+    expect(openAttachmentEl.getAttribute('target')).to.eql('_top');
+  });
+
   it('should build the inline page attachment UI with one image', async () => {
     toggleExperiment(win, 'amp-story-page-attachment-ui-v2', true);
 


### PR DESCRIPTION
Closes #34024

#33656 introduced a change in outlink navigation for swipe up. By not using the `navigator` anymore, we essentially changed from `target="_top"` to  `target="self"`. This PR adds `target="_top"` to the `<a>` of the `page-attachment`.

Tested on iOS Safari (test navigating, hitting back, navigating again). iOS 14.4.2


<!--
# Instructions:

- Pick a meaningful title for your pull request. (Use sentence case.)
  - Prefix the title with an emoji to identify what is being done. (Copy-paste the emoji from the list below.)
  - Do not overuse punctuation in the title (like `(chore):`).
  - If it is helpful, use a simple prefix (like `ProjectX: Implement some feature`).
- Enter a succinct description that says why the PR is necessary, and what it does.
  - Mention the GitHub issue that is being addressed by the pull request.
  - The keywords `Fixes`, `Closes`, or `Resolves` followed the issue number will automatically close the issue.

> NOTE1: All non-trivial changes (like introducing new features or components) should have an associated issue or reference an I2I (intent-to-implement: go.amp.dev/i2i). Please read through the contribution process (go.amp.dev/contributing/code) for more information.
> NOTE2: To ensure that all PR checks are triggered, make sure you've authenticated with the services listed in the one-time setup instructions at https://github.com/ampproject/amphtml/blob/main/contributing/getting-started-quick.md#one-time-setup (see last step).

# Example of a good description:

- Implement aspect X
- Leave out feature Y because of A
- Improve performance by B
- Improve accessibility by C

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Reverting a previous change
♻️ Refactoring
🚮 Deleting code
🧪 Experimental code
-->
