### PR TITLE
♻️ Use Bento VideoIframe directly

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -248,12 +248,10 @@ exports.rules = [
       // Bento AMP Youtube
       'extensions/amp-youtube/1.0/base-element.js->extensions/amp-video/1.0/base-element.js',
       'extensions/amp-youtube/1.0/component.js->extensions/amp-video/1.0/video-iframe.js',
-      'extensions/amp-youtube/1.0/component.js->extensions/amp-video/1.0/video-wrapper.js',
 
       // Bento Vimeo
       'extensions/amp-vimeo/1.0/base-element.js->extensions/amp-video/1.0/base-element.js',
       'extensions/amp-vimeo/1.0/component.js->extensions/amp-video/1.0/video-iframe.js',
-      'extensions/amp-vimeo/1.0/component.js->extensions/amp-video/1.0/video-wrapper.js',
 
       // Shared definition of Vimeo API
       'extensions/amp-vimeo/0.1/amp-vimeo.js->extensions/amp-vimeo/vimeo-api.js',

--- a/extensions/amp-video/1.0/storybook/VideoIframe.js
+++ b/extensions/amp-video/1.0/storybook/VideoIframe.js
@@ -21,7 +21,6 @@ import {
   AccordionSection,
 } from '../../../amp-accordion/1.0/component';
 import {VideoIframe} from '../video-iframe';
-import {VideoWrapper} from '../video-wrapper';
 import {boolean, text, withKnobs} from '@storybook/addon-knobs';
 import {createCustomEvent} from '../../../../src/event-helper';
 import {useCallback} from '../../../../src/preact';
@@ -59,10 +58,9 @@ const AmpVideoIframeLike = ({unloadOnPause, ...rest}) => {
   );
 
   return (
-    <VideoWrapper
+    <VideoIframe
       {...rest}
       unloadOnPause={unloadOnPause}
-      component={VideoIframe}
       allow="autoplay" // this is not safe for a generic frame
       onMessage={onMessage}
       makeMethodMessage={makeMethodMessage}

--- a/extensions/amp-video/1.0/test/test-video-iframe.js
+++ b/extensions/amp-video/1.0/test/test-video-iframe.js
@@ -25,7 +25,7 @@ function dispatchMessage(window, opt_event) {
   window.dispatchEvent(Object.assign(event, opt_event));
 }
 
-describes.realWin('VideoIframe Preact component', {}, (env) => {
+describes.realWin('VideoIframeInternal Preact component', {}, (env) => {
   let window;
   let document;
 

--- a/extensions/amp-video/1.0/test/test-video-iframe.js
+++ b/extensions/amp-video/1.0/test/test-video-iframe.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {VideoIframe} from '../video-iframe';
+import {VideoIframe, VideoIframeInternal} from '../video-iframe';
 import {createRef} from '../../../../src/preact';
 import {mount} from 'enzyme';
 
@@ -39,7 +39,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
     const onCanPlay = env.sandbox.spy();
     const makeMethodMessage = env.sandbox.spy();
     const videoIframe = mount(
-      <VideoIframe
+      <VideoIframeInternal
         src="about:blank"
         makeMethodMessage={makeMethodMessage}
         onIframeLoad={onIframeLoad}
@@ -57,7 +57,10 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
   it('unmutes per lack of `muted` prop', async () => {
     const makeMethodMessage = env.sandbox.spy();
     const videoIframe = mount(
-      <VideoIframe src="about:blank" makeMethodMessage={makeMethodMessage} />,
+      <VideoIframeInternal
+        src="about:blank"
+        makeMethodMessage={makeMethodMessage}
+      />,
       {attachTo: document.body}
     );
 
@@ -69,7 +72,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
   it('mutes per `muted` prop', async () => {
     const makeMethodMessage = env.sandbox.spy();
     const videoIframe = mount(
-      <VideoIframe
+      <VideoIframeInternal
         src="about:blank"
         makeMethodMessage={makeMethodMessage}
         muted
@@ -85,7 +88,10 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
   it('hides controls per lack of `controls` prop', async () => {
     const makeMethodMessage = env.sandbox.spy();
     const videoIframe = mount(
-      <VideoIframe src="about:blank" makeMethodMessage={makeMethodMessage} />,
+      <VideoIframeInternal
+        src="about:blank"
+        makeMethodMessage={makeMethodMessage}
+      />,
       {attachTo: document.body}
     );
 
@@ -97,7 +103,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
   it('shows controls per `controls` prop', async () => {
     const makeMethodMessage = env.sandbox.spy();
     const videoIframe = mount(
-      <VideoIframe
+      <VideoIframeInternal
         src="about:blank"
         makeMethodMessage={makeMethodMessage}
         controls
@@ -113,7 +119,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
   it('passes messages to onMessage', async () => {
     const onMessage = env.sandbox.spy();
     const videoIframe = mount(
-      <VideoIframe src="about:blank" onMessage={onMessage} controls />,
+      <VideoIframeInternal src="about:blank" onMessage={onMessage} controls />,
       {attachTo: document.body}
     );
 
@@ -135,9 +141,12 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
 
   it("ignores messages if source doesn't match iframe", async () => {
     const onMessage = env.sandbox.spy();
-    mount(<VideoIframe src="about:blank" onMessage={onMessage} controls />, {
-      attachTo: document.body,
-    });
+    mount(
+      <VideoIframeInternal src="about:blank" onMessage={onMessage} controls />,
+      {
+        attachTo: document.body,
+      }
+    );
     dispatchMessage(window, {source: null, data: 'whatever'});
     expect(onMessage).to.not.have.been.called;
   });
@@ -145,7 +154,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
   it('stops listening to messages on unmount', async () => {
     const onMessage = env.sandbox.spy();
     const videoIframe = mount(
-      <VideoIframe src="about:blank" onMessage={onMessage} />,
+      <VideoIframeInternal src="about:blank" onMessage={onMessage} />,
       {attachTo: document.body}
     );
     const iframe = videoIframe.getDOMNode();
@@ -159,7 +168,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
     const removeEventListener = env.sandbox.stub(window, 'removeEventListener');
 
     const videoIframe = mount(
-      <VideoIframe src="about:blank" onMessage={() => {}} />,
+      <VideoIframeInternal src="about:blank" onMessage={() => {}} />,
       {attachTo: document.body}
     );
 
@@ -184,7 +193,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
     const makeMethodMessageStub = env.sandbox.stub();
 
     const videoIframe = mount(
-      <VideoIframe
+      <VideoIframeInternal
         ref={ref}
         src="about:blank"
         makeMethodMessage={makeMethodMessageStub}
@@ -218,7 +227,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
 
       // no value.
       mount(
-        <VideoIframe
+        <VideoIframeInternal
           ref={ref}
           src="about:blank"
           makeMethodMessage={makeMethodMessage}
@@ -230,7 +239,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
       // null value.
       const playerStateRef = createRef();
       mount(
-        <VideoIframe
+        <VideoIframeInternal
           ref={ref}
           src="about:blank"
           makeMethodMessage={makeMethodMessage}
@@ -243,7 +252,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
       // empty value.
       playerStateRef.current = {};
       mount(
-        <VideoIframe
+        <VideoIframeInternal
           ref={ref}
           src="about:blank"
           makeMethodMessage={makeMethodMessage}
@@ -259,7 +268,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
       const playerStateRef = createRef();
       playerStateRef.current = {duration: 111, currentTime: 11};
       mount(
-        <VideoIframe
+        <VideoIframeInternal
           ref={ref}
           src="about:blank"
           makeMethodMessage={makeMethodMessage}
@@ -276,7 +285,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
     });
   });
 
-  describe('uses makeMethodMessage to posts imperative handle methods', () => {
+  describe('uses makeMethodMessage to post imperative handle methods', () => {
     ['play', 'pause'].forEach((method) => {
       it(`with \`${method}\``, async () => {
         let videoIframeRef;
@@ -286,7 +295,7 @@ describes.realWin('VideoIframe Preact component', {}, (env) => {
         const makeMethodMessageSpy = env.sandbox.spy(makeMethodMessage);
 
         const videoIframe = mount(
-          <VideoIframe
+          <VideoIframeInternal
             ref={(ref) => (videoIframeRef = ref)}
             src="about:blank"
             makeMethodMessage={makeMethodMessageSpy}

--- a/extensions/amp-video/1.0/test/test-video-iframe.js
+++ b/extensions/amp-video/1.0/test/test-video-iframe.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {VideoIframe, VideoIframeInternal} from '../video-iframe';
+import {VideoIframeInternal} from '../video-iframe';
 import {createRef} from '../../../../src/preact';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -45,20 +45,14 @@ function usePropRef(prop) {
 }
 
 /**
- * Goes inside a VideoWrapper.
- *
- *    import {VideoIframe} from '.../video-iframe';
- *    import {VideoWrapper} from '.../video-wrapper';
- *    render(<VideoWrapper component={VideoIframe} ... />)
- *
+ * VideoWrapper using an <iframe> for implementation
  * Usable on the AMP layer through VideoBaseElement.
- *
  * @param {!VideoIframeDef.Props} props
  * @param {{current: (T|null)}} ref
  * @return {PreactDef.Renderable}
  * @template T
  */
-function VideoIframeWithRef(
+function VideoIframeInternalWithRef(
   {
     loading,
     unloadOnPause = false,
@@ -191,6 +185,19 @@ function VideoIframeWithRef(
   );
 }
 
+const VideoIframeInternal = forwardRef(VideoIframeInternalWithRef);
+VideoIframeInternal.displayName = 'VideoIframeInternal';
+
+/**
+ * @param {VideoIframeDef.Props} props
+ * @param {{current: T|null}} ref
+ * @return {PreactDef.Renderable}
+ * @template T
+ */
+function VideoIframeWithRef(props, ref) {
+  return <VideoWrapper ref={ref} {...props} component={VideoIframeInternal} />;
+}
+
 const VideoIframe = forwardRef(VideoIframeWithRef);
-VideoIframe.displayName = 'VideoIframe'; // Make findable for tests.
+VideoIframe.displayName = 'VideoIframe';
 export {VideoIframe};

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -184,8 +184,10 @@ function VideoIframeInternalWithRef(
   );
 }
 
+/** @visibleForTesting */
 const VideoIframeInternal = forwardRef(VideoIframeInternalWithRef);
 VideoIframeInternal.displayName = 'VideoIframeInternal';
+export {VideoIframeInternal};
 
 /**
  * VideoWrapper using an <iframe> for implementation.

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -16,6 +16,7 @@
 
 import * as Preact from '../../../src/preact';
 import {Deferred} from '../../../src/core/data-structures/promise';
+import {VideoWrapper} from './video-wrapper';
 import {forwardRef} from '../../../src/preact/compat';
 import {
   useCallback,

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -198,6 +198,12 @@ function VideoIframeWithRef(props, ref) {
   return <VideoWrapper ref={ref} {...props} component={VideoIframeInternal} />;
 }
 
+/**
+ * VideoWrapper using an <iframe> for implementation.
+ * Usable on the AMP layer through VideoBaseElement.
+ * @param {VideoIframeDef.Props} props
+ * @return {PreactDef.Renderable}=
+ */
 const VideoIframe = forwardRef(VideoIframeWithRef);
 VideoIframe.displayName = 'VideoIframe';
 export {VideoIframe};

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -45,8 +45,6 @@ function usePropRef(prop) {
 }
 
 /**
- * VideoWrapper using an <iframe> for implementation
- * Usable on the AMP layer through VideoBaseElement.
  * @param {!VideoIframeDef.Props} props
  * @param {{current: (T|null)}} ref
  * @return {PreactDef.Renderable}
@@ -189,6 +187,8 @@ const VideoIframeInternal = forwardRef(VideoIframeInternalWithRef);
 VideoIframeInternal.displayName = 'VideoIframeInternal';
 
 /**
+ * VideoWrapper using an <iframe> for implementation.
+ * Usable on the AMP layer through VideoBaseElement.
  * @param {VideoIframeDef.Props} props
  * @param {{current: T|null}} ref
  * @return {PreactDef.Renderable}

--- a/extensions/amp-vimeo/1.0/component.js
+++ b/extensions/amp-vimeo/1.0/component.js
@@ -23,7 +23,6 @@ import {
   makeVimeoMessage,
 } from '../vimeo-api';
 import {VideoIframe} from '../../amp-video/1.0/video-iframe';
-import {VideoWrapper} from '../../amp-video/1.0/video-wrapper';
 import {dispatchCustomEvent} from '../../../src/dom';
 import {forwardRef} from '../../../src/preact/compat';
 import {
@@ -109,11 +108,10 @@ export function VimeoWithRef(
   }, []);
 
   return (
-    <VideoWrapper
+    <VideoIframe
       ref={ref}
       {...rest}
       origin={origin}
-      component={VideoIframe}
       autoplay={autoplay}
       src={src}
       onMessage={onMessage}

--- a/extensions/amp-youtube/1.0/component.js
+++ b/extensions/amp-youtube/1.0/component.js
@@ -17,7 +17,6 @@
 import * as Preact from '../../../src/preact';
 import {VideoEvents} from '../../../src/video-interface';
 import {VideoIframe} from '../../amp-video/1.0/video-iframe';
-import {VideoWrapper} from '../../amp-video/1.0/video-wrapper';
 import {addParamsToUrl} from '../../../src/url';
 import {dict} from '../../../src/core/types/object';
 import {dispatchCustomEvent} from '../../../src/dom';
@@ -181,10 +180,9 @@ function YoutubeWithRef(
   };
 
   return (
-    <VideoWrapper
+    <VideoIframe
       ref={ref}
       {...rest}
-      component={VideoIframe}
       autoplay={autoplay}
       src={src}
       onMessage={onMessage}
@@ -203,7 +201,7 @@ function YoutubeWithRef(
       }}
       sandbox="allow-scripts allow-same-origin allow-presentation"
       playerStateRef={playerStateRef}
-    ></VideoWrapper>
+    />
   );
 }
 


### PR DESCRIPTION
Makes internal implementations simpler, while allowing `<amp-video-iframe>` to use a `VideoIframe` directly.

```diff
- <VideoWrapper
-   component={VideoIframe}
+ <VideoIframe
    ...
  />
```