### PR TITLE
🐛 Bento <amp-video-iframe>: assorted fixes

### DIFF
--- a/extensions/amp-video-iframe/1.0/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/1.0/amp-video-iframe.js
@@ -91,7 +91,11 @@ function onMessage(e) {
     // Whatever the VideoManager does, needs to be refactored.
     return;
   }
-  if (event === 'error' || BUBBLE_MESSAGE_EVENTS.indexOf(event) > -1) {
+  if (
+    event === 'error' ||
+    event === 'canplay' ||
+    BUBBLE_MESSAGE_EVENTS.indexOf(event) > -1
+  ) {
     currentTarget.dispatchEvent(
       createCustomEvent(window, event, /* detail */ null, {
         bubbles: true,

--- a/extensions/amp-video-iframe/1.0/base-element.js
+++ b/extensions/amp-video-iframe/1.0/base-element.js
@@ -28,6 +28,7 @@ BaseElement['props'] = {
   'implements-media-session': {attr: 'mediasession', type: 'boolean'},
   'poster': {attr: 'poster'},
   'src': {attr: 'src'},
+  'controls': {attr: 'controls', type: 'boolean'},
 
   // TODO(alanorozco): These props have no internal implementation yet.
   'dock': {attr: 'dock'},

--- a/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
@@ -16,12 +16,11 @@
 
 import * as Preact from '../../../../src/preact';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
-import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
   title: 'amp-video-iframe-1_0',
-  decorators: [withA11y, withKnobs, withAmp],
+  decorators: [withKnobs, withAmp],
   parameters: {
     extensions: [{name: 'amp-video-iframe', version: '1.0'}],
     experiments: ['bento'],


### PR DESCRIPTION
- `canplay` is not part of `BUBBLE_EVENTS` since `0.1` dispatches `load` instead. Dispatch from Bento as it's required.

- `controls` has to be passed from AMP layer.

- remove `withA11y` from Storybook
