### PR TITLE
 🏗 Perform `esbuild` package upgrades via a separate PR

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -78,6 +78,15 @@
       }
     },
     {
+      "groupName": "esbuild devDependencies",
+      "matchPackagePatterns": ["\\besbuild\\b"],
+      "automerge": true,
+      "major": {
+        "groupName": null,
+        "additionalBranchPrefix": "esbuild-"
+      }
+    },
+    {
       "excludePackagePatterns": ["^@ampproject/"],
       "automerge": false,
       "matchDepTypes": ["dependencies"],


### PR DESCRIPTION
This will serve two purposes:
- Enable `esbuild` (and `karma-esbuild`) upgrades to be tested in isolation
- Prevent other upgrades from being held back because of a breaking change in `esbuild` (e.g. #33443)

