### PR TITLE
Typechecking Pride: add a few files to pride list, and fix extern cal…

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -45,6 +45,15 @@
  */
 var FetchInitDef;
 
+// TODO: add MediaQueryListEvent to closure's builtin externs.
+/**
+ * @typedef {{
+ *   matches: function():boolean,
+ *   media: string
+ * }}
+ */
+var MediaQueryListEvent;
+
 /**
  * Externed due to being passed across component/runtime boundary.
  * @typedef {{xhrUrl: string, fetchOpt: !FetchInitDef}}
@@ -60,15 +69,6 @@ FormDataWrapperInterface.prototype.getFormData = function () {};
 FormData.prototype.entries = function () {};
 
 /**
- * @typedef {{
- *   YOU_MUST_USE: string,
- *   jsonLiteral: function(),
- *   TO_MAKE_THIS_TYPE: string,
- * }}
- */
-var InternalJsonLiteralTypeDef;
-
-/**
  * Force the dataset property to be handled as a JsonObject.
  * @type {!JsonObject}
  */
@@ -79,6 +79,25 @@ Element.prototype.__AMP_SHADOW_ROOT;
 
 /** @type {?ShadowRoot} */
 Element.prototype.shadowRoot;
+
+// Fullscreen methods
+Document.prototype.cancelFullScreen = function () {};
+Document.prototype.webkitExitFullscreen = function () {};
+Element.prototype.cancelFullScreen = function () {};
+Element.prototype.exitFullscreen = function () {};
+Element.prototype.webkitExitFullscreen = function () {};
+Element.prototype.webkitCancelFullScreen = function () {};
+Element.prototype.mozCancelFullScreen = function () {};
+Element.prototype.msExitFullscreen = function () {};
+Element.prototype.requestFullscreen = function () {};
+Element.prototype.requestFullScreen = function () {};
+Element.prototype.webkitRequestFullscreen = function () {};
+Element.prototype.webkitEnterFullscreen = function () {};
+Element.prototype.msRequestFullscreen = function () {};
+Element.prototype.mozRequestFullScreen = function () {};
+
+/** @type {boolean|undefined} */
+Element.prototype.webkitDisplayingFullscreen;
 
 /**
  * - n is the name.
@@ -174,7 +193,7 @@ process.env.NODE_ENV;
 
 // Exposed to ads.
 // Preserve these filedNames so they can be accessed by 3p code.
-window.context = {};
+window.context;
 window.context.sentinel;
 window.context.clientId;
 window.context.initialLayoutRect;
@@ -203,9 +222,7 @@ window.context.tagName;
 
 // Safeframe
 // TODO(bradfrizzell) Move to its own extern. Not relevant to all AMP.
-/** @type {?Object} */
-window.sf_ = {};
-/** @type {?Object} */
+window.sf_;
 window.sf_.cfg;
 
 // Exposed to custom ad iframes.
@@ -223,7 +240,19 @@ window.__AMP_TOP;
 window.__AMP_PARENT;
 window.__AMP_WEAKREF_ID;
 window.__AMP_URL_CACHE;
-window.AMP = {};
+window.__AMP_LOG;
+
+/** @type {undefined|boolean} */
+window.ENABLE_LOG;
+
+// TODO: uncomment line below when src/mode.js is added to typechecking.
+// /** @type {undefined|../../src/mode.ModeDef} */
+window.__AMP_MODE;
+
+/** @type {boolean|undefined} */
+window.AMP_DEV_MODE;
+
+window.AMP;
 window.AMP._ = {};
 window.AMP.push;
 window.AMP.title;
@@ -241,10 +270,19 @@ window.AMP.toggleExperiment;
 window.AMP.setLogLevel;
 window.AMP.setTickFunction;
 window.AMP.viewer;
-window.AMP.viewport = {};
+window.AMP.viewport;
 window.AMP.viewport.getScrollLeft;
 window.AMP.viewport.getScrollWidth;
 window.AMP.viewport.getWidth;
+
+/**
+ * This symbol is exposed by bundles transformed by `scoped-require.js` to avoid
+ * polluting the global namespace with `require`.
+ * It allows AMP extensions to consume code injected into their binaries that
+ * cannot be run through Closure Compiler, e.g. React code with JSX.
+ * @type {!function(string):?}
+ */
+window.AMP.require;
 
 /** @type {function(!HTMLElement, !Document, !string, Object)} */
 window.AMP.attachShadowDoc = function (element, document, url, options) {};
@@ -369,9 +407,9 @@ RRule.prototype.after = function (unusedDt, unusedInc) {};
 let PropTypes = {};
 
 /**
- * @@dict
+ * @dict
  */
-let ReactDates = {};
+let ReactDates;
 
 /** @constructor */
 ReactDates.DayPickerSingleDateController;
@@ -425,11 +463,6 @@ window.AMP.dependencies = {};
  */
 window.AMP.dependencies.inputmaskFactory = function (unusedElement) {};
 
-// Should have been defined in the closure compiler's extern file for
-// IntersectionObserverEntry, but appears to have been omitted.
-/** @type {?ClientRect} */
-IntersectionObserverEntry.prototype.rootBounds;
-
 // TODO (remove after we update closure compiler externs)
 window.PerformancePaintTiming;
 window.PerformanceObserver;
@@ -442,7 +475,7 @@ var time;
 
 /**
  * Just an element, but used with AMP custom elements..
- * @constructor @extends {Element}
+ * @constructor @extends {HTMLElement}
  */
 var AmpElement = function () {};
 
@@ -477,8 +510,14 @@ AmpElement.prototype.togglePlaceholder = function (show) {};
 AmpElement.prototype.getLayoutSize = function () {};
 
 /**
+ * TODO: remove this when typechecking is restored to AMP.BaseElement.
+ * @typedef {*}
+ */
+var BaseElement;
+
+/**
  * @param {boolean=} opt_waitForBuild
- * @return {!Promise<!AMP.BaseElement>}
+ * @return {!Promise<!BaseElement>}
  */
 AmpElement.prototype.getImpl = function (opt_waitForBuild) {};
 
@@ -752,49 +791,50 @@ AmpStoryVariableService.prototype.onStateChange = function (event) {};
 AmpStoryVariableService.pageIndex;
 AmpStoryVariableService.pageId;
 
-var AMP = {};
-window.AMP;
-// Externed explicitly because we do not export Class shaped names
-// by default.
-/**
- * This uses the internal name of the type, because there appears to be no
- * other way to reference an ES6 type from an extern that is defined in
- * the app.
- * @constructor @struct
- * @extends {BaseElement$$module$src$base_element}
- */
-AMP.BaseElement = class {
-  /** @param {!AmpElement} element */
-  constructor(element) {}
-};
+// TODO: uncomment when typechecking restored to BaseElement.
+// // Externed explicitly because we do not export Class shaped names
+// // by default.
+// /**
+//  * This uses the internal name of the type, because there appears to be no
+//  * other way to reference an ES6 type from an extern that is defined in
+//  * the app.
+//  * @constructor @struct
+//  * @extends {BaseElement$$module$src$base_element}
+//  */
+// AMP.BaseElement = class {
+//   /** @param {!AmpElement} element */
+//   constructor(element) {}
+// };
 
-/**
- * This uses the internal name of the type, because there appears to be no
- * other way to reference an ES6 type from an extern that is defined in
- * the app.
- * @constructor @struct
- * @extends {AmpAdXOriginIframeHandler$$module$extensions$amp_ad$0_1$amp_ad_xorigin_iframe_handler}
- */
-AMP.AmpAdXOriginIframeHandler = class {
-  /**
-   * @param {!AmpAd3PImpl$$module$extensions$amp_ad$0_1$amp_ad_3p_impl|!AmpA4A$$module$extensions$amp_a4a$0_1$amp_a4a} baseInstance
-   */
-  constructor(baseInstance) {}
-};
+// TODO: uncomment when typechecking restored to AmpAdXOriginIframeHandler.
+// /**
+//  * This uses the internal name of the type, because there appears to be no
+//  * other way to reference an ES6 type from an extern that is defined in
+//  * the app.
+//  * @constructor @struct
+//  * @extends {AmpAdXOriginIframeHandler$$module$extensions$amp_ad$0_1$amp_ad_xorigin_iframe_handler}
+//  */
+// AMP.AmpAdXOriginIframeHandler = class {
+//   /**
+//    * @param {!AmpAd3PImpl$$module$extensions$amp_ad$0_1$amp_ad_3p_impl|!AmpA4A$$module$extensions$amp_a4a$0_1$amp_a4a} baseInstance
+//    */
+//   constructor(baseInstance) {}
+// };
 
-/**
- * This uses the internal name of the type, because there appears to be no
- * other way to reference an ES6 type from an extern that is defined in
- * the app.
- * @constructor @struct
- * @extends {AmpAdUIHandler$$module$extensions$amp_ad$0_1$amp_ad_ui}
- */
-AMP.AmpAdUIHandler = class {
-  /**
-   * @param {!AMP.BaseElement} baseInstance
-   */
-  constructor(baseInstance) {}
-};
+// TODO: uncomment when typechecking is restored to AmpAdUIHandler.
+// /**
+//  * This uses the internal name of the type, because there appears to be no
+//  * other way to reference an ES6 type from an extern that is defined in
+//  * the app.
+//  * @constructor @struct
+//  * @extends {AmpAdUIHandler$$module$extensions$amp_ad$0_1$amp_ad_ui}
+//  */
+// AMP.AmpAdUIHandler = class {
+//   /**
+//    * @param {!AMP.BaseElement} baseInstance
+//    */
+//   constructor(baseInstance) {}
+// };
 
 /**
  * Actual filled values for this exists in
@@ -809,15 +849,6 @@ const RTC_ERROR_ENUM = {};
       callout: string,
       error: (RTC_ERROR_ENUM|undefined)}} */
 var rtcResponseDef;
-
-/**
- * This symbol is exposed by bundles transformed by `scoped-require.js` to avoid
- * polluting the global namespace with `require`.
- * It allows AMP extensions to consume code injected into their binaries that
- * cannot be run through Closure Compiler, e.g. React code with JSX.
- * @type {!function(string):?}
- */
-AMP.require;
 
 /**
  * TransitionDef function that accepts normtime, typically between 0 and 1 and
@@ -1049,11 +1080,6 @@ class FeaturePolicy {
   getAllowlistForFeature(feature) {}
 }
 
-/**
- * @type {?FeaturePolicy}
- */
-HTMLIFrameElement.prototype.featurePolicy;
-
 /** @type {boolean} */
 HTMLVideoElement.prototype.playsInline;
 
@@ -1085,3 +1111,6 @@ MediaQueryList.prototype.onchange;
 
 /** @type {!Array<!CSSStyleSheet>|undefined} */
 ShadowRoot.prototype.adoptedStyleSheets;
+
+/** @type {undefined|boolean} */
+Error.prototype.expected;

--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -43,7 +43,7 @@
  *   prerenderSafe: (boolean|undefined),
  * }}
  */
-var FetchInitDef;
+let FetchInitDef;
 
 // TODO: add MediaQueryListEvent to closure's builtin externs.
 /**
@@ -52,16 +52,16 @@ var FetchInitDef;
  *   media: string
  * }}
  */
-var MediaQueryListEvent;
+let MediaQueryListEvent;
 
 /**
  * Externed due to being passed across component/runtime boundary.
  * @typedef {{xhrUrl: string, fetchOpt: !FetchInitDef}}
  */
-var FetchRequestDef;
+let FetchRequestDef;
 
 /** @constructor */
-var FormDataWrapperInterface = function () {};
+let FormDataWrapperInterface = function () {};
 
 FormDataWrapperInterface.prototype.entries = function () {};
 FormDataWrapperInterface.prototype.getFormData = function () {};
@@ -81,20 +81,21 @@ Element.prototype.__AMP_SHADOW_ROOT;
 Element.prototype.shadowRoot;
 
 // Fullscreen methods
-Document.prototype.cancelFullScreen = function () {};
-Document.prototype.webkitExitFullscreen = function () {};
-Element.prototype.cancelFullScreen = function () {};
-Element.prototype.exitFullscreen = function () {};
-Element.prototype.webkitExitFullscreen = function () {};
-Element.prototype.webkitCancelFullScreen = function () {};
-Element.prototype.mozCancelFullScreen = function () {};
-Element.prototype.msExitFullscreen = function () {};
-Element.prototype.requestFullscreen = function () {};
-Element.prototype.requestFullScreen = function () {};
-Element.prototype.webkitRequestFullscreen = function () {};
-Element.prototype.webkitEnterFullscreen = function () {};
-Element.prototype.msRequestFullscreen = function () {};
-Element.prototype.mozRequestFullScreen = function () {};
+// TODO: upstream these types to closure.
+Document.prototype.cancelFullScreen;
+Document.prototype.webkitExitFullscreen;
+Element.prototype.cancelFullScreen;
+Element.prototype.exitFullscreen;
+Element.prototype.webkitExitFullscreen;
+Element.prototype.webkitCancelFullScreen;
+Element.prototype.mozCancelFullScreen;
+Element.prototype.msExitFullscreen;
+Element.prototype.requestFullscreen;
+Element.prototype.requestFullScreen;
+Element.prototype.webkitRequestFullscreen;
+Element.prototype.webkitEnterFullscreen;
+Element.prototype.msRequestFullscreen;
+Element.prototype.mozRequestFullScreen;
 
 /** @type {boolean|undefined} */
 Element.prototype.webkitDisplayingFullscreen;
@@ -158,7 +159,7 @@ ExtensionPayload.prototype.f;
 /**
  * @typedef {?JsonObject|undefined|string|number|!Array<JsonValue>}
  */
-var JsonValue;
+let JsonValue;
 
 /**
  * @constructor
@@ -187,7 +188,7 @@ VideoAnalyticsDetailsDef.prototype.state;
 VideoAnalyticsDetailsDef.prototype.width;
 
 // Node.js global
-var process = {};
+let process = {};
 process.env;
 process.env.NODE_ENV;
 
@@ -246,6 +247,8 @@ window.__AMP_LOG;
 window.ENABLE_LOG;
 
 // TODO: uncomment line below when src/mode.js is added to typechecking.
+// https://github.com/ampproject/amphtml/issues/34099
+
 // /** @type {undefined|../../src/mode.ModeDef} */
 window.__AMP_MODE;
 
@@ -441,7 +444,7 @@ ReactDatesConstants.HORIZONTAL_ORIENTATION;
 /**
  * @constructor
  */
-var Inputmask = class {};
+let Inputmask = class {};
 
 /** @param {!Object} unusedOpts */
 Inputmask.extendAliases = function (unusedOpts) {};
@@ -471,13 +474,13 @@ Window.prototype.origin;
 HTMLAnchorElement.prototype.origin;
 
 /** @typedef {number}  */
-var time;
+let time;
 
 /**
  * Just an element, but used with AMP custom elements..
  * @constructor @extends {HTMLElement}
  */
-var AmpElement = function () {};
+let AmpElement = function () {};
 
 /** @return {boolean} */
 AmpElement.prototype.V1 = function () {};
@@ -513,7 +516,7 @@ AmpElement.prototype.getLayoutSize = function () {};
  * TODO: remove this when typechecking is restored to AMP.BaseElement.
  * @typedef {*}
  */
-var BaseElement;
+let BaseElement;
 
 /**
  * @param {boolean=} opt_waitForBuild
@@ -618,7 +621,7 @@ AmpElement.prototype.expand = function () {};
 /** */
 AmpElement.prototype.collapse = function () {};
 
-var Signals = class {};
+let Signals = class {};
 /**
  * @param {string} unusedName
  * @return {number|!Error|null}
@@ -648,19 +651,19 @@ Signals.prototype.reset = function (unusedName) {};
 
 // Temp until we figure out forward declarations
 /** @constructor */
-var AccessService = function () {};
+let AccessService = function () {};
 /** @constructor @struct */
-var UserNotificationManager = function () {};
+let UserNotificationManager = function () {};
 UserNotificationManager.prototype.get;
 /** @constructor @struct */
-var Cid = function () {};
+let Cid = function () {};
 /** @constructor @struct */
-var Activity = function () {};
+let Activity = function () {};
 /** @constructor */
-var AmpStoryVariableService = function () {};
+let AmpStoryVariableService = function () {};
 
 // data
-var data;
+let data;
 data.tweetid;
 data.requestedHeight;
 data.requestedWidth;
@@ -708,7 +711,7 @@ data.sitekey;
 data.fortesting;
 
 // 3p code
-var twttr;
+let twttr;
 twttr.events;
 twttr.events.bind;
 twttr.widgets;
@@ -716,26 +719,26 @@ twttr.widgets.createTweet;
 twttr.widgets.createMoment;
 twttr.widgets.createTimeline;
 
-var FB;
+let FB;
 FB.init;
 
-var gist;
+let gist;
 gist.gistid;
 
-var bodymovin;
+let bodymovin;
 bodymovin.loadAnimation;
-var animationHandler;
+let animationHandler;
 animationHandler.play;
 animationHandler.pause;
 animationHandler.stop;
 animationHandler.goToAndStop;
 animationHandler.totalFrames;
 
-var grecaptcha;
+let grecaptcha;
 grecaptcha.execute;
 
 // Validator
-var amp;
+let amp;
 amp.validator;
 amp.validator.validateUrlAndLog = function (string, doc) {};
 
@@ -757,7 +760,7 @@ AccessService.prototype.getAuthdataField = function (field) {};
  *   cookieName: (string|undefined),
  * }}
  */
-var GetCidDef;
+let GetCidDef;
 /**
  * @param {string|!GetCidDef} externalCidScope Name of the fallback cookie
  *     for the case where this doc is not served by an AMP proxy. GetCidDef
@@ -792,6 +795,8 @@ AmpStoryVariableService.pageIndex;
 AmpStoryVariableService.pageId;
 
 // TODO: uncomment when typechecking restored to BaseElement.
+// https://github.com/ampproject/amphtml/issues/34099
+
 // // Externed explicitly because we do not export Class shaped names
 // // by default.
 // /**
@@ -807,6 +812,8 @@ AmpStoryVariableService.pageId;
 // };
 
 // TODO: uncomment when typechecking restored to AmpAdXOriginIframeHandler.
+// https://github.com/ampproject/amphtml/issues/34099
+
 // /**
 //  * This uses the internal name of the type, because there appears to be no
 //  * other way to reference an ES6 type from an extern that is defined in
@@ -822,6 +829,8 @@ AmpStoryVariableService.pageId;
 // };
 
 // TODO: uncomment when typechecking is restored to AmpAdUIHandler.
+// https://github.com/ampproject/amphtml/issues/34099
+
 // /**
 //  * This uses the internal name of the type, because there appears to be no
 //  * other way to reference an ES6 type from an extern that is defined in
@@ -848,7 +857,7 @@ const RTC_ERROR_ENUM = {};
       rtcTime: number,
       callout: string,
       error: (RTC_ERROR_ENUM|undefined)}} */
-var rtcResponseDef;
+let rtcResponseDef;
 
 /**
  * TransitionDef function that accepts normtime, typically between 0 and 1 and
@@ -858,7 +867,7 @@ var rtcResponseDef;
  * transition and "false" for ongoing.
  * @typedef {function(number, boolean):?|function(number):?}
  */
-var TransitionDef;
+let TransitionDef;
 
 ///////////////////
 // amp-bind externs
@@ -937,7 +946,7 @@ let BindSetStateOptionsDef;
  *   !WebKeyframeAnimationDef
  * }
  */
-var WebAnimationDef;
+let WebAnimationDef;
 
 /**
  * @mixes WebAnimationSelectorDef
@@ -948,7 +957,7 @@ var WebAnimationDef;
  *   animations: !Array<!WebAnimationDef>,
  * }}
  */
-var WebMultiAnimationDef;
+let WebMultiAnimationDef;
 
 /**
  * @mixes WebAnimationSelectorDef
@@ -959,7 +968,7 @@ var WebMultiAnimationDef;
  *   switch: !Array<!WebAnimationDef>,
  * }}
  */
-var WebSwitchAnimationDef;
+let WebSwitchAnimationDef;
 
 /**
  * @mixes WebAnimationSelectorDef
@@ -970,7 +979,7 @@ var WebSwitchAnimationDef;
  *   animation: string,
  * }}
  */
-var WebCompAnimationDef;
+let WebCompAnimationDef;
 
 /**
  * @mixes WebAnimationSelectorDef
@@ -981,12 +990,12 @@ var WebCompAnimationDef;
  *   keyframes: (string|!WebKeyframesDef),
  * }}
  */
-var WebKeyframeAnimationDef;
+let WebKeyframeAnimationDef;
 
 /**
  * @typedef {!Object<string, *>|!Array<!Object<string, *>>}
  */
-var WebKeyframesDef;
+let WebKeyframesDef;
 
 /**
  * See https://developer.mozilla.org/en-US/docs/Web/API/AnimationEffectTimingProperties
@@ -1003,7 +1012,7 @@ var WebKeyframesDef;
  *   fill: (?|undefined),
  * }}
  */
-var WebAnimationTimingDef;
+let WebAnimationTimingDef;
 
 /**
  * Indicates an extension to a type that allows specifying vars. Vars are
@@ -1012,7 +1021,7 @@ var WebAnimationTimingDef;
  * @mixin
  * @typedef {Object}
  */
-var WebAnimationVarsDef;
+let WebAnimationVarsDef;
 
 /**
  * Defines media parameters for an animation.
@@ -1023,7 +1032,7 @@ var WebAnimationVarsDef;
  *   supports: (string|undefined),
  * }}
  */
-var WebAnimationConditionalDef;
+let WebAnimationConditionalDef;
 
 /**
  * @typedef {{
@@ -1032,7 +1041,7 @@ var WebAnimationConditionalDef;
  *   subtargets: (!Array<!WebAnimationSubtargetDef>|undefined),
  * }}
  */
-var WebAnimationSelectorDef;
+let WebAnimationSelectorDef;
 
 /**
  * @mixes WebAnimationTimingDef
@@ -1043,9 +1052,9 @@ var WebAnimationSelectorDef;
  *   selector: (string|undefined),
  * }}
  */
-var WebAnimationSubtargetDef;
+let WebAnimationSubtargetDef;
 
-var ampInaboxPositionObserver;
+let ampInaboxPositionObserver;
 ampInaboxPositionObserver.observe;
 ampInaboxPositionObserver.getTargetRect;
 ampInaboxPositionObserver.getViewportRect;

--- a/build-system/externs/dompurify.extern.js
+++ b/build-system/externs/dompurify.extern.js
@@ -23,8 +23,7 @@ DomPurifyConfig.prototype.ALLOWED_TAGS;
 DomPurifyConfig.prototype.ALLOWED_ATTR;
 DomPurifyConfig.prototype.FORBID_TAGS;
 DomPurifyConfig.prototype.FORBID_ATTR;
-/** @type {?Object} */
-DomPurifyConfig.prototype.USE_PROFILES = {};
+DomPurifyConfig.prototype.USE_PROFILES;
 /** @type {boolean} */
 DomPurifyConfig.prototype.USE_PROFILES.html;
 /** @type {boolean} */

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -25,6 +25,7 @@ const {
 } = require('../compile/debug-compilation-lifecycle');
 const {cleanupBuildDir, closureCompile} = require('../compile/compile');
 const {compileCss} = require('./css');
+const {compileJison} = require('./compile-jison');
 const {cyan, green, yellow, red} = require('kleur/colors');
 const {extensions, maybeInitializeExtensions} = require('./extension-helpers');
 const {log} = require('../common/logging');
@@ -35,7 +36,22 @@ const {typecheckNewServer} = require('../server/typescript-compile');
  * Note: This is a TEMPORARY holding point during the transition to type-safety.
  * @type {!Array<string>}
  */
-const PRIDE_FILES_GLOBS = ['src/resolved-promise.js', 'src/types.js'];
+const PRIDE_FILES_GLOBS = [
+  // Core
+  'src/core{,/**}/*.js',
+
+  // Runtime
+  'src/resolved-promise.js',
+  'src/types.js',
+  'src/url-parse-query-string.js',
+
+  // Third Party
+  'third_party/css-escape/css-escape.js',
+  'third_party/webcomponentsjs/ShadowCSS.js',
+  'node_modules/promise-pjs/package.json',
+  'node_modules/promise-pjs/promise.mjs',
+];
+
 const CORE_EXTERNS_GLOB = 'src/core{,/**}/*.extern.js';
 
 /**
@@ -188,9 +204,11 @@ async function typeCheck(targetName) {
 
   // If srcGlobs and externGlobs are defined, determine the externs/extraGlobs
   if (srcGlobs.length || externGlobs.length) {
-    opts.eterns = externGlobs.flatMap(globby.sync);
+    opts.externs = externGlobs.flatMap(globby.sync);
+
     // Included globs should explicitly exclude any externs
-    opts.extraGlobs = externGlobs.map((glob) => `!${glob}`).concat(srcGlobs);
+    const excludedExterns = externGlobs.map((glob) => `!${glob}`);
+    opts.extraGlobs = srcGlobs.concat(excludedExterns);
   }
 
   // If no entry point is defined, we want to scan the globs provided without
@@ -233,7 +251,7 @@ async function checkTypes() {
   cleanupBuildDir();
   maybeInitializeExtensions();
   typecheckNewServer();
-  await compileCss();
+  await Promise.all([compileCss(), compileJison()]);
 
   // Use the list of targets if provided, otherwise check all targets
   const targets = argv.targets

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -38,7 +38,7 @@ const {typecheckNewServer} = require('../server/typescript-compile');
  */
 const PRIDE_FILES_GLOBS = [
   // Core
-  'src/core{,/**}/*.js',
+  'src/core/**/*.js',
 
   // Runtime
   'src/resolved-promise.js',

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -44,6 +44,7 @@ const PRIDE_FILES_GLOBS = [
   'src/resolved-promise.js',
   'src/types.js',
   'src/url-parse-query-string.js',
+  'src/url-try-decode-uri-component.js',
 
   // Third Party
   'third_party/css-escape/css-escape.js',

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1061,7 +1061,11 @@ const forbiddenTermsSrcInclusive = {
   '\\.indexOf\\(.*===?.*\\.length': 'use endsWith helper in src/string.js',
   '/url-parse-query-string': {
     message: 'Import parseQueryString from `src/url.js`',
-    allowlist: ['src/url.js', 'src/mode.js'],
+    allowlist: [
+      'build-system/tasks/check-types.js',
+      'src/mode.js',
+      'src/url.js',
+    ],
   },
   '\\.trim(Left|Right)\\(\\)': {
     message: 'Unsupported on IE; use trim() or a helper instead.',

--- a/src/json.js
+++ b/src/json.js
@@ -50,6 +50,15 @@ let JSONArrayDef;
 let JSONValueDef;
 
 /**
+ * @typedef {{
+ *   YOU_MUST_USE: string,
+ *   jsonLiteral: function(),
+ *   TO_MAKE_THIS_TYPE: string,
+ * }}
+ */
+let InternalJsonLiteralTypeDef;
+
+/**
  * Recreates objects with prototype-less copies.
  * @param {!JsonObject} obj
  * @return {!JsonObject}


### PR DESCRIPTION
Split off partial of: https://github.com/ampproject/amphtml/pull/33957

- fixes extern calculation
- Comments out parts of `amp.extern.js` that would fail without including src files
- Fixes typing in dompurify extern
- Moves a json extern that is only used within `src/json.js` to from amp.extern.js to the json file.