### PR TITLE
🏗 Allow Performance WG to manage check-types

### DIFF
--- a/build-system/tasks/OWNERS
+++ b/build-system/tasks/OWNERS
@@ -9,6 +9,6 @@
     {
       pattern: 'check-types.js',
       owners: [{name: 'ampproject/wg-performance'}]
-    }
+    },
   ],
 }

--- a/build-system/tasks/OWNERS
+++ b/build-system/tasks/OWNERS
@@ -8,7 +8,7 @@
     },
     {
       pattern: 'check-types.js',
-      owners: [{name: 'ampproject/wg-performance'}]
+      owners: [{name: 'ampproject/wg-performance'}],
     },
   ],
 }

--- a/build-system/tasks/OWNERS
+++ b/build-system/tasks/OWNERS
@@ -6,5 +6,9 @@
     {
       owners: [{name: 'ampproject/wg-infra'}],
     },
+    {
+      pattern: 'check-types.js',
+      owners: [{name: 'ampproject/wg-performance'}]
+    }
   ],
 }


### PR DESCRIPTION
We're frequently adding/tweaking the lists of files that are passing type-checking. This adds wg-performance to the OWNERS for the `check-types` task. Will still request review from infra on any substantive changes to the task.