### PR TITLE
🏗 Use correct suffix for `renovate-approve` bot

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,7 @@
 // https://github.com/ampproject/amp-github-apps/blob/main/owners/OWNERS.example
 
 {
-  reviewerPool: ['ampproject/reviewers-amphtml', 'renovate-approve'],
+  reviewerPool: ['ampproject/reviewers-amphtml', 'renovate-approve[bot]'],
   rules: [
     {
       owners: [


### PR DESCRIPTION
We use the `renovate-approve` app to auto-approve low-risk package upgrade PRs that have otherwise passed all other CI checks. In order to allow this, owners bot needs to be satisfied that the bot account is listed in `reviewerPool`.

From looking at the [review payload](https://api.github.com/repos/ampproject/amphtml/pulls/34180/reviews) on GitHub, the `renovate-approve` account shows up with a `[bot]` suffix. This PR adds that suffix to the entry in `reviewerPool` so owners bot recognizes it.

![image](https://user-images.githubusercontent.com/26553114/117061446-336f6900-acf0-11eb-830c-e9c5a7edd110.png)


Partial fix for #33959

