### PR TITLE
🏗  Automate bento publishing with a GitHub Action

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.extensions) }}
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
         with:
@@ -41,7 +42,7 @@ jobs:
         run: |
           npm install
           node ./build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
-          node ./build-system/npm-publish/write-package-json.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
+          node ./build-system/npm-publish/write-package-jsons.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
       - name: Publish v1
         run: npm publish ./extensions/${{ matrix.extension }}/1.0 --access public --tag ${{ github.event.inputs.tag }}
         env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -39,6 +39,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Build package
         run: |
+          npm install
           node ./build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
           node ./build-system/npm-publish/write-package-json.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
       - name: Publish v1

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,4 +1,4 @@
-name: Publish NPM Packages
+name: Publish Bento Packages on NPM
 on:
   workflow_dispatch:
     inputs:
@@ -10,6 +10,7 @@ on:
         required: true
 jobs:
   publish:
+    if: github.repository == 'ampproject/amphtml'
     environment: NPM_TOKEN #TODO: change environment name in repo settings
     runs-on: ubuntu-latest
     strategy:
@@ -33,23 +34,20 @@ jobs:
           ref: ${{ github.events.inputs.ampversion }}
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          check-latest: true
           registry-url: https://registry.npmjs.org
       - name: Build package
         run: |
-          node ${{ github.workspace }}/build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
-          node ${{ github.workspace }}/build-system/npm-publish/write-package-json.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
+          node ./build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
+          node ./build-system/npm-publish/write-package-json.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
       - name: Publish v1
-        run: |
-          cd ${{ github.workspace }}/extensions/${{ matrix.extension }}/1.0 
-          npm publish --access public --tag ${{ github.event.inputs.tag }}
+        run: npm publish ./extensions/${{ matrix.extension }}/1.0 --access public --tag ${{ github.event.inputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish v2 if it exists
         run: |
           if $(test -d ${{ github.workspace }}/extensions/${{ matrix.extension }}/2.0); then      
-            cd ${{ github.workspace }}/extensions/${{ matrix.extension }}/2.0
-            npm publish --access public --tag ${{ github.event.inputs.tag }}
+            npm publish ./extensions/${{ matrix.extension }}/2.0 --access public --tag ${{ github.event.inputs.tag }}
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,55 @@
+name: Publish NPM Packages
+on:
+  workflow_dispatch:
+    inputs:
+      ampversion:
+        description: 'AMP version'
+        required: true
+      tag:
+        description: 'NPM package tag (latest | nightly)'
+        required: true
+jobs:
+  publish:
+    environment: NPM_TOKEN #TODO: change environment name in repo settings
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        extension:
+          [
+            'amp-selector',
+            'amp-accordion',
+            'amp-date-countdown',
+            'amp-date-display',
+            'amp-fit-text',
+            'amp-inline-gallery',
+            'amp-instagram',
+            'amp-lightbox',
+            'amp-timeago',
+            'amp-youtube',
+          ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.events.inputs.ampversion }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org
+      - name: Build package
+        run: |
+          node ${{ github.workspace }}/build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
+          node ${{ github.workspace }}/build-system/npm-publish/write-package-json.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
+      - name: Publish v1
+        run: |
+          cd ${{ github.workspace }}/extensions/${{ matrix.extension }}/1.0 
+          npm publish --access public --tag ${{ github.event.inputs.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish v2 if it exists
+        run: |
+          if $(test -d ${{ github.workspace }}/extensions/${{ matrix.extension }}/2.0); then      
+            cd ${{ github.workspace }}/extensions/${{ matrix.extension }}/2.0
+            npm publish --access public --tag ${{ github.event.inputs.tag }}
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,7 +23,7 @@ jobs:
           EXTENSIONS=$(node ./build-system/npm-publish/get-extensions.js)
           echo "::set-output name=extensions::{\"include\":${EXTENSIONS}}"
   publish:
-    # if: github.repository == 'ampproject/amphtml'
+    if: github.repository == 'ampproject/amphtml'
     environment: NPM_TOKEN #TODO: change environment name in repo settings
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -9,25 +9,26 @@ on:
         description: 'NPM package tag (latest | nightly)'
         required: true
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      extensions: ${{ steps.get-extensions.outputs.extensions }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.events.inputs.ampversion }}
+      - name: Get extensions to publish
+        id: get-extensions
+        run: |
+          EXTENSIONS=$(node ./build-system/publish-npm/get-extensions.js)
+          echo "::set-output name=extensions::{\"include\":${EXTENSIONS}}"
   publish:
     if: github.repository == 'ampproject/amphtml'
     environment: NPM_TOKEN #TODO: change environment name in repo settings
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        extension:
-          [
-            'amp-selector',
-            'amp-accordion',
-            'amp-date-countdown',
-            'amp-date-display',
-            'amp-fit-text',
-            'amp-inline-gallery',
-            'amp-instagram',
-            'amp-lightbox',
-            'amp-timeago',
-            'amp-youtube',
-          ]
+      matrix: ${{ fromJson(needs.setup.outputs.extensions) }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get extensions to publish
         id: get-extensions
         run: |
-          EXTENSIONS=$(node ./build-system/publish-npm/get-extensions.js)
+          EXTENSIONS=$(node ./build-system/npm-publish/get-extensions.js)
           echo "::set-output name=extensions::{\"include\":${EXTENSIONS}}"
   publish:
     if: github.repository == 'ampproject/amphtml'

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,7 +23,7 @@ jobs:
           EXTENSIONS=$(node ./build-system/npm-publish/get-extensions.js)
           echo "::set-output name=extensions::{\"include\":${EXTENSIONS}}"
   publish:
-    if: github.repository == 'ampproject/amphtml'
+    # if: github.repository == 'ampproject/amphtml'
     environment: NPM_TOKEN #TODO: change environment name in repo settings
     needs: setup
     runs-on: ubuntu-latest

--- a/build-system/npm-publish/build-npm-binaries.js
+++ b/build-system/npm-publish/build-npm-binaries.js
@@ -20,8 +20,8 @@
  */
 
 const [extension] = process.argv.slice(2);
-const {timedExecOrDie} = require('../../../build-system/pr-check/utils');
-const {updatePackages} = require('../../../build-system/common/update-packages');
+const {timedExecOrDie} = require('../pr-check/utils');
+const {updatePackages} = require('../common/update-packages');
 
 updatePackages();
 timedExecOrDie(`amp build --extensions=${extension} --core_runtime_only`);

--- a/build-system/npm-publish/get-extensions.js
+++ b/build-system/npm-publish/get-extensions.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * Gets Bento components to publish.
+ */
+
+const bundles = require('../compile/bundles.config.extensions.json');
+const extensions = bundles
+  .filter((bundle) => bundle.options?.npm)
+  .map((bundle) => ({'extension': bundle.name}));
+console /*OK*/
+  .log(JSON.stringify(extensions));

--- a/build-system/npm-publish/write-package-jsons.js
+++ b/build-system/npm-publish/write-package-jsons.js
@@ -21,7 +21,7 @@
  */
 
 const [extension, ampVersion] = process.argv.slice(2);
-const {log} = require('../../../build-system/common/logging');
+const {log} = require('../common/logging');
 const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
 
@@ -38,7 +38,11 @@ async function writePackageJson(extensionVersion) {
   const minor = ampVersion.slice(0, 10);
   const patch = Number(ampVersion.slice(-3)); // npm trims leading zeroes in patch number, so mimic this in package.json
   const version = `${major}.${minor}.${patch}`;
-  if (!valid(version) || ampVersion.length != 13 || extensionVersionArr[1] !== '0') {
+  if (
+    !valid(version) ||
+    ampVersion.length != 13 ||
+    extensionVersionArr[1] !== '0'
+  ) {
     log(
       'Invalid semver version',
       version,


### PR DESCRIPTION
Creates a GH Action to publish bento packages on npm under ampprojectbot https://www.npmjs.com/~ampprojectbot

`NPM_TOKEN` was added to the repo last week, but won't be usable until merged into main for security reasons

I also moved node scripts from `.github/workflows/publish` to `build-system/npm-publish` because GitHub doesn't pick up workflow files from a subdir in `.github/workflows/`