### PR TITLE
Ads/Runtime: move getIntersectionChangeEntry out of Runtime and into Ads only

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -596,6 +596,9 @@ AmpElement.prototype.expand = function () {};
 /** */
 AmpElement.prototype.collapse = function () {};
 
+/** */
+AmpElement.prototype.getIntersectionElementLayoutBox = function () {};
+
 let Signals = class {};
 /**
  * @param {string} unusedName

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1083,7 +1083,6 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js',
       'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
-      'extensions/amp-iframe/0.1/amp-iframe.js',
       'src/custom-element.js',
       'src/utils/intersection-observer-3p-host.js',
     ],

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1078,6 +1078,7 @@ const forbiddenTermsSrcInclusive = {
   '\\.getIntersectionElementLayoutBox': {
     message: measurementApiDeprecated,
     allowlist: [
+      'build-system/externs/amp.extern.js',
       'extensions/amp-a4a/0.1/amp-a4a.js',
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js',

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1078,11 +1078,13 @@ const forbiddenTermsSrcInclusive = {
   '\\.getIntersectionElementLayoutBox': {
     message: measurementApiDeprecated,
     allowlist: [
-      'src/utils/intersection-observer-3p-host.js',
       'extensions/amp-a4a/0.1/amp-a4a.js',
-      'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js',
+      'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
+      'extensions/amp-iframe/0.1/amp-iframe.js',
+      'src/custom-element.js',
+      'src/utils/intersection-observer-3p-host.js',
     ],
   },
   "require\\('fancy-log'\\)": {

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1030,6 +1030,7 @@ const forbiddenTermsSrcInclusive = {
       'src/service/mutator-impl.js',
       'src/service/resource.js',
       'src/service/resources-impl.js',
+      'src/utils/intersection-observer-3p-host.js',
       'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
       'extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js',
       'extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js',
@@ -1077,7 +1078,7 @@ const forbiddenTermsSrcInclusive = {
   '\\.getIntersectionElementLayoutBox': {
     message: measurementApiDeprecated,
     allowlist: [
-      'src/custom-element.js',
+      'src/utils/intersection-observer-3p-host.js',
       'extensions/amp-a4a/0.1/amp-a4a.js',
       'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -30,6 +30,8 @@ import {Services} from '#service';
 import {installRealTimeConfigServiceForDoc} from '#service/real-time-config/real-time-config-impl';
 import {installUrlReplacementsForEmbed} from '#service/url-replacements-impl';
 
+import {getIntersectionChangeEntry} from 'src/utils/intersection-observer-3p-host';
+
 import {A4AVariableSource} from './a4a-variable-source';
 import {getExtensionsFromMetadata} from './amp-ad-utils';
 import {processHead} from './head-validation';
@@ -2086,7 +2088,7 @@ export class AmpA4A extends AMP.BaseElement {
       this.sentinel
     );
 
-    const intersection = this.element.getIntersectionChangeEntry();
+    const intersection = getIntersectionChangeEntry(this.element);
     contextMetadata['_context']['initialIntersection'] =
       intersectionEntryToJson(intersection);
     return this.iframeRenderHelper_(
@@ -2161,7 +2163,7 @@ export class AmpA4A extends AMP.BaseElement {
         this.getAdditionalContextMetadata(method == XORIGIN_MODE.SAFEFRAME)
       );
 
-      const intersection = this.element.getIntersectionChangeEntry();
+      const intersection = getIntersectionChangeEntry(this.element);
       contextMetadata['initialIntersection'] =
         intersectionEntryToJson(intersection);
       if (method == XORIGIN_MODE.NAMEFRAME) {

--- a/extensions/amp-a4a/0.1/name-frame-renderer.js
+++ b/extensions/amp-a4a/0.1/name-frame-renderer.js
@@ -3,6 +3,8 @@ import {intersectionEntryToJson} from '#core/dom/layout/intersection';
 import {dict} from '#core/types/object';
 import {utf8Decode} from '#core/types/string/bytes';
 
+import {getIntersectionChangeEntry} from 'src/utils/intersection-observer-3p-host';
+
 import {Renderer} from './amp-ad-type-defs';
 
 import {getDefaultBootstrapBaseUrl} from '../../../src/3p-frame';
@@ -40,7 +42,7 @@ export class NameFrameRenderer extends Renderer {
     );
     contextMetadata['creative'] = creative;
 
-    const intersection = element.getIntersectionChangeEntry();
+    const intersection = getIntersectionChangeEntry(element);
     contextMetadata['_context']['initialIntersection'] =
       intersectionEntryToJson(intersection);
     const attributes = dict({

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -382,6 +382,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       const ampdocService = Services.ampdocServiceFor(doc.defaultView);
       return ampdocService.getAmpDoc(element);
     };
+    element.getOwner = () => null;
     element.isBuilt = () => {
       return true;
     };

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -389,6 +389,8 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
     element.getLayout = () => 'fixed';
     element.getLayoutBox = () => layoutBox;
     element.getLayoutSize = () => layoutSizeFromRect(layoutBox);
+    element.getIntersectionElementLayoutBox = () =>
+      layoutSizeFromRect(layoutBox);
     element.getIntersectionChangeEntry = () => {
       return {
         time: null,

--- a/extensions/amp-a4a/0.1/test/test-name-frame-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-name-frame-renderer.js
@@ -32,8 +32,8 @@ describes.realWin('NameFrameRenderer', realWinConfig, (env) => {
     containerElement = env.win.document.createElement('div');
     containerElement.setAttribute('height', 50);
     containerElement.setAttribute('width', 320);
+    containerElement.getIntersectionElementLayoutBox = () => ({});
     containerElement.getIntersectionChangeEntry = () => ({
-      time: null,
       boundingClientRect: {},
       rootBounds: {},
       intersectionRect: {},

--- a/extensions/amp-a4a/0.1/test/test-name-frame-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-name-frame-renderer.js
@@ -38,6 +38,9 @@ describes.realWin('NameFrameRenderer', realWinConfig, (env) => {
       rootBounds: {},
       intersectionRect: {},
     });
+    containerElement.getOwner = () => undefined;
+    containerElement.getLayoutBox = () => ({});
+    containerElement.getAmpDoc = () => env.ampdoc;
     env.win.document.body.appendChild(containerElement);
 
     await new NameFrameRenderer().render(

--- a/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
@@ -39,11 +39,6 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
       width: 0,
       height: 0,
     });
-    containerElement.getIntersectionChangeEntry = () => ({
-      rootBounds: {},
-      intersectionRect: {},
-      boundingClientRect: {},
-    });
     containerElement.isInViewport = () => true;
     containerElement.getAmpDoc = () => env.ampdoc;
     doc.body.appendChild(containerElement);

--- a/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
@@ -40,6 +40,8 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
       width: 0,
       height: 0,
     });
+    containerElement.getIntersectionElementLayoutBox = () =>
+      containerElement.getLayoutBox();
     containerElement.isInViewport = () => true;
     containerElement.getAmpDoc = () => env.ampdoc;
     doc.body.appendChild(containerElement);

--- a/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
+++ b/extensions/amp-ad-custom/0.1/test/test-amp-ad-custom.js
@@ -32,6 +32,7 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
       reset: () => {},
       whenSignal: () => Promise.resolve(),
     });
+    containerElement.getOwner = () => undefined;
     containerElement.renderStarted = () => {};
     containerElement.getLayoutBox = () => ({
       left: 0,

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -39,6 +39,7 @@ import {
   unobserveWithSharedInOb,
 } from '#core/dom/layout/viewport-observer';
 import {toWin} from '#core/window';
+import {getIntersectionChangeEntry} from '../../../src/utils/intersection-observer-3p-host';
 
 /** @const {string} Tag name for 3P AD implementation. */
 export const TAG_3P_IMPL = 'amp-ad-3p-impl';
@@ -394,7 +395,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         // here, though, allows us to measure the impact of ad throttling via
         // incrementLoadingAds().
 
-        const intersection = this.element.getIntersectionChangeEntry();
+        const intersection = getIntersectionChangeEntry(this.element);
         const iframe = getIframe(
           toWin(this.element.ownerDocument.defaultView),
           this.element,

--- a/extensions/amp-ad/0.1/test/test-legacy-ad-intersection-observer-host.js
+++ b/extensions/amp-ad/0.1/test/test-legacy-ad-intersection-observer-host.js
@@ -2,7 +2,7 @@ import {BaseElement} from '../../../../src/base-element';
 import {LegacyAdIntersectionObserverHost} from '../legacy-ad-intersection-observer-host';
 import {createAmpElementForTesting} from '../../../../src/custom-element';
 import {deserializeMessage} from '#core/3p-frame-messaging';
-import {getIntersectionChangeEntry} from '../../../../src/utils/intersection-observer-3p-host';
+import {getIntersectionChangeEntryHelper} from '../../../../src/utils/intersection-observer-3p-host';
 import {layoutRectLtwh} from '#core/dom/layout/rect';
 
 describes.sandboxed('IntersectionObserverHostForAd', {}, (env) => {
@@ -24,7 +24,7 @@ describes.sandboxed('IntersectionObserverHostForAd', {}, (env) => {
   function getInObEntry() {
     const rootBounds = layoutRectLtwh(198, 299, 100, 100);
     const layoutBox = layoutRectLtwh(50, 100, 150, 200);
-    return getIntersectionChangeEntry(layoutBox, null, rootBounds);
+    return getIntersectionChangeEntryHelper(layoutBox, null, rootBounds);
   }
 
   function getIframe(src) {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -32,7 +32,6 @@ import {
 import {dev, devAssert, user, userAssert} from './log';
 import {getMode} from './mode';
 import {applyStaticLayout} from './static-layout';
-import {getIntersectionChangeEntry} from './utils/intersection-observer-3p-host';
 
 const TAG = 'CustomElement';
 
@@ -1473,24 +1472,6 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      */
     getOwner() {
       return this.getResource_().getOwner();
-    }
-
-    /**
-     * Returns a change entry for that should be compatible with
-     * IntersectionObserverEntry.
-     * @return {?IntersectionObserverEntry} A change entry.
-     * @final
-     */
-    getIntersectionChangeEntry() {
-      const box = this.impl_
-        ? this.impl_.getIntersectionElementLayoutBox()
-        : this.getLayoutBox();
-      const owner = this.getOwner();
-      const viewport = Services.viewportForDoc(this.getAmpDoc());
-      const viewportBox = viewport.getRect();
-      // TODO(jridgewell, #4826): We may need to make this recursive.
-      const ownerBox = owner && owner.getLayoutBox();
-      return getIntersectionChangeEntry(box, ownerBox, viewportBox);
     }
 
     /**

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1458,6 +1458,17 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     }
 
     /**
+     * Returns the layout rectangle used for calculating this element's
+     * intersection with the viewport.
+     * @return {!./layout-rect.LayoutRectDef}
+     */
+    getIntersectionElementLayoutBox() {
+      return this.impl_
+        ? this.impl_.getIntersectionElementLayoutBox()
+        : this.getLayoutBox();
+    }
+
+    /**
      * Returns a previously measured layout size.
      * @return {!./layout-rect.LayoutSizeDef}
      * @final

--- a/src/utils/intersection-observer-3p-host.js
+++ b/src/utils/intersection-observer-3p-host.js
@@ -63,9 +63,7 @@ export function getIntersectionChangeEntryHelper(
  * @return {?IntersectionObserverEntry} A change entry.
  */
 export function getIntersectionChangeEntry(element) {
-  const box = element.impl_
-    ? element.impl_.getIntersectionElementLayoutBox()
-    : element.getLayoutBox();
+  const box = element.getIntersectionElementLayoutBox();
   const ownerBox = element.getOwner()?.getLayoutBox();
   const viewportBox = Services.viewportForDoc(element.getAmpDoc()).getRect();
 

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -375,14 +375,6 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(element.signals().get(CommonSignals.LOAD_END)).to.be.ok;
       });
 
-      it('Element - getIntersectionChangeEntry', () => {
-        const element = new ElementClass();
-        container.appendChild(element);
-        element.updateLayoutBox({top: 0, left: 0, width: 111, height: 51});
-        element.getIntersectionChangeEntry();
-        expect(testElementGetInsersectionElementLayoutBox).to.be.calledOnce;
-      });
-
       it('Element - updateLayoutBox', () => {
         const element = new ElementClass();
         container.appendChild(element);

--- a/test/unit/test-intersection-observer-polyfill.js
+++ b/test/unit/test-intersection-observer-polyfill.js
@@ -5,7 +5,7 @@ import {installHiddenObserverForDoc} from '#service/hidden-observer-impl';
 
 import {
   IntersectionObserver3pHost,
-  getIntersectionChangeEntry,
+  getIntersectionChangeEntryHelper,
   intersectionRatio,
 } from '../../src/utils/intersection-observer-3p-host';
 
@@ -110,7 +110,7 @@ describes.sandboxed('getIntersectionChangeEntry', {}, (env) => {
 
   it('without owner', () => {
     expect(
-      getIntersectionChangeEntry(
+      getIntersectionChangeEntryHelper(
         layoutRectLtwh(0, 100, 50, 50),
         null,
         layoutRectLtwh(0, 100, 100, 100)
@@ -123,7 +123,7 @@ describes.sandboxed('getIntersectionChangeEntry', {}, (env) => {
       intersectionRatio: 1,
     });
     expect(
-      getIntersectionChangeEntry(
+      getIntersectionChangeEntryHelper(
         layoutRectLtwh(50, 200, 150, 200),
         null,
         layoutRectLtwh(0, 100, 100, 100)
@@ -138,7 +138,7 @@ describes.sandboxed('getIntersectionChangeEntry', {}, (env) => {
   });
   it('with owner', () => {
     expect(
-      getIntersectionChangeEntry(
+      getIntersectionChangeEntryHelper(
         layoutRectLtwh(50, 50, 150, 200),
         layoutRectLtwh(0, 50, 100, 100),
         layoutRectLtwh(0, 100, 100, 100)


### PR DESCRIPTION
**summary**
I have been attempting to remove all usages of `getIntersectionChangeEntry` from the Runtime since last December (https://github.com/ampproject/amphtml/pull/31753). One last usage has been particularly tricky to remove because of being part of the ads render flow, and the requirement to ensure it doesn't degrade impressions.

This PR opts to remove ads as a blocker, by simply moving all the same logic to `ads` folders and out of `custom-element`. Note: this creates a usage of `custom-element.getLayoutBox`, but we can deal with that in a future PR.


**changes**
- Renames `getIntersectionChangeEntry` within intersection-observer-3p-host to `getIntersectionChangeEntryHelper`.
- Moves `getIntersectionChangeEntry` from custom-element to intersection-observer-3p-host, and updates all the associated tests.

---

Size changes:
```
dist/v0/amp-apester-media-0.1.mjs: Δ +0.03KB
dist/v0/amp-iframe-0.1.js: Δ -0.01KB
dist/v0/amp-apester-media-0.1.js: Δ -0.01KB
dist/compiler.mjs: Δ +0.02KB
dist/compiler.js: Δ -0.01KB
dist/v0/amp-ad-0.1.mjs: Δ +0.23KB
dist/v0/amp-ad-0.1.js: Δ +0.24KB
dist/v0/amp-ad-custom-0.1.mjs: Δ +0.22KB
dist/v0/amp-ad-custom-0.1.js: Δ +0.29KB
dist/v0/amp-ad-network-dianomi-impl-0.1.mjs: Δ +0.31KB
dist/v0/amp-ad-network-nws-impl-0.1.mjs: Δ +0.26KB
dist/v0/amp-ad-network-adzerk-impl-0.1.mjs: Δ +0.28KB
dist/v0/amp-ad-network-fake-impl-0.1.mjs: Δ +0.27KB
dist/v0/amp-ad-network-dianomi-impl-0.1.js: Δ +0.20KB
dist/v0/amp-ad-network-nws-impl-0.1.js: Δ +0.19KB
dist/v0/amp-ad-network-adzerk-impl-0.1.js: Δ +0.26KB
dist/v0/amp-ad-network-fake-impl-0.1.js: Δ +0.24KB
dist/v0/amp-ad-network-valueimpression-impl-0.1.mjs: Δ +0.23KB
dist/v0/amp-ad-network-valueimpression-impl-0.1.js: Δ +0.20KB
dist/v0/amp-ad-network-adsense-impl-0.1.mjs: Δ +0.23KB
dist/v0/amp-ad-network-adsense-impl-0.1.js: Δ +0.30KB
dist/amp4ads-v0.mjs: Δ -0.19KB
dist/v0/amp-ad-network-doubleclick-impl-0.1.mjs: Δ +0.22KB
dist/v0/amp-ad-network-doubleclick-impl-0.1.js: Δ +0.20KB
dist/amp4ads-v0.js: Δ -0.22KB
dist/shadow-v0.mjs: Δ -0.22KB
dist/v0.mjs: Δ -0.19KB
dist/shadow-v0.js: Δ -0.22KB
dist/v0.js: Δ -0.24KB
```