### PR TITLE
🏗 Further group package updates to reduce noise

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -20,16 +20,14 @@
     {
       "groupName": "subpackage devDependencies",
       "matchPaths": ["**/*"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
+      "major": {"automerge": false, "assignAutomerge": false},
       "automerge": true,
       "assignAutomerge": true
     },
     {
       "groupName": "build-system devDependencies",
       "matchPaths": ["build-system/**"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
+      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra"],
       "automerge": true,
       "assignAutomerge": true
@@ -37,8 +35,7 @@
     {
       "groupName": "validator devDependencies",
       "matchPaths": ["validator/**"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
+      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: caching"],
       "automerge": true,
       "assignAutomerge": true
@@ -46,8 +43,7 @@
     {
       "groupName": "core devDependencies",
       "matchFiles": ["package.json"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
+      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra"],
       "automerge": true,
       "assignAutomerge": true
@@ -56,8 +52,7 @@
       "groupName": "linting devDependencies",
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\b(prettier|eslint)\\b"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
+      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra"],
       "automerge": true,
       "assignAutomerge": true
@@ -66,8 +61,7 @@
       "groupName": "babel devDependencies",
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\bbabel"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
+      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra", "WG: performance"],
       "automerge": true,
       "assignAutomerge": true
@@ -76,8 +70,7 @@
       "groupName": "esbuild devDependencies",
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\besbuild\\b"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
+      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra", "WG: performance"],
       "automerge": true,
       "assignAutomerge": true
@@ -87,9 +80,8 @@
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
-      "labels": ["WG: bento", "WG: performance"],
+      "major": {"automerge": false, "assignAutomerge": false},
+      "labels": ["WG: bento", "WG: components", "WG: performance"],
       "automerge": true,
       "assignAutomerge": true
     },
@@ -98,8 +90,6 @@
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
       "labels": ["WG: bento", "WG: components", "WG: performance"],
       "automerge": false,
       "assignAutomerge": false
@@ -109,8 +99,6 @@
       "matchFiles": ["package.json"],
       "excludePackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "major": {"groupName": null},
       "labels": ["WG: bento", "WG: components", "WG: performance"],
       "automerge": false,
       "assignAutomerge": false


### PR DESCRIPTION
This is part of the effort to streamline package updates and reduce unnecessary manual toil.

This PR tries a new approach to grouping package updates as far as possible, while not auto-merging `major` updates. The expectation is that this will further reduce PR noise over time (now that we're also updating our `dependencies`).

**Reference:** https://docs.renovatebot.com/configuration-options

Partial fix for #33959

