### PR TITLE
🏗 Sandbox `describes.repeated` and get rid of the global `window.sandbox`

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -122,6 +122,10 @@ const forbiddenTermsGlobal = {
       '  If this is same domain, mark /*OK*/.\n' +
       '  If this is cross domain, overwrite the method directly.',
   },
+  'window\\.sandbox': {
+    message: 'Usage of window.sandbox is forbidden. Use env.sandbox instead.',
+    checkInTestFolder: true,
+  },
   'console\\.\\w+\\(': {
     message: String(
       'console.log is generally forbidden. For the runtime, use ' +

--- a/extensions/amp-form/0.1/test/test-form-proxy.js
+++ b/extensions/amp-form/0.1/test/test-form-proxy.js
@@ -43,7 +43,7 @@ describes.repeated(
     'legacy w/ inputs': {denylist: true, inputs: true},
     'no EventTarget': {eventTarget: true},
   },
-  (name, variant) => {
+  (name, variant, env) => {
     let form;
     let inputs;
 
@@ -51,7 +51,7 @@ describes.repeated(
       // Stub only to work around the fact that there's no Ampdoc, so the service
       // cannot be retrieved.
       // Otherwise this test would barf because `form` is detached.
-      window.sandbox.stub(Services, 'urlForDoc').returns({
+      env.sandbox.stub(Services, 'urlForDoc').returns({
         parse: parseUrlDeprecated,
       });
 

--- a/extensions/amp-mustache/0.1/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.1/test/test-amp-mustache.js
@@ -27,11 +27,11 @@ describes.repeated(
     },
     'with template[type=amp-mustache]': {templateType: 'template'},
   },
-  (name, variant) => {
+  (name, variant, env) => {
     let viewerCanRenderTemplates = false;
 
     beforeEach(() => {
-      const getServiceForDocStub = window.sandbox.stub(
+      const getServiceForDocStub = env.sandbox.stub(
         service,
         'getServiceForDoc'
       );
@@ -595,14 +595,14 @@ describes.repeated(
       });
 
       it('should not call mustache parsing', () => {
-        window.sandbox.spy(mustache, 'parse');
+        env.sandbox.spy(mustache, 'parse');
         template.compileCallback();
         expect(mustache.parse).to.have.not.been.called;
       });
 
       it('should not mustache render but still sanitize html', () => {
-        window.sandbox.spy(sanitizer, 'sanitizeHtml');
-        window.sandbox.spy(mustache, 'render');
+        env.sandbox.spy(sanitizer, 'sanitizeHtml');
+        env.sandbox.spy(mustache, 'render');
         template.setHtml('<div>test</div>');
         expect(mustache.render).to.have.not.been.called;
         expect(sanitizer.sanitizeHtml).to.have.been.called;

--- a/extensions/amp-mustache/0.2/test/test-amp-mustache.js
+++ b/extensions/amp-mustache/0.2/test/test-amp-mustache.js
@@ -27,11 +27,11 @@ describes.repeated(
     },
     'with template[type=amp-mustache]': {templateType: 'template'},
   },
-  (name, variant) => {
+  (name, variant, env) => {
     let viewerCanRenderTemplates = false;
 
     beforeEach(() => {
-      const getServiceForDocStub = window.sandbox.stub(
+      const getServiceForDocStub = env.sandbox.stub(
         service,
         'getServiceForDoc'
       );
@@ -618,14 +618,14 @@ describes.repeated(
       });
 
       it('should not call mustache parsing', () => {
-        window.sandbox.spy(mustache, 'parse');
+        env.sandbox.spy(mustache, 'parse');
         template.compileCallback();
         expect(mustache.parse).to.have.not.been.called;
       });
 
       it('should not mustache render but still purify html', () => {
-        window.sandbox.spy(Purifier.prototype, 'purifyHtml');
-        window.sandbox.spy(mustache, 'render');
+        env.sandbox.spy(Purifier.prototype, 'purifyHtml');
+        env.sandbox.spy(mustache, 'render');
         template.setHtml('<div>test</div>');
         expect(mustache.render).to.have.not.been.called;
         expect(Purifier.prototype.purifyHtml).to.have.been.called;

--- a/testing/_init_tests.js
+++ b/testing/_init_tests.js
@@ -251,7 +251,6 @@ beforeEach(function () {
   this.timeout(BEFORE_AFTER_TIMEOUT);
   beforeTest();
   testName = this.currentTest.fullTitle();
-  window.sandbox = sinon.createSandbox();
   maybeStubConsoleInfoLogWarn();
   preventAsyncErrorThrows();
   warnForConsoleError();
@@ -282,7 +281,6 @@ afterEach(function () {
   if (consoleInfoLogWarnSandbox) {
     consoleInfoLogWarnSandbox.restore();
   }
-  window.sandbox.restore();
   restoreConsoleError();
   restoreAsyncErrorThrows();
   this.timeout(BEFORE_AFTER_TIMEOUT);


### PR DESCRIPTION
**Background:**

- In #34286, `describes` was made configurable
- In #34305, most of AMP's unit and integration tests were sandboxed

**PR Highlights:**

- Updates `describes.repeated` to make it configurable and internally use a `sandboxed` wrapper
- Switches all `describes.repeated` tests to use `env.sandbox` instead of the global `window.sandbox`
- Removes `window.sandbox` from `_init_tests.js`
- Adds a lint rule to prevent future use of `window.sandbox` in tests