### PR TITLE
🐛  [Story devtools] Toggle devtools on mjs build

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -103,7 +103,7 @@ import {getConsentPolicyState} from '../../../src/consent';
 import {getDetail} from '../../../src/event-helper';
 import {getLocalizationService} from './amp-story-localization-service';
 import {getMediaQueryService} from './amp-story-media-query-service';
-import {getMode} from '../../../src/mode';
+import {getMode, isModeDevelopment} from '../../../src/mode';
 import {getState} from '../../../src/history';
 import {isExperimentOn} from '../../../src/experiments';
 import {isPageAttachmentUiV2ExperimentOn} from './amp-story-page-attachment-ui-v2';
@@ -2940,7 +2940,7 @@ export class AmpStory extends AMP.BaseElement {
    */
   maybeLoadStoryDevTools_() {
     if (
-      !getMode().development ||
+      !isModeDevelopment(this.win) ||
       this.element.getAttribute('mode') === 'inspect'
     ) {
       return false;

--- a/src/mode.js
+++ b/src/mode.js
@@ -128,6 +128,7 @@ function getRtvVersion(win) {
  * Note that AMP_DEV_MODE flag is used for testing purposes.
  * Uses Array.indexOf instead of Array.includes because of #24219
  * @param {!Window} win
+ * @return {boolean}
  */
 export function isModeDevelopment(win) {
   const hashQuery = parseQueryString_(

--- a/src/mode.js
+++ b/src/mode.js
@@ -89,15 +89,7 @@ function getMode_(win) {
   // paths for localhost/testing/development are eliminated.
   return {
     localDev: isLocalDev,
-    // Triggers validation or enable pub level logging. Validation can be
-    // bypassed via #validate=0.
-    // Note that AMP_DEV_MODE flag is used for testing purposes.
-    // Use Array.indexOf instead of Array.includes because of #24219
-    development: !!(
-      ['1', 'actions', 'amp', 'amp4ads', 'amp4email'].indexOf(
-        hashQuery['development']
-      ) >= 0 || win.AMP_DEV_MODE
-    ),
+    development: isModeDevelopment(win),
     examiner: hashQuery['development'] == '2',
     esm: IS_ESM,
     // amp-geo override
@@ -128,6 +120,24 @@ function getRtvVersion(win) {
   // TODO(erwinmombay): decide whether internalRuntimeVersion should contain
   // minor version.
   return `01${internalRuntimeVersion()}`;
+}
+
+/**
+ * Triggers validation or enable pub level logging. Validation can be
+ * bypassed via #validate=0.
+ * Note that AMP_DEV_MODE flag is used for testing purposes.
+ * Uses Array.indexOf instead of Array.includes because of #24219
+ * @param {!Window} win
+ */
+export function isModeDevelopment(win) {
+  const hashQuery = parseQueryString_(
+    win.location['originalHash'] || win.location.hash
+  );
+  return !!(
+    ['1', 'actions', 'amp', 'amp4ads', 'amp4email'].indexOf(
+      hashQuery['development']
+    ) >= 0 || win.AMP_DEV_MODE
+  );
 }
 
 /**

--- a/src/mode.js
+++ b/src/mode.js
@@ -135,9 +135,9 @@ export function isModeDevelopment(win) {
     win.location['originalHash'] || win.location.hash
   );
   return !!(
-    ['1', 'actions', 'amp', 'amp4ads', 'amp4email'].indexOf(
+    ['1', 'actions', 'amp', 'amp4ads', 'amp4email'].includes(
       hashQuery['development']
-    ) >= 0 || win.AMP_DEV_MODE
+    ) || win.AMP_DEV_MODE
   );
 }
 

--- a/src/mode.js
+++ b/src/mode.js
@@ -126,7 +126,6 @@ function getRtvVersion(win) {
  * Triggers validation or enable pub level logging. Validation can be
  * bypassed via #validate=0.
  * Note that AMP_DEV_MODE flag is used for testing purposes.
- * Uses Array.indexOf instead of Array.includes because of #24219
  * @param {!Window} win
  * @return {boolean}
  */


### PR DESCRIPTION
On the minified JS build, `getMode().development` gets replaced with `false` so the Web Story DevTools don't get triggered.

Exposing a function `isModeDevelopment` can be used by `amp-story.js` to check whether to trigger the tools without relying on `getMode()`

Closes #34364