### PR TITLE
♻️ Create plain `<img>` placeholders

### DIFF
--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -253,9 +253,8 @@ class AmpApesterMedia extends AMP.BaseElement {
    * @return {!Element}
    */
   constructLoaderImg_() {
-    const img = this.element.ownerDocument.createElement('amp-img');
+    const img = this.element.ownerDocument.createElement('img');
     img.setAttribute('src', this.loaderUrl_);
-    img.setAttribute('layout', 'fixed');
     img.setAttribute('width', '100');
     img.setAttribute('height', '100');
     return img;

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -32,8 +32,8 @@ import {
   observeWithSharedInOb,
   unobserveWithSharedInOb,
 } from '../../../src/viewport-observer';
+import {px, setStyles} from '../../../src/style';
 import {removeElement} from '../../../src/dom';
-import {setStyles} from '../../../src/style';
 
 /** @const */
 const TAG = 'amp-apester-media';
@@ -254,9 +254,9 @@ class AmpApesterMedia extends AMP.BaseElement {
    */
   constructLoaderImg_() {
     const img = this.element.ownerDocument.createElement('img');
+    img.setAttribute('loading', 'lazy');
     img.setAttribute('src', this.loaderUrl_);
-    img.setAttribute('width', '100');
-    img.setAttribute('height', '100');
+    setStyles(img, {'width': px(100), 'height': px(100)});
     return img;
   }
 

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -250,17 +250,17 @@ class AmpBridPlayer extends AMP.BaseElement {
     this.propagateAttributes(['aria-label'], placeholder);
     this.applyFillContent(placeholder);
 
-    placeholder.setAttribute(
-      'src',
-      `https://cdn.brid.tv/live/partners/${encodeURIComponent(partnerID)}` +
-        `/snapshot/${encodeURIComponent(feedID)}.jpg`
-    );
-
     const altText = placeholder.hasAttribute('aria-label')
       ? 'Loading video - ' + placeholder.getAttribute('aria-label')
       : 'Loading video';
 
     placeholder.setAttribute('alt', altText);
+
+    placeholder.setAttribute(
+      'src',
+      `https://cdn.brid.tv/live/partners/${encodeURIComponent(partnerID)}` +
+        `/snapshot/${encodeURIComponent(feedID)}.jpg`
+    );
 
     this.loadPromise(placeholder).catch(() => {
       placeholder.src = 'https://cdn.brid.tv/live/default/defaultSnapshot.png';

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -242,12 +242,10 @@ class AmpBridPlayer extends AMP.BaseElement {
 
     const {partnerID_: partnerID, feedID_: feedID} = this;
 
-    const placeholder = htmlFor(element)`
-      <amp-img referrerpolicy=origin layout=fill placeholder>
-        <amp-img referrerpolicy=origin layout=fill fallback
-            src="https://cdn.brid.tv/live/default/defaultSnapshot.png">
-        </amp-img>
-      </amp-img>`;
+    const html = htmlFor(element);
+    const placeholder = html`
+      <img placeholder referrerpolicy="origin" loading="lazy" />
+    `;
 
     this.propagateAttributes(['aria-label'], placeholder);
     this.applyFillContent(placeholder);
@@ -263,6 +261,10 @@ class AmpBridPlayer extends AMP.BaseElement {
       : 'Loading video';
 
     placeholder.setAttribute('alt', altText);
+
+    this.loadPromise(placeholder).catch(() => {
+      placeholder.src = 'https://cdn.brid.tv/live/default/defaultSnapshot.png';
+    });
 
     return placeholder;
   }

--- a/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/test/test-amp-brid-player.js
@@ -216,13 +216,13 @@ describes.realWin(
           'data-player': '979',
           'data-video': '13663',
         }).then((brid) => {
-          const img = brid.querySelector('amp-img');
+          const img = brid.querySelector('img');
           expect(img).to.not.be.null;
           expect(img.getAttribute('src')).to.equal(
             'https://cdn.brid.tv/live/partners/264/snapshot/13663.jpg'
           );
-          expect(img.getAttribute('layout')).to.equal('fill');
-          expect(img.hasAttribute('placeholder')).to.be.true;
+          expect(img).to.have.class('i-amphtml-fill-content');
+          expect(img).to.have.attribute('placeholder');
           expect(img.getAttribute('alt')).to.equal('Loading video');
           expect(img.getAttribute('referrerpolicy')).to.equal('origin');
         });
@@ -234,28 +234,11 @@ describes.realWin(
           'data-video': '13663',
           'aria-label': 'great video',
         }).then((brid) => {
-          const img = brid.querySelector('amp-img');
+          const img = brid.querySelector('img');
           expect(img).to.not.be.null;
           expect(img.getAttribute('alt')).to.equal(
             'Loading video - great video'
           );
-        });
-      });
-      it('should create a fallback for default snapshot', () => {
-        return getBridPlayer({
-          'data-partner': '264',
-          'data-player': '979',
-          'data-video': '13663',
-        }).then((brid) => {
-          const img = brid.querySelector('amp-img');
-          const fallbackImg = img.querySelector('amp-img');
-          expect(fallbackImg).to.not.be.null;
-          expect(fallbackImg.getAttribute('src')).to.equal(
-            'https://cdn.brid.tv/live/default/defaultSnapshot.png'
-          );
-          expect(fallbackImg.getAttribute('layout')).to.equal('fill');
-          expect(fallbackImg.hasAttribute('fallback')).to.be.true;
-          expect(fallbackImg.getAttribute('referrerpolicy')).to.equal('origin');
         });
       });
     });

--- a/extensions/amp-delight-player/0.1/amp-delight-player.css
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.css
@@ -16,10 +16,6 @@
 
 amp-delight-player [placeholder] {
   transition: opacity 0.5s ease-out;
-  background: no-repeat 50%;
-  background-size: cover;
-  width: 100%;
-  height: 100%;
 }
 
 amp-delight-player [placeholder].i-amphtml-delight-player-faded {

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -238,10 +238,10 @@ class AmpDelightPlayer extends AMP.BaseElement {
       <img placeholder referrerpolicy="origin" loading="lazy" />
     `;
 
-    const src = `${this.baseURL_}/poster/${this.contentID_}`;
-
-    placeholder.setAttribute('src', src);
     this.applyFillContent(placeholder);
+
+    const src = `${this.baseURL_}/poster/${this.contentID_}`;
+    placeholder.setAttribute('src', src);
 
     this.placeholderEl_ = /** @type {HTMLElement} */ (placeholder);
 

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -235,12 +235,13 @@ class AmpDelightPlayer extends AMP.BaseElement {
   createPlaceholderCallback() {
     const html = htmlFor(this.element);
     const placeholder = html`
-      <div placeholder><amp-img layout="fill"></amp-img></div>
+      <img placeholder referrerpolicy="origin" loading="lazy" />
     `;
 
     const src = `${this.baseURL_}/poster/${this.contentID_}`;
 
-    placeholder.firstElementChild.setAttribute('src', src);
+    placeholder.setAttribute('src', src);
+    this.applyFillContent(placeholder);
 
     this.placeholderEl_ = /** @type {HTMLElement} */ (placeholder);
 

--- a/extensions/amp-gfycat/0.1/amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/amp-gfycat.js
@@ -87,14 +87,14 @@ class AmpGfycat extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    const placeholder = this.win.document.createElement('amp-img');
+    const placeholder = this.win.document.createElement('img');
     const videoid = dev().assertString(this.videoid_);
     this.propagateAttributes(['alt', 'aria-label'], placeholder);
     placeholder.setAttribute(
       'src',
       'https://thumbs.gfycat.com/' + encodeURIComponent(videoid) + '-poster.jpg'
     );
-    placeholder.setAttribute('layout', 'fill');
+    placeholder.setAttribute('loading', 'lazy');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
     if (this.element.hasAttribute('aria-label')) {

--- a/extensions/amp-gfycat/0.1/amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/amp-gfycat.js
@@ -89,11 +89,8 @@ class AmpGfycat extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('img');
     const videoid = dev().assertString(this.videoid_);
+    this.applyFillContent(placeholder);
     this.propagateAttributes(['alt', 'aria-label'], placeholder);
-    placeholder.setAttribute(
-      'src',
-      'https://thumbs.gfycat.com/' + encodeURIComponent(videoid) + '-poster.jpg'
-    );
     placeholder.setAttribute('loading', 'lazy');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
@@ -110,7 +107,10 @@ class AmpGfycat extends AMP.BaseElement {
     } else {
       placeholder.setAttribute('alt', 'Loading gif');
     }
-    this.applyFillContent(placeholder);
+    placeholder.setAttribute(
+      'src',
+      'https://thumbs.gfycat.com/' + encodeURIComponent(videoid) + '-poster.jpg'
+    );
 
     return placeholder;
   }

--- a/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/test/test-amp-gfycat.js
@@ -129,8 +129,11 @@ describes.realWin(
       return getGfycat('LeanMediocreBeardeddragon', {
         withAlt: true,
       }).then((gfycat) => {
-        const placeHolder = gfycat.querySelector('amp-img');
+        const placeHolder = gfycat.querySelector('img');
         expect(placeHolder).to.not.be.null;
+        expect(placeHolder).to.have.attribute('placeholder');
+        expect(placeHolder).to.have.class('i-amphtml-fill-content');
+        expect(placeHolder.getAttribute('loading')).to.equal('lazy');
         expect(placeHolder.getAttribute('alt')).to.equal(
           'Loading gif test alt label'
         );
@@ -140,7 +143,7 @@ describes.realWin(
       return getGfycat('LeanMediocreBeardeddragon', {
         withAria: true,
       }).then((gfycat) => {
-        const placeHolder = gfycat.querySelector('amp-img');
+        const placeHolder = gfycat.querySelector('img');
         expect(placeHolder).to.not.be.null;
         expect(placeHolder.getAttribute('alt')).to.equal(
           'Loading gif test aria label'

--- a/extensions/amp-iframely/0.1/amp-iframely.js
+++ b/extensions/amp-iframely/0.1/amp-iframely.js
@@ -122,15 +122,17 @@ export class AmpIframely extends AMP.BaseElement {
         this.constructSrc_('/thumbnail'),
         this.options_
       );
-      return createElementWithAttributes(
+      const element = createElementWithAttributes(
         this.element.ownerDocument,
-        'amp-img',
+        'img',
         {
           'src': src,
+          'loading': 'lazy',
           'placeholder': '',
-          'layout': 'fill',
         }
       );
+      this.applyFillContent(element);
+      return element;
     }
     return null;
   }

--- a/extensions/amp-iframely/0.1/test/test-amp-iframely.js
+++ b/extensions/amp-iframely/0.1/test/test-amp-iframely.js
@@ -141,18 +141,16 @@ describes.realWin(
 
     it('renders image placeholder', () => {
       return renderIframely(paramsID).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
-        expect(image.tagName).to.equal('AMP-IMG');
-        expect(image.className).to.match(
-          /i-amphtml-element i-amphtml-notbuilt amp-notbuilt i-amphtml-layout-fill i-amphtml-layout-size-defined/
-        );
+        expect(image).to.have.class('i-amphtml-fill-content');
+        expect(image.getAttribute('loading')).to.equal('lazy');
       });
     });
 
     it('renders image placeholder with proper URL for ID version', () => {
       return renderIframely(paramsID).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(image.getAttribute('src')).to.equal(
           `https://cdn.iframe.ly/${TestID}/thumbnail?amp=1`
@@ -162,7 +160,7 @@ describes.realWin(
 
     it('renders image placeholder with proper URL for Key-URL version', () => {
       return renderIframely(paramsKU).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(image.getAttribute('src')).to.equal(
           `https://cdn.iframe.ly/api/thumbnail?url=${encodeURIComponent(
@@ -183,7 +181,7 @@ describes.realWin(
         'layout': 'responsive',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(image.getAttribute('src')).to.equal(
           `https://${properDomain}/${TestID}/thumbnail?amp=1`
@@ -203,7 +201,7 @@ describes.realWin(
         'layout': 'responsive',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(image.getAttribute('src')).to.equal(
           `https://${domain}/${TestID}/thumbnail?amp=1`
@@ -220,7 +218,7 @@ describes.realWin(
         'layout': 'fill',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -235,7 +233,7 @@ describes.realWin(
         'layout': 'responsive',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -251,7 +249,7 @@ describes.realWin(
         'layout': 'responsive',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -265,7 +263,7 @@ describes.realWin(
         'layout': 'fixed',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -280,7 +278,7 @@ describes.realWin(
         'layout': 'fixed',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -296,7 +294,7 @@ describes.realWin(
         'layout': 'responsive',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -311,7 +309,7 @@ describes.realWin(
         'layout': 'fixed',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.not.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -325,7 +323,7 @@ describes.realWin(
         'resizable': '',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -340,7 +338,7 @@ describes.realWin(
         'layout': 'responsive',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         expect(image).to.be.null;
         expect(iframely.querySelector('iframe')).to.not.be.null;
       });
@@ -372,7 +370,7 @@ describes.realWin(
         'layout': 'responsive',
       };
       return renderIframely(data).then((iframely) => {
-        const image = iframely.querySelector('amp-img');
+        const image = iframely.querySelector('img');
         const iframe = iframely.querySelector('iframe');
         expect(image).to.not.be.null;
         expect(iframe).to.not.be.null;

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -348,7 +348,7 @@ class AmpJWPlayer extends AMP.BaseElement {
     if (!this.element.hasAttribute('data-media-id')) {
       return;
     }
-    const placeholder = this.win.document.createElement('amp-img');
+    const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
     placeholder.setAttribute(
       'src',
@@ -356,7 +356,6 @@ class AmpJWPlayer extends AMP.BaseElement {
         encodeURIComponent(this.contentid_) +
         '-720.jpg'
     );
-    placeholder.setAttribute('layout', 'fill');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
     if (placeholder.hasAttribute('aria-label')) {
@@ -367,6 +366,8 @@ class AmpJWPlayer extends AMP.BaseElement {
     } else {
       placeholder.setAttribute('alt', 'Loading video');
     }
+    placeholder.setAttribute('loading', 'lazy');
+    this.applyFillContent(placeholder);
     return placeholder;
   }
 

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -350,12 +350,7 @@ class AmpJWPlayer extends AMP.BaseElement {
     }
     const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
-    placeholder.setAttribute(
-      'src',
-      'https://content.jwplatform.com/thumbs/' +
-        encodeURIComponent(this.contentid_) +
-        '-720.jpg'
-    );
+    this.applyFillContent(placeholder);
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
     if (placeholder.hasAttribute('aria-label')) {
@@ -367,7 +362,12 @@ class AmpJWPlayer extends AMP.BaseElement {
       placeholder.setAttribute('alt', 'Loading video');
     }
     placeholder.setAttribute('loading', 'lazy');
-    this.applyFillContent(placeholder);
+    placeholder.setAttribute(
+      'src',
+      'https://content.jwplatform.com/thumbs/' +
+        encodeURIComponent(this.contentid_) +
+        '-720.jpg'
+    );
     return placeholder;
   }
 

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -352,13 +352,14 @@ describes.realWin(
           'data-media-id': 'Wferorsv',
           'data-player-id': 'sDZEo0ea',
         });
-        const img = jw.querySelector('amp-img');
+        const img = jw.querySelector('img');
         expect(img).to.not.be.null;
         expect(img.getAttribute('src')).to.equal(
           'https://content.jwplatform.com/thumbs/Wferorsv-720.jpg'
         );
-        expect(img.getAttribute('layout')).to.equal('fill');
-        expect(img.hasAttribute('placeholder')).to.be.true;
+        expect(img).to.have.class('i-amphtml-fill-content');
+        expect(img).to.have.attribute('placeholder');
+        expect(img.getAttribute('loading')).to.equal('lazy');
         expect(img.getAttribute('referrerpolicy')).to.equal('origin');
         expect(img.getAttribute('alt')).to.equal('Loading video');
       });
@@ -368,7 +369,7 @@ describes.realWin(
           'data-player-id': 'sDZEo0ea',
           'aria-label': 'interesting video',
         });
-        const img = jw.querySelector('amp-img');
+        const img = jw.querySelector('img');
         expect(img).to.not.be.null;
         expect(img.getAttribute('aria-label')).to.equal('interesting video');
         expect(img.getAttribute('alt')).to.equal(
@@ -380,7 +381,7 @@ describes.realWin(
           'data-playlist-id': 'Wferorsv',
           'data-player-id': 'sDZEo0ea',
         });
-        const img = jw.querySelector('amp-img');
+        const img = jw.querySelector('img');
         expect(img).to.be.null;
       });
     });

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -124,7 +124,7 @@ class AmpKaltura extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    const placeholder = this.win.document.createElement('amp-img');
+    const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
     const width = this.element.getAttribute('width');
     const height = this.element.getAttribute('height');
@@ -140,7 +140,7 @@ class AmpKaltura extends AMP.BaseElement {
       src += `/height/${height}`;
     }
     placeholder.setAttribute('src', src);
-    placeholder.setAttribute('layout', 'fill');
+    placeholder.setAttribute('loading', 'lazy');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
     if (placeholder.hasAttribute('aria-label')) {
@@ -151,6 +151,7 @@ class AmpKaltura extends AMP.BaseElement {
     } else {
       placeholder.setAttribute('alt', 'Loading video');
     }
+    this.applyFillContent(placeholder);
     return placeholder;
   }
 

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -126,6 +126,18 @@ class AmpKaltura extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
+    this.applyFillContent(placeholder);
+    placeholder.setAttribute('loading', 'lazy');
+    placeholder.setAttribute('placeholder', '');
+    placeholder.setAttribute('referrerpolicy', 'origin');
+    if (placeholder.hasAttribute('aria-label')) {
+      placeholder.setAttribute(
+        'alt',
+        'Loading video - ' + placeholder.getAttribute('aria-label')
+      );
+    } else {
+      placeholder.setAttribute('alt', 'Loading video');
+    }
     const width = this.element.getAttribute('width');
     const height = this.element.getAttribute('height');
     let src = `https://${encodeURIComponent(
@@ -140,18 +152,6 @@ class AmpKaltura extends AMP.BaseElement {
       src += `/height/${height}`;
     }
     placeholder.setAttribute('src', src);
-    placeholder.setAttribute('loading', 'lazy');
-    placeholder.setAttribute('placeholder', '');
-    placeholder.setAttribute('referrerpolicy', 'origin');
-    if (placeholder.hasAttribute('aria-label')) {
-      placeholder.setAttribute(
-        'alt',
-        'Loading video - ' + placeholder.getAttribute('aria-label')
-      );
-    } else {
-      placeholder.setAttribute('alt', 'Loading video');
-    }
-    this.applyFillContent(placeholder);
     return placeholder;
   }
 

--- a/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/test/test-amp-kaltura-player.js
@@ -144,13 +144,15 @@ describes.realWin(
           'data-entryid': '1_3ts1ms9c',
           'data-uiconf': '33502051',
         }).then((kp) => {
-          const img = kp.querySelector('amp-img');
+          const img = kp.querySelector('img');
           expect(img).to.not.be.null;
+          expect(img).to.have.attribute('placeholder');
+          expect(img).to.have.class('i-amphtml-fill-content');
+          expect(img.getAttribute('loading')).to.equal('lazy');
           expect(img.getAttribute('src')).to.equal(
             'https://cdnapisec.kaltura.com/p/1281471/thumbnail/entry_id/' +
               '1_3ts1ms9c/width/111/height/222'
           );
-          expect(img.getAttribute('layout')).to.equal('fill');
           expect(img.hasAttribute('placeholder')).to.be.true;
           expect(img.getAttribute('referrerpolicy')).to.equal('origin');
           expect(img.getAttribute('alt')).to.equal('Loading video');
@@ -163,9 +165,8 @@ describes.realWin(
           'data-uiconf': '33502051',
           'aria-label': 'great video',
         }).then((kp) => {
-          const img = kp.querySelector('amp-img');
+          const img = kp.querySelector('img');
           expect(img).to.not.be.null;
-          expect(img.hasAttribute('placeholder')).to.be.true;
           expect(img.getAttribute('aria-label')).to.equal('great video');
           expect(img.getAttribute('alt')).to.equal(
             'Loading video - great video'

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -153,7 +153,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    const placeholder = this.win.document.createElement('amp-img');
+    const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
     placeholder.setAttribute(
       'src',
@@ -182,6 +182,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
     } else {
       placeholder.setAttribute('alt', 'Loading video');
     }
+    this.applyFillContent(placeholder);
     return placeholder;
   }
 }

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -155,25 +155,9 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
-    placeholder.setAttribute(
-      'src',
-      'https://www.springboardplatform.com/storage/' +
-        encodeURIComponent(this.domain_) +
-        '/snapshots/' +
-        encodeURIComponent(this.contentId_) +
-        '.jpg'
-    );
-    /** Show default image for playlist */
-    if (this.mode_ == 'playlist') {
-      placeholder.setAttribute(
-        'src',
-        'https://www.springboardplatform.com/storage/default/' +
-          'snapshots/default_snapshot.png'
-      );
-    }
+    this.applyFillContent(placeholder);
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
-    placeholder.setAttribute('layout', 'fill');
     if (placeholder.hasAttribute('aria-label')) {
       placeholder.setAttribute(
         'alt',
@@ -182,7 +166,15 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
     } else {
       placeholder.setAttribute('alt', 'Loading video');
     }
-    this.applyFillContent(placeholder);
+    placeholder.setAttribute(
+      'src',
+      'https://www.springboardplatform.com/storage/' +
+        (this.mode_ == 'playlist'
+          ? 'default/snapshots/default_snapshot.png'
+          : `${encodeURIComponent(this.domain_)}/snapshots/${encodeURIComponent(
+              this.contentId_
+            )}.jpg`)
+    );
     return placeholder;
   }
 }

--- a/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
@@ -171,14 +171,14 @@ describes.realWin(
           'data-domain': 'test.com',
           'data-items': '10',
         }).then((kp) => {
-          const img = kp.querySelector('amp-img');
+          const img = kp.querySelector('img');
           expect(img).to.not.be.null;
           expect(img.getAttribute('src')).to.equal(
             'https://www.springboardplatform.com/storage/test.com' +
               '/snapshots/1578473.jpg'
           );
-          expect(img.getAttribute('layout')).to.equal('fill');
-          expect(img.hasAttribute('placeholder')).to.be.true;
+          expect(img).to.have.class('i-amphtml-fill-content');
+          expect(img).to.have.attribute('placeholder');
           expect(img.getAttribute('referrerpolicy')).to.equal('origin');
           expect(img.getAttribute('alt')).to.equal('Loading video');
         });
@@ -193,14 +193,14 @@ describes.realWin(
           'data-items': '10',
           'aria-label': 'sporty video',
         }).then((kp) => {
-          const img = kp.querySelector('amp-img');
+          const img = kp.querySelector('img');
           expect(img).to.not.be.null;
           expect(img.getAttribute('src')).to.equal(
             'https://www.springboardplatform.com/storage/test.com' +
               '/snapshots/1578473.jpg'
           );
-          expect(img.getAttribute('layout')).to.equal('fill');
-          expect(img.hasAttribute('placeholder')).to.be.true;
+          expect(img).to.have.class('i-amphtml-fill-content');
+          expect(img).to.have.attribute('placeholder');
           expect(img.getAttribute('referrerpolicy')).to.equal('origin');
           expect(img.getAttribute('aria-label')).to.equal('sporty video');
           expect(img.getAttribute('alt')).to.equal(
@@ -218,7 +218,7 @@ describes.realWin(
           'data-domain': 'test.com',
           'data-items': '10',
         }).then((kp) => {
-          const img = kp.querySelector('amp-img');
+          const img = kp.querySelector('img');
           expect(img).to.not.be.null;
           expect(img.getAttribute('src')).to.equal(
             'https://www.springboardplatform.com/storage/default/' +

--- a/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/test/test-amp-springboard-player.js
@@ -224,8 +224,8 @@ describes.realWin(
             'https://www.springboardplatform.com/storage/default/' +
               'snapshots/default_snapshot.png'
           );
-          expect(img.getAttribute('layout')).to.equal('fill');
-          expect(img.hasAttribute('placeholder')).to.be.true;
+          expect(img).to.have.class('i-amphtml-fill-content');
+          expect(img).to.have.attribute('placeholder');
           expect(img.getAttribute('referrerpolicy')).to.equal('origin');
         });
       });

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -198,6 +198,7 @@ class AmpVideoIframe extends AMP.BaseElement {
     }
     const img = new Image();
     img.src = addDataParamsToUrl(poster, element);
+    img.setAttribute('loading', 'lazy');
     img.setAttribute('placeholder', '');
     this.applyFillContent(img);
     return img;

--- a/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/test/test-amp-video-iframe.js
@@ -274,6 +274,7 @@ describes.realWin(
         expect(placeholder).to.have.attribute('placeholder');
         expect(placeholder.tagName.toLowerCase()).to.equal('img');
         expect(placeholder).to.have.class('i-amphtml-fill-content');
+        expect(placeholder.getAttribute('loading')).to.equal('lazy');
         expect(placeholder.getAttribute('src')).to.equal(poster);
       });
 

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -204,7 +204,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
 
   /** @override */
   createPlaceholderCallback() {
-    const placeholder = this.element.ownerDocument.createElement('amp-img');
+    const placeholder = this.element.ownerDocument.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
     if (placeholder.hasAttribute('aria-label')) {
       placeholder.setAttribute(
@@ -218,7 +218,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
       'src',
       `https://cdn.viqeo.tv/preview/${encodeURIComponent(this.videoId_)}.jpg`
     );
-    placeholder.setAttribute('layout', 'fill');
+    placeholder.setAttribute('loading', 'lazy');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
     this.applyFillContent(placeholder);

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -206,6 +206,10 @@ class AmpViqeoPlayer extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.element.ownerDocument.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
+    this.applyFillContent(placeholder);
+    placeholder.setAttribute('loading', 'lazy');
+    placeholder.setAttribute('placeholder', '');
+    placeholder.setAttribute('referrerpolicy', 'origin');
     if (placeholder.hasAttribute('aria-label')) {
       placeholder.setAttribute(
         'alt',
@@ -218,10 +222,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
       'src',
       `https://cdn.viqeo.tv/preview/${encodeURIComponent(this.videoId_)}.jpg`
     );
-    placeholder.setAttribute('loading', 'lazy');
-    placeholder.setAttribute('placeholder', '');
-    placeholder.setAttribute('referrerpolicy', 'origin');
-    this.applyFillContent(placeholder);
+
     return placeholder;
   }
 

--- a/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/test/test-amp-viqeo-player.js
@@ -116,13 +116,14 @@ describes.realWin(
     describe('createPlaceholderCallback', () => {
       it('should create a placeholder image', () => {
         return getViqeo().then((p) => {
-          const img = p.viqeoElement.querySelector('amp-img');
+          const img = p.viqeoElement.querySelector('img');
           expect(img).to.not.be.null;
+          expect(img.getAttribute('loading')).to.equal('lazy');
           expect(img.getAttribute('src')).to.equal(
             'https://cdn.viqeo.tv/preview/922d04f30b66f1a32eb2.jpg'
           );
-          expect(img.getAttribute('layout')).to.equal('fill');
-          expect(img.hasAttribute('placeholder')).to.be.true;
+          expect(img).to.have.class('i-amphtml-fill-content');
+          expect(img).to.have.attribute('placeholder');
           expect(img.getAttribute('referrerpolicy')).to.equal('origin');
           expect(img.getAttribute('alt')).to.equal('Loading video');
         });


### PR DESCRIPTION
Where extensions would previously create `<amp-img>` placeholders, now create a plain `<img>` element with `loading="lazy"`