### PR TITLE
🏗 Flag an error and exit when Karma runs zero tests

### DIFF
--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -18,7 +18,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs');
 const path = require('path');
-const {green, yellow, cyan} = require('kleur/colors');
+const {green, yellow, cyan, red} = require('kleur/colors');
 const {isCiBuild} = require('../../common/ci');
 const {log, logWithoutTimestamp} = require('../../common/logging');
 const {maybePrintCoverageMessage} = require('../helpers');
@@ -157,10 +157,10 @@ async function karmaBrowserComplete_(browser) {
   const result = browser.lastResult;
   result.total = result.success + result.failed + result.skipped;
   // This used to be a warning with karma-browserify. See #16851 and #24957.
-  // Now, with karma-esbuild, this is a fatal error.
+  // Now, with karma-esbuild, this is a fatal error. See #34040.
   if (result.total == 0) {
     const message = 'Karma returned a status with zero tests.';
-    log(yellow('ERROR:'), message, cyan(JSON.stringify(result)));
+    log(red('ERROR:'), message, cyan(JSON.stringify(result)));
     throw new Error(message);
   }
 }

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -159,9 +159,13 @@ async function karmaBrowserComplete_(browser) {
   // This used to be a warning with karma-browserify. See #16851 and #24957.
   // Now, with karma-esbuild, this is a fatal error. See #34040.
   if (result.total == 0) {
-    const message = 'Karma returned a status with zero tests.';
-    log(red('ERROR:'), message, cyan(JSON.stringify(result)));
-    throw new Error(message);
+    log(
+      red('ERROR:'),
+      'Karma returned a result with zero tests.',
+      'This usually indicates a transformation error. See logs above.'
+    );
+    log(cyan(JSON.stringify(result)));
+    process.exit(1);
   }
 }
 

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -156,15 +156,12 @@ function maybePrintArgvMessages() {
 async function karmaBrowserComplete_(browser) {
   const result = browser.lastResult;
   result.total = result.success + result.failed + result.skipped;
-  // Initially we were reporting an error with reportTestErrored() when zero tests were detected (see #16851),
-  // but since Karma sometimes returns a transient, recoverable state, we will
-  // print a warning without reporting an error to the github test status. (see #24957)
+  // This used to be a warning with karma-browserify. See #16851 and #24957.
+  // Now, with karma-esbuild, this is a fatal error.
   if (result.total == 0) {
-    log(
-      yellow('WARNING:'),
-      'Received a status with zero tests:',
-      cyan(JSON.stringify(result))
-    );
+    const message = 'Karma returned a status with zero tests.';
+    log(yellow('ERROR:'), message, cyan(JSON.stringify(result)));
+    throw new Error(message);
   }
 }
 

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -107,7 +107,7 @@ const unitTestPaths = [
 
 // TODO(amphtml): Opt-in more unit tests to run on Safari / FF / Edge.
 const unitTestCrossBrowserPaths = [
-  'test/unit/test-error.js',
+  'test/unit/core/test-error.js',
   'test/unit/test-log.js',
 ];
 

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -105,8 +105,11 @@ const unitTestPaths = [
   'extensions/**/test/unit/*.js',
 ];
 
-// TODO(rsimha, #28838): Refine this opt-in mechanism.
-const unitTestCrossBrowserPaths = ['test/unit/test-error.js'];
+// TODO(amphtml): Opt-in more unit tests to run on Safari / FF / Edge.
+const unitTestCrossBrowserPaths = [
+  'test/unit/test-error.js',
+  'test/unit/test-log.js',
+];
 
 const integrationTestPaths = [
   'test/integration/**/*.js',


### PR DESCRIPTION
Back in the days of `karma-browserify`, a result with zero tests was an occasional transitional condition and wasn't flagged as a fatal error. See #16851 and #24957.

Now, with `karma-esbuild`, transformation errors can result in zero tests, and it must be flagged as a fatal error. This PR surfaces silent failures like the one in https://github.com/ampproject/amphtml/pull/33418#issuecomment-827846534.

A more correct fix would be to get `karma-esbuild` to throw an error when it encounters errors like the ones in https://github.com/ampproject/amphtml/pull/34020#issuecomment-827923414.