### PR TITLE
🏗 Make package update review requests less noisy

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -25,10 +25,17 @@
       owners: [{name: 'ampproject/wg-infra'}],
     },
     {
-      pattern: '{babel.config.js,package.json,package-lock.json,package-scripts.js}',
+      pattern: '{babel.config.js,package-scripts.js}',
       owners: [
         {name: 'ampproject/wg-infra'},
         {name: 'ampproject/wg-performance'},
+      ],
+    },
+    {
+      pattern: '{package.json,package-lock.json}',
+      owners: [
+        {name: 'ampproject/wg-infra', requestReviews: false},
+        {name: 'ampproject/wg-performance', requestReviews: false},
       ],
     },
     {

--- a/extensions/amp-access/0.1/iframe-api/OWNERS
+++ b/extensions/amp-access/0.1/iframe-api/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      pattern: 'package.json',
+      pattern: '{package.json,package-lock.json}',
       owners: [
         {name: 'ampproject/wg-infra', requestReviews: false},
         {name: 'ampproject/wg-performance', requestReviews: false},

--- a/third_party/amp-toolbox-cache-url/OWNERS
+++ b/third_party/amp-toolbox-cache-url/OWNERS
@@ -4,7 +4,7 @@
 {
   rules: [
     {
-      pattern: 'package.json',
+      pattern: '{package.json,package-lock.json}',
       owners: [
         {name: 'ampproject/wg-infra', requestReviews: false},
         {name: 'ampproject/wg-performance', requestReviews: false},

--- a/validator/OWNERS
+++ b/validator/OWNERS
@@ -6,5 +6,9 @@
     {
       owners: [{name: 'ampproject/wg-caching', required: true}],
     },
+    {
+      pattern: '{package.json,package-lock.json}',
+      owners: [{name: 'ampproject/wg-caching', requestReviews: false}],
+    },
   ],
 }


### PR DESCRIPTION
This is part of the effort to streamline package updates and reduce unnecessary manual toil.

We're in the process of automating most package updates using an auto-review and auto-merge workflow for low-risk non-dependency PRs that pass all CI checks.

This PR separates out package upgrades and prevents owners-bot from automatically adding reviewers. Shortly, we're going to add an auto-approval bot to do this work. Working groups will still remain owners, and can manually merge PRs if they'd like.

This should reduce the noise being seen by working groups while preventing their npm packages from bit-rotting.

Partial fix for #33959

