### PR TITLE
🐛 Log output when onError set

### DIFF
--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -285,7 +285,8 @@ async function typeCheck(targetName) {
 
   let errorMsg;
   if (target.onError) {
-    // If an onError handler is defined, steal the output and log it manually.
+    // If an onError handler is defined, steal the output and let onError handle
+    // logging
     opts.logger = (m) => (errorMsg = m);
   }
 

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -285,10 +285,7 @@ async function typeCheck(targetName) {
 
   if (target.onError) {
     // If an onError handler is defined, steal the output and log it manually.
-    opts.logger = (m) => {
-      errorMsg = m;
-      log(m);
-    };
+    opts.logger = (m) => (errorMsg = m);
   }
 
   let errorMsg;

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -283,12 +283,12 @@ async function typeCheck(targetName) {
     return;
   }
 
+  let errorMsg;
   if (target.onError) {
     // If an onError handler is defined, steal the output and log it manually.
     opts.logger = (m) => (errorMsg = m);
   }
 
-  let errorMsg;
   await closureCompile(entryPoints, './dist', `${targetName}-check-types.js`, {
     noAddDeps,
     include3pDirectories: !noAddDeps,

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -283,13 +283,20 @@ async function typeCheck(targetName) {
     return;
   }
 
+  if (target.onError) {
+    // If an onError handler is defined, steal the output and log it manually.
+    opts.logger = (m) => {
+      errorMsg = m;
+      log(m);
+    };
+  }
+
   let errorMsg;
   await closureCompile(entryPoints, './dist', `${targetName}-check-types.js`, {
     noAddDeps,
     include3pDirectories: !noAddDeps,
     includePolyfills: !noAddDeps,
     typeCheckOnly: true,
-    logger: (m) => (errorMsg = m),
     ...opts,
   }).catch((error) => {
     if (!target.onError) {


### PR DESCRIPTION
A change in https://github.com/ampproject/amphtml/pull/34105 accidentally made all type-checks use a custom logger that swallowed output, when we only needed to take a copy of the log output. This patches that issue, unmasking typecheck errors.