### PR TITLE
🚀🖍 `<amp-ima-video>`: Render early poster

### DIFF
--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -329,6 +329,19 @@ class AmpImaVideo extends AMP.BaseElement {
   }
 
   /** @override */
+  createPlaceholderCallback() {
+    const {poster} = this.element.dataset;
+    if (!poster) {
+      return null;
+    }
+    const img = new Image();
+    img.src = poster;
+    img.setAttribute('placeholder', '');
+    this.applyFillContent(img);
+    return img;
+  }
+
+  /** @override */
   pauseCallback() {
     this.pause();
   }


### PR DESCRIPTION
We currently pass a `data-poster` attribute into the loaded iframe to propagate into the `<video>`.

There's a lag between the AMP element building and the iframe rendering a `<video>`. By drawing the same poster on the AMP layer, we improved perceived performance. (Other players like `<amp-video-iframe>` do this already.)

![earlyposter](https://user-images.githubusercontent.com/254946/117483724-efac7780-af1a-11eb-8dbf-46240c9a9003.png)

(We lack element tests, so I'll add a specific one after merging #34229).