### PR TITLE
🏗 Log extension name while building npm binaries

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -393,7 +393,10 @@ async function finishBundle(
     );
     endBuildStep(logPrefix, `${destFilename} → ${latestName}`, startTime);
   } else {
-    endBuildStep(logPrefix, destFilename, startTime);
+    const loggingName = destFilename.startsWith('component-')
+      ? `${options.name} → ${destFilename}`
+      : destFilename;
+    endBuildStep(logPrefix, loggingName, startTime);
   }
 
   const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -393,9 +393,10 @@ async function finishBundle(
     );
     endBuildStep(logPrefix, `${destFilename} → ${latestName}`, startTime);
   } else {
-    const loggingName = destFilename.startsWith('component-')
-      ? `${options.name} → ${destFilename}`
-      : destFilename;
+    const loggingName =
+      options.npm && !destFilename.startsWith('amp-')
+        ? `${options.name} → ${destFilename}`
+        : destFilename;
     endBuildStep(logPrefix, loggingName, startTime);
   }
 


### PR DESCRIPTION
This PR improves logging during `amp dist` and `amp build`.

**Before:**

![image](https://user-images.githubusercontent.com/26553114/116322574-53e87200-a78a-11eb-8895-0f490c4c73aa.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/116322604-5ea30700-a78a-11eb-86fe-79a76605323f.png)
