### PR TITLE
 🏗 Also add `renovate-approve` as an owner for package updates

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -40,7 +40,7 @@
     },
     {
       pattern: '**/package{,-lock}.json',
-      owners: [{name: 'renovate-bot'}],
+      owners: [{name: 'renovate-bot'}, {name: 'renovate-approve'}],
     },
     {
       pattern: '**/OWNERS',


### PR DESCRIPTION
#34145 added @renovate-bot as an owner of package updates because that's the underlying github ID used by the `renovate-approve` bot account.

The owners bot [documentation](https://github.com/ampproject/amp-github-apps/blob/46d0fa09054cee569595b1f2053b8e03c4e2dd37/owners/OWNERS.example#L54-L55) says `name` should be a "github username". However, the owners check wasn't satisfied by `renovate-bot` (see #34140 and #34139).

This PR also adds `renovate-approve` as an owner in the hope that it satisfies the check. 🤞 

Partial fix for #33959

