### PR TITLE
🏗 Allow auto-merge for low-risk validator upgrades

### DIFF
--- a/validator/OWNERS
+++ b/validator/OWNERS
@@ -7,7 +7,7 @@
       owners: [{name: 'ampproject/wg-caching', required: true}],
     },
     {
-      pattern: '{package.json,package-lock.json}',
+      pattern: '{package.json,package-lock.json,WORKSPACE}',
       owners: [{name: 'ampproject/wg-caching', required: false}],
     },
   ],

--- a/validator/OWNERS
+++ b/validator/OWNERS
@@ -8,7 +8,7 @@
     },
     {
       pattern: '{package.json,package-lock.json}',
-      owners: [{name: 'ampproject/wg-caching', requestReviews: false}],
+      owners: [{name: 'ampproject/wg-caching', required: false}],
     },
   ],
 }


### PR DESCRIPTION
Right now, all validator package updates require a manual review from someone in @ampproject/wg-caching. With this PR, low-risk updates to validator `devDependecies` like the ones in #34205 will be auto-merged if / when all PR checks go green.

