### PR TITLE
update amp-script console error to mention data-ampdevmode

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -601,6 +601,7 @@ export class AmpScriptService {
         throw user().createError(
           TAG,
           `Script hash not found or incorrect for ${debugId}. You must include <meta name="amp-script-src" content="sha384-${hash}">. ` +
+            `During development, you can disable this check by adding the "data-ampdevmode" attribute to ${debugId}, or the root html node` +
             'See https://amp.dev/documentation/components/amp-script/#script-hash.'
         );
       }


### PR DESCRIPTION
`amp-script` development can be frustrating, as every change triggers the invalid hash error. Wanted to highlight the `data-ampdevmode` [we mention in the documentation](https://amp.dev/documentation/components/amp-script/#script-hash) to improve DX