### PR TITLE
🐛 Initialize Logs in web-push's helper frame endpoint

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -324,6 +324,7 @@ const forbiddenTermsGlobal = {
       'ads/alp/install-alp.js',
       'ads/inabox/inabox-host.js',
       'extensions/amp-access/0.1/amp-login-done.js',
+      'extensions/amp-web-push/0.1/amp-web-push-helper-frame.js',
       'src/amp-story-player/amp-story-component-manager.js',
       'src/runtime.js',
       'src/log.js',

--- a/extensions/amp-web-push/0.1/amp-web-push-helper-frame.js
+++ b/extensions/amp-web-push/0.1/amp-web-push-helper-frame.js
@@ -17,8 +17,12 @@
 import {TAG} from './vars';
 import {WindowMessenger} from './window-messenger';
 import {getMode} from '../../../src/mode';
+import {initLogConstructor, setReportError, user} from '../../../src/log';
 import {parseQueryString} from '../../../src/url.js';
-import {user} from '../../../src/log';
+import {reportError} from '../../../src/error-reporting';
+
+initLogConstructor();
+setReportError(reportError);
 
 /**
  * @typedef {{


### PR DESCRIPTION
It seems we forgot that web-push has a helper iframe, which acts as an entry point into our JS. It doesn't include `v0.js`, so it needs to initialize the log constructor for logging to work.

Fixes https://github.com/ampproject/amphtml/issues/34318.