### PR TITLE
amp-twitter:1.0 - Allow binding to data-tweetid and other configuration attrs

### DIFF
--- a/extensions/amp-twitter/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/0.1/storybook/Basic.amp.js
@@ -28,6 +28,10 @@ export default {
         name: 'amp-twitter',
         version: '0.1',
       },
+      {
+        name: 'amp-bind',
+        version: '0.1',
+      },
     ],
   },
 };
@@ -48,5 +52,25 @@ export const Default = () => {
         </p>
       </blockquote>
     </amp-twitter>
+  );
+};
+
+export const mutatedTweetId = () => {
+  return (
+    <>
+      <button on="tap:AMP.setState({tweetid: '495719809695621121'})">
+        Change tweet
+      </button>
+      <amp-state id="tweetid">
+        <script type="application/json">1356304203044499462</script>
+      </amp-state>
+      <amp-twitter
+        width="375"
+        height="472"
+        layout="responsive"
+        data-tweetid="1356304203044499462"
+        data-amp-bind-data-tweetid="tweetid"
+      ></amp-twitter>
+    </>
   );
 };

--- a/extensions/amp-twitter/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.amp.js
@@ -28,6 +28,10 @@ export default {
         name: 'amp-twitter',
         version: '1.0',
       },
+      {
+        name: 'amp-bind',
+        version: '0.1',
+      },
     ],
     experiments: ['bento'],
   },
@@ -49,5 +53,25 @@ export const Default = () => {
         </p>
       </blockquote>
     </amp-twitter>
+  );
+};
+
+export const mutatedTweetId = () => {
+  return (
+    <>
+      <button on="tap:AMP.setState({tweetid: '495719809695621121'})">
+        Change tweet
+      </button>
+      <amp-state id="tweetid">
+        <script type="application/json">1356304203044499462</script>
+      </amp-state>
+      <amp-twitter
+        width="375"
+        height="472"
+        layout="responsive"
+        data-tweetid="1356304203044499462"
+        data-amp-bind-data-tweetid="tweetid"
+      ></amp-twitter>
+    </>
   );
 };

--- a/extensions/amp-twitter/1.0/test/test-amp-twitter.js
+++ b/extensions/amp-twitter/1.0/test/test-amp-twitter.js
@@ -65,7 +65,7 @@ describes.realWin(
     it("container's height is changed", async () => {
       const initialHeight = 300;
       element = createElementWithAttributes(win.document, 'amp-twitter', {
-        'data-shortcode': '585110598171631616',
+        'data-tweetid': '585110598171631616',
         'height': initialHeight,
         'width': 500,
         'layout': 'responsive',
@@ -88,6 +88,37 @@ describes.realWin(
       ).contentWindow;
       win.dispatchEvent(mockEvent);
       expect(forceChangeHeightStub).to.be.calledOnce.calledWith(1000);
+    });
+
+    it('should replace iframe after tweetid mutation', async () => {
+      const newTweetId = '638793490521001985';
+      element = createElementWithAttributes(win.document, 'amp-twitter', {
+        'data-tweetid': '585110598171631616',
+        'height': 500,
+        'width': 500,
+        'layout': 'responsive',
+      });
+      doc.body.appendChild(element);
+      await waitForRender();
+
+      const iframe = element.shadowRoot.querySelector('iframe');
+      const oldName = iframe.getAttribute('name');
+      expect(oldName).to.contain('585110598171631616');
+      expect(oldName).not.to.contain('638793490521001985');
+
+      element.setAttribute('data-tweetid', newTweetId);
+      await waitFor(
+        () =>
+          element.shadowRoot.querySelector('iframe').getAttribute('name') !=
+          oldName,
+        'iframe changed'
+      );
+
+      const name = element.shadowRoot
+        .querySelector('iframe')
+        .getAttribute('name');
+      expect(name).not.to.contain('585110598171631616');
+      expect(name).to.contain('638793490521001985');
     });
   }
 );

--- a/src/preact/component/iframe.js
+++ b/src/preact/component/iframe.js
@@ -93,6 +93,9 @@ export function IframeEmbedWithRef(
       get readyState() {
         return loadedRef.current ? ReadyState.COMPLETE : ReadyState.LOADING;
       },
+      get node() {
+        return iframeRef.current;
+      },
     }),
     []
   );


### PR DESCRIPTION
This is needed for feature parity with 0.1. 