### PR TITLE
🏗 Use bot name of `renovate-approve` for owner approval of upgrade PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -40,7 +40,7 @@
     },
     {
       pattern: '**/package{,-lock}.json',
-      owners: [{name: 'renovate-bot'}],
+      owners: [{name: 'renovate-approve'}],
     },
     {
       pattern: '**/OWNERS',


### PR DESCRIPTION
This PR is a follow up to #34176 and #34148. Looks like Owners bot uses the name of the approving bot while running its check (and not the underlying github ID used by the bot).

This PR changes the owner to `renovate-approve` to see if owners checks like the one in https://github.com/ampproject/amphtml/pull/34180/checks?check_run_id=2495249187 will be satisfied.

**Screenshot for posterity:** (see #34180)

![image](https://user-images.githubusercontent.com/26553114/116929269-2c7f2280-ac2c-11eb-91bb-6af0c259b92a.png)


Partial fix for #33959