### PR TITLE
Bento: Assign placeholder and fallback elements to service slot

### DIFF
--- a/extensions/amp-facebook-comments/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook-comments/1.0/storybook/Basic.amp.js
@@ -51,7 +51,11 @@ export const _default = () => {
       data-locale={locale}
       data-numposts={numPosts}
       data-order-by={orderBy}
-    ></amp-facebook-comments>
+    >
+      <div placeholder>
+        <h1>Placeholder</h1>
+      </div>
+    </amp-facebook-comments>
   );
 };
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -114,8 +114,10 @@ const SHADOW_CONTAINER_ATTRS = dict({
   'part': 'c',
 });
 
+const SERVICE_SLOT_NAME = 'i-amphtml-svc';
+
 /** @const {!JsonObject<string, string>} */
-const SERVICE_SLOT_ATTRS = dict({'name': 'i-amphtml-svc'});
+const SERVICE_SLOT_ATTRS = dict({'name': SERVICE_SLOT_NAME});
 
 /**
  * The same as `applyFillContent`, but inside the shadow.
@@ -624,6 +626,8 @@ export class PreactBaseElement extends AMP.BaseElement {
             SERVICE_SLOT_ATTRS
           );
           shadowRoot.appendChild(serviceSlot);
+          this.getPlaceholder()?.setAttribute('slot', SERVICE_SLOT_NAME);
+          this.getFallback()?.setAttribute('slot', SERVICE_SLOT_NAME);
         }
         this.container_ = container;
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -114,6 +114,7 @@ const SHADOW_CONTAINER_ATTRS = dict({
   'part': 'c',
 });
 
+/** @const {string} */
 const SERVICE_SLOT_NAME = 'i-amphtml-svc';
 
 /** @const {!JsonObject<string, string>} */

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -18,6 +18,7 @@ import * as Preact from '../../../src/preact/index';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Slot} from '../../../src/preact/slot';
 import {createElementWithAttributes} from '../../../src/dom';
+import {expect} from 'chai';
 import {htmlFor} from '../../../src/static-template';
 import {omit} from '../../../src/core/types/object';
 import {testElementR1} from '../../../testing/element-v1';
@@ -351,6 +352,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       element = html`
         <amp-preact layout="fixed" width="100" height="100">
           <div id="child1"></div>
+          <div placeholder>foo</div>
+          <div fallback>bar</div>
         </amp-preact>
       `;
     });
@@ -371,6 +374,23 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(
         element.shadowRoot.querySelectorAll('slot[name="i-amphtml-svc"]')
       ).to.have.lengthOf(1);
+    });
+
+    it('should pass placeholder and fallback elements to service slot', async () => {
+      doc.body.appendChild(element);
+      await element.buildInternal();
+      await waitFor(() => component.callCount > 0, 'component rendered');
+      const serviceSlot = element.shadowRoot.querySelectorAll(
+        'slot[name="i-amphtml-svc"]'
+      );
+      expect(serviceSlot).to.have.lengthOf(1);
+      const placeholder = element.querySelector('[placeholder]');
+      const fallback = element.querySelector('[fallback]');
+      expect(placeholder.getAttribute('slot')).to.equal('i-amphtml-svc');
+      expect(fallback.getAttribute('slot')).to.equal('i-amphtml-svc');
+      expect(serviceSlot[0].assignedElements()).to.have.lengthOf(2);
+      expect(serviceSlot[0].assignedElements()[0]).to.equal(placeholder);
+      expect(serviceSlot[0].assignedElements()[1]).to.equal(fallback);
     });
 
     describe('SSR', () => {

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -18,7 +18,6 @@ import * as Preact from '../../../src/preact/index';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Slot} from '../../../src/preact/slot';
 import {createElementWithAttributes} from '../../../src/dom';
-import {expect} from 'chai';
 import {htmlFor} from '../../../src/static-template';
 import {omit} from '../../../src/core/types/object';
 import {testElementR1} from '../../../testing/element-v1';


### PR DESCRIPTION
This PR will allow components which are built using Shadow DOM to display their placeholder and fallback elements, which otherwise are hidden once the shadow root gets attached. cc @dmanek 