### PR TITLE
♻️ Simplify log/assert code and use core assert

### DIFF
--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -28,8 +28,6 @@ import {remove} from './types/array';
  * Supports argument substitution into the message via %s placeholders.
  *
  * Throws an error object that has two extra properties:
- * - associatedElement: This is the first element provided in the var args.
- *   It can be used for improved display of error messages.
  * - messageArray: The elements of the substituted message as non-stringified
  *   elements in an array. When e.g. passed to console.error this yields
  *   native displays of things like HTML elements.
@@ -76,6 +74,12 @@ function assertion(
 
   const error = new Error(message);
   error.messageArray = remove(messageArray, (x) => x !== '');
+  // __AMP_REPORT_ERROR is installed globally per window in the entry point in
+  // AMP documents. It may not be present for Bento/Preact elements on non-AMP
+  // pages.
+  if (self.__AMP_REPORT_ERROR) {
+    self.__AMP_REPORT_ERROR(error);
+  }
   throw error;
 }
 

--- a/src/core/assert.js
+++ b/src/core/assert.js
@@ -39,7 +39,7 @@ import {remove} from './types/array';
  * @template T
  * @throws {Error} when shouldBeTruthy is not truthy.
  */
-function assertion(
+export function assertion(
   sentinel,
   shouldBeTruthy,
   opt_message = 'Assertion failed',

--- a/src/error-reporting.js
+++ b/src/error-reporting.js
@@ -26,6 +26,7 @@ import {dict} from './core/types/object';
 import {duplicateErrorIfNecessary} from './core/error';
 import {experimentTogglesOrNull, getBinaryType, isCanary} from './experiments';
 import {exponentialBackoff} from './exponential-backoff';
+import {findIndex} from './core/types/array';
 import {getMode} from './mode';
 import {isLoadErrorMessage} from './event-helper';
 import {isProxyOrigin} from './url';
@@ -183,6 +184,15 @@ export function reportError(error, opt_associatedElement) {
     }
     error.reported = true;
 
+    // `associatedElement` is used to add the i-amphtml-error class; in
+    // `#development=1` mode, it also adds `i-amphtml-element-error` to the
+    // element and sets the `error-message` attribute.
+    if (error.messageArray) {
+      const elIndex = findIndex(error.messageArray, (item) => item?.tagName);
+      if (elIndex > -1) {
+        error.associatedElement = error.messageArray[elIndex];
+      }
+    }
     // Update element.
     const element = opt_associatedElement || error.associatedElement;
     if (element && element.classList) {

--- a/src/log.js
+++ b/src/log.js
@@ -18,13 +18,13 @@ import {
   USER_ERROR_SENTINEL,
   elementStringOrPassThru,
 } from './core/error-message-helpers';
+import {assertion} from './core/assert';
 import {createErrorVargs, duplicateErrorIfNecessary} from './core/error';
 import {findIndex, isArray} from './core/types/array';
 import {getMode} from './mode';
 import {internalRuntimeVersion} from './internal-version';
 import {isEnumValue} from './core/types';
 import {once} from './core/types/function';
-import {pureDevAssert, pureUserAssert} from './core/assert';
 import {urls} from './config';
 
 const noop = () => {};
@@ -402,8 +402,7 @@ export class Log {
       );
     }
 
-    const assertion = this == logs.user ? pureUserAssert : pureDevAssert;
-    return assertion.apply(null, arguments);
+    return assertion.bind(null, this.suffix_).apply(null, arguments);
   }
 
   /**

--- a/src/log.js
+++ b/src/log.js
@@ -20,10 +20,9 @@ import {
 } from './core/error-message-helpers';
 import {assertion} from './core/assert';
 import {createErrorVargs, duplicateErrorIfNecessary} from './core/error';
-import {findIndex, isArray} from './core/types/array';
 import {getMode} from './mode';
 import {internalRuntimeVersion} from './internal-version';
-import {isEnumValue} from './core/types';
+import {isArray, isEnumValue} from './core/types';
 import {once} from './core/types/function';
 import {urls} from './config';
 
@@ -534,15 +533,6 @@ export class Log {
   prepareError_(error) {
     error = duplicateErrorIfNecessary(error);
 
-    // `associatedElement` is used to add the i-amphtml-error class; in
-    // `#development=1` mode, it also adds `i-amphtml-element-error` to the
-    // element and sets the `error-message` attribute.
-    if (error.messageArray) {
-      const elIndex = findIndex(error.messageArray, (item) => item?.tagName);
-      if (elIndex > -1) {
-        error.associatedElement = error.messageArray[elIndex];
-      }
-    }
     if (this.suffix_) {
       if (!error.message) {
         error.message = this.suffix_;

--- a/src/log.js
+++ b/src/log.js
@@ -401,7 +401,10 @@ export class Log {
       );
     }
 
-    return assertion.bind(null, this.suffix_).apply(null, arguments);
+    return assertion.apply(
+      null,
+      [this.suffix_].concat(Array.prototype.slice.call(arguments))
+    );
   }
 
   /**

--- a/src/log.js
+++ b/src/log.js
@@ -402,15 +402,8 @@ export class Log {
       );
     }
 
-    try {
-      const assertion = this == logs.user ? pureUserAssert : pureDevAssert;
-      return assertion.apply(null, arguments);
-    } catch (e) {
-      this.prepareError_(e);
-      // __AMP_REPORT_ERROR is installed globally per window in the entry point.
-      self.__AMP_REPORT_ERROR(e);
-      throw e;
-    }
+    const assertion = this == logs.user ? pureUserAssert : pureDevAssert;
+    return assertion.apply(null, arguments);
   }
 
   /**

--- a/test/unit/test-log.js
+++ b/test/unit/test-log.js
@@ -369,7 +369,14 @@ describe('Logging', () => {
       }
       expect(error).to.be.instanceof(Error);
       expect(error.message).to.equal('1 a 2 b 3' + USER_ERROR_SENTINEL);
-      expect(error.messageArray).to.deep.equal([1, 'a', 2, 'b', 3]);
+      expect(error.messageArray).to.deep.equal([
+        1,
+        'a',
+        2,
+        'b',
+        3,
+        USER_ERROR_SENTINEL,
+      ]);
     });
 
     it('should add element and assert info', () => {


### PR DESCRIPTION
Moves detection of `error.associatedElement` from `log#prepareError_` to `error-reporting` where it is used. Simplifies `log#assert` method in preparation for adding type assertion helpres to core.