### PR TITLE
♻️ (Draft) Unwrap IframeEmbed from ContainWrapper

### DIFF
--- a/extensions/amp-facebook-comments/1.0/component.js
+++ b/extensions/amp-facebook-comments/1.0/component.js
@@ -15,6 +15,7 @@
  */
 
 import * as Preact from '../../../src/preact';
+import {ContainWrapper} from '../../../src/preact/component';
 import {
   MessageType,
   ProxyIframeEmbed,
@@ -23,7 +24,12 @@ import {dashToUnderline} from '../../../src/core/types/string';
 import {deserializeMessage} from '../../../src/3p-frame-messaging';
 import {forwardRef} from '../../../src/preact/compat';
 import {tryParseJson} from '../../../src/json';
-import {useCallback, useLayoutEffect, useState} from '../../../src/preact';
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from '../../../src/preact';
 
 /** @const {string} */
 const TYPE = 'facebook';
@@ -83,23 +89,32 @@ function FacebookCommentsWithRef(
     setLocale(dashToUnderline(win.navigator.language));
   }, [localeProp, ref]);
 
+  const contentRef = useRef(null);
   return (
-    <ProxyIframeEmbed
-      contextOptions={{tagName: 'AMP-FACEBOOK-COMMENTS'}}
-      options={{colorScheme, href, locale, numPosts, orderBy}}
-      ref={ref}
-      title={title}
-      {...rest}
-      /* non-overridable props */
-      // We sandbox all 3P iframes however facebook embeds completely break in
-      // sandbox mode since they need access to document.domain, so we
-      // exclude facebook.
-      excludeSandbox
-      matchesMessagingOrigin={MATCHES_MESSAGING_ORIGIN}
-      messageHandler={messageHandler}
-      type={TYPE}
+    <ContainWrapper
+      contentRef={contentRef}
       wrapperStyle={{height}}
-    />
+      layout
+      size
+      paint
+    >
+      <ProxyIframeEmbed
+        contentRef={contentRef}
+        contextOptions={{tagName: 'AMP-FACEBOOK-COMMENTS'}}
+        options={{colorScheme, href, locale, numPosts, orderBy}}
+        ref={ref}
+        title={title}
+        {...rest}
+        /* non-overridable props */
+        // We sandbox all 3P iframes however facebook embeds completely break in
+        // sandbox mode since they need access to document.domain, so we
+        // exclude facebook.
+        excludeSandbox
+        matchesMessagingOrigin={MATCHES_MESSAGING_ORIGIN}
+        messageHandler={messageHandler}
+        type={TYPE}
+      />
+    </ContainWrapper>
   );
 }
 

--- a/extensions/amp-twitter/1.0/component.js
+++ b/extensions/amp-twitter/1.0/component.js
@@ -15,13 +15,14 @@
  */
 
 import * as Preact from '../../../src/preact';
+import {ContainWrapper} from '../../../src/preact/component';
 import {
   MessageType,
   ProxyIframeEmbed,
 } from '../../../src/preact/component/3p-frame';
 import {deserializeMessage} from '../../../src/3p-frame-messaging';
 import {forwardRef} from '../../../src/preact/compat';
-import {useCallback, useState} from '../../../src/preact';
+import {useCallback, useRef, useState} from '../../../src/preact';
 
 /** @const {string} */
 const TYPE = 'twitter';
@@ -51,18 +52,27 @@ function TwitterWithRef({requestResize, title, ...rest}, ref) {
     [requestResize]
   );
 
+  const contentRef = useRef(null);
   return (
-    <ProxyIframeEmbed
-      allowFullscreen
-      ref={ref}
-      title={title}
-      {...rest}
-      // non-overridable props
-      matchesMessagingOrigin={MATCHES_MESSAGING_ORIGIN}
-      messageHandler={messageHandler}
-      type={TYPE}
+    <ContainWrapper
+      contentRef={contentRef}
       wrapperStyle={{height}}
-    />
+      layout
+      size
+      paint
+    >
+      <ProxyIframeEmbed
+        contentRef={contentRef}
+        allowFullscreen
+        ref={ref}
+        title={title}
+        {...rest}
+        // non-overridable props
+        matchesMessagingOrigin={MATCHES_MESSAGING_ORIGIN}
+        messageHandler={messageHandler}
+        type={TYPE}
+      />
+    </ContainWrapper>
   );
 }
 

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -30,7 +30,7 @@ import {
 import {includes} from '../../core/types/string';
 import {parseUrlDeprecated} from '../../url';
 import {sequentialIdGenerator} from '../../utils/id-generator';
-import {useLayoutEffect, useMemo, useRef, useState} from '../../../src/preact';
+import {useLayoutEffect, useMemo, useState} from '../../../src/preact';
 
 /** @type {!Object<string,function>} 3p frames for that type. */
 export const countGenerators = {};
@@ -71,6 +71,7 @@ function ProxyIframeEmbedWithRef(
     src: srcProp,
     type,
     title = type,
+    contentRef,
     ...rest
   },
   ref
@@ -81,7 +82,6 @@ function ProxyIframeEmbedWithRef(
     );
   }
 
-  const contentRef = useRef(null);
   const count = useMemo(() => {
     if (!countGenerators[type]) {
       countGenerators[type] = sequentialIdGenerator();
@@ -132,12 +132,21 @@ function ProxyIframeEmbedWithRef(
       ),
       src,
     });
-  }, [contextOptions, count, nameProp, options, srcProp, title, type]);
+  }, [
+    contentRef,
+    contextOptions,
+    count,
+    nameProp,
+    options,
+    ref,
+    srcProp,
+    title,
+    type,
+  ]);
 
   return (
     <IframeEmbed
       allow={allow}
-      contentRef={contentRef}
       messageHandler={messageHandler}
       name={name}
       ref={ref}

--- a/src/preact/component/iframe.js
+++ b/src/preact/component/iframe.js
@@ -15,7 +15,6 @@
  */
 
 import * as Preact from '../../../src/preact';
-import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Loading} from '../../../src/core/loading-instructions';
 import {ReadyState} from '../../../src/core/constants/ready-state';
 import {forwardRef} from '../../../src/preact/compat';
@@ -27,6 +26,7 @@ import {
   useLayoutEffect,
   useRef,
 } from '../../../src/preact';
+import {useValueRef} from '../../../src/preact/component';
 
 const DEFAULT_MATCHES_MESSAGING_ORIGIN = () => false;
 const ABOUT_BLANK = 'about:blank';
@@ -60,7 +60,6 @@ export function IframeEmbedWithRef(
     onReadyState,
     sandbox,
     src,
-    ...rest
   },
   ref
 ) {
@@ -148,31 +147,30 @@ export function IframeEmbedWithRef(
   }, [matchesMessagingOrigin, messageHandler, mount, ready]);
 
   return (
-    <ContainWrapper {...rest} layout size paint>
-      {mount && ready && (
-        <iframe
-          allow={allow}
-          allowFullScreen={allowFullScreen}
-          allowTransparency={allowTransparency}
-          frameborder="0"
-          loading={loading}
-          name={name}
-          onLoad={() => setLoaded(true)}
-          part="iframe"
-          ref={iframeRef}
-          sandbox={sandbox}
-          scrolling="no"
-          src={src}
-          style={{
-            ...iframeStyle,
-            width: '100%',
-            height: '100%',
-            contentVisibility: 'auto',
-          }}
-          title={title}
-        />
-      )}
-    </ContainWrapper>
+    mount &&
+    ready && (
+      <iframe
+        allow={allow}
+        allowFullScreen={allowFullScreen}
+        allowTransparency={allowTransparency}
+        frameborder="0"
+        loading={loading}
+        name={name}
+        onLoad={() => setLoaded(true)}
+        part="iframe"
+        ref={iframeRef}
+        sandbox={sandbox}
+        scrolling="no"
+        src={src}
+        style={{
+          ...iframeStyle,
+          width: '100%',
+          height: '100%',
+          contentVisibility: 'auto',
+        }}
+        title={title}
+      />
+    )
   );
 }
 


### PR DESCRIPTION
Unwraps `IframeEmbed` to prevent double wrappers, for example if one needed to do:

```js
<VideoWrapper component={IframeEmbed} />
```

or:

```js
<VideoWrapper component={ProxyIframeEmbed} />
```
