### PR TITLE
Bento: Find rendered `lightDomTag` elements by attribute instead of `tagName`

### DIFF
--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -34,6 +34,7 @@ import {
   subscribe,
 } from '../context';
 import {
+  childElementByAttr,
   childElementByTag,
   createElementWithAttributes,
   dispatchCustomEvent,
@@ -119,6 +120,12 @@ const SERVICE_SLOT_NAME = 'i-amphtml-svc';
 
 /** @const {!JsonObject<string, string>} */
 const SERVICE_SLOT_ATTRS = dict({'name': SERVICE_SLOT_NAME});
+
+/** @const {string} */
+const RENDERED_ATTR = 'i-amphtml-rendered';
+
+/** @const {!JsonObject<string, string>} */
+const RENDERED_ATTRS = dict({'i-amphtml-rendered': ''});
 
 /**
  * The same as `applyFillContent`, but inside the shadow.
@@ -643,8 +650,8 @@ export class PreactBaseElement extends AMP.BaseElement {
       } else if (lightDomTag) {
         this.container_ = this.element;
         const replacement =
-          childElementByTag(this.container_, lightDomTag) ||
-          doc.createElement(lightDomTag);
+          childElementByAttr(this.container_, RENDERED_ATTR) ||
+          createElementWithAttributes(doc, lightDomTag, RENDERED_ATTRS);
         replacement[RENDERED_PROP] = true;
         if (Ctor['layoutSizeDefined']) {
           replacement.classList.add('i-amphtml-fill-content');
@@ -706,7 +713,7 @@ export class PreactBaseElement extends AMP.BaseElement {
       hydrate(v, this.container_);
     } else {
       const replacement = lightDomTag
-        ? childElementByTag(this.container_, lightDomTag)
+        ? childElementByAttr(this.container_, RENDERED_ATTR)
         : null;
       if (replacement) {
         replacement[RENDERED_PROP] = true;
@@ -1035,6 +1042,7 @@ function collectProps(Ctor, element, ref, defaultProps, mediaQueryProps) {
 
   // Light DOM.
   if (lightDomTag) {
+    props[RENDERED_ATTR] = true;
     props[RENDERED_PROP] = true;
     props['as'] = lightDomTag;
   }

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -503,6 +503,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(component).to.be.calledOnce;
       const lightDom = element.querySelector(':scope > time');
       expect(lightDom.className).to.equal('');
+      expect(lightDom.hasAttribute('i-amphtml-rendered')).to.be.true;
       expect(lightDom.querySelector(':scope > #component')).to.be.ok;
       expect(lastProps.as).to.equal('time');
       await waitFor(
@@ -522,6 +523,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       const lightDom = element.querySelector(':scope > time');
       expect(lightDom.querySelector(':scope > #component')).to.be.ok;
       expect(lightDom.className).to.equal('i-amphtml-fill-content');
+      expect(lightDom.hasAttribute('i-amphtml-rendered')).to.be.true;
       expect(lastProps.className).to.equal('i-amphtml-fill-content');
       expect(lastProps.as).to.equal('time');
       await waitFor(
@@ -532,7 +534,9 @@ describes.realWin('PreactBaseElement', spec, (env) => {
 
     it('should use the existing element if exists', async () => {
       Impl['layoutSizeDefined'] = true;
-      const existing = document.createElement('time');
+      const existing = createElementWithAttributes(document, 'time', {
+        'i-amphtml-rendered': '',
+      });
       element.appendChild(existing);
       doc.body.appendChild(element);
       await element.buildInternal();


### PR DESCRIPTION
Identifying existing element by `tagName` alone can cause collisions with other elements i.e. placeholder, fallback, overflow. cc @dmanek 