### PR TITLE
Unlaunch auto-ads-no-insertion-above holdback experiment

### DIFF
--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -16,6 +16,5 @@
   "amp-consent-granular-consent": 1,
   "amp-cid-backup": 1,
   "3p-vendor-split": 0.1,
-  "story-ad-placements": 0.01,
-  "auto-ads-no-insertion-above": 0.2
+  "story-ad-placements": 0.01
 }

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -20,7 +20,6 @@ import {
   cloneLayoutMarginsChangeDef,
 } from '../../../src/layout-rect';
 import {Services} from '../../../src/services';
-import {addExperimentIdToElement} from '../../../ads/google/a4a/traffic-experiments';
 import {
   closestAncestorElementBySelector,
   createElementWithAttributes,
@@ -29,11 +28,6 @@ import {
 } from '../../../src/dom';
 import {dev, user} from '../../../src/log';
 import {dict} from '../../../src/core/types/object';
-import {
-  getExperimentBranch,
-  isExperimentOn,
-  randomlySelectUnsetExperiments,
-} from '../../../src/experiments';
 import {measurePageLayoutBox} from '../../../src/utils/page-layout-box';
 
 /** @const */
@@ -200,30 +194,7 @@ export class Placement {
    */
   placeAd(baseAttributes, sizing, adTracker, isResponsiveEnabled) {
     return this.getEstimatedPosition().then((yPosition) => {
-      // TODO(powerivq@) Remove this after finishing the experiment
-      const controlBranch = '31060868';
-      const expBranch = '31060869';
-      const holdbackExp = isExperimentOn(
-        this.ampdoc.win,
-        'auto-ads-no-insertion-above'
-      );
-      if (holdbackExp) {
-        const expInfoList =
-          /** @type {!Array<!../../../experiments.ExperimentInfo>} */ ([
-            {
-              experimentId: 'auto-ads-no-insertion-above',
-              isTrafficEligible: () => true,
-              branches: [controlBranch, expBranch],
-            },
-          ]);
-        randomlySelectUnsetExperiments(this.ampdoc.win, expInfoList);
-      }
-      if (
-        (!holdbackExp ||
-          getExperimentBranch(this.ampdoc.win, 'auto-ads-no-insertion-above') ==
-            expBranch) &&
-        this.ampdoc.win./*OK*/ scrollY > yPosition
-      ) {
+      if (this.ampdoc.win./*OK*/ scrollY > yPosition) {
         this.state_ = PlacementState.UNUSED;
         return this.state_;
       }
@@ -239,12 +210,6 @@ export class Placement {
         this.adElement_ = shouldUseFullWidthResponsive
           ? this.createFullWidthResponsiveAdElement_(baseAttributes)
           : this.createAdElement_(baseAttributes, sizing.width);
-        if (holdbackExp) {
-          addExperimentIdToElement(
-            getExperimentBranch(this.ampdoc.win, 'auto-ads-no-insertion-above'),
-            this.getAdElement()
-          );
-        }
 
         this.injector_(this.anchorElement_, this.getAdElement());
 


### PR DESCRIPTION
It is showing that the ads inserted above the viewport are rarely viewed. Therefore it makes sense to keep preventing ads from being inserted above to avoid the unnecessary CLS.