### PR TITLE
resources: rename V1 to R1, to clear up ambiguity

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -483,7 +483,7 @@ let time;
 let AmpElement = function () {};
 
 /** @return {boolean} */
-AmpElement.prototype.V1 = function () {};
+AmpElement.prototype.R1 = function () {};
 
 /** @return {boolean} */
 AmpElement.prototype.deferredMount = function () {};

--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -5,7 +5,7 @@
     "environment": "AMP",
     "issue": "https://github.com/ampproject/amphtml/issues/31915",
     "expiration_date_utc": "2021-06-30",
-    "define_experiment_constant": "V1_IMG_DEFERRED_BUILD"
+    "define_experiment_constant": "R1_IMG_DEFERRED_BUILD"
   },
   "experimentC": {}
 }

--- a/build-system/global-configs/experiments-const.json
+++ b/build-system/global-configs/experiments-const.json
@@ -1,6 +1,6 @@
 {
   "INI_LOAD_INOB": true,
   "NO_SIGNING_RTV": true,
-  "V1_IMG_DEFERRED_BUILD": false,
+  "R1_IMG_DEFERRED_BUILD": false,
   "WITHIN_VIEWPORT_INOB": false
 }

--- a/builtins/amp-img.js
+++ b/builtins/amp-img.js
@@ -47,8 +47,8 @@ const ATTRIBUTES_TO_PROPAGATE = [
 
 export class AmpImg extends BaseElement {
   /** @override @nocollapse */
-  static V1() {
-    return V1_IMG_DEFERRED_BUILD;
+  static R1() {
+    return R1_IMG_DEFERRED_BUILD;
   }
 
   /** @override @nocollapse */
@@ -141,7 +141,7 @@ export class AmpImg extends BaseElement {
         guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
       }
 
-      if (AmpImg.V1() && !this.img_.complete) {
+      if (AmpImg.R1() && !this.img_.complete) {
         this.setReadyState(ReadyState.LOADING);
       }
     }
@@ -238,8 +238,8 @@ export class AmpImg extends BaseElement {
    * @private
    */
   maybeGenerateSizes_(sync) {
-    if (V1_IMG_DEFERRED_BUILD) {
-      // The `getLayoutSize()` is not available for a V1 element. Skip this
+    if (R1_IMG_DEFERRED_BUILD) {
+      // The `getLayoutSize()` is not available for a R1 element. Skip this
       // codepath. Also: is this feature at all useful? E.g. it doesn't even
       // execute in the `i-amphtml-ssr` mode.
       return;
@@ -367,8 +367,8 @@ export class AmpImg extends BaseElement {
 
   /** @override */
   unlayoutCallback() {
-    if (AmpImg.V1()) {
-      // TODO(#31915): Reconsider if this is still desired for V1. This helps
+    if (AmpImg.R1()) {
+      // TODO(#31915): Reconsider if this is still desired for R1. This helps
       // with network interruption when a document is inactivated.
       return;
     }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -106,7 +106,7 @@ import {toWin} from './types';
  */
 export class BaseElement {
   /**
-   * Whether this element supports V1 protocol, which includes:
+   * Whether this element supports R1 protocol, which includes:
    * 1. Layout/unlayout are not managed by the runtime, but instead are
    *    implemented by the element as needed.
    * 2. The element can defer its build until later. See `deferredMount`.
@@ -119,7 +119,7 @@ export class BaseElement {
    * @return {boolean}
    * @nocollapse
    */
-  static V1() {
+  static R1() {
     return false;
   }
 
@@ -128,7 +128,7 @@ export class BaseElement {
    * element's build will be deferred roughly based on the
    * `content-visibility: auto` rules.
    *
-   * Only used for V1 elements.
+   * Only used for R1 elements.
    *
    * @param {!AmpElement} unusedElement
    * @return {boolean}
@@ -284,7 +284,7 @@ export class BaseElement {
    *
    * The default priority for base elements is LayoutPriority.CONTENT.
    * @return {number}
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   getLayoutPriority() {
     return LayoutPriority.CONTENT;
@@ -317,7 +317,7 @@ export class BaseElement {
    * mainly affects fixed-position elements that are adjusted to be always
    * relative to the document position in the viewport.
    * @return {!./layout-rect.LayoutRectDef}
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   getLayoutBox() {
     return this.element.getLayoutBox();
@@ -326,7 +326,7 @@ export class BaseElement {
   /**
    * Returns a previously measured layout size.
    * @return {!./layout-rect.LayoutSizeDef}
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   getLayoutSize() {
     return this.element.getLayoutSize();
@@ -437,7 +437,7 @@ export class BaseElement {
    * hosts and prefetch resources it is likely to need. May be called
    * multiple times because connections can time out.
    * @param {boolean=} opt_onLayout
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   preconnectCallback(opt_onLayout) {
     // Subclasses may override.
@@ -463,7 +463,7 @@ export class BaseElement {
 
   /**
    * Set itself as a container element that can be monitored by the scheduler
-   * for auto-mounting. Scheduler is used for V1 elements. A container is
+   * for auto-mounting. Scheduler is used for R1 elements. A container is
    * usually a top-level scrollable overlay such as a lightbox or a sidebar.
    * The main scheduler (`IntersectionObserver`) cannot properly handle elements
    * inside a non-document scroller and this method instructs the scheduler
@@ -533,14 +533,14 @@ export class BaseElement {
   /**
    * Ensure that the element is being eagerly loaded.
    *
-   * Only used for V1 elements.
+   * Only used for R1 elements.
    */
   ensureLoaded() {}
 
   /**
    * Update the current `readyState`.
    *
-   * Only used for V1 elements.
+   * Only used for R1 elements.
    *
    * @param {!./ready-state.ReadyState} state
    * @param {*=} opt_failure
@@ -590,7 +590,7 @@ export class BaseElement {
    * {@link isRelayoutNeeded} method.
    *
    * @return {!Promise}
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   layoutCallback() {
     return Promise.resolve();
@@ -613,7 +613,7 @@ export class BaseElement {
    * Requests the element to stop its activity when the document goes into
    * inactive state. The scope is up to the actual component. Among other
    * things the active playback of video or audio content must be stopped.
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   pauseCallback() {}
 
@@ -621,7 +621,7 @@ export class BaseElement {
    * Requests the element to resume its activity when the document returns from
    * an inactive state. The scope is up to the actual component. Among other
    * things the active playback of video or audio content may be resumed.
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   resumeCallback() {}
 
@@ -632,7 +632,7 @@ export class BaseElement {
    * {@link layoutCallback} in case document becomes active again.
    *
    * @return {boolean}
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   unlayoutCallback() {
     return false;
@@ -642,7 +642,7 @@ export class BaseElement {
    * Subclasses can override this method to opt-in into calling
    * {@link unlayoutCallback} when paused.
    * @return {boolean}
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   unlayoutOnPause() {
     return false;
@@ -1099,7 +1099,7 @@ export class BaseElement {
    * This may currently not work with extended elements. Please file
    * an issue if that is required.
    * @public
-   * TODO(#31915): remove once V1 migration is complete.
+   * TODO(#31915): remove once R1 migration is complete.
    */
   onLayoutMeasure() {}
 

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -393,7 +393,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       this.classList.remove('i-amphtml-unresolved');
       this.assertLayout_();
       this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
-      if (!this.V1()) {
+      if (!this.R1()) {
         this.getResources().upgraded(this);
       }
       this.signals_.signal(CommonSignals.UPGRADED);
@@ -430,7 +430,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     /**
      * Get the priority to load the element.
      * @return {number}
-     * TODO(#31915): remove once V1 migration is complete.
+     * TODO(#31915): remove once R1 migration is complete.
      */
     getLayoutPriority() {
       return this.impl_
@@ -543,7 +543,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           this.classList.remove('amp-notbuilt');
           this.signals_.signal(CommonSignals.BUILT);
 
-          if (this.V1()) {
+          if (this.R1()) {
             this.setReadyStateInternal(
               this.readyState_ != ReadyState.BUILDING
                 ? this.readyState_
@@ -579,7 +579,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
             /** @type {!Error} */ (reason)
           );
 
-          if (this.V1()) {
+          if (this.R1()) {
             this.setReadyStateInternal(ReadyState.ERROR, reason);
           }
 
@@ -603,7 +603,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         CommonSignals.READY_TO_UPGRADE
       );
       return readyPromise.then(() => {
-        if (this.V1()) {
+        if (this.R1()) {
           const scheduler = getSchedulerForDoc(this.getAmpDoc());
           scheduler.scheduleAsap(this);
         }
@@ -630,7 +630,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       const {signal} = this.mountAbortController_;
       return (this.mountPromise_ = this.buildInternal()
         .then(() => {
-          devAssert(this.V1());
+          devAssert(this.R1());
           if (signal.aborted) {
             // Mounting has been canceled.
             return;
@@ -694,7 +694,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         CommonSignals.READY_TO_UPGRADE
       );
       return readyPromise.then(() => {
-        if (!this.V1()) {
+        if (!this.R1()) {
           return this.whenBuilt();
         }
         if (signal.aborted) {
@@ -717,8 +717,8 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         this.pause();
       }
 
-      // Legacy pre-V1 elements simply unlayout.
-      if (!this.V1()) {
+      // Legacy R0 elements simply unlayout.
+      if (!this.R1()) {
         this.unlayout_();
         return;
       }
@@ -775,7 +775,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      */
     ensureLoaded(opt_parentPriority) {
       return this.mount().then(() => {
-        if (this.V1()) {
+        if (this.R1()) {
           if (this.implClass_.usesLoading(this)) {
             this.impl_.ensureLoaded();
           }
@@ -848,7 +848,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
 
       this.readyState_ = state;
 
-      if (!this.V1()) {
+      if (!this.R1()) {
         return;
       }
 
@@ -888,7 +888,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * Called to instruct the element to preconnect to hosts it uses during
      * layout.
      * @param {boolean} onLayout Whether this was called after a layout.
-     * TODO(#31915): remove once V1 migration is complete.
+     * TODO(#31915): remove once R1 migration is complete.
      */
     preconnect(onLayout) {
       devAssert(this.isUpgraded());
@@ -908,13 +908,13 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     }
 
     /**
-     * See `BaseElement.V1()`.
+     * See `BaseElement.R1()`.
      *
      * @return {boolean}
      * @final
      */
-    V1() {
-      return this.implClass_ ? this.implClass_.V1() : false;
+    R1() {
+      return this.implClass_ ? this.implClass_.R1() : false;
     }
 
     /**
@@ -1172,13 +1172,13 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           this.reset_();
         }
         if (this.isUpgraded()) {
-          if (reconstruct && !this.V1()) {
+          if (reconstruct && !this.R1()) {
             this.getResources().upgraded(this);
           }
           this.connected_();
           this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
         }
-        if (this.implClass_ && this.V1()) {
+        if (this.implClass_ && this.R1()) {
           this.upgradeOrSchedule_();
         }
       } else {
@@ -1222,12 +1222,12 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     }
 
     /**
-     * Upgrade or schedule element based on V1.
+     * Upgrade or schedule element based on R1.
      * @param {boolean=} opt_disablePreload
      * @private @final
      */
     upgradeOrSchedule_(opt_disablePreload) {
-      if (!this.V1()) {
+      if (!this.R1()) {
         this.tryUpgrade_();
         return;
       }
@@ -1374,7 +1374,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       if (this.impl_) {
         this.impl_.detachedCallback();
       }
-      if (this.V1()) {
+      if (this.R1()) {
         this.unmount();
       }
       this.toggleLoading(false);
@@ -1526,7 +1526,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * should be called again when layout changes.
      * @return {boolean}
      * @package @final
-     * TODO(#31915): remove once V1 migration is complete.
+     * TODO(#31915): remove once R1 migration is complete.
      */
     isRelayoutNeeded() {
       return this.impl_ ? this.impl_.isRelayoutNeeded() : false;
@@ -1589,7 +1589,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * @param {!AbortSignal} signal
      * @return {!Promise}
      * @package @final
-     * TODO(#31915): remove once V1 migration is complete.
+     * TODO(#31915): remove once R1 migration is complete.
      */
     layoutCallback(signal) {
       assertNotTemplate(this);
@@ -1665,7 +1665,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       this.impl_.pauseCallback();
 
       // Legacy unlayoutOnPause support.
-      if (!this.V1() && this.impl_.unlayoutOnPause()) {
+      if (!this.R1() && this.impl_.unlayoutOnPause()) {
         this.unlayout_();
       }
     }
@@ -1693,7 +1693,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      *
      * @return {boolean}
      * @package @final
-     * TODO(#31915): remove once V1 migration is complete.
+     * TODO(#31915): remove once R1 migration is complete.
      */
     unlayoutCallback() {
       assertNotTemplate(this);

--- a/src/inabox/inabox-resources.js
+++ b/src/inabox/inabox-resources.js
@@ -209,7 +209,7 @@ export class InaboxResources {
     dev().fine(TAG, 'doPass');
     // measure in a batch
     this.resources_.forEach((resource) => {
-      if (!resource.isLayoutPending() || resource.element.V1()) {
+      if (!resource.isLayoutPending() || resource.element.R1()) {
         return;
       }
       resource.measure();
@@ -217,7 +217,7 @@ export class InaboxResources {
     // mutation in a batch
     this.resources_.forEach((resource) => {
       if (
-        !resource.element.V1() &&
+        !resource.element.R1() &&
         resource.getState() === ResourceState.READY_FOR_LAYOUT &&
         resource.isDisplayed()
       ) {

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -193,7 +193,7 @@ const IS_EMPTY_TEXT_NODE = (node) =>
  */
 export class PreactBaseElement extends AMP.BaseElement {
   /** @override @nocollapse */
-  static V1() {
+  static R1() {
     return true;
   }
 

--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -960,7 +960,7 @@ export class Resource {
    * @return {!Promise}
    */
   loadedOnce() {
-    if (this.element.V1()) {
+    if (this.element.R1()) {
       return this.element.whenLoaded();
     }
     return this.loadPromise_;

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -1071,7 +1071,7 @@ export class ResourcesImpl {
       if (
         r.getState() == ResourceState.NOT_BUILT &&
         !r.isBuilding() &&
-        !r.element.V1()
+        !r.element.R1()
       ) {
         this.buildOrScheduleBuildForResource_(r, /* checkForDupes */ true);
       }
@@ -1101,7 +1101,7 @@ export class ResourcesImpl {
     ) {
       for (let i = 0; i < this.resources_.length; i++) {
         const r = this.resources_[i];
-        if ((r.hasOwner() && !r.isMeasureRequested()) || r.element.V1()) {
+        if ((r.hasOwner() && !r.isMeasureRequested()) || r.element.R1()) {
           // If element has owner, and measure is not requested, do nothing.
           continue;
         }
@@ -1165,7 +1165,7 @@ export class ResourcesImpl {
       if (
         r.getState() == ResourceState.NOT_BUILT ||
         r.hasOwner() ||
-        r.element.V1()
+        r.element.R1()
       ) {
         continue;
       }
@@ -1191,7 +1191,7 @@ export class ResourcesImpl {
           !r.isBuilt() &&
           !r.isBuilding() &&
           !r.hasOwner() &&
-          !r.element.V1() &&
+          !r.element.R1() &&
           r.hasBeenMeasured() &&
           r.isDisplayed() &&
           r.overlaps(loadRect)
@@ -1227,7 +1227,7 @@ export class ResourcesImpl {
         if (
           r.getState() == ResourceState.READY_FOR_LAYOUT &&
           !r.hasOwner() &&
-          !r.element.V1() &&
+          !r.element.R1() &&
           r.isDisplayed() &&
           r.idleRenderOutsideViewport()
         ) {
@@ -1247,7 +1247,7 @@ export class ResourcesImpl {
         if (
           r.getState() == ResourceState.READY_FOR_LAYOUT &&
           !r.hasOwner() &&
-          !r.element.V1() &&
+          !r.element.R1() &&
           r.isDisplayed()
         ) {
           dev().fine(TAG_, 'idle layout:', r.debugid);
@@ -1537,7 +1537,7 @@ export class ResourcesImpl {
     opt_parentPriority,
     opt_forceOutsideViewport
   ) {
-    if (resource.element.V1()) {
+    if (resource.element.R1()) {
       return;
     }
     const isBuilt = resource.getState() != ResourceState.NOT_BUILT;

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -85,7 +85,7 @@ t.run('Viewer Visibility State', () => {
           shouldPass = true;
           resources.schedulePass();
         }).then(() => {
-          if (V1_IMG_DEFERRED_BUILD) {
+          if (R1_IMG_DEFERRED_BUILD) {
             return new Promise((resolve) => setTimeout(resolve, 20));
           }
         });
@@ -127,8 +127,8 @@ t.run('Viewer Visibility State', () => {
             img.setAttribute('width', 100);
             img.setAttribute('height', 100);
             img.setAttribute('layout', 'fixed');
-            // TODO(#31915): Cleanup when V1_IMG_DEFERRED_BUILD is complete.
-            if (!V1_IMG_DEFERRED_BUILD) {
+            // TODO(#31915): Cleanup when R1_IMG_DEFERRED_BUILD is complete.
+            if (!R1_IMG_DEFERRED_BUILD) {
               win.document.body.appendChild(img);
             }
 
@@ -138,16 +138,16 @@ t.run('Viewer Visibility State', () => {
             prerenderAllowed = env.sandbox.stub(img, 'prerenderAllowed');
             prerenderAllowed.returns(false);
 
-            if (V1_IMG_DEFERRED_BUILD) {
+            if (R1_IMG_DEFERRED_BUILD) {
               win.document.body.appendChild(img);
             }
             return img.getImpl(false);
           })
           .then((impl) => {
-            layoutCallback = V1_IMG_DEFERRED_BUILD
+            layoutCallback = R1_IMG_DEFERRED_BUILD
               ? env.sandbox.stub(impl, 'mountCallback')
               : env.sandbox.stub(impl, 'layoutCallback');
-            unlayoutCallback = V1_IMG_DEFERRED_BUILD
+            unlayoutCallback = R1_IMG_DEFERRED_BUILD
               ? env.sandbox.stub(impl, 'unmountCallback')
               : env.sandbox.stub(impl, 'unlayoutCallback');
             pauseCallback = env.sandbox.stub(impl, 'pauseCallback');
@@ -260,7 +260,7 @@ t.run('Viewer Visibility State', () => {
             });
             changeVisibility('hidden');
             return waitForNextPass().then(() => {
-              if (V1_IMG_DEFERRED_BUILD) {
+              if (R1_IMG_DEFERRED_BUILD) {
                 expect(layoutCallback).to.have.been.called;
               } else {
                 expect(layoutCallback).not.to.have.been.called;
@@ -439,7 +439,7 @@ t.run('Viewer Visibility State', () => {
           });
           changeVisibility('hidden');
           return waitForNextPass().then(() => {
-            if (V1_IMG_DEFERRED_BUILD) {
+            if (R1_IMG_DEFERRED_BUILD) {
               expect(layoutCallback).to.have.been.called;
             } else {
               expect(layoutCallback).not.to.have.been.called;

--- a/test/unit/inabox/test-inabox-resources.js
+++ b/test/unit/inabox/test-inabox-resources.js
@@ -149,10 +149,10 @@ describes.realWin('inabox-resources', {amp: true}, (env) => {
     expect(resource2.unload).to.be.calledOnce;
   });
 
-  it('should ignore V1 resources for layout pass', async () => {
+  it('should ignore R1 resources for layout pass', async () => {
     const element1 = env.createAmpElement('amp-foo');
     const element2 = env.createAmpElement('amp-bar');
-    env.sandbox.stub(element2, 'V1').returns(true);
+    env.sandbox.stub(element2, 'R1').returns(true);
 
     win.document.body.appendChild(element1);
     win.document.body.appendChild(element2);

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -20,7 +20,7 @@ import {Slot} from '../../../src/preact/slot';
 import {createElementWithAttributes} from '../../../src/dom';
 import {htmlFor} from '../../../src/static-template';
 import {omit} from '../../../src/core/types/object';
-import {testElementV1} from '../../../testing/element-v1';
+import {testElementR1} from '../../../testing/element-v1';
 import {upgradeOrRegisterElement} from '../../../src/service/custom-element-registry';
 import {waitFor} from '../../../testing/test-helper';
 
@@ -75,9 +75,9 @@ describes.realWin('PreactBaseElement', spec, (env) => {
     });
   }
 
-  describe('V1', () => {
-    it('testElementV1', () => {
-      testElementV1(PreactBaseElement);
+  describe('R1', () => {
+    it('testElementR1', () => {
+      testElementR1(PreactBaseElement);
     });
 
     it('by default prerenderAllowed is tied to the "loadable" flag', () => {

--- a/test/unit/test-amp-img-v1.js
+++ b/test/unit/test-amp-img-v1.js
@@ -18,9 +18,9 @@ import {AmpImg} from '../../builtins/amp-img';
 import {BaseElement} from '../../src/base-element';
 import {Layout, LayoutPriority} from '../../src/layout';
 import {createElementWithAttributes, dispatchCustomEvent} from '../../src/dom';
-import {testElementV1} from '../../testing/element-v1';
+import {testElementR1} from '../../testing/element-v1';
 
-describes.realWin('amp-img V1', {amp: true}, (env) => {
+describes.realWin('amp-img R1', {amp: true}, (env) => {
   let win, doc;
   let sandbox;
   let windowWidth;
@@ -33,7 +33,7 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
     doc = win.document;
     sandbox = env.sandbox;
 
-    sandbox.stub(AmpImg, 'V1').returns(true);
+    sandbox.stub(AmpImg, 'R1').returns(true);
 
     windowWidth = 320;
     sandbox.stub(BaseElement.prototype, 'getViewport').callsFake(() => {
@@ -65,8 +65,8 @@ describes.realWin('amp-img V1', {amp: true}, (env) => {
     return img;
   }
 
-  it('testElementV1', () => {
-    testElementV1(AmpImg, {
+  it('testElementR1', () => {
+    testElementR1(AmpImg, {
       exceptions: [
         'Must not have preconnectCallback',
         'Must not have layoutCallback',

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -69,7 +69,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
   });
 
   class TestElement extends BaseElement {
-    static V1() {
+    static R1() {
       return true;
     }
 

--- a/test/unit/test-resources.js
+++ b/test/unit/test-resources.js
@@ -76,7 +76,7 @@ describes.realWin('Resources', {amp: true}, (env) => {
     };
 
     const element = document.createElement('amp-el');
-    element.V1 = () => false;
+    element.R1 = () => false;
     element.isBuilt = () => isBuilt;
     element.isBuilding = () => isBuilding;
     element.pause = () => {};
@@ -619,7 +619,7 @@ describes.realWin('Resources discoverWork', {amp: true}, (env) => {
   function createElement(rect) {
     const element = env.win.document.createElement('amp-test');
     element.classList.add('i-amphtml-element');
-    element.V1 = () => false;
+    element.R1 = () => false;
     element.signals = () => new Signals();
     element.whenBuilt = () => Promise.resolve();
     element.isBuilt = () => true;

--- a/testing/element-v1.js
+++ b/testing/element-v1.js
@@ -24,8 +24,8 @@ import {BaseElement} from '../src/base-element';
  */
 const RULES = [
   {
-    name: 'V1=true',
-    test: (implClass) => implClass.V1() === true,
+    name: 'R1=true',
+    test: (implClass) => implClass.R1() === true,
   },
 
   {
@@ -138,7 +138,7 @@ const RULES = [
  *   exceptions: (!Array<string>|undefined),
  * }=} options
  */
-export function testElementV1(implClass, options = {}) {
+export function testElementR1(implClass, options = {}) {
   const exceptions = options.exceptions || [];
   RULES.forEach(({name, notes, test}) => {
     if (exceptions.includes(name)) {


### PR DESCRIPTION
**summary**
See go/what-amp.

In order to clear up ambiguity around all the different things being called "V1" these days (bento components, bento runtime, etc.), we've decided to rename the new resources system from "V1" to "R1".

- Classic Resources --> R0
- New Resources --> R1
