### PR TITLE
Revert "🏗 Use bot name of `renovate-approve` for owner approval of upgrade PRs"

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -40,7 +40,7 @@
     },
     {
       pattern: '**/package{,-lock}.json',
-      owners: [{name: 'renovate-approve'}],
+      owners: [{name: 'renovate-bot'}],
     },
     {
       pattern: '**/OWNERS',


### PR DESCRIPTION
Reverts ampproject/amphtml#34182

Reason for revert: https://github.com/ampproject/amphtml/pull/34182#issuecomment-831545515

Related to #33959