### PR TITLE
🐛 amp-brightcove: improve autoplay handling

### DIFF
--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -367,9 +367,8 @@ class AmpBrightcove extends AMP.BaseElement {
     el.setAttribute('data-param-playsinline', 'true');
 
     if (el.hasAttribute('data-param-autoplay')) {
-      el.removeAttribute('style');
+      el.removeAttribute('data-param-autoplay');
     }
-
     // Pass through data-param-* attributes as params for plugin use
     return addParamsToUrl(src, getDataParamsFromAttributes(el));
   }

--- a/extensions/amp-brightcove/0.1/amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/amp-brightcove.js
@@ -332,7 +332,7 @@ class AmpBrightcove extends AMP.BaseElement {
       `https://players.brightcove.net/${encodeURIComponent(account)}` +
       `/${encodeURIComponent(this.playerId_)}` +
       `_${encodeURIComponent(embed)}/index.html` +
-      '?amp=1&autoplay=false' +
+      '?amp=1' +
       // These are encodeURIComponent'd in encodeId_().
       (el.getAttribute('data-playlist-id')
         ? '&playlistId=' + this.encodeId_(el.getAttribute('data-playlist-id'))
@@ -365,6 +365,10 @@ class AmpBrightcove extends AMP.BaseElement {
     }
 
     el.setAttribute('data-param-playsinline', 'true');
+
+    if (el.hasAttribute('data-param-autoplay')) {
+      el.removeAttribute('style');
+    }
 
     // Pass through data-param-* attributes as params for plugin use
     return addParamsToUrl(src, getDataParamsFromAttributes(el));
@@ -456,8 +460,8 @@ class AmpBrightcove extends AMP.BaseElement {
   }
 
   /** @override */
-  play(unusedIsAutoplay) {
-    this.sendCommand_('play');
+  play(isAutoplay) {
+    this.sendCommand_('play', isAutoplay);
   }
 
   /** @override */

--- a/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
+++ b/extensions/amp-brightcove/0.1/test/test-amp-brightcove.js
@@ -114,7 +114,7 @@ describes.realWin(
         expect(iframe.tagName).to.equal('IFRAME');
         expect(iframe.src).to.equal(
           'https://players.brightcove.net/1290862519001/default_default' +
-            '/index.html?amp=1&autoplay=false' +
+            '/index.html?amp=1' +
             '&videoId=ref:amp-test-video&playsinline=true'
         );
       });
@@ -145,6 +145,18 @@ describes.realWin(
       });
     });
 
+    it('should exclude data-param-autoplay attribute', () => {
+      return getBrightcove({
+        'data-account': '1290862519001',
+        'data-video-id': 'ref:amp-test-video',
+        'data-param-autoplay': 'muted',
+      }).then((bc) => {
+        const iframe = bc.querySelector('iframe');
+        const params = parseUrlDeprecated(iframe.src).search.split('&');
+        expect(params).to.not.contain('autoplay');
+      });
+    });
+
     it('should propagate mutated attributes', () => {
       return getBrightcove({
         'data-account': '1290862519001',
@@ -154,7 +166,7 @@ describes.realWin(
 
         expect(iframe.src).to.equal(
           'https://players.brightcove.net/1290862519001/default_default' +
-            '/index.html?amp=1&autoplay=false' +
+            '/index.html?amp=1' +
             '&videoId=ref:amp-test-video&playsinline=true'
         );
 
@@ -167,7 +179,7 @@ describes.realWin(
 
         expect(iframe.src).to.equal(
           'https://players.brightcove.net/' +
-            '12345/default_default/index.html?amp=1&autoplay=false' +
+            '12345/default_default/index.html?amp=1' +
             '&videoId=abcdef&playsinline=true'
         );
       });
@@ -324,6 +336,21 @@ describes.realWin(
         );
         expect(iframe.src).to.contain('ampInitialConsentValue=abc');
       });
+    });
+
+    it('should distinguish autoplay', async () => {
+      const bc = await getBrightcove({
+        'data-account': '1290862519001',
+        'data-video-id': 'ref:amp-test-video',
+      });
+      const impl = await bc.getImpl();
+      const spy = env.sandbox.spy(impl, 'sendCommand_');
+
+      impl.play(true);
+      expect(spy).to.be.calledWith('play', true);
+
+      impl.play(false);
+      expect(spy).to.be.calledWith('play', false);
     });
   }
 );


### PR DESCRIPTION
Following an update to the Brightcove Player's AMP support plugin, this update makes sure autoplay is handled correctly in all cases.

- Removes any autoplay query param, including the interim autoplay=false
- Distinguishes play messages sent through postmessage which are autoplay requests

cc @alanorozco 