### PR TITLE
remove brotli check as these files do not exist on cdn anymore

### DIFF
--- a/extensions/amp-ad-network-fake-impl/0.1/external-reorder-head-transformer.js
+++ b/extensions/amp-ad-network-fake-impl/0.1/external-reorder-head-transformer.js
@@ -165,9 +165,7 @@ export class ExternalReorderHeadTransformer {
       isAsync &&
       ((src.startsWith(urls.cdn) &&
         (endsWith(src, '/v0.js') ||
-          endsWith(src, '/v0.js.br') ||
-          endsWith(src, '/amp4ads-v0.js') ||
-          endsWith(src, '/amp4ads-v0.js.br'))) ||
+          endsWith(src, '/amp4ads-v0.js'))) ||
         endsWith(src, '/dist/amp.js') ||
         endsWith(src, '/dist/amp-inabox.js') ||
         endsWith(src, '/dist/v0.js') ||


### PR DESCRIPTION
These files are no longer served on cdn.ampproject.org any more:
[v0.js.br](https://cdn.ampproject.org/amp4ads-v0.js.br)
[amp4ads-v0.js.br](https://cdn.ampproject.org/amp4ads-v0.js.br)