### PR TITLE
✨ [Amp story] [Page attachments] Render page attachment in layoutCallback

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -184,6 +184,22 @@
   --i-amphtml-arrow-color: white !important;
 }
 
+.i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  flex-direction: column !important;
+  position: absolute !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  width: 100% !important;
+  background: linear-gradient(0, rgba(0, 0, 0, 0.15), transparent) !important;
+  pointer-events: none !important;
+  z-index: 3 !important;
+  -webkit-touch-callout: default !important; /* Allow long pressing the button to open context menu in iOS */
+  text-decoration: none !important;
+}
+
 /** For amp-story-inline-page-attachment-v2 inline default. */
 .i-amphtml-amp-story-page-attachment-ui-v2 .i-amphtml-story-page-open-attachment-icon {
   animation: none !important;

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -201,7 +201,7 @@
 }
 
 .i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment:not([active]) {
-  /* Prevent tabbing to innactive page's buttons */
+  /* Prevent tabbing to inactive page's buttons */
   visibility: hidden !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -195,7 +195,6 @@
   width: 100% !important;
   background: linear-gradient(0, rgba(0, 0, 0, 0.15), transparent) !important;
   pointer-events: none !important;
-  z-index: 3 !important;
   -webkit-touch-callout: default !important; /* Allow long pressing the button to open context menu in iOS */
   text-decoration: none !important;
 }

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -200,6 +200,11 @@
   text-decoration: none !important;
 }
 
+.i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-open-attachment:not([active]) {
+  /* Prevent tabbing to innactive page's buttons */
+  visibility: hidden !important;
+}
+
 /** For amp-story-inline-page-attachment-v2 inline default. */
 .i-amphtml-amp-story-page-attachment-ui-v2 .i-amphtml-story-page-open-attachment-icon {
   animation: none !important;

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -565,7 +565,6 @@ export class AmpStoryPage extends AMP.BaseElement {
       this.maybeStartAnimations_();
       this.checkPageHasAudio_();
       this.checkPageHasElementWithPlayback_();
-      this.renderOpenAttachmentUI_();
       this.findAndPrepareEmbeddedComponents_();
     }
 
@@ -585,6 +584,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     this.getViewport().onResize(
       debounce(this.win, () => this.onResize_(), RESIZE_TIMEOUT_MS)
     );
+
+    this.renderOpenAttachmentUI_();
+
     return Promise.all([
       this.beforeVisible(),
       this.waitForMediaLayout_(),


### PR DESCRIPTION
Context / Fixes #33954

This follows the natural flow of page layout and allows the images to preload in the new attachment UI.

- Renders page attachments in `layoutCallback`.
- Always styles `amp-story-page-attachment-ui-v2` in natural position (`display: none` prevents images from loading).

