### PR TITLE
✨ [bento][amp-sidebar] Toolbar design for AMP side for amp-sidebar

### DIFF
--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
+import * as Preact from '../../../src/preact';
+import {AmpSidebarToolbar, Sidebar} from './component';
 import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
-import {Sidebar} from './component';
 import {dict} from '../../../src/core/types/object';
 import {pauseAll} from '../../../src/utils/resource-container-helper';
 import {toggle} from '../../../src/style';
 import {toggleAttribute} from '../../../src/dom';
 
 export class BaseElement extends PreactBaseElement {
+  /** @override */
+  static deferredMount(unusedElement) {
+    return false;
+  }
+
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
@@ -37,6 +43,25 @@ export class BaseElement extends PreactBaseElement {
       'onBeforeOpen': () => this.beforeOpen_(),
       'onAfterOpen': () => this.afterOpen_(),
       'onAfterClose': () => this.afterClose_(),
+    });
+  }
+
+  /** @override */
+  updatePropsForRendering(props) {
+    this.getRealChildNodes().map((child) => {
+      if (
+        child.nodeName === 'NAV' &&
+        child.hasAttribute('toolbar') &&
+        child.hasAttribute('toolbar-target')
+      ) {
+        props['children'].push(
+          <AmpSidebarToolbar
+            toolbar={child.getAttribute('toolbar')}
+            toolbarTarget={child.getAttribute('toolbar-target')}
+            domElement={child}
+          ></AmpSidebarToolbar>
+        );
+      }
     });
   }
 

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -15,13 +15,15 @@
  */
 
 import * as Preact from '../../../src/preact';
-import {AmpSidebarToolbar, Sidebar} from './component';
 import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
+import {Sidebar} from './component';
 import {dict} from '../../../src/core/types/object';
 import {pauseAll} from '../../../src/utils/resource-container-helper';
 import {toggle} from '../../../src/style';
 import {toggleAttribute} from '../../../src/dom';
+import {useToolbarHook} from './sidebar-toolbar-hook';
+import {useValueRef} from '../../../src/preact/component';
 
 export class BaseElement extends PreactBaseElement {
   /** @override */
@@ -55,11 +57,11 @@ export class BaseElement extends PreactBaseElement {
         child.hasAttribute('toolbar-target')
       ) {
         props['children'].push(
-          <AmpSidebarToolbar
+          <ToolbarShim
             toolbar={child.getAttribute('toolbar')}
             toolbarTarget={child.getAttribute('toolbar-target')}
             domElement={child}
-          ></AmpSidebarToolbar>
+          ></ToolbarShim>
         );
       }
     });
@@ -118,3 +120,15 @@ BaseElement['props'] = {
   'children': {passthrough: true},
   'side': {attr: 'side', type: 'string'},
 };
+
+/**
+ * @param {!SidebarDef.ToolbarShimProps} props
+ */
+function ToolbarShim({
+  domElement,
+  toolbar: mediaQueryProp,
+  toolbarTarget: toolbarTargetProp,
+}) {
+  const ref = useValueRef(domElement);
+  useToolbarHook(ref, mediaQueryProp, toolbarTargetProp);
+}

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -23,9 +23,11 @@ import {forwardRef} from '../../../src/preact/compat';
 import {isRTL} from '../../../src/dom';
 import {
   useCallback,
+  useContext,
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from '../../../src/preact';
@@ -180,12 +182,63 @@ const Sidebar = forwardRef(SidebarWithRef);
 Sidebar.displayName = 'Sidebar'; // Make findable for tests.
 export {Sidebar};
 
+const ToolbarContext = Preact.createContext(
+  /** @type {SidebarDef.ToolbarContext} */ ({})
+);
+
 /**
  * @param {!SidebarDef.SidebarToolbarProps} props
  * @return {PreactDef.Renderable}
  */
+<<<<<<< HEAD
 export function SidebarToolbar({
   children,
+=======
+export function SidebarToolbar(props) {
+  const context = useMemo(
+    () => ({
+      preactMode: true,
+      domElement: null,
+    }),
+    []
+  );
+
+  return (
+    <ToolbarContext.Provider value={context}>
+      <ToolbarHelper {...props}></ToolbarHelper>
+    </ToolbarContext.Provider>
+  );
+}
+
+/**
+ * @param {!SidebarDef.AmpSidebarToolbarProps} props
+ * @return {PreactDef.Renderable}
+ */
+export function AmpSidebarToolbar(props) {
+  const childProps = {...props};
+  const {domElement} = childProps;
+  delete childProps.domElement;
+  const context = useMemo(
+    () => ({
+      preactMode: false,
+      domElement,
+    }),
+    [domElement]
+  );
+
+  return (
+    <ToolbarContext.Provider value={context}>
+      <ToolbarHelper {...childProps}></ToolbarHelper>
+    </ToolbarContext.Provider>
+  );
+}
+
+/**
+ * @param {!SidebarDef.ToolbarHelperProps} props
+ * @return {PreactDef.Renderable}
+ */
+function ToolbarHelper({
+>>>>>>> 2b67abd5f (Amp sidebar ssr design)
   toolbar: mediaQueryProp,
   toolbarTarget: toolbarTargetProp,
   ...rest
@@ -194,6 +247,11 @@ export function SidebarToolbar({
   const [mediaQuery, setMediaQuery] = useState(null);
   const [toolbarTarget, setToolbarTarget] = useState(null);
   const [targetEl, setTargetEl] = useState(null);
+
+  const {preactMode, domElement} = useContext(ToolbarContext);
+  if (!preactMode) {
+    ref.current = domElement;
+  }
 
   useEffect(() => {
     const doc = ref.current?.ownerDocument;
@@ -237,14 +295,16 @@ export function SidebarToolbar({
   }, [mediaQuery, toolbarTarget, targetEl]);
 
   return (
-    <nav
-      ref={ref}
-      toolbar={mediaQueryProp}
-      toolbar-target={toolbarTargetProp}
-      {...rest}
-    >
-      {children}
-    </nav>
+    preactMode && (
+      <nav
+        ref={ref}
+        toolbar={mediaQueryProp}
+        toolbar-target={toolbarTargetProp}
+        {...rest}
+      >
+        {children}
+      </nav>
+    )
   );
 }
 

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -18,7 +18,6 @@ import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {Side} from './sidebar-config';
-
 import {forwardRef} from '../../../src/preact/compat';
 import {isRTL} from '../../../src/dom';
 import {

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -18,21 +18,20 @@ import * as Preact from '../../../src/preact';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {Side} from './sidebar-config';
-import {escapeCssSelectorIdent} from '../../../src/core/dom/css-selectors';
+
 import {forwardRef} from '../../../src/preact/compat';
 import {isRTL} from '../../../src/dom';
 import {
   useCallback,
-  useContext,
   useEffect,
   useImperativeHandle,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from '../../../src/preact';
 import {useSidebarAnimation} from './sidebar-animations-hook';
 import {useStyles} from './component.jss';
+import {useToolbarHook} from './sidebar-toolbar-hook';
 import objstr from 'obj-str';
 
 /**
@@ -182,132 +181,27 @@ const Sidebar = forwardRef(SidebarWithRef);
 Sidebar.displayName = 'Sidebar'; // Make findable for tests.
 export {Sidebar};
 
-const ToolbarContext = Preact.createContext(
-  /** @type {SidebarDef.ToolbarContext} */ ({})
-);
-
 /**
  * @param {!SidebarDef.SidebarToolbarProps} props
  * @return {PreactDef.Renderable}
  */
-export function SidebarToolbar(props) {
-  const context = useMemo(
-    () => ({
-      preactMode: true,
-      domElement: null,
-    }),
-    []
-  );
-
-  return (
-    <ToolbarContext.Provider value={context}>
-      <ToolbarHelper {...props}></ToolbarHelper>
-    </ToolbarContext.Provider>
-  );
-}
-
-/**
- * @param {!SidebarDef.AmpSidebarToolbarProps} props
- * @return {PreactDef.Renderable}
- */
-export function AmpSidebarToolbar(props) {
-  const childProps = {...props};
-  const {domElement} = childProps;
-  delete childProps.domElement;
-  const context = useMemo(
-    () => ({
-      preactMode: false,
-      domElement,
-    }),
-    [domElement]
-  );
-
-  return (
-    <ToolbarContext.Provider value={context}>
-      <ToolbarHelper {...childProps}></ToolbarHelper>
-    </ToolbarContext.Provider>
-  );
-}
-
-/**
- * @param {!SidebarDef.ToolbarHelperProps} props
- * @return {PreactDef.Renderable}
- */
-function ToolbarHelper({
+export function SidebarToolbar({
+  children,
   toolbar: mediaQueryProp,
   toolbarTarget: toolbarTargetProp,
   ...rest
 }) {
   const ref = useRef(null);
-  const [mediaQuery, setMediaQuery] = useState(null);
-  const [toolbarTarget, setToolbarTarget] = useState(null);
-  const [targetEl, setTargetEl] = useState(null);
-
-  const {domElement, preactMode} = useContext(ToolbarContext);
-  if (!preactMode) {
-    ref.current = domElement;
-  }
-
-  useEffect(() => {
-    const doc = ref.current?.ownerDocument;
-    if (!doc) {
-      return;
-    }
-
-    const sanitizedToolbarTarget = escapeCssSelectorIdent(toolbarTargetProp);
-    setToolbarTarget(sanitizedToolbarTarget);
-    setTargetEl(doc.getElementById(sanitizedToolbarTarget));
-  }, [toolbarTargetProp]);
-
-  useEffect(() => {
-    const win = ref.current?.ownerDocument?.defaultView;
-    if (!win) {
-      return;
-    }
-
-    setMediaQuery(sanitizeMediaQuery(win, mediaQueryProp));
-  }, [mediaQueryProp]);
-
-  useEffect(() => {
-    const element = ref.current;
-    const doc = ref.current?.ownerDocument;
-    if (!doc || !targetEl || mediaQuery == null) {
-      return;
-    }
-
-    const clone = element.cloneNode(true);
-    const style = doc.createElement('style');
-    style./*OK*/ textContent =
-      `#${toolbarTarget}{display: none;}` +
-      `@media ${mediaQuery}{#${toolbarTarget}{display: initial;}}`;
-
-    targetEl.appendChild(clone);
-    targetEl.appendChild(style);
-    return () => {
-      targetEl.removeChild(clone);
-      targetEl.removeChild(style);
-    };
-  }, [mediaQuery, toolbarTarget, targetEl]);
+  useToolbarHook(ref, mediaQueryProp, toolbarTargetProp);
 
   return (
-    preactMode && (
-      <nav
-        ref={ref}
-        toolbar={mediaQueryProp}
-        toolbar-target={toolbarTargetProp}
-        {...rest}
-      >
-        {children}
-      </nav>
-    )
+    <nav
+      ref={ref}
+      toolbar={mediaQueryProp}
+      toolbar-target={toolbarTargetProp}
+      {...rest}
+    >
+      {children}
+    </nav>
   );
-}
-
-/**
- * @param {!Window} win
- * @param {string|undefined} query
- * @return {string}
- */
-function sanitizeMediaQuery(win, query) {
-  return win.matchMedia(query).media;
 }

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -190,10 +190,6 @@ const ToolbarContext = Preact.createContext(
  * @param {!SidebarDef.SidebarToolbarProps} props
  * @return {PreactDef.Renderable}
  */
-<<<<<<< HEAD
-export function SidebarToolbar({
-  children,
-=======
 export function SidebarToolbar(props) {
   const context = useMemo(
     () => ({
@@ -238,7 +234,6 @@ export function AmpSidebarToolbar(props) {
  * @return {PreactDef.Renderable}
  */
 function ToolbarHelper({
->>>>>>> 2b67abd5f (Amp sidebar ssr design)
   toolbar: mediaQueryProp,
   toolbarTarget: toolbarTargetProp,
   ...rest
@@ -248,7 +243,7 @@ function ToolbarHelper({
   const [toolbarTarget, setToolbarTarget] = useState(null);
   const [targetEl, setTargetEl] = useState(null);
 
-  const {preactMode, domElement} = useContext(ToolbarContext);
+  const {domElement, preactMode} = useContext(ToolbarContext);
   if (!preactMode) {
     ref.current = domElement;
   }

--- a/extensions/amp-sidebar/1.0/component.type.js
+++ b/extensions/amp-sidebar/1.0/component.type.js
@@ -42,6 +42,33 @@ SidebarDef.SidebarProps;
  */
 SidebarDef.SidebarToolbarProps;
 
+/**
+ * @typedef {{
+ *   toolbar: (string|undefined),
+ *   toolbarTarget: (string|undefined),
+ *   domElement: (!Element)
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+SidebarDef.AmpSidebarToolbarProps;
+
+/**
+ * @typedef {{
+ *   toolbar: (string|undefined),
+ *   toolbarTarget: (string|undefined),
+ *   children: (?PreactDef.Renderable|undefined),
+ * }}
+ */
+SidebarDef.ToolbarHelperProps;
+
+/**
+ * @typedef {{
+ *   preactMode: (boolean),
+ *   domElement: (?Element),
+ * }}
+ */
+SidebarDef.ToolbarContext;
+
 /** @interface */
 SidebarDef.SidebarApi = class {
   /** Open the sidebar */

--- a/extensions/amp-sidebar/1.0/component.type.js
+++ b/extensions/amp-sidebar/1.0/component.type.js
@@ -44,30 +44,12 @@ SidebarDef.SidebarToolbarProps;
 
 /**
  * @typedef {{
- *   toolbar: (string|undefined),
- *   toolbarTarget: (string|undefined),
  *   domElement: (!Element)
- *   children: (?PreactDef.Renderable|undefined),
- * }}
- */
-SidebarDef.AmpSidebarToolbarProps;
-
-/**
- * @typedef {{
  *   toolbar: (string|undefined),
  *   toolbarTarget: (string|undefined),
- *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-SidebarDef.ToolbarHelperProps;
-
-/**
- * @typedef {{
- *   preactMode: (boolean),
- *   domElement: (?Element),
- * }}
- */
-SidebarDef.ToolbarContext;
+SidebarDef.ToolbarShimProps;
 
 /** @interface */
 SidebarDef.SidebarApi = class {

--- a/extensions/amp-sidebar/1.0/component.type.js
+++ b/extensions/amp-sidebar/1.0/component.type.js
@@ -44,7 +44,7 @@ SidebarDef.SidebarToolbarProps;
 
 /**
  * @typedef {{
- *   domElement: (!Element)
+ *   domElement: (!Element),
  *   toolbar: (string|undefined),
  *   toolbarTarget: (string|undefined),
  * }}

--- a/extensions/amp-sidebar/1.0/sidebar-toolbar-hook.js
+++ b/extensions/amp-sidebar/1.0/sidebar-toolbar-hook.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {escapeCssSelectorIdent} from '../../../src/core/dom/css-selectors';
+import {useEffect, useState} from '../../../src/preact';
+
+/**
+ * @param {{current: (Element|null)}} ref
+ * @param {string|undefined} mediaQueryProp
+ * @param {string|undefined} toolbarTargetProp
+ */
+export function useToolbarHook(ref, mediaQueryProp, toolbarTargetProp) {
+  const [mediaQuery, setMediaQuery] = useState(null);
+  const [toolbarTarget, setToolbarTarget] = useState(null);
+  const [targetEl, setTargetEl] = useState(null);
+
+  useEffect(() => {
+    const doc = ref.current?.ownerDocument;
+    if (!doc) {
+      return;
+    }
+
+    const sanitizedToolbarTarget = escapeCssSelectorIdent(toolbarTargetProp);
+    setToolbarTarget(sanitizedToolbarTarget);
+    setTargetEl(doc.getElementById(sanitizedToolbarTarget));
+  }, [toolbarTargetProp, ref]);
+
+  useEffect(() => {
+    const win = ref.current?.ownerDocument?.defaultView;
+    if (!win) {
+      return;
+    }
+
+    setMediaQuery(sanitizeMediaQuery(win, mediaQueryProp));
+  }, [mediaQueryProp, ref]);
+
+  useEffect(() => {
+    const element = ref.current;
+    const doc = ref.current?.ownerDocument;
+    if (!doc || !targetEl || mediaQuery == null) {
+      return;
+    }
+
+    const clone = element.cloneNode(true);
+    const style = doc.createElement('style');
+    style./*OK*/ textContent =
+      `#${toolbarTarget}{display: none;}` +
+      `@media ${mediaQuery}{#${toolbarTarget}{display: initial;}}`;
+
+    targetEl.appendChild(clone);
+    targetEl.appendChild(style);
+    return () => {
+      targetEl.removeChild(clone);
+      targetEl.removeChild(style);
+    };
+  }, [mediaQuery, toolbarTarget, targetEl, ref]);
+}
+
+/**
+ * @param {!Window} win
+ * @param {string|undefined} query
+ * @return {string}
+ */
+function sanitizeMediaQuery(win, query) {
+  return win.matchMedia(query).media;
+}

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -80,6 +80,57 @@ export const _default = () => {
   );
 };
 
+export const toolbar = () => {
+  const sideConfigurations = ['left', 'right', undefined];
+  const side = select('side', sideConfigurations, sideConfigurations[0]);
+  const foregroundColor = color('color');
+  const backgroundColor = color('background');
+  const backdropColor = color('backdrop color');
+  const toolbarMedia = text('toolbar media', '(max-width: 500px)');
+
+  return (
+    <main>
+      <style>
+        {`
+          amp-sidebar {
+              color: ${foregroundColor};
+              background-color: ${backgroundColor};
+          }
+          amp-sidebar::part(backdrop) {
+              background-color: ${backdropColor};
+          }
+          `}
+      </style>
+      <amp-sidebar layout="nodisplay" id="sidebar" side={side}>
+        <span>
+          Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
+          inermis reprehendunt.
+        </span>
+        <ul>
+          <li>1</li>
+          <li>2</li>
+          <li>3</li>
+        </ul>
+        <nav toolbar={toolbarMedia} toolbar-target="toolbar-target">
+          <ul>
+            <li>Toolbar Item 1</li>
+            <li>Toolbar Item 2</li>
+          </ul>
+        </nav>
+        <button on="tap:sidebar.toggle()">toggle</button>
+        <button on="tap:sidebar.open()">open</button>
+        <button on="tap:sidebar.close()">close</button>
+      </amp-sidebar>
+      <div class="buttons" style={{margin: 8}}>
+        <button on="tap:sidebar.toggle()">toggle</button>
+        <button on="tap:sidebar.open()">open</button>
+        <button on="tap:sidebar.close()">close</button>
+      </div>
+      <div id="toolbar-target"></div>
+    </main>
+  );
+};
+
 export const styles = () => {
   const sideConfigurations = ['left', 'right', undefined];
   const side = select('side', sideConfigurations, sideConfigurations[0]);

--- a/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test/test-amp-sidebar.js
@@ -760,5 +760,142 @@ describes.realWin(
         expect(animation.reverse).to.be.calledTwice;
       });
     });
+
+    describe('toolbar', () => {
+      let win;
+      let html;
+      let element;
+      let target;
+
+      beforeEach(async () => {
+        win = env.win;
+        html = htmlFor(win.document);
+        toggleExperiment(win, 'bento-sidebar', true, true);
+      });
+
+      it('toolbar target should receive expected content from toolbar', async () => {
+        target = html`<div id="toolbar-target"></div>`;
+        element = html`
+          <amp-sidebar id="sidebar" side="left">
+            <span>
+              Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at
+              aeque inermis reprehendunt.
+            </span>
+            <nav toolbar="" toolbar-target="toolbar-target">
+              <ul>
+                <li>Toolbar Item 1</li>
+                <li>Toolbar Item 2</li>
+              </ul>
+            </nav>
+          </amp-sidebar>
+        `;
+
+        win.document.body.appendChild(target);
+        win.document.body.appendChild(element);
+        await element.buildInternal();
+        await waitFor(() => target.hasChildNodes(), 'effects have run');
+
+        expect(target.hasChildNodes()).to.be.true;
+        expect(target.childElementCount).to.equal(2);
+        expect(target.firstElementChild.nodeName).to.equal('NAV');
+        expect(target.lastElementChild.nodeName).to.equal('STYLE');
+      });
+
+      it('existing children in toolbar target should not be overwritten', async () => {
+        target = html`
+        <div id="toolbar-target">
+          <span>hello world<span>
+        </div>`;
+        element = html`
+          <amp-sidebar id="sidebar" side="left">
+            <span>
+              Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at
+              aeque inermis reprehendunt.
+            </span>
+            <nav toolbar="" toolbar-target="toolbar-target">
+              <ul>
+                <li>Toolbar Item 1</li>
+                <li>Toolbar Item 2</li>
+              </ul>
+            </nav>
+          </amp-sidebar>
+        `;
+
+        win.document.body.appendChild(target);
+        win.document.body.appendChild(element);
+        await element.buildInternal();
+        await waitFor(() => target.childElementCount != 1, 'effects have run');
+
+        expect(target.hasChildNodes()).to.be.true;
+        expect(target.childElementCount).to.equal(3);
+        expect(target.firstElementChild.nodeName).to.equal('SPAN');
+        expect(target.children[1].nodeName).to.equal('NAV');
+        expect(target.lastElementChild.nodeName).to.equal('STYLE');
+      });
+
+      it('toolbar should sanitize an invalid media query', async () => {
+        target = html`<div id="toolbar-target"></div>`;
+        element = html`
+          <amp-sidebar id="sidebar" side="left">
+            <span>
+              Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at
+              aeque inermis reprehendunt.
+            </span>
+            <nav toolbar="foo {}" toolbar-target="toolbar-target">
+              <ul>
+                <li>Toolbar Item 1</li>
+                <li>Toolbar Item 2</li>
+              </ul>
+            </nav>
+          </amp-sidebar>
+        `;
+
+        win.document.body.appendChild(target);
+        win.document.body.appendChild(element);
+        await element.buildInternal();
+        await waitFor(() => target.hasChildNodes(), 'effects have run');
+
+        expect(target.hasChildNodes()).to.be.true;
+        expect(target.childElementCount).to.equal(2);
+        const styleElementText = target.lastElementChild.textContent;
+        expect(styleElementText).to.include('not all'); //sanitized media query
+        expect(styleElementText).not.to.include('foo'); //unsanitized media query
+      });
+
+      it('toolbar should sanitize the toolbar target attribute', async () => {
+        const getElementByIdSpy = env.sandbox.spy(
+          win.document,
+          'getElementById'
+        );
+        target = html`<div id="toolbar-target"></div>`;
+        element = html`
+          <amp-sidebar id="sidebar" side="left">
+            <span>
+              Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at
+              aeque inermis reprehendunt.
+            </span>
+            <nav toolbar="foo {}" toolbar-target="toolbar-target:.">
+              <ul>
+                <li>Toolbar Item 1</li>
+                <li>Toolbar Item 2</li>
+              </ul>
+            </nav>
+          </amp-sidebar>
+        `;
+
+        win.document.body.appendChild(target);
+        win.document.body.appendChild(element);
+        await element.buildInternal();
+        await waitFor(
+          () => getElementByIdSpy.callCount != 0,
+          'effects have run'
+        );
+
+        expect(getElementByIdSpy).to.be.calledOnce;
+        //sanitized toolbar target attribute
+        expect(getElementByIdSpy).to.be.calledWith('toolbar-target\\:\\.');
+        expect(target.hasChildNodes()).to.be.false;
+      });
+    });
   }
 );


### PR DESCRIPTION
Sidebar Tracker: https://github.com/ampproject/amphtml/issues/31366

Toolbar design amp side for amp-sidebar

How does this work?

1. The preact Toolbar will be leveraged in both cases.  It has been refactored into `ToolbarHelper` with a wrapper preact component to be used each in `amp` and `preact` modes.
2. Each of the wrapper components pass down context to indicate whether we are in `amp` or `preact` mode.  When in `amp` mode, there is also an actual `Toolbar` `domElement` which is passed via context.
3. When in `preact` mode, the behavior is relatively unchanged.
4. When in `amp` mode, the `base-element` updates the `children` prop to be passed into preact by appending `amp` version of the `Toolbar` (the amp wrapper from 1 above).  This amp version of the toolbar takes in the actual `domElement` and clones it into the toolbar target.  It also does not render anything in place.  So the `children` prop will include `slot` and a number of these `amp` version `Toolbars`.

What is Toolbar?

Toolbar takes a `nav` element from within the `Sidebar` and clones itself as a child onto an arbitrary element somewhere on the page.  (Which I'll refer to as `Toolbar Target`).  An additional `style` element is also appended to the `Toolbar Target` to conditionally display the element when a `mediaQuery` is true.

Design doc: [Doc](https://docs.google.com/document/d/1YPQ1ObQc0qpLm01TgsXACnwVwYppwZI_8ETBfK0wyOA/edit)
Preact Side toolbar: https://github.com/ampproject/amphtml/pull/34158

to do: tests