### PR TITLE
✨ [Amp story][Page attachments] Render V2 attachment CTA buttons for bot rendering

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -80,6 +80,7 @@
    */
 .i-amphtml-story-page-open-attachment {
   display: none !important;
+  z-index: 3 !important;
 }
 
 .i-amphtml-story-page-open-attachment[active] {
@@ -93,7 +94,6 @@
   width: 100% !important;
   background: linear-gradient(0, rgba(0, 0, 0, 0.15), transparent) !important;
   pointer-events: none !important;
-  z-index: 3 !important;
   animation: open-attachment-fly-in 0.3s cubic-bezier(0.4, 0, 0.2, 1) both !important;
   -webkit-touch-callout: default !important; /* Allow long pressing the button to open context menu in iOS */
   text-decoration: none !important;

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -229,10 +229,10 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     this.element.classList.add('i-amphtml-story-page-attachment-remote');
     // Use an anchor element to make this a real link in vertical rendering.
     const link = htmlFor(this.element)`
-      <a class="i-amphtml-story-page-attachment-remote-content" target="_blank">
+      <div class="i-amphtml-story-page-attachment-remote-content" target="_blank">
         <span class="i-amphtml-story-page-attachment-remote-title"><span ref="openStringEl"></span><span ref="urlStringEl"></span></span>
         <svg class="i-amphtml-story-page-attachment-remote-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><path d="M38 38H10V10h14V6H10c-2.21 0-4 1.79-4 4v28c0 2.21 1.79 4 4 4h28c2.21 0 4-1.79 4-4V24h-4v14zM28 6v4h7.17L15.51 29.66l2.83 2.83L38 12.83V20h4V6H28z"></path></svg>
-      </a>`;
+      </div>`;
     const hrefAttr = this.element.getAttribute('href');
     link.setAttribute('href', hrefAttr);
     const {openStringEl, urlStringEl} = htmlRefs(link);

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -72,11 +72,12 @@ import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {isAutoplaySupported} from '../../../src/utils/video';
 import {isExperimentOn} from '../../../src/experiments';
+import {isPageAttachmentUiV2ExperimentOn} from './amp-story-page-attachment-ui-v2';
 import {isPrerenderActivePage} from './prerender-active-page';
 import {listen} from '../../../src/event-helper';
 import {CSS as pageAttachmentCSS} from '../../../build/amp-story-open-page-attachment-0.1.css';
 import {prefersReducedMotion} from '../../../src/utils/media-query-props';
-import {px, toggle} from '../../../src/style';
+import {px, setImportantStyles, toggle} from '../../../src/style';
 import {renderPageAttachmentUI} from './amp-story-open-page-attachment';
 import {renderPageDescription} from './semantic-render';
 import {toArray} from '../../../src/core/types/array';
@@ -670,9 +671,17 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   onUIStateUpdate_(uiState) {
-    // On vertical rendering, render all the animations with their final state.
+    // For bot rendering.
     if (uiState === UIType.VERTICAL) {
+      // Render all animations in their final state.
       this.maybeFinishAnimations_();
+      if (isPageAttachmentUiV2ExperimentOn(this.win)) {
+        // Render open attachment element and make it visible.
+        this.renderOpenAttachmentUI_();
+        if (this.openAttachmentEl_) {
+          setImportantStyles(this.openAttachmentEl_, {'visibility': 'visible'});
+        }
+      }
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -676,7 +676,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       // Render all animations in their final state.
       this.maybeFinishAnimations_();
       if (isPageAttachmentUiV2ExperimentOn(this.win)) {
-        // Render open attachment element and make it visible.
+        // Render open attachment element and make it visible so it's visible to bots.
         this.renderOpenAttachmentUI_();
         if (this.openAttachmentEl_) {
           setImportantStyles(this.openAttachmentEl_, {'visibility': 'visible'});

--- a/extensions/amp-story/1.0/amp-story-vertical.css
+++ b/extensions/amp-story/1.0/amp-story-vertical.css
@@ -62,7 +62,7 @@ amp-story[i-amphtml-vertical].i-amphtml-element amp-story-page.i-amphtml-element
   overflow: visible !important;
 }
 
-[i-amphtml-vertical] .amp-story-draggable-drawer-root {
+[i-amphtml-vertical] .amp-story-draggable-drawer-root:not(.i-amphtml-amp-story-page-attachment-ui-v2) {
   visibility: visible !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1906,16 +1906,18 @@ export class AmpStory extends AMP.BaseElement {
           this.element.removeAttribute('desktop');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-panels');
-          for (let i = 0; i < pageAttachments.length; i++) {
-            this.element.insertBefore(
-              pageAttachments[i],
-              // Attachments that are just links are rendered in-line with their
-              // story page.
-              pageAttachments[i].getAttribute('href')
-                ? pageAttachments[i].parentElement.nextElementSibling
-                : // Other attachments are rendered at the end.
-                  null
-            );
+          if (!isPageAttachmentUiV2ExperimentOn(this.win)) {
+            for (let i = 0; i < pageAttachments.length; i++) {
+              this.element.insertBefore(
+                pageAttachments[i],
+                // Attachments that are just links are rendered in-line with their
+                // story page.
+                pageAttachments[i].getAttribute('href')
+                  ? pageAttachments[i].parentElement.nextElementSibling
+                  : // Other attachments are rendered at the end.
+                    null
+              );
+            }
           }
         });
 


### PR DESCRIPTION
Context / Fixes #34015

For V2 attachment CTA buttons.
- Renders all CTA buttons instead of page attachments.

<img width="699" alt="Screen Shot 2021-05-04 at 11 26 58 AM" src="https://user-images.githubusercontent.com/3860311/117028504-c5b14600-accb-11eb-8d42-2258bd087e17.png">