### PR TITLE
✨ ♿ Toggle aria-modal in modal.js helpers

### DIFF
--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -209,7 +209,6 @@ export class AmpStoryEducation extends AMP.BaseElement {
             this.storyPausedStateToRestore_
           );
           setModalAsClosed(this.element);
-          this.element.removeAttribute('aria-modal');
         });
         break;
       case State.NAVIGATION_TAP:
@@ -282,7 +281,6 @@ export class AmpStoryEducation extends AMP.BaseElement {
       this.containerEl_.appendChild(template);
       if (!this.element.hasAttribute('aria-modal')) {
         setModalAsOpen(this.element);
-        this.element.setAttribute('aria-modal', 'true');
       }
     });
   }

--- a/src/modal.js
+++ b/src/modal.js
@@ -172,7 +172,6 @@ export function setModalAsOpen(element) {
   devAssert(isConnectedNode(element));
 
   element.setAttribute('aria-modal', 'true');
-  element.setAttribute('role', 'dialog');
 
   const elements = getElementsToAriaHide(element);
   const ancestry = getAncestors(element).filter(
@@ -237,7 +236,6 @@ export function setModalAsClosed(element) {
   devAssert(topModalElement === element);
 
   element.removeAttribute('aria-modal');
-  element.removeAttribute('role');
 
   // Put aria-hidden back to how it was before the call.
   hiddenElementInfos.forEach((hiddenElementInfo) => {

--- a/src/modal.js
+++ b/src/modal.js
@@ -171,6 +171,8 @@ export function setModalAsOpen(element) {
   devAssert(modalEntryStack.every((info) => info.element !== element));
   devAssert(isConnectedNode(element));
 
+  element.setAttribute('aria-modal', 'true');
+
   const elements = getElementsToAriaHide(element);
   const ancestry = getAncestors(element).filter(
     (n) => n.nodeType == Node.ELEMENT_NODE
@@ -232,6 +234,8 @@ export function setModalAsClosed(element) {
 
   devAssert(isConnectedNode(element));
   devAssert(topModalElement === element);
+
+  element.removeAttribute('aria-modal');
 
   // Put aria-hidden back to how it was before the call.
   hiddenElementInfos.forEach((hiddenElementInfo) => {

--- a/src/modal.js
+++ b/src/modal.js
@@ -172,6 +172,7 @@ export function setModalAsOpen(element) {
   devAssert(isConnectedNode(element));
 
   element.setAttribute('aria-modal', 'true');
+  element.setAttribute('role', 'dialog');
 
   const elements = getElementsToAriaHide(element);
   const ancestry = getAncestors(element).filter(
@@ -236,6 +237,7 @@ export function setModalAsClosed(element) {
   devAssert(topModalElement === element);
 
   element.removeAttribute('aria-modal');
+  element.removeAttribute('role');
 
   // Put aria-hidden back to how it was before the call.
   hiddenElementInfos.forEach((hiddenElementInfo) => {


### PR DESCRIPTION
Improve a11y of the modal helper functions by toggling the `aria-modal` attribute.
Contributes to #32499

[`aria-modal` from w3:](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html)
> Tells assistive technologies that the windows underneath the current dialog are not available for interaction (inert).
