### PR TITLE
🏗 Disable JSDoc requirement on Storybook files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -317,8 +317,13 @@ module.exports = {
         '**/storybook/*.js',
       ],
       'rules': {
-        'require-jsdoc': 0,
         'local/no-forbidden-terms': [2, forbiddenTermsGlobal],
+      },
+    },
+    {
+      'files': ['**/storybook/*.js'],
+      'rules': {
+        'require-jsdoc': 0,
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -317,6 +317,7 @@ module.exports = {
         '**/storybook/*.js',
       ],
       'rules': {
+        'require-jsdoc': 0,
         'local/no-forbidden-terms': [2, forbiddenTermsGlobal],
       },
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -314,7 +314,6 @@ module.exports = {
         '**/_init_tests.js',
         '**/*_test.js',
         '**/testing/**',
-        '**/storybook/*.js',
       ],
       'rules': {
         'local/no-forbidden-terms': [2, forbiddenTermsGlobal],
@@ -324,6 +323,7 @@ module.exports = {
       'files': ['**/storybook/*.js'],
       'rules': {
         'require-jsdoc': 0,
+        'local/no-forbidden-terms': [2, forbiddenTermsGlobal],
       },
     },
     {

--- a/extensions/amp-video/1.0/storybook/_helpers.js
+++ b/extensions/amp-video/1.0/storybook/_helpers.js
@@ -15,10 +15,6 @@
  */
 import * as Preact from '../../../../src/preact';
 
-/**
- * @param {*} props
- * @return {*}
- */
 export const VideoElementWithActions = ({
   id,
   children,


### PR DESCRIPTION
Disable `require-jsdoc` since it auto-fixes, and we don't need JSDoc in these locations.

We preserve the following rules since they ensure correctness, like type-check already does.

```
jsdoc/check-param-names
jsdoc/check-tag-names
jsdoc/check-types
jsdoc/require-param
jsdoc/require-param-name
jsdoc/require-param-type
jsdoc/require-returns
jsdoc/require-returns-type
```
