### PR TITLE
🐛 [Amp story] [Page attachments] Set active on renderOpenAttachment

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1804,6 +1804,12 @@ export class AmpStoryPage extends AMP.BaseElement {
         attachmentEl
       );
 
+      // This ensures `active` is set on first render.
+      // Otherwise setState may be called before this.openAttachmentEl_ exists.
+      if (this.element.hasAttribute('active')) {
+        this.openAttachmentEl_.setAttribute('active', '');
+      }
+
       const container = this.win.document.createElement('div');
       container.classList.add('i-amphtml-story-page-open-attachment-host');
       container.setAttribute('role', 'button');


### PR DESCRIPTION
[`setState`](https://github.com/ampproject/amphtml/blob/main/extensions/amp-story/1.0/amp-story-page.js#L508-L545) can potentially be called before [`renderOpenAttachmentUI_`](https://github.com/ampproject/amphtml/blob/main/extensions/amp-story/1.0/amp-story-page.js#L1783) which could prevent the attachment from being visible on first page load.

Fixes [TODO](https://github.com/ampproject/amphtml/blob/main/examples/visual-tests/amp-story/amp-story-page-attachment.js#L28-L37) in flaky test.
