### PR TITLE
[bento][amp-sidebar] SSR compatible design for Sidebar Toolbar

### DIFF
--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -212,6 +212,7 @@ export function SidebarToolbar({
     if (!win) {
       return;
     }
+
     setMediaQuery(sanitizeMediaQuery(win, mediaQueryProp));
   }, [mediaQueryProp]);
 

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -253,7 +253,7 @@ export function SidebarToolbar({
 /**
  * @param {!Window} win
  * @param {string|undefined} query
- * @return {boolean}
+ * @return {string}
  */
 function sanitizeMediaQuery(win, query) {
   return win.matchMedia(query).media;

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -192,18 +192,23 @@ export function SidebarToolbar({
   ...rest
 }) {
   const ref = useRef(null);
-  const [target, setTarget] = useState();
+  const [target, setTarget] = useState(null);
 
   useEffect(() => {
+    const doc = ref.current?.ownerDocument;
+    if (!doc) {
+      return;
+    }
+
     const selector = `#${escapeCssSelectorIdent(toolbarTarget)}`;
-    const newTarget = document.querySelector(selector);
+    const newTarget = doc.querySelector(selector);
     setTarget(newTarget);
   }, [toolbarTarget]);
 
   useEffect(() => {
     const element = ref.current;
     const doc = ref.current?.ownerDocument;
-    if (!element || !doc || !target) {
+    if (!doc || !target) {
       return;
     }
 

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -231,10 +231,8 @@ export function SidebarToolbar({
     targetEl.appendChild(clone);
     targetEl.appendChild(style);
     return () => {
-      if (targetEl) {
-        targetEl.removeChild(clone);
-        targetEl.removeChild(style);
-      }
+      targetEl.removeChild(clone);
+      targetEl.removeChild(style);
     };
   }, [mediaQuery, toolbarTarget, targetEl]);
 

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -200,9 +200,7 @@ export function SidebarToolbar({
       return;
     }
 
-    const selector = `#${escapeCssSelectorIdent(toolbarTarget)}`;
-    const newTarget = doc.querySelector(selector);
-    setTarget(newTarget);
+    setTarget(doc.getElementById(toolbarTarget));
   }, [toolbarTarget]);
 
   useEffect(() => {
@@ -222,8 +220,8 @@ export function SidebarToolbar({
     target.appendChild(style);
     return () => {
       if (target) {
-        clone && target.removeChild(clone);
-        style && target.removeChild(style);
+        target.removeChild(clone);
+        target.removeChild(style);
       }
     };
   }, [mediaQueryProp, toolbarTarget, target]);

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -18,6 +18,7 @@ import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {Side} from './sidebar-config';
+import {escapeCssSelectorIdent} from '../../../src/core/dom/css';
 import {forwardRef} from '../../../src/preact/compat';
 import {isRTL} from '../../../src/dom';
 import {
@@ -190,11 +191,11 @@ export function SidebarToolbar({
   children,
   ...rest
 }) {
-  const ref = useRef();
+  const ref = useRef(null);
   const [target, setTarget] = useState();
 
   useEffect(() => {
-    const selector = `#${CSS.escape(toolbarTarget)}`;
+    const selector = `#${escapeCssSelectorIdent(toolbarTarget)}`;
     const newTarget = document.querySelector(selector);
     setTarget(newTarget);
   }, [toolbarTarget]);
@@ -208,21 +209,17 @@ export function SidebarToolbar({
 
     const clone = element.cloneNode(true);
     const style = doc.createElement('style');
-    style./*OK*/ innerHTML = `
-    #${toolbarTarget} {
-        display: none;
-    }
-    @media ${mediaQueryProp} {
-      #${toolbarTarget} {
-        display: initial;
-      }
-    }`;
+    style./*OK*/ textContent =
+      `#${toolbarTarget}{display: none;}` +
+      `@media ${mediaQueryProp}{#${toolbarTarget}{display: initial;}}`;
 
     target.appendChild(clone);
     target.appendChild(style);
     return () => {
-      target.removeChild(clone);
-      target.removeChild(style);
+      if (target) {
+        clone && target.removeChild(clone);
+        style && target.removeChild(style);
+      }
     };
   }, [mediaQueryProp, toolbarTarget, target]);
 

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -212,9 +212,7 @@ export function SidebarToolbar({
     if (!win) {
       return;
     }
-    setMediaQuery(
-      isValidMediaQuery(win, mediaQueryProp) ? mediaQueryProp : null
-    );
+    setMediaQuery(sanitizeMediaQuery(win, mediaQueryProp));
   }, [mediaQueryProp]);
 
   useEffect(() => {
@@ -257,11 +255,6 @@ export function SidebarToolbar({
  * @param {string|undefined} query
  * @return {boolean}
  */
-function isValidMediaQuery(win, query) {
-  try {
-    win.matchMedia(query);
-    return true;
-  } catch {
-    return false;
-  }
+function sanitizeMediaQuery(win, query) {
+  return win.matchMedia(query).media;
 }

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -18,7 +18,6 @@ import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {Side} from './sidebar-config';
-import {escapeCssSelectorIdent} from '../../../src/core/dom/css';
 import {forwardRef} from '../../../src/preact/compat';
 import {isRTL} from '../../../src/dom';
 import {

--- a/extensions/amp-sidebar/1.0/test/test-component.js
+++ b/extensions/amp-sidebar/1.0/test/test-component.js
@@ -681,7 +681,7 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       document.body.removeChild(target);
     });
 
-    it('toolbar target receives content when media query is true', () => {
+    it('toolbar target receives expected content from toolbar', () => {
       // this media query is always true
       mediaQuery = '';
       wrapper = mount(
@@ -698,12 +698,40 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
         </>
       );
 
-      // Toolbar target should have children
+      // Toolbar nodes were appended to the target
       expect(target.hasChildNodes()).to.be.true;
+      expect(target.childElementCount).to.equal(2);
+      expect(target.firstElementChild.nodeName).to.equal('NAV');
+      expect(target.lastElementChild.nodeName).to.equal('STYLE');
     });
 
-    it('toolbar target does not receive content when media query is false', () => {
+    it('existing children in toolbar target are not overwritten', () => {
       // this media query is always true
+      mediaQuery = '';
+      target.innerHTML = '<span>hello world<span>';
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref} side="left">
+            <div>Content</div>
+            <SidebarToolbar toolbar={mediaQuery} toolbarTarget="toolbar-target">
+              <ul>
+                <li>Toolbar Item 1</li>
+                <li>Toolbar Item 2</li>
+              </ul>
+            </SidebarToolbar>
+          </Sidebar>
+        </>
+      );
+
+      // Toolbar target now has 3 nodes, 1 existing, 2 appended from toolbar
+      expect(target.hasChildNodes()).to.be.true;
+      expect(target.childElementCount).to.equal(3);
+      expect(target.children[1].nodeName).to.equal('NAV');
+      expect(target.lastElementChild.nodeName).to.equal('STYLE');
+    });
+
+    it('verify toolbar target content is removed on unmount', () => {
+      // this media query is always false
       mediaQuery = 'false';
       wrapper = mount(
         <>
@@ -719,117 +747,11 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
         </>
       );
 
-      // Toolbar target should have children
+      expect(target.hasChildNodes()).to.be.true;
+      expect(target.childElementCount).to.equal(2);
+
+      wrapper.unmount();
       expect(target.hasChildNodes()).to.be.false;
-    });
-
-    it('toolbar target content changes when sidebar is opened and closed', () => {
-      // disable animations for synchronous testing
-      const animateFunction = Element.prototype.animate;
-      Element.prototype.animate = null;
-
-      // this media query is always true
-      mediaQuery = '';
-      wrapper = mount(
-        <>
-          <Sidebar ref={ref} side="left">
-            <div>Content</div>
-            <SidebarToolbar toolbar={mediaQuery} toolbarTarget="toolbar-target">
-              <ul>
-                <li>Toolbar Item 1</li>
-                <li>Toolbar Item 2</li>
-              </ul>
-            </SidebarToolbar>
-          </Sidebar>
-          <button id="open" onClick={() => ref.current.open()}></button>
-          <button id="close" onClick={() => ref.current.close()}></button>
-        </>
-      );
-
-      const openButton = wrapper.find('#open');
-      const closeButton = wrapper.find('#close');
-
-      // verify sidebar is closed
-      let sidebarElement = wrapper.find(Sidebar).getDOMNode();
-      expect(isOpened(sidebarElement)).to.be.false;
-
-      // Toolbar target should have children
-      expect(target.hasChildNodes()).to.be.true;
-
-      // click to open the sidebar
-      openButton.simulate('click');
-
-      // verify sidebar is opened and toolbar has children
-      sidebarElement = wrapper.find(Sidebar).getDOMNode();
-      expect(isOpened(sidebarElement)).to.be.true;
-      expect(target.hasChildNodes()).to.be.true;
-
-      // click to close the sidebar
-      closeButton.simulate('click');
-
-      // verify sidebar is closed and toolbar has children
-      sidebarElement = wrapper.find(Sidebar).getDOMNode();
-      expect(isOpened(sidebarElement)).to.be.false;
-      expect(target.hasChildNodes()).to.be.true;
-
-      Element.prototype.animate = animateFunction;
-    });
-
-    it('toolbar target content updates when media query truthiness change', () => {
-      // disable animations for synchronous testing
-      const animateFunction = Element.prototype.animate;
-      Element.prototype.animate = null;
-
-      // mock the media query to manually update matching
-      let mockMediaQueryList;
-      window.matchMedia = (media) => {
-        const mql = matchMediaFunction(media);
-        mockMediaQueryList = {
-          matches: mql.matches,
-          addEventListener: function (type, callback) {
-            this.callback = callback;
-          },
-          removeEventListener: function () {
-            this.callback = null;
-          },
-        };
-        return mockMediaQueryList;
-      };
-
-      // this media query is always true
-      mediaQuery = '';
-      wrapper = mount(
-        <>
-          <Sidebar ref={ref} side="left">
-            <div>Content</div>
-            <SidebarToolbar toolbar={mediaQuery} toolbarTarget="toolbar-target">
-              <ul>
-                <li>Toolbar Item 1</li>
-                <li>Toolbar Item 2</li>
-              </ul>
-            </SidebarToolbar>
-          </Sidebar>
-        </>
-      );
-
-      // media query is true so toolbar-target should have content
-      expect(target.hasChildNodes()).to.be.true;
-
-      // update the media query to be false (mocked)
-      // verify toolbar-target no longer has children
-      mockMediaQueryList.matches = false;
-      mockMediaQueryList.callback();
-      wrapper.update();
-      expect(target.hasChildNodes()).to.be.false;
-
-      // update the media query to be true (mocked)
-      // verify toolbar-target has children
-      mockMediaQueryList.matches = true;
-      mockMediaQueryList.callback();
-      wrapper.update();
-      expect(target.hasChildNodes()).to.be.true;
-
-      Element.prototype.animate = animateFunction;
     });
   });
 });

--- a/extensions/amp-sidebar/1.0/test/test-component.js
+++ b/extensions/amp-sidebar/1.0/test/test-component.js
@@ -726,13 +726,14 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       // Toolbar target now has 3 nodes, 1 existing, 2 appended from toolbar
       expect(target.hasChildNodes()).to.be.true;
       expect(target.childElementCount).to.equal(3);
+      expect(target.firstElementChild.nodeName).to.equal('SPAN');
       expect(target.children[1].nodeName).to.equal('NAV');
       expect(target.lastElementChild.nodeName).to.equal('STYLE');
     });
 
     it('verify toolbar target content is removed on unmount', () => {
       // this media query is always false
-      mediaQuery = 'false';
+      mediaQuery = '(max-height: 0px)';
       wrapper = mount(
         <>
           <Sidebar ref={ref} side="left">

--- a/extensions/amp-sidebar/1.0/test/test-component.js
+++ b/extensions/amp-sidebar/1.0/test/test-component.js
@@ -681,7 +681,7 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       document.body.removeChild(target);
     });
 
-    it('toolbar target receives expected content from toolbar', () => {
+    it('toolbar target should receive expected content from toolbar', () => {
       // this media query is always true
       mediaQuery = '';
       wrapper = mount(
@@ -705,7 +705,7 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(target.lastElementChild.nodeName).to.equal('STYLE');
     });
 
-    it('existing children in toolbar target are not overwritten', () => {
+    it('existing children in toolbar target should not be overwritten', () => {
       // this media query is always true
       mediaQuery = '';
       target.innerHTML = '<span>hello world<span>';
@@ -731,7 +731,7 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(target.lastElementChild.nodeName).to.equal('STYLE');
     });
 
-    it('verify toolbar target content is removed on unmount', () => {
+    it('toolbar target content should be removed on unmount', () => {
       // this media query is always false
       mediaQuery = '(max-height: 0px)';
       wrapper = mount(
@@ -752,6 +752,54 @@ describes.sandboxed('Sidebar preact component', {}, (env) => {
       expect(target.childElementCount).to.equal(2);
 
       wrapper.unmount();
+      expect(target.hasChildNodes()).to.be.false;
+    });
+
+    it('toolbar should sanitize an invalid media query', () => {
+      // this is an invalid media query
+      mediaQuery = 'foo {}';
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref} side="left">
+            <div>Content</div>
+            <SidebarToolbar toolbar={mediaQuery} toolbarTarget="toolbar-target">
+              <ul>
+                <li>Toolbar Item 1</li>
+                <li>Toolbar Item 2</li>
+              </ul>
+            </SidebarToolbar>
+          </Sidebar>
+        </>
+      );
+
+      expect(target.hasChildNodes()).to.be.true;
+      expect(target.childElementCount).to.equal(2);
+      const styleElementText = target.lastElementChild.textContent;
+      expect(styleElementText).to.include('not all'); //sanitized media query
+      expect(styleElementText).not.to.include('foo'); //unsanitized media query
+    });
+
+    it('toolbar should sanitize the toolbar target attribute', () => {
+      // this media query is always true
+      mediaQuery = '';
+      const toolbarTarget = 'toolbar-target:.';
+      const getElementByIdSpy = env.sandbox.spy(document, 'getElementById');
+      wrapper = mount(
+        <>
+          <Sidebar ref={ref} side="left">
+            <div>Content</div>
+            <SidebarToolbar toolbar={mediaQuery} toolbarTarget={toolbarTarget}>
+              <ul>
+                <li>Toolbar Item 1</li>
+                <li>Toolbar Item 2</li>
+              </ul>
+            </SidebarToolbar>
+          </Sidebar>
+        </>
+      );
+
+      expect(getElementByIdSpy).to.be.calledOnce;
+      expect(getElementByIdSpy).to.be.calledWith('toolbar-target\\:\\.');
       expect(target.hasChildNodes()).to.be.false;
     });
   });


### PR DESCRIPTION
Updating the Preact component to an SSR compatible design.  See `Design Proposal: Media Query Based Approach` on page 3 of [AMP Sidebar Design Doc](https://docs.google.com/document/d/1YPQ1ObQc0qpLm01TgsXACnwVwYppwZI_8ETBfK0wyOA/edit#heading=h.4zli8r3l75p6)

This PR updates the Preact side only.  Design works by duplicating `Toolbar` into the `Toolbar Target Element` and appending a style element that controls visibility of the duplicated `Toolbar` using a media query in CSS.

One optimization over the previous iteration is that duplicating of nodes is done with `Node.cloneNode()` instead of relying on portals.  This matches the 0.1 design AND solves the `ref` issue encountered in the previous design.  (The issue was inconsistent ref behavior between Preact vs React).  Now a `ref` to the Toolbar element will only point to the original element and not the cloned element.

Here is a test in React for reference: https://codepen.io/krdwan/pen/wvgLeNR?editors=1111
Preact can be tested directly in the storybook.