### PR TITLE
📖 Improve references to the AMP plugin for WordPress in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,7 +9,7 @@ body:
     value: |
       Thanks for filling out this bug report.
       - Bugs related to the [AMP](https://amp.dev) format and cache can be reported using the form below.
-      - Bugs related to the [AMP Wordpress Plugin](https://wordpress.org/plugins/accelerated-mobile-pages/) can be reported at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
+      - Bugs related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository, but first consider the [support forum](https://wordpress.org/support/plugin/amp/).
       - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
       - Questions about Google Search can be asked at Google's [Help Community](https://goo.gl/utQ1KZ).
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,8 +9,8 @@ body:
     value: |
       Thanks for filling out this bug report.
       - Bugs related to the [AMP](https://amp.dev) format and cache can be reported using the form below.
-      - Bugs related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository, but first consider the [support forum](https://wordpress.org/support/plugin/amp/).
-      - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
+      - Bugs related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [support forum](https://wordpress.org/support/plugin/amp/) or at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
+      - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or at the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
       - Questions about Google Search can be asked at Google's [Help Community](https://goo.gl/utQ1KZ).
 - type: textarea
   id: description

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -9,8 +9,8 @@ body:
     value: |
       Thanks for filling out this feature request.
       - Feature requests related to the [AMP](https://amp.dev) format and cache can be reported using the form below.
-      - Feature requests related to the [AMP Wordpress Plugin](https://wordpress.org/plugins/accelerated-mobile-pages/) can be reported at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
-      - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
+      - Feature requests related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [support forum](https://wordpress.org/support/plugin/amp/) or at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
+      - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or at the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
       - Questions about Google Search can be asked at Google's [Help Community](https://goo.gl/utQ1KZ).
 - type: textarea
   id: description


### PR DESCRIPTION
This is a follow up to #34398, improving the bug report template in three ways:

* `s/Wordpress/WordPress/` per [`capital_P_dangit()`](https://developer.wordpress.org/reference/functions/capital_p_dangit/)
* Fixes WordPress AMP plugin link to point to the correct plugin.
* Adds a link to the support forum to encourage checking there before opening an issue on GitHub.