### PR TITLE
[bento] Disable 1.0 only attributes for amp4email

### DIFF
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -99,6 +99,9 @@ tags: {  # <amp-accordion> > <section>
   }
   # amp-bind
   attrs: {
+    # this attribute is used in 1.0 only
+    # this is disabled in AMP4EMAIL which only uses 0.1
+    disabled_by: "amp4email"
     name: "[expanded]"
   }
   child_tags: {

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -37,6 +37,7 @@ tags: {  # <amp-date-countdown>
     value_casei: "seconds"
   }
   attrs: {  # attribute is not used in version 0.1 of the component (see #33480)
+    disabled_by: "amp4email"
     name: "count-up"
     value: ""
   }

--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -37,7 +37,6 @@ tags: {  # <amp-date-countdown>
     value_casei: "seconds"
   }
   attrs: {  # attribute is not used in version 0.1 of the component (see #33480)
-    disabled_by: "amp4email"
     name: "count-up"
     value: ""
   }

--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -79,6 +79,7 @@ tags: {  # <amp-lightbox>
     value_casei: "fly-in-top"
   }
   attrs: {
+    disabled_by: "amp4email"
     name: "animation" # 1.0 only
     value_casei: "fade-in"
     value_casei: "fly-in-bottom"


### PR DESCRIPTION
Disable attributes in amp4email that are only used in `1.0` version of the component since amp4email does not currently use `1.0` and validator is unable to specify attributes specific to a version.

This impacts the following components:
- `amp-accordion`
- `amp-lightbox`