### PR TITLE
🏗 Refine renovate configuration

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -4,14 +4,11 @@
     "supportPolicy": ["lts_latest"]
   },
   "ignoreDeps": ["ubuntu-2004"],
-
   "commitMessagePrefix": "📦",
   "timezone": "America/Los_Angeles",
   "schedule": "after 12am every weekday",
-
   "dependencyDashboard": true,
   "prBodyColumns": ["Package", "Update", "Type", "Change", "Package file"],
-  "separateMinorPatch": true,
   "prBodyNotes": [
     "<details>",
     "<summary>How to resolve breaking changes</summary>",
@@ -19,98 +16,104 @@
     "```sh\n# Check out the PR branch (these steps are from GitHub)\ngit checkout -b renovate-bot-{{{branchName}}} main\ngit pull https://github.com/renovate-bot/amphtml.git {{{branchName}}}\n\n# Directly make fixes and commit them\namp lint --fix # For lint errors in JS files\namp prettify --fix # For prettier errors in non-JS files\n# Edit source code in case of new compiler warnings / errors\n\n# Push the changes to the branch\ngit push git@github.com:renovate-bot/amphtml.git renovate-bot-{{{branchName}}}:{{{branchName}}}\n```",
     "</details>"
   ],
-
+  "major": {
+    "packageRules": [
+      {
+        "matchDepTypes": ["devDependencies"],
+        "labels": ["WG: infra"],
+        "automerge": true,
+        "assignAutomerge": true
+      },
+      {
+        "matchDepTypes": ["dependencies"],
+        "labels": ["WG: bento", "WG: performance"],
+        "automerge": false,
+        "assignAutomerge": false
+      }
+    ]
+  },
   "packageRules": [
     {
       "groupName": "subpackage devDependencies",
       "matchPaths": ["**/*"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "subpackage-"
-      }
+      "assignAutomerge": true
     },
     {
-      "groupName": "build system devDependencies",
+      "groupName": "build-system devDependencies",
       "matchPaths": ["build-system/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "labels": ["WG: infra"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "build-system-"
-      }
+      "assignAutomerge": true
     },
     {
       "groupName": "validator devDependencies",
       "matchPaths": ["validator/**"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "labels": ["WG: caching"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "validator-"
-      }
+      "assignAutomerge": true
     },
     {
       "groupName": "core devDependencies",
       "matchPaths": ["+(package.json)"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["WG: infra"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "core-"
-      }
+      "assignAutomerge": true
     },
     {
       "groupName": "linting devDependencies",
       "matchPackagePatterns": ["\\b(prettier|eslint)\\b"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["WG: infra"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "linting-"
-      }
+      "assignAutomerge": true
     },
     {
       "groupName": "babel devDependencies",
       "matchPackagePatterns": ["\\bbabel"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["WG: infra", "WG: performance"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "babel-"
-      }
+      "assignAutomerge": true
     },
     {
       "groupName": "esbuild devDependencies",
       "matchPackagePatterns": ["\\besbuild\\b"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["WG: infra", "WG: performance"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "esbuild-"
-      }
-    },
-    {
-      "excludePackagePatterns": ["^@ampproject/"],
-      "automerge": false,
-      "matchDepTypes": ["dependencies"],
-      "enabled": false
+      "assignAutomerge": true
     },
     {
       "groupName": "ampproject devDependencies",
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["WG: bento", "WG: performance"],
       "automerge": true,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "ampproject-"
-      }
+      "assignAutomerge": true
     },
     {
       "groupName": "ampproject dependencies",
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["WG: bento", "WG: performance"],
       "automerge": false,
-      "major": {
-        "groupName": null,
-        "additionalBranchPrefix": "ampproject-"
-      }
+      "assignAutomerge": false
+    },
+    {
+      "groupName": "core dependencies",
+      "excludePackagePatterns": ["^@ampproject/"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "labels": ["WG: bento", "WG: performance"],
+      "automerge": false,
+      "assignAutomerge": false
     }
   ]
 }


### PR DESCRIPTION
This is part of the effort to streamline package updates and reduce unnecessary manual toil.

**PR Highlights:**
- **[existing]** Test all `major` in isolation via independent PRs
- **[new]** Consolidate configuration for `major` updates in one place (simplifies currently separate config)
- **[new]** Group `minor`, `patch`, `pin`, and `digest` updates in the same category (separating them proved to be too noisy)
- **[existing]** Further group updates to `devDependencies` into `subpackage`, `build-system`, `validator`, `core`, `linting`, `babel`, `esbuild`, and `ampproject`
- **[existing]** Also group updates to `dependencies` into `ampproject` (published by `@ampproject`) and `core` (all others)
- **[new]** Enable renovate updates for `core` (not published by `@ampproject`) `dependencies` (see https://github.com/ampproject/amphtml/pull/30043#issuecomment-821478569)
- **[new]** Explicitly enable `automerge` for `devDependencies`, and explicitly disable for `dependencies`
- **[new]** Enable `assignAutomerge` for all groups that have `automerge` set to `true` (to be used by [`renovate-approve`](https://github.com/apps/renovate-approve))
- **[new]** Make sure all upgrade PRs are tagged with appropriate working-group label(s)

**Reference:** https://docs.renovatebot.com/configuration-options

Partial fix for #33959

