### PR TITLE
🐛 ✅ [Amp story] [Attachments] Get reference to win

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -24,6 +24,7 @@ import {getLocalizationService} from './amp-story-localization-service';
 import {getRGBFromCssColorValue, getTextColorForRGB} from './utils';
 import {htmlFor, htmlRefs} from '../../../src/static-template';
 import {isPageAttachmentUiV2ExperimentOn} from './amp-story-page-attachment-ui-v2';
+import {toWin} from '../../../src/types';
 
 /**
  * @enum {string}
@@ -269,7 +270,9 @@ export const setCustomThemeStyles = (attachmentEl, openAttachmentEl) => {
     setImportantStyles(attachmentEl, {
       'background-color': attachmentEl.getAttribute('cta-accent-color'),
     });
-    const styles = computedStyle(attachmentEl.getAmpDoc().win, attachmentEl);
+
+    const win = toWin(attachmentEl.ownerDocument.defaultView);
+    const styles = computedStyle(win, attachmentEl);
     const rgb = getRGBFromCssColorValue(styles['background-color']);
     contrastColor = getTextColorForRGB(rgb);
     setImportantStyles(attachmentEl, {


### PR DESCRIPTION
The following test was failing since a reference to the win via element was undefined.
https://github.com/ampproject/amphtml/blob/main/extensions/amp-story/1.0/test/test-amp-story-page.js#L787-L810

Get reference to win with `toWin` instead of from element.  

@ampproject/wg-stories