### PR TITLE
🏗 Restrict all root-level upgrade groups to the root `package.json`

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -45,7 +45,7 @@
     },
     {
       "groupName": "core devDependencies",
-      "matchPaths": ["+(package.json)"],
+      "matchFiles": ["package.json"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "major": {"groupName": null},
       "labels": ["WG: infra"],
@@ -54,6 +54,7 @@
     },
     {
       "groupName": "linting devDependencies",
+      "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\b(prettier|eslint)\\b"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "major": {"groupName": null},
@@ -63,6 +64,7 @@
     },
     {
       "groupName": "babel devDependencies",
+      "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\bbabel"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "major": {"groupName": null},
@@ -72,6 +74,7 @@
     },
     {
       "groupName": "esbuild devDependencies",
+      "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\besbuild\\b"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "major": {"groupName": null},
@@ -81,6 +84,7 @@
     },
     {
       "groupName": "ampproject devDependencies",
+      "matchFiles": ["package.json"],
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
@@ -91,6 +95,7 @@
     },
     {
       "groupName": "ampproject dependencies",
+      "matchFiles": ["package.json"],
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
@@ -101,6 +106,7 @@
     },
     {
       "groupName": "core dependencies",
+      "matchFiles": ["package.json"],
       "excludePackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
This is part of the effort to streamline package updates and reduce unnecessary manual toil.

- In #34064, we enabled updates for `dependencies` (which had been ignored thus far and had bit-rotted)
- In #34082, we refined the grouping of `dependencies` to apply to just the sub-groups

These had a combined effect of unnecessarily splitting off subpackage-level `dependencies` (e.g. ones in `validator/`). The subgroups like `core`, `babel`, `linting`, `esbuild`, etc. should only apply to the root `package.json` file. This PR adds a `matchFiles` specification to the groups.

This should reduce the noise being seen by @ampproject/wg-caching while preventing their old `dependencies` from bit-rotting. (Sorry about that! I'll go in and make sure your existing set of many PRs is consolidated.)

**Reference:** https://docs.renovatebot.com/configuration-options

Partial fix for #33959

