### PR TITLE
🐛 [Amp story] [Page attachments] [Outlink] Split outlink codepaths for open attachment

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -352,7 +352,11 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     );
 
     if (this.type_ === AttachmentType.REMOTE) {
-      this.openRemote_();
+      if (isPageAttachmentUiV2ExperimentOn(this.win)) {
+        this.openRemoteV2_();
+      } else {
+        this.openRemote_();
+      }
     }
   }
 
@@ -361,7 +365,7 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    * specified URL.
    * @private
    */
-  openRemote_() {
+  openRemoteV2_() {
     const clickTarget = this.element.parentElement
       .querySelector('.i-amphtml-story-page-open-attachment-host')
       .shadowRoot.querySelector('a.i-amphtml-story-page-open-attachment');
@@ -389,6 +393,32 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
         triggerClickFromLightDom(clickTarget, this.element);
       }, 1000);
     }
+  }
+
+  /**
+   * Triggers a remote attachment opening animation, and redirects to the
+   * specified URL.
+   * @private
+   */
+  openRemote_() {
+    const animationEl = this.win.document.createElement('div');
+    animationEl.classList.add('i-amphtml-story-page-attachment-expand');
+    const storyEl = closest(this.element, (el) => el.tagName === 'AMP-STORY');
+
+    this.mutateElement(() => {
+      storyEl.appendChild(animationEl);
+    }).then(() => {
+      // Give some time for the 120ms CSS animation to run (cf
+      // amp-story-page-attachment.css). The navigation itself will take some
+      // time, depending on the target and network conditions.
+      this.win.setTimeout(() => {
+        const navigationService = Services.navigationForDoc(this.getAmpDoc());
+        navigationService.navigateTo(
+          this.win,
+          this.element.getAttribute('href')
+        );
+      }, 50);
+    });
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -81,6 +81,7 @@ import {renderPageAttachmentUI} from './amp-story-open-page-attachment';
 import {renderPageDescription} from './semantic-render';
 import {toArray} from '../../../src/core/types/array';
 import {upgradeBackgroundAudio} from './audio';
+import {isPageAttachmentUiV2ExperimentOn} from './amp-story-page-attachment-ui-v2';
 
 /**
  * CSS class for an amp-story-page that indicates the entire page is loaded.
@@ -1810,8 +1811,10 @@ export class AmpStoryPage extends AMP.BaseElement {
       container.setAttribute('role', 'button');
 
       container.addEventListener('click', (e) => {
-        // Prevent default so link can be opened programmatically after URL preview is shown.
-        e.preventDefault();
+        if (isPageAttachmentUiV2ExperimentOn(this.win)) {
+          // Prevent default so link can be opened programmatically after URL preview is shown.
+          e.preventDefault();
+        }
         this.openAttachment();
       });
 
@@ -1832,7 +1835,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   openAttachment(shouldAnimate = true) {
     const attachmentEl = this.element.querySelector(
-      'amp-story-page-attachment'
+      'amp-story-page-attachment, amp-story-page-outlink'
     );
 
     if (!attachmentEl) {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -72,6 +72,7 @@ import {getMode} from '../../../src/mode';
 import {htmlFor} from '../../../src/static-template';
 import {isAutoplaySupported} from '../../../src/utils/video';
 import {isExperimentOn} from '../../../src/experiments';
+import {isPageAttachmentUiV2ExperimentOn} from './amp-story-page-attachment-ui-v2';
 import {isPrerenderActivePage} from './prerender-active-page';
 import {listen, listenOnce} from '../../../src/event-helper';
 import {CSS as pageAttachmentCSS} from '../../../build/amp-story-open-page-attachment-0.1.css';
@@ -81,7 +82,6 @@ import {renderPageAttachmentUI} from './amp-story-open-page-attachment';
 import {renderPageDescription} from './semantic-render';
 import {toArray} from '../../../src/core/types/array';
 import {upgradeBackgroundAudio} from './audio';
-import {isPageAttachmentUiV2ExperimentOn} from './amp-story-page-attachment-ui-v2';
 
 /**
  * CSS class for an amp-story-page that indicates the entire page is loaded.


### PR DESCRIPTION
Adds codepath for `openRemoteV2_`.
Add selector for `amp-story-page-outlink` in `attachmentEl`.

Context / Fixes #34323