### PR TITLE
🏗 Optionally exclude JSS with `make-extension --nojss`

### DIFF
--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -229,15 +229,23 @@ async function makeExtensionFromTemplates(
       options.bento ? "experiments: ['bento']," : '',
     ...(!options.nocss
       ? {
+          '__css_import__': `import {CSS} from '../../../build/amp-${name}-${version}.css'`,
+          '__css_id__': `CSS`,
+          '__register_element_args__': `TAG, Amp${namePascalCase}, CSS`,
+        }
+      : {
+          '__css_import__': '',
+          '__css_id__': '',
+          '__register_element_args__': `TAG, Amp${namePascalCase}`,
+        }),
+    ...(!options.nojss
+      ? {
           '__jss_import_component_css__': `import {CSS as COMPONENT_CSS} from './component.jss'`,
           '__jss_component_css__': 'COMPONENT_CSS',
           '__jss_import_use_styles__': `import {useStyles} from './component.jss'`,
           '__jss_styles_use_styles__': 'const styles = useStyles()',
           '__jss_styles_example_or_placeholder__':
             '`${styles.exampleContentHidden}`',
-          '__css_import__': `import {CSS} from '../../../build/amp-${name}-${version}.css'`,
-          '__css_id__': `CSS`,
-          '__register_element_args__': `TAG, Amp${namePascalCase}, CSS`,
         }
       : {
           '__jss_import_component_css_': '',
@@ -245,9 +253,6 @@ async function makeExtensionFromTemplates(
           '__jss_import_use_styles__': '',
           '__jss_styles_use_styles__': '',
           '__jss_styles_example_or_placeholder__': `'my-classname'`,
-          '__css_import__': '',
-          '__css_id__': '',
-          '__register_element_args__': `TAG, Amp${namePascalCase}`,
         }),
     // eslint-disable-next-line local/no-forbidden-terms
     // This allows generated code to contain "DO NOT SUBMIT", which will cause
@@ -373,14 +378,14 @@ async function runExtensionTests(name) {
 async function makeExtension() {
   let testError;
 
-  const {bento, nocss} = argv;
+  const {bento, nocss, nojss} = argv;
 
   const templateDirs = objstr({
     shared: true,
     bento,
     classic: !bento,
     css: !nocss,
-    jss: bento && !nocss,
+    jss: bento && !nojss,
   })
     .split(/\s+/)
     .map((name) => getTemplateDir(name));
@@ -429,7 +434,9 @@ makeExtension.flags = {
   name: 'The name of the extension. The prefix `amp-*` is added if necessary',
   cleanup: 'Undo file changes before exiting. This is useful alongside --test',
   bento: 'Generate a Bento component',
-  nocss: 'Exclude extension-specific CSS',
+  nocss:
+    'Exclude extension-specific CSS. (If specifying --bento, JSS is still generated unless combined with --nojss)',
+  nojss: 'Exclude extension-specific JSS when specifying --bento.',
   test: 'Build and test the generated extension',
   version: 'Sets the version number (default: 0.1; or 1.0 with --bento)',
   overwrite:

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
@@ -36,7 +36,7 @@ BaseElement['layoutSizeDefined'] = true;
 /** @override */
 BaseElement['usesShadowDom'] = true;
 
-// DO NOT SUBMIT: If BaseElement['shadowCss']  is set to `null`, remove the
+// __do_not_submit__: If BaseElement['shadowCss']  is set to `null`, remove the
 // following declaration.
 // Otherwise, keep it when defined to an actual value like `COMPONENT_CSS`.
 // Once addressed, remove this set of comments.

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
@@ -36,5 +36,9 @@ BaseElement['layoutSizeDefined'] = true;
 /** @override */
 BaseElement['usesShadowDom'] = true;
 
+// DO NOT SUBMIT: If BaseElement['shadowCss']  is set to `null`, remove the
+// following declaration.
+// Otherwise, keep it when defined to an actual value like `COMPONENT_CSS`.
+// Once addressed, remove this set of comments.
 /** @override */
 BaseElement['shadowCss'] = __jss_component_css__;

--- a/contributing/building-a-bento-amp-extension.md
+++ b/contributing/building-a-bento-amp-extension.md
@@ -52,6 +52,8 @@ To bootstrap the creation of a new component (or the Bento version of an existin
 $ amp make-extension --bento --name=amp-my-element
 ```
 
+This generates CSS used by the AMP element `<amp-my-element>`, and JSS used by the Preact component `<MyElement>`. To exclude either, you may additionally specify `--nocss` and/or `--nojss`.
+
 ## Naming
 
 All Bento AMP component extensions have their tag names prefixed with `amp-`.

--- a/contributing/building-a-bento-amp-extension.md
+++ b/contributing/building-a-bento-amp-extension.md
@@ -68,7 +68,7 @@ The directory structure is below:
 
 ```sh
 /extensions/amp-my-element/
-├── 0.1/
+├── 1.0/
 |   ├── storybook/                       # Element's manual sample playground (req'd)
 |   |   ├── Basic.js                     # Preact usage examples
 |   |   ├── Basic.amp.js                 # AMP usage examples


### PR DESCRIPTION
Since they require CSS on the AMP layer, but not JSS on the component, I'd like to specify on a guide that Bento video players can be started with:

```console
amp make-extension --bento --nojss
```
