### PR TITLE
allow http and relative for amp-story-page-attachment

### DIFF
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -884,9 +884,8 @@ tags: {  # <amp-story-page-attachment> with href
   attrs: {
     name: "cta-image"
     value_url: {
-      # protocol: "http"  # TODO(honeybaderdontcare): readd once transformers in prod
+      protocol: "http"
       protocol: "https"
-      allow_relative: false  # TODO(honeybaderdontcare): remove once transformers in prod
     }
   }
   child_tags: {
@@ -909,17 +908,15 @@ tags: {  # <amp-story-page-attachment> with no href
   attrs: {
     name: "cta-image"
     value_url: {
-      # protocol: "http"  # TODO(honeybaderdontcare): readd once transformers in prod
+      protocol: "http"
       protocol: "https"
-      allow_relative: false  # TODO(honeybaderdontcare): remove once transformers in prod
     }
   }
   attrs: {
     name: "cta-image-2"
     value_url: {
-      # protocol: "http"  # TODO(honeybaderdontcare): readd once transformers in prod
+      protocol: "http"
       protocol: "https"
-      allow_relative: false  # TODO(honeybaderdontcare): remove once transformers in prod
     }
   }
   attrs: {


### PR DESCRIPTION
This is a follow up to #33142, allowing for the http protocol and relative urls. This is a result of cl/362183596 being in prod now.