### PR TITLE
🏗 `make-extension` always creates Storybook file

### DIFF
--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -220,6 +220,13 @@ async function makeExtensionFromTemplates(
     '__component_name_hyphenated__': name,
     '__component_name_hyphenated_capitalized__': name.toUpperCase(),
     '__component_name_pascalcase__': namePascalCase,
+    // TODO(alanorozco): Remove __storybook_experiments...__ once we stop
+    // requiring the bento experiment.
+    '__storybook_experiments_do_not_add_trailing_comma__':
+      // Don't add a trailing comma in the template, instead we add it here.
+      // This is because the property added is optional, and a double comma would
+      // cause a syntax error.
+      options.bento ? "experiments: ['bento']," : '',
     ...(!options.nocss
       ? {
           '__jss_import_component_css__': `import {CSS as COMPONENT_CSS} from './component.jss'`,

--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
@@ -24,12 +24,9 @@ export default {
 
   parameters: {
     extensions: [
-      {
-        name: 'amp-__component_name_hyphenated__',
-        version: '__component_version__',
-      },
+      {name: 'amp-__component_name_hyphenated__', version: '__component_version__'},
     ],
-    experiments: ['bento'],
+    __storybook_experiments_do_not_add_trailing_comma__
   },
 };
 


### PR DESCRIPTION
Share the `storybook/Basic.amp.js` template so that Classic extensions generate one as well.
