### PR TITLE
🏗 Switch top-level reviewer list from `reviewerTeam` to `reviewerPool`

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,7 @@
 // https://github.com/ampproject/amp-github-apps/blob/main/owners/OWNERS.example
 
 {
-  reviewerTeam: 'ampproject/reviewers-amphtml',
+  reviewerPool: ['ampproject/reviewers-amphtml', 'renovate-bot'],
   rules: [
     {
       owners: [

--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,7 @@
 // https://github.com/ampproject/amp-github-apps/blob/main/owners/OWNERS.example
 
 {
-  reviewerPool: ['ampproject/reviewers-amphtml', 'renovate-bot'],
+  reviewerPool: ['ampproject/reviewers-amphtml', 'renovate-approve'],
   rules: [
     {
       owners: [


### PR DESCRIPTION
This PR is necessary due to the reasons outlined in https://github.com/ampproject/amphtml/pull/34148#issuecomment-831308299.

The supplementary fix to owners bot can be found in https://github.com/ampproject/amp-github-apps/pull/1284. This PR will need to merged in conjunction with the owners bot change.

Partial fix for #33959
Partial fix for https://github.com/ampproject/amp-github-apps/issues/1283