### PR TITLE
amp-twitter: Add Storybook samples

### DIFF
--- a/extensions/amp-twitter/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/0.1/storybook/Basic.amp.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {text, withKnobs} from '@storybook/addon-knobs';
+import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
@@ -33,20 +33,53 @@ export default {
 };
 
 export const Default = () => {
-  const tweetId = text('tweet id', '1356304203044499462');
+  const tweetId = select(
+    'tweet id',
+    ['1356304203044499462', '495719809695621121', '463440424141459456'],
+    '1356304203044499462'
+  );
+  const cards = boolean('show cards', true) ? undefined : 'hidden';
+  const conversation = boolean('show conversation', false) ? undefined : 'none';
   return (
-    <amp-twitter width="300" height="200" data-tweetid={tweetId}>
-      <blockquote placeholder>
-        <p lang="en" dir="ltr">
-          In case you missed it last week, check out our recap of AMP in 2020
-          ⚡🙌
-        </p>
-        <p>
-          Watch here ➡️
-          <br />
-          <a href="https://t.co/eaxT3MuSAK">https://t.co/eaxT3MuSAK</a>
-        </p>
-      </blockquote>
-    </amp-twitter>
+    <amp-twitter
+      width="300"
+      height="200"
+      data-tweetid={tweetId}
+      data-cards={cards}
+      data-conversation={conversation}
+    />
+  );
+};
+
+export const moments = () => {
+  const limit = number('limit to', 2);
+  return (
+    <amp-twitter
+      data-limit={limit}
+      data-momentid="1009149991452135424"
+      width="300"
+      height="200"
+    />
+  );
+};
+
+export const timelines = () => {
+  const tweetLimit = number('limit to', 5);
+  const timelineSourceType = select(
+    'source type',
+    ['profile', 'likes', 'list', 'source', 'collection', 'url', 'widget'],
+    'profile'
+  );
+  const timelineScreenName = 'amphtml';
+  const timelineUserId = '3450662892';
+  return (
+    <amp-twitter
+      data-tweet-limit={tweetLimit}
+      data-timeline-source-type={timelineSourceType}
+      data-timeline-scree-name={timelineScreenName}
+      data-timeline-user-id={timelineUserId}
+      width="300"
+      height="200"
+    />
   );
 };

--- a/extensions/amp-twitter/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.amp.js
@@ -15,7 +15,7 @@
  */
 
 import * as Preact from '../../../../src/preact';
-import {text, withKnobs} from '@storybook/addon-knobs';
+import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 
 export default {
@@ -34,20 +34,53 @@ export default {
 };
 
 export const Default = () => {
-  const tweetId = text('tweet id', '1356304203044499462');
+  const tweetId = select(
+    'tweet id',
+    ['1356304203044499462', '495719809695621121', '463440424141459456'],
+    '1356304203044499462'
+  );
+  const cards = boolean('show cards', true) ? undefined : 'hidden';
+  const conversation = boolean('show conversation', false) ? undefined : 'none';
   return (
-    <amp-twitter width="300" height="200" data-tweetid={tweetId}>
-      <blockquote placeholder>
-        <p lang="en" dir="ltr">
-          In case you missed it last week, check out our recap of AMP in 2020
-          ⚡🙌
-        </p>
-        <p>
-          Watch here ➡️
-          <br />
-          <a href="https://t.co/eaxT3MuSAK">https://t.co/eaxT3MuSAK</a>
-        </p>
-      </blockquote>
-    </amp-twitter>
+    <amp-twitter
+      width="300"
+      height="200"
+      data-tweetid={tweetId}
+      data-cards={cards}
+      data-conversation={conversation}
+    />
+  );
+};
+
+export const moments = () => {
+  const limit = number('limit to', 2);
+  return (
+    <amp-twitter
+      data-limit={limit}
+      data-momentid="1009149991452135424"
+      width="300"
+      height="200"
+    />
+  );
+};
+
+export const timelines = () => {
+  const tweetLimit = number('limit to', 5);
+  const timelineSourceType = select(
+    'source type',
+    ['profile', 'likes', 'list', 'source', 'collection', 'url', 'widget'],
+    'profile'
+  );
+  const timelineScreenName = 'amphtml';
+  const timelineUserId = '3450662892';
+  return (
+    <amp-twitter
+      data-tweet-limit={tweetLimit}
+      data-timeline-source-type={timelineSourceType}
+      data-timeline-scree-name={timelineScreenName}
+      data-timeline-user-id={timelineUserId}
+      width="300"
+      height="200"
+    />
   );
 };


### PR DESCRIPTION
This PR adds samples to the amp-twitter Storybooks (0.1 and 1.0) to cover Tweets, Moments, and Timelines and associated options, whereas before we only had samples for non-configured embedded Tweets.