### PR TITLE
[Amp story] [Page attachments] [Outlink] Remove open attachment delay and animation

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.css
@@ -318,16 +318,6 @@
   animation: tap-scale var(--i-amphtml-page-attachment-ui-animation-duration) var(--i-amphtml-page-attachment-ui-animation-delay) both !important;
 }
 
-.i-amphtml-story-page-open-attachment.i-amphtml-story-page-open-attachment-opening {
-  animation: fade-out 0.3s both !important;
-}
-
-@keyframes fade-out {
-  100% {
-    opacity: 0;
-  }
-}
-
 .i-amphtml-story-outlink-page-attachment-arrow {
   display: block !important;
   cursor: pointer !important;

--- a/extensions/amp-story/1.0/amp-story-page-attachment.css
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.css
@@ -172,7 +172,7 @@ amp-story[desktop] .i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-pa
   background-color: var(--i-amphtml-outlink-cta-text-color) !important;
   opacity: .6 !important;
   transform-origin: left !important;
-  animation: progress-bar-animation both 1s !important;
+  animation: progress-bar-animation .6s both cubic-bezier(0.4, 0.0, 1, 1) !important;
 }
 
 [dir="rtl"] .i-amphtml-amp-story-page-attachment-ui-v2.i-amphtml-story-page-attachment-remote.i-amphtml-story-draggable-drawer-open:after {

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -54,6 +54,14 @@ const DRAG_CAP_PX = 48;
 const DRAG_CAP_PX_V2 = 56;
 
 /**
+ * Duration of post-tap URL preview progress bar animation minus 100ms.
+ * The minus 100ms roughly accounts for the small system delay in opening a link.
+ * Used for the amp-story-outlink-page-attachment-v2 experiment.
+ * @const {number}
+ */
+const POST_TAP_ANIMATION_DURATION = 500;
+
+/**
  * @enum {string}
  */
 export const AttachmentTheme = {
@@ -361,14 +369,25 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
   }
 
   /**
-   * Redirects to the specified URL.
+   * Triggers a remote attachment preview URL animation, and redirects
+   * to the specified URL.
    * @private
    */
   openRemoteV2_() {
     const clickTarget = this.element.parentElement
       .querySelector('.i-amphtml-story-page-open-attachment-host')
       .shadowRoot.querySelector('a.i-amphtml-story-page-open-attachment');
-    triggerClickFromLightDom(clickTarget, this.element);
+
+    const isMobileUI =
+      this.storeService_.get(StateProperty.UI_STATE) === UIType.MOBILE;
+    // Shows outlink url preview on mobile only.
+    if (!isMobileUI) {
+      triggerClickFromLightDom(clickTarget, this.element);
+    } else {
+      this.win.setTimeout(() => {
+        triggerClickFromLightDom(clickTarget, this.element);
+      }, POST_TAP_ANIMATION_DURATION);
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -361,38 +361,14 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
   }
 
   /**
-   * Triggers a remote attachment opening animation, and redirects to the
-   * specified URL.
+   * Redirects to the specified URL.
    * @private
    */
   openRemoteV2_() {
     const clickTarget = this.element.parentElement
       .querySelector('.i-amphtml-story-page-open-attachment-host')
       .shadowRoot.querySelector('a.i-amphtml-story-page-open-attachment');
-
-    const isMobileUI =
-      this.storeService_.get(StateProperty.UI_STATE) === UIType.MOBILE;
-    // Shows outlink url preview on mobile only.
-    if (!isMobileUI) {
-      triggerClickFromLightDom(clickTarget, this.element);
-    } else {
-      const animationEl = this.win.document.createElement('div');
-      const storyEl = closest(this.element, (el) => el.tagName === 'AMP-STORY');
-
-      this.mutateElement(() => {
-        clickTarget.classList.add(
-          'i-amphtml-story-page-open-attachment-opening'
-        );
-      });
-      // Play post-tap animation before opening link.
-      this.win.setTimeout(() => {
-        this.mutateElement(() => {
-          animationEl.classList.add('i-amphtml-story-page-attachment-expand');
-          storyEl.appendChild(animationEl);
-        });
-        triggerClickFromLightDom(clickTarget, this.element);
-      }, 1000);
-    }
+    triggerClickFromLightDom(clickTarget, this.element);
   }
 
   /**


### PR DESCRIPTION
Reduces post-tap progress bar animation time.
Edits motion curve of progress bar to lead into the opening attachment experience.
Removes the open attachment page overlay.

![May-21-2021 10-38-15](https://user-images.githubusercontent.com/3860311/119156135-ee527300-ba21-11eb-9484-bcf37522df3d.gif)

All edits are hidden behind the `amp-story-page-attachment-ui-v2` experiment.
The experiment is forced on in the [demo](https://philipbell-stamp-ui.web.app/examples/amp-story/attachment.html#page=outlink-dark-theme)

Fixes #34470

Edits discussed with and approved by @hongcatlover 