### PR TITLE
🐛 Apply fill content to carousel v2's slide container

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.css
+++ b/extensions/amp-carousel/0.2/amp-carousel.css
@@ -25,10 +25,6 @@ amp-carousel:not([type="slides"]) .i-amphtml-carousel-scroll {
   white-space: nowrap !important;
 }
 
-amp-carousel:not([type="slides"]) .i-amphtml-carousel-content {
-  position: static;
-}
-
 .amp-scrollable-carousel-slide {
   display: inline-block !important;
   /*

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -153,6 +153,8 @@ class AmpCarousel extends AMP.BaseElement {
     this.prevButton_ = this.element.querySelector('.amp-carousel-button-prev');
     this.nextButton_ = this.element.querySelector('.amp-carousel-button-next');
 
+    this.applyFillContent(this.scrollContainer_);
+
     this.carousel_ = new Carousel({
       win,
       element,


### PR DESCRIPTION
This fixes an issue where the slide container has 0 size when all slides are `fill` layout (or similar non-sized content).