### PR TITLE
🏗 Disable updates for validator webui

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -41,6 +41,11 @@
       "assignAutomerge": true
     },
     {
+      "groupName": "validator webui",
+      "matchPaths": ["validator/js/webui/**"],
+      "enabled": false
+    },
+    {
       "groupName": "core devDependencies",
       "matchFiles": ["package.json"],
       "major": {"automerge": false, "assignAutomerge": false},


### PR DESCRIPTION
The validator webui implementation uses an older version of Polymer that works just fine. Since there are no plans to upgrade to the latest version of Polymer, this PR disables package updates for `validator/js/webui/package.json`.

With this, PRs like #34157 and #34184 will no longer be auto-generated when there are pending upgrades.

Addresses https://github.com/ampproject/amphtml/pull/34157#issuecomment-831570050
Addresses https://github.com/ampproject/amphtml/pull/34186#discussion_r625412393
Closes #34186
