### PR TITLE
🏗 Use terminal width for test log wrapping if possible

### DIFF
--- a/build-system/common/logging.js
+++ b/build-system/common/logging.js
@@ -19,9 +19,10 @@ const {bold, yellow, gray} = require('kleur/colors');
 const {isCiBuild} = require('./ci');
 
 /**
- * Used by tests to wrap progress dots.
+ * Used by tests to wrap progress dots. Attempts to match the terminal width
+ * during local development and defaults to 150 if it couldn't be determined.
  */
-const dotWrappingWidth = 150;
+const dotWrappingWidth = isCiBuild() ? 150 : process.stdout.columns ?? 150;
 
 /**
  * Used by CI job scripts to print a prefix before top-level logging lines.


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/26553114/116606428-b498bb80-a8fe-11eb-8f68-2c1dd4dc3789.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/116606668-0ccfbd80-a8ff-11eb-8238-dc257f8caf39.png)
