### PR TITLE
❄️ Skip flaky stories tests

### DIFF
--- a/extensions/amp-story/1.0/test/test-page-advancement.js
+++ b/extensions/amp-story/1.0/test/test-page-advancement.js
@@ -130,7 +130,8 @@ describes.realWin('page-advancement', {amp: true}, (env) => {
         expect(advancement).to.not.be.instanceOf(TimeBasedAdvancement);
       });
 
-      it('should update delayMs_ when updateTimeDelay() is called', () => {
+      // TODO(zaparent, #34153): This test is flaky during CI.
+      it.skip('should update delayMs_ when updateTimeDelay() is called', () => {
         const pageEl = html`
           <amp-story-page auto-advance-after="3s"> </amp-story-page>
         `;
@@ -143,7 +144,8 @@ describes.realWin('page-advancement', {amp: true}, (env) => {
         expect(advancement.remainingDelayMs_).to.be.equal(null);
       });
 
-      it('should update remainingDelayMs_ when updateTimeDelay() is called', () => {
+      // TODO(zaparent, #34153): This test is flaky during CI.
+      it.skip('should update remainingDelayMs_ when updateTimeDelay() is called', () => {
         const pageEl = html`
           <amp-story-page auto-advance-after="3s"> </amp-story-page>
         `;


### PR DESCRIPTION
These tests compare millisecond values when the test is running, and there's no guarantee that there's an exact match. See https://github.com/ampproject/amphtml/pull/34153#pullrequestreview-656192589.

**Links:**
- https://app.circleci.com/pipelines/github/ampproject/amphtml/8866/workflows/2ea8df92-b56c-434a-98e3-f03f5b8d556f/jobs/134483/parallel-runs/0/steps/0-112
- https://app.circleci.com/pipelines/github/ampproject/amphtml/8873/workflows/8940beff-c45a-4835-9188-5997da23b5da/jobs/134598/parallel-runs/0/steps/0-112

**Logs:**
```
AssertionError: expected 1999 to equal 2000
	    at Context.<anonymous> (home/circleci/project/extensions/amp-story/1.0/test/test-page-advancement.js:155:53)
```

```
AssertionError: expected 1998 to equal 2000
	    at Context.<anonymous> (home/circleci/project/extensions/amp-story/1.0/test/test-page-advancement.js:155:53)
```

/cc @zaparent, @ampproject/build-on-duty 