### PR TITLE
🏗 [bento][npm][amp-twitter] Update npm definition and package file for publishing

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -635,7 +635,15 @@
       "cssBinaries": ["amp-truncate-text", "amp-truncate-text-shadow"]
     }
   },
-  {"name": "amp-twitter", "version": ["0.1", "1.0"], "latestVersion": "0.1"},
+  {"name": "amp-twitter", "version": "0.1", "latestVersion": "0.1"},
+  {
+    "name": "amp-twitter",
+    "version": "1.0",
+    "latestVersion": "0.1",
+    "options": {
+      "npm": true
+    }
+  },
   {
     "name": "amp-user-notification",
     "version": "0.1",

--- a/extensions/amp-twitter/1.0/package.json
+++ b/extensions/amp-twitter/1.0/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ampproject/amp-twitter",
+  "version": "VERSION",
+  "description": "AMP Twitter Component",
+  "author": "The AMP HTML Authors",
+  "license": "Apache-2.0",
+  "main": "dist/component.js",
+  "module": "dist/component.mjs",
+  "exports": {
+    ".": "./preact",
+    "./preact": {
+      "import": "dist/component-preact.mjs",
+      "require": "dist/component-preact.js"
+    },
+    "./react": {
+      "import": "dist/component-react.mjs",
+      "require": "dist/component-react.js"
+    }
+  },
+  "files": ["dist/*"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ampproject/amphtml.git",
+    "directory": "extensions/amp-twitter/1.0"
+  },
+  "homepage": "https://github.com/ampproject/amphtml/tree/main/extensions/amp-twitter/1.0",
+  "peerDependencies": {
+    "preact": "^10.2.1",
+    "react": "^17.0.0"
+  }
+}


### PR DESCRIPTION
NPM Publishing Tracker Issue https://github.com/ampproject/amphtml/issues/34137
NPM Publishing Status: [Doc](https://docs.google.com/spreadsheets/d/1JnCfYzgEojX_vPVy6h0fOnOLIHOcfPl4FCOZUDpclfE/edit#gid=0)

Get `amp-twitter` ready for NPM publishing.

1. Add `npm` definition.
2. Add `package.json` file.