### PR TITLE
♻️ Name amp-ima-video methods uniformly for Bento

### DIFF
--- a/ads/google/imaVideo.js
+++ b/ads/google/imaVideo.js
@@ -1470,7 +1470,7 @@ function onMessage(global, event) {
     return;
   }
   switch (msg['func']) {
-    case 'playVideo':
+    case 'play':
       if (adsActive || playbackStarted) {
         playVideo();
       } else {
@@ -1478,13 +1478,13 @@ function onMessage(global, event) {
         onBigPlayClick(global);
       }
       break;
-    case 'pauseVideo':
+    case 'pause':
       pauseVideo();
       break;
     case 'mute':
       muteVideo();
       break;
-    case 'unMute':
+    case 'unmute':
       unmuteVideo();
       break;
     case 'hideControls':
@@ -1526,7 +1526,7 @@ function onMessage(global, event) {
         requestAds();
       }
       break;
-    case 'enterFullscreen':
+    case 'requestFullscreen':
       if (fullscreen) {
         return;
       }

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -347,12 +347,12 @@ class AmpImaVideo extends AMP.BaseElement {
 
   /** @override */
   play(unusedIsAutoplay) {
-    this.sendCommand_('playVideo');
+    this.sendCommand_('play');
   }
 
   /** @override */
   pause() {
-    this.sendCommand_('pauseVideo');
+    this.sendCommand_('pause');
   }
 
   /** @override */
@@ -362,7 +362,7 @@ class AmpImaVideo extends AMP.BaseElement {
 
   /** @override */
   unmute() {
-    this.sendCommand_('unMute');
+    this.sendCommand_('unmute');
   }
 
   /** @override */
@@ -377,7 +377,7 @@ class AmpImaVideo extends AMP.BaseElement {
 
   /** @override */
   fullscreenEnter() {
-    this.sendCommand_('enterFullscreen');
+    this.sendCommand_('requestFullscreen');
   }
 
   /** @override */


### PR DESCRIPTION
Rename `postMessage` method names so that they're uniform with `VideoIframe`'s. This simplifies the upcoming Bento implementation.
