### PR TITLE
🏗 Flag an error if `--files` matches zero test files

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -108,12 +108,16 @@ function getFilesFromArgv() {
   // TODO(#30223): globby only takes posix globs. Find a Windows alternative.
   const toPosix = (str) => str.replace(/\\\\?/g, '/');
   const globs = Array.isArray(argv.files) ? argv.files : argv.files.split(',');
-  const files = globby.sync(globs.map((glob) => toPosix(glob.trim())));
-  if (files.length == 0) {
-    log(red('ERROR:'), 'Argument(s)', cyan(argv.files), 'matched zero files.');
-    throw new Error('Argument(s) matched zero files.');
+  const allFiles = [];
+  for (const glob of globs) {
+    const files = globby.sync(toPosix(glob.trim()));
+    if (files.length == 0) {
+      log(red('ERROR:'), 'Argument', cyan(glob), 'matched zero files.');
+      throw new Error('Argument matched zero files.');
+    }
+    allFiles.push(...files);
   }
-  return files;
+  return allFiles;
 }
 
 /**

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -108,7 +108,7 @@ function getFilesFromArgv() {
   // TODO(#30223): globby only takes posix globs. Find a Windows alternative.
   const toPosix = (str) => str.replace(/\\\\?/g, '/');
   const globs = Array.isArray(argv.files) ? argv.files : argv.files.split(',');
-  const files = globby.sync(globs.map((glob) => glob.trim()).map(toPosix));
+  const files = globby.sync(globs.map((glob) => toPosix(glob.trim())));
   if (files.length == 0) {
     log(red('ERROR:'), 'Argument(s)', cyan(argv.files), 'matched zero files.');
     throw new Error('No tests to run.');

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -111,7 +111,7 @@ function getFilesFromArgv() {
   const files = globby.sync(globs.map((glob) => toPosix(glob.trim())));
   if (files.length == 0) {
     log(red('ERROR:'), 'Argument(s)', cyan(argv.files), 'matched zero files.');
-    throw new Error('No tests to run.');
+    throw new Error('Argument(s) matched zero files.');
   }
   return files;
 }


### PR DESCRIPTION
This PR adds a useful message if `amp [unit|integration|e2e] --files` is called with non-existent test files.

**Before:**

![image](https://user-images.githubusercontent.com/26553114/116441374-65c82480-a81f-11eb-8a5c-90b433f2eff7.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/116447858-6dd79280-a826-11eb-9470-517f5ba033ad.png)