### PR TITLE
validator update

### DIFF
--- a/extensions/amp-vimeo/validator-amp-vimeo.protoascii
+++ b/extensions/amp-vimeo/validator-amp-vimeo.protoascii
@@ -14,18 +14,6 @@
 # limitations under the license.
 #
 
-tags: {  # amp-vimeo 1.0
-  html_format: AMP
-  tag_name: "SCRIPT"
-  satisfies: "amp-vimeo 1.0"
-  excludes: "amp-vimeo 0.1"
-  extension_spec: {
-    name: "amp-vimeo"
-    version_name: "v1.0"
-    version: "1.0"
-  }
-  attr_lists: "common-extension-attrs"
-}
 tags: {  # amp-vimeo
   html_format: AMP
   tag_name: "SCRIPT"
@@ -38,6 +26,18 @@ tags: {  # amp-vimeo
     version: "latest"
     requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-vimeo 1.0
+  html_format: AMP
+  tag_name: "SCRIPT"
+  satisfies: "amp-vimeo 1.0"
+  excludes: "amp-vimeo 0.1"
+  extension_spec: {
+    name: "amp-vimeo"
+    version_name: "v1.0"
+    version: "1.0"
   }
   attr_lists: "common-extension-attrs"
 }


### PR DESCRIPTION
cl/372175665 amp-vimeo: prioritize v0.1 over v1.0 in tagspec ordering