### PR TITLE
Types: fix all type parse errors and ensure no new ones crop up

### DIFF
--- a/ads/vendors/feedad.js
+++ b/ads/vendors/feedad.js
@@ -57,7 +57,7 @@ import {setStyle} from '../../src/style';
  */
 
 /**
- * @param {!FeedAdGlobal & Window} global
+ * @param {!FeedAdGlobal} global
  * @param {!FeedAdData} data
  */
 export function feedad(global, data) {

--- a/build-system/compile/closure-compile.js
+++ b/build-system/compile/closure-compile.js
@@ -52,7 +52,9 @@ function logClosureCompilerError(message) {
  */
 function handleClosureCompilerError(err, outputFilename, options) {
   if (options.typeCheckOnly) {
-    log(`${red('ERROR:')} Type checking failed`);
+    if (!options.logger) {
+      log(`${red('ERROR:')} Type checking failed`);
+    }
     return err;
   }
   log(`${red('ERROR:')} Could not minify ${cyan(outputFilename)}`);
@@ -69,10 +71,14 @@ function handleClosureCompilerError(err, outputFilename, options) {
  * on Windows exceeds the command line size limit. The stream mode is 'IN'
  * because output files and sourcemaps are written directly to disk.
  * @param {Array<string>} flags
+ * @param {!Object} options
  * @return {!Object}
  */
-function initializeClosure(flags) {
-  const pluginOptions = {streamMode: 'IN', logger: logClosureCompilerError};
+function initializeClosure(flags, options) {
+  const pluginOptions = {
+    streamMode: 'IN',
+    logger: options.logger || logClosureCompilerError,
+  };
   return compiler.gulp()(flags, pluginOptions);
 }
 
@@ -88,7 +94,7 @@ function runClosure(outputFilename, options, flags, srcFiles) {
   return new Promise((resolve, reject) => {
     vinylFs
       .src(srcFiles, {base: getBabelOutputDir()})
-      .pipe(initializeClosure(flags))
+      .pipe(initializeClosure(flags, options))
       .on('error', (err) => {
         const reason = handleClosureCompilerError(err, outputFilename, options);
         reason ? reject(reason) : resolve();
@@ -99,5 +105,6 @@ function runClosure(outputFilename, options, flags, srcFiles) {
 }
 
 module.exports = {
+  logClosureCompilerError,
   runClosure,
 };

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -262,10 +262,8 @@ async function typeCheck(targetName) {
  * of closure errors.
  *
  * This is a temporary measure while we restore 100% typechecking.
- *
- * @param {Array<string>} entryPoints
  */
-async function ensureMinTypeQuality(entryPoints) {
+async function ensureMinTypeQuality() {
   const srcGlobs = ['src/**/*.js', 'extensions/**/*.js'];
   const errorsToCheckFor = [
     'JSC_BAD_JSDOC_ANNOTATION',
@@ -274,7 +272,7 @@ async function ensureMinTypeQuality(entryPoints) {
   ];
 
   let msg = '';
-  await closureCompile(entryPoints, './dist', `check-types.js`, {
+  await closureCompile('src/amp.js', './dist', `check-types.js`, {
     include3pDirectories: false,
     includePolyfills: false,
     typeCheckOnly: true,
@@ -317,7 +315,7 @@ async function checkTypes() {
   log(`Checking types for targets: ${targets.map(cyan).join(', ')}`);
   displayLifecycleDebugging();
 
-  await ensureMinTypeQuality(['src/amp.js']);
+  await ensureMinTypeQuality();
   await Promise.all(targets.map(typeCheck));
   exitCtrlcHandler(handlerProcess);
 }

--- a/extensions/amp-a4a/0.1/amp-ad-utils.js
+++ b/extensions/amp-a4a/0.1/amp-ad-utils.js
@@ -167,7 +167,7 @@ export function getAmpAdMetadata(creative) {
 /**
  * Merges any elements from customElementExtensions array into extensions array if
  * the element is not present.
- * @param {!Array<{custom-element: string, 'src': string}} extensions
+ * @param {!Array<{custom-element: string, 'src': string}>} extensions
  * @param {!Array<string>} customElementExtensions
  */
 export function mergeExtensionsMetadata(extensions, customElementExtensions) {

--- a/extensions/amp-accordion/1.0/component.type.js
+++ b/extensions/amp-accordion/1.0/component.type.js
@@ -57,7 +57,7 @@ AccordionDef.AccordionHeaderProps;
 /**
  * @typedef {{
  *   as: (string|PreactDef.FunctionalComponent|undefined),
- *   role: (string|undefined)
+ *   role: (string|undefined),
  *   className: (string|undefined),
  *   id: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -404,12 +404,17 @@ class AmpAddThis extends AMP.BaseElement {
   }
 
   /**
+   * @typedef {{
+   *   ampdoc: !../../../src/service/ampdoc-impl.AmpDoc,
+   *   loc: *,
+   *   pubId: *,
+   * }} SetupListenersInput
+   */
+
+  /**
    * Sets up listeners.
    *
-   * @param {!Object} input
-   * @param {!../../../src/service/ampdoc-impl.AmpDoc} [input.ampdoc]
-   * @param {*} [input.loc]
-   * @param {*} [input.pubId]
+   * @param {!SetupListenersInput} input
    * @memberof AmpAddThis
    */
   setupListeners_(input) {

--- a/extensions/amp-addthis/0.1/config-manager.js
+++ b/extensions/amp-addthis/0.1/config-manager.js
@@ -111,14 +111,19 @@ export class ConfigManager {
   }
 
   /**
-   * @param {!Object} input
-   * @param {*} [input.iframe]
-   * @param {string} [input.widgetId]
-   * @param {string} [input.pubId]
-   * @param {!Object} [input.shareConfig]
-   * @param {!Object} [input.atConfig]
-   * @param {string} [input.productCode]
-   * @param {string} [input.containerClassName]
+   * @typedef {{
+   *  iframe: *,
+   *  widgetId: string,
+   *  pubId: string,
+   *  shareConfig: !Object,
+   *  atConfig: !Object,
+   *  productCode: string,
+   *  containerClassName: string,
+   * }} SendConfigurationInput
+   */
+
+  /**
+   * @param {!SendConfigurationInput} input
    * @private
    */
   sendConfiguration_(input) {

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -99,14 +99,11 @@ let BoundElementDef;
 
 /**
  * The options bag for binding application.
- * - skipAmpState: If true, skips <amp-state> elements.
- * - constrain: If provided, restricts application to children of the provided elements.
- * - evaluateOnly: If provided, caches the evaluated result on each bound element and skips the actual DOM updates.
  *
  * @typedef {Record} ApplyOptionsDef
- * @property {boolean=} skipAmpState - If true, skips <amp-state> elements.
- * @property {Array<!Element>=} constrain
- * @property {boolean=} evaluateOnly
+ * @property {boolean=} skipAmpState If true, skips <amp-state> elements.
+ * @property {Array<!Element>=} constrain If provided, restricts application to children of the provided elements.
+ * @property {boolean=} evaluateOnly If provided, caches the evaluated result on each bound element and skips the actual DOM updates.
  */
 
 /**

--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -98,6 +98,18 @@ let BoundPropertyDef;
 let BoundElementDef;
 
 /**
+ * The options bag for binding application.
+ * - skipAmpState: If true, skips <amp-state> elements.
+ * - constrain: If provided, restricts application to children of the provided elements.
+ * - evaluateOnly: If provided, caches the evaluated result on each bound element and skips the actual DOM updates.
+ *
+ * @typedef {Record} ApplyOptionsDef
+ * @property {boolean=} skipAmpState - If true, skips <amp-state> elements.
+ * @property {Array<!Element>=} constrain
+ * @property {boolean=} evaluateOnly
+ */
+
+/**
  * A map of tag names to arrays of attributes that do not have non-bind
  * counterparts. For instance, amp-carousel allows a `[slide]` attribute,
  * but does not support a `slide` attribute.
@@ -1188,12 +1200,7 @@ export class Bind {
    * Applies expression results to elements in the document.
    *
    * @param {Object<string, BindExpressionResultDef>} results
-   * @param {!Object} opts
-   * @param {boolean=} opts.skipAmpState If true, skips <amp-state> elements.
-   * @param {Array<!Element>=} opts.constrain If provided, restricts application
-   *   to children of the provided elements.
-   * @param {boolean=} opts.evaluateOnly If provided, caches the evaluated
-   *   result on each bound element and skips the actual DOM updates.
+   * @param {!ApplyOptionsDef} opts
    * @return {!Promise}
    * @private
    */

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -142,7 +142,7 @@ class AmpBrightcove extends AMP.BaseElement {
   }
 
   /**
-   * @return {Promise[]}
+   * @return {Promise}
    */
   getConsents_() {
     const consentPolicy = super.getConsentPolicy();

--- a/extensions/amp-lightbox-gallery/1.0/component.type.js
+++ b/extensions/amp-lightbox-gallery/1.0/component.type.js
@@ -32,7 +32,7 @@ LightboxGalleryDef.Props;
  *   as: (string|undefined),
  *   children: (!PreactDef.Renderable),
  *   enableActivation: (boolean|undefined),
- *   onClick: (function(Event)|undefined)
+ *   onClick: (function(Event)|undefined),
  *   render: (function():PreactDef.Renderable),
  * }}
  */
@@ -42,7 +42,7 @@ LightboxGalleryDef.WithLightboxProps;
  * @typedef {{
  *   deregister: (function(string):undefined),
  *   register: (function(string, Element):undefined),
- *   open: (function:undefined),
+ *   open: (function():undefined),
  * }}
  */
 LightboxGalleryDef.ContextProps;

--- a/extensions/amp-lightbox/1.0/component.type.js
+++ b/extensions/amp-lightbox/1.0/component.type.js
@@ -23,12 +23,12 @@ var LightboxDef = {};
  *   id: (string),
  *   animation: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
- *   closeButtonAs: (function:PreactDef.Renderable|undefined),
+ *   closeButtonAs: (function():PreactDef.Renderable|undefined),
  *   scrollable: (boolean),
  *   initialOpen: (boolean),
- *   onBeforeOpen: (function|undefined),
- *   onAfterOpen: (function|undefined),
- *   onAfterClose: (function|undefined),
+ *   onBeforeOpen: (function():void|undefined),
+ *   onAfterOpen: (function():void|undefined),
+ *   onAfterClose: (function():void|undefined),
  * }}
  */
 LightboxDef.Props;
@@ -36,14 +36,14 @@ LightboxDef.Props;
 /**
  * @typedef {{
  *   aria-label: (string),
- *   as: (function:PreactDef.Renderable|undefined),
- *   onClick: function,
+ *   as: (function():PreactDef.Renderable|undefined),
+ *   onClick: function():void,
  * }}
  */
 LightboxDef.CloseButtonProps;
 
 /** @interface */
-Lightbox.LightboxApi = class {
+LightboxDef.LightboxApi = class {
   /** Open the lightbox */
   open() {}
 

--- a/extensions/amp-render/1.0/component.type.js
+++ b/extensions/amp-render/1.0/component.type.js
@@ -22,7 +22,7 @@ var RenderDef = {};
 /**
  * @typedef {{
  *   src: (!string),
- *   getJson: (!Function)
+ *   getJson: (!Function),
  *   render: (?RendererFunctionType|undefined),
  * }}
  */

--- a/extensions/amp-selector/1.0/component.type.js
+++ b/extensions/amp-selector/1.0/component.type.js
@@ -56,7 +56,7 @@ SelectorDef.OptionProps;
 /**
  * @typedef {{
  *   disabled: (boolean|undefined),
- *   focusRef: ({current: {active: *, focusMap: !Object}),
+ *   focusRef: ({current: {active: *, focusMap: !Object}}),
  *   keyboardSelectMode: (string|undefined),
  *   multiple: (boolean|undefined),
  *   optionsRef: ({current: !Array<*>}),

--- a/extensions/amp-sidebar/1.0/component.type.js
+++ b/extensions/amp-sidebar/1.0/component.type.js
@@ -23,9 +23,9 @@ var SidebarDef = {};
  * @typedef {{
  *   as: (string|PreactDef.FunctionalComponent|undefined),
  *   side: (string|undefined),
- *   onBeforeOpen: (function|undefined),
- *   onAfterOpen: (function|undefined),
- *   onAfterClose: (function|undefined),
+ *   onBeforeOpen: (function():void|undefined),
+ *   onAfterOpen: (function():void|undefined),
+ *   onAfterClose: (function():void|undefined),
  *   backdropStyle: (?Object|undefined),
  *   backdropClassName: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),

--- a/extensions/amp-sidebar/1.0/sidebar-animations-hook.js
+++ b/extensions/amp-sidebar/1.0/sidebar-animations-hook.js
@@ -49,12 +49,12 @@ function safelySetStyles(element, styles) {
 /**
  * @param {boolean} mounted
  * @param {boolean} opened
- * @param {{current: function|undefined}} onAfterOpen
- * @param {{current: function|undefined}} onAfterClose
+ * @param {{current: function():void} | {current: void}} onAfterOpen
+ * @param {{current: function():void} | {current: void}} onAfterClose
  * @param {string} side
- * @param {{current: Element|null}} sidebarRef
- * @param {{current: Element|null}} backdropRef
- * @param {function} setMounted
+ * @param {{current: (Element|null)}} sidebarRef
+ * @param {{current: (Element|null)}} backdropRef
+ * @param {function():undefined} setMounted
  */
 export function useSidebarAnimation(
   mounted,

--- a/extensions/amp-story-auto-ads/0.1/story-ad-page-manager.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page-manager.js
@@ -69,7 +69,7 @@ export class StoryAdPageManager {
     /** @private {!./story-ad-button-text-fitter.ButtonTextFitter} */
     this.buttonFitter_ = new ButtonTextFitter(this.ampdoc_);
 
-    /** @private {Object<string, StoryAdPage} */
+    /** @private {Object<string, StoryAdPage>} */
     this.pages_ = {};
 
     /** @private {!../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService} **/

--- a/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
@@ -111,7 +111,7 @@ export function getStoryAdMetadataFromElement(adElement) {
 /**
  * Returns a boolean indicating if there is sufficent metadata to render CTA.
  * @param {!StoryAdUIMetadata} metadata
- * @param {=boolean} opt_inabox
+ * @param {boolean=} opt_inabox
  * @return {boolean}
  */
 export function validateCtaMetadata(metadata, opt_inabox) {

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -236,7 +236,7 @@ const MAX_DEVICE_SPACES = 4;
  *  deviceHeight: ?number,
  *  deviceSpaces: number,
  * }} DeviceInfo
- * 
+ *
  * Contains the data related to the device.
  * Width and height refer to the story viewport, while deviceHeight is the device screen height.
  * The deviceSpaces refers to the MAX_DEVICE_SPACES, ensuring the devices on screen don't go over the max space set.

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -229,18 +229,18 @@ const MAX_DEVICE_SPACES = 4;
 /**
  * @typedef {{
  *  element: !Element,
- *  player: !Element
+ *  player: !Element,
  *  chip: !Element,
  *  width: number,
  *  height: number,
  *  deviceHeight: ?number,
  *  deviceSpaces: number,
- * }}
+ * }} DeviceInfo
+ * 
  * Contains the data related to the device.
  * Width and height refer to the story viewport, while deviceHeight is the device screen height.
  * The deviceSpaces refers to the MAX_DEVICE_SPACES, ensuring the devices on screen don't go over the max space set.
  */
-export let DeviceInfo;
 
 const DEFAULT_DEVICES = 'iphone11native;oneplus5t;pixel2';
 
@@ -363,7 +363,7 @@ function simplifyDeviceName(name) {
  * Eg: `devices="ipad;iphone"` will find the ipad and also the first device in ALL_DEVICES
  * that starts with "iphone" (ignoring case and symbols).
  * @param {string} queryHash
- * @return {any[]}
+ * @return {Array<*>}
  */
 function parseDevices(queryHash) {
   const screenSizes = [];

--- a/extensions/amp-subscriptions/0.1/entitlement.js
+++ b/extensions/amp-subscriptions/0.1/entitlement.js
@@ -24,6 +24,20 @@ export const GrantReason = {
 };
 
 /**
+ * The constructor arg for an {@link Entitlement}
+ *
+ * @typedef {{
+ *   source: string,
+ *   raw: string,
+ *   service: string,
+ *   granted: boolean,
+ *   grantReason: ?GrantReason,
+ *   dataObject: ?JsonObject,
+ *   decryptedDocumentKey: ?string
+ * }} EntitlementConstructorInputDef
+ */
+
+/**
  * The single entitlement object.
  */
 export class Entitlement {
@@ -41,14 +55,7 @@ export class Entitlement {
   }
 
   /**
-   * @param {Object} input
-   * @param {string} [input.source]
-   * @param {string} [input.raw]
-   * @param {string} [input.service]
-   * @param {boolean} [input.granted]
-   * @param {?GrantReason} [input.grantReason]
-   * @param {?JsonObject} [input.dataObject]
-   * @param {?string} [input.decryptedDocumentKey]
+   * @param {!EntitlementConstructorInputDef} input
    */
   constructor(input) {
     const {

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -193,7 +193,7 @@ export {VideoIframeInternal};
  * VideoWrapper using an <iframe> for implementation.
  * Usable on the AMP layer through VideoBaseElement.
  * @param {VideoIframeDef.Props} props
- * @param {{current: T|null}} ref
+ * @param {{current: (T|null)}} ref
  * @return {PreactDef.Renderable}
  * @template T
  */

--- a/src/amp-story-player/amp-story-player-viewport-observer.js
+++ b/src/amp-story-player/amp-story-player-viewport-observer.js
@@ -27,7 +27,7 @@ export class AmpStoryPlayerViewportObserver {
   /**
    * @param {!Window} win
    * @param {!Element} element
-   * @param {function} viewportCb
+   * @param {function():void} viewportCb
    */
   constructor(win, element, viewportCb) {
     /** @private {!Window} */
@@ -36,10 +36,10 @@ export class AmpStoryPlayerViewportObserver {
     /** @private {!Element} */
     this.element_ = element;
 
-    /** @private {function} */
+    /** @private {function():void} */
     this.cb_ = viewportCb;
 
-    /** @private {?function} */
+    /** @private {?function():void} */
     this.scrollHandler_ = null;
 
     this.initializeInObOrFallback_();

--- a/src/context/node.js
+++ b/src/context/node.js
@@ -396,7 +396,7 @@ export class ContextNode {
    * of factory is important to reduce bundling costs for context node.
    *
    * @param {*} id
-   * @param {fucntion(new:./subscriber.Subscriber, function(...?), !Array<!ContextProp>)} constr
+   * @param {function(new:./subscriber.Subscriber, function(...?), !Array<!ContextProp>):void} constr
    * @param {!Function} func
    * @param {!Array<!ContextProp>} deps
    */

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -89,7 +89,7 @@ function isTemplateTagSupported() {
  * Creates a named custom element class.
  *
  * @param {!Window} win The window in which to register the custom element.
- * @param {function(!./service/ampdoc-impl.AmpDoc, !AmpElement element, ?(typeof BaseElement))} elementConnectedCallback
+ * @param {function(!./service/ampdoc-impl.AmpDoc, !AmpElement, ?(typeof BaseElement))} elementConnectedCallback
  * @return {typeof AmpElement} The custom element class.
  */
 export function createCustomElementClass(win, elementConnectedCallback) {
@@ -107,7 +107,7 @@ export function createCustomElementClass(win, elementConnectedCallback) {
  * Creates a base custom element class.
  *
  * @param {!Window} win The window in which to register the custom element.
- * @param {function(!./service/ampdoc-impl.AmpDoc, !AmpElement element, ?(typeof BaseElement))} elementConnectedCallback
+ * @param {function(!./service/ampdoc-impl.AmpDoc, !AmpElement, ?(typeof BaseElement))} elementConnectedCallback
  * @return {typeof HTMLElement}
  */
 function createBaseCustomElementClass(win, elementConnectedCallback) {
@@ -2177,7 +2177,7 @@ function isInternalOrServiceNode(node) {
  *
  * @param {!Window} win The window in which to register the custom element.
  * @param {(typeof ./base-element.BaseElement)=} opt_implementationClass For testing only.
- * @param {function(!./service/ampdoc-impl.AmpDoc, !AmpElement element, ?(typeof BaseElement))=} opt_elementConnectedCallback
+ * @param {function(!./service/ampdoc-impl.AmpDoc, !AmpElement, ?(typeof BaseElement))=} opt_elementConnectedCallback
  * @return {!Object} Prototype of element.
  * @visibleForTesting
  */

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -32,7 +32,7 @@ import {parseUrlDeprecated} from '../../url';
 import {sequentialIdGenerator} from '../../utils/id-generator';
 import {useLayoutEffect, useMemo, useRef, useState} from '../../../src/preact';
 
-/** @type {!Object<string,function>} 3p frames for that type. */
+/** @type {!Object<string,function():void>} 3p frames for that type. */
 export const countGenerators = {};
 
 /** @enum {string} */

--- a/src/preact/component/component.type.js
+++ b/src/preact/component/component.type.js
@@ -63,7 +63,7 @@ var IframeEmbedDef = {};
  *   allowFullScreen: (boolean|undefined),
  *   allowTransparency: (boolean|undefined),
  *   loading: (string),
- *   manageMessageHandler: (function({current: HTMLIFrameElement}, function):function|undefined),
+ *   manageMessageHandler: (function({current: HTMLIFrameElement}, function():void):function():void|undefined),
  *   name: (string|undefined),
  *   onReadyState: (function(string)|undefined),
  *   ready: (boolean|undefined),

--- a/src/preact/slot.js
+++ b/src/preact/slot.js
@@ -142,7 +142,7 @@ export function useSlotContext(ref, opt_props) {
 
 /**
  * @param {!Element} slot
- * @param {function(!AmpElement|!Array<!AmpElement>)} action
+ * @param {function(!AmpElement):void|function(!Array<!AmpElement>):void} action
  */
 function execute(slot, action) {
   const assignedElements = slot.assignedElements


### PR DESCRIPTION
**summary**
- Fixes all `JSC_BAD_JSDOC_ANNOTATION`, `JSC_INVALID_PARAM`, and `JSC_TYPE_PARSE_ERROR` errors within `src` and `extensions` directories.
- Creates a new function that is run on each `amp check-types` that ensures these errors don't occur again in new code.

**sample failure when introducing a new malformed type**
![Screen Shot 2021-04-29 at 4 25 50 PM](https://user-images.githubusercontent.com/4656974/116614191-9b483d00-a907-11eb-94b9-c9ae5bc01844.png)
