### PR TITLE
🏗 Enable VSCode auto-formatting and prettier checks for `.yml` files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,59 +1,59 @@
 ---
 name: Bug Report
 description: Report a bug in AMP.
-labels: "Type: Bug"
+labels: 'Type: Bug'
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      Thanks for filling out this bug report.
-      - Bugs related to the [AMP](https://amp.dev) format and cache can be reported using the form below.
-      - Bugs related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [support forum](https://wordpress.org/support/plugin/amp/) or at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
-      - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or at the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
-      - Questions about Google Search can be asked at Google's [Help Community](https://goo.gl/utQ1KZ).
-- type: textarea
-  id: description
-  attributes:
-    label: Description
-    description: A brief description of the bug.
-    placeholder: Describe the expected vs. the current behavior, so this issue can be directed to the correct working group for investigation.
-  validations:
-    required: true
-- type: textarea
-  id: repro_steps
-  attributes:
-    label: Reproduction Steps
-    description: Step-by-step instructions for reproducing the issue.
-    placeholder: Provide a publicly accessible URL and a reduced set of steps that clearly demonstrate the issue.
-  validations:
-    required: true
-- type: textarea
-  id: logs
-  attributes:
-    label: Relevant Logs
-    description: Relevant logging output.
-    placeholder: Paste any plain-text logs here (e.g. console warnings or errors from Chrome DevTools). They will automatically be formatted as code.
-    render: shell
-- type: dropdown
-  id: browsers
-  attributes:
-    label: Browser(s) Affected
-    description: Select one or more browser(s).
-    multiple: true
-    options:
-      - Chrome
-      - Firefox
-      - Safari
-      - Edge
-      - UC Browser
-  validations:
-    required: true
-- type: input
-  id: version
-  attributes:
-    label: AMP Version Affected
-    description: If applicable, indicate a version in the format YYMMDDHHMMXXX. Otherwise just put down 'latest'.
-    placeholder: e.g. 2101280515000
-  validations:
-    required: true
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        Thanks for filling out this bug report.
+        - Bugs related to the [AMP](https://amp.dev) format and cache can be reported using the form below.
+        - Bugs related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [support forum](https://wordpress.org/support/plugin/amp/) or at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
+        - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or at the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
+        - Questions about Google Search can be asked at Google's [Help Community](https://goo.gl/utQ1KZ).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the bug.
+      placeholder: Describe the expected vs. the current behavior, so this issue can be directed to the correct working group for investigation.
+    validations:
+      required: true
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: Reproduction Steps
+      description: Step-by-step instructions for reproducing the issue.
+      placeholder: Provide a publicly accessible URL and a reduced set of steps that clearly demonstrate the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: Relevant logging output.
+      placeholder: Paste any plain-text logs here (e.g. console warnings or errors from Chrome DevTools). They will automatically be formatted as code.
+      render: shell
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Browser(s) Affected
+      description: Select one or more browser(s).
+      multiple: true
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - UC Browser
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: AMP Version Affected
+      description: If applicable, indicate a version in the format YYMMDDHHMMXXX. Otherwise just put down 'latest'.
+      placeholder: e.g. 2101280515000
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/cherry-pick-request.yml
+++ b/.github/ISSUE_TEMPLATE/cherry-pick-request.yml
@@ -1,127 +1,134 @@
 ---
 name: Cherry-Pick Request
 description: Request a cherry-pick to an AMP release.
-labels: ["Type: Release", "Cherry-pick: Beta", "Cherry-pick: Experimental", "Cherry-pick: LTS", "Cherry-pick: Stable"]
+labels:
+  [
+    'Type: Release',
+    'Cherry-pick: Beta',
+    'Cherry-pick: Experimental',
+    'Cherry-pick: LTS',
+    'Cherry-pick: Stable',
+  ]
 title: "\U0001F338 Cherry-pick request for #ISSUE into #RELEASE"
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      Thanks for filling out this cherry-pick request.
-      - See AMP's [release schedule](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md) to learn about how releases work.
-      - See AMP's [release calendar](https://amp-release-calendar.appspot.com) for information about past releases (e.g. versions, dates, submission times, notes).
-      - See AMP's [code contribution docs](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks) for an overview of the cherry-pick process.
-- type: input
-  id: issue
-  attributes:
-    label: Issue (P0 Bug)
-    description: The P0 bug that necessitates this cherry-pick. Remember to update the issue title with this info.
-    placeholder: "e.g. #11111"
-  validations:
-    required: true
-- type: input
-  id: pull_request
-  attributes:
-    label: Pull Request(s)
-    description: The PR(s) that fix the bug. Make sure they are merged and have passing [CI builds](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=main).
-    placeholder: "e.g. #22222, #33333"
-  validations:
-    required: true
-- type: input
-  id: release_tracker
-  attributes:
-    label: Release Tracker(s)
-    description: The [tracker issue(s)](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) for the release to which the cherry-pick will be applied. Remember to update the issue title with this info.
-    placeholder: "e.g. #44444, #55555"
-  validations:
-    required: true
-- type: dropdown
-  id: channels
-  attributes:
-    label: Channels
-    description: The [release channels](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md#release-channels) to which the cherry-pick will be applied. Remember to update the issue labels with this info.
-    multiple: true
-    options:
-      - Beta / Experimental
-      - Stable
-      - LTS
-  validations:
-    required: true
-- type: textarea
-  id: justification
-  attributes:
-    label: Justification
-    description: Why you believe this issue meets the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks).
-    placeholder: Provide a specific rationale for why this fix cannot wait until the next Stable release.
-  validations:
-    required: true
-- type: textarea
-  id: verification_steps
-  attributes:
-    label: Verification Steps
-    description: How the fix can be verified once the cherry-pick has been performed.
-    placeholder: Provide detailed steps to manually verify the changes in this cherry-pick. They will be run by a developer or a QA expert to ensure that the bug was indeed fixed.
-  validations:
-    required: true
-- type: markdown
-  id: mini_postmortem
-  attributes:
-    value: |
-      ## Mini Postmortem
-      For cherry-picks to Stable or LTS, the following sections serve as a postmortem, and are meant to document things like the bug summary, its root causes, user impact, and action items. Fill in these sections to the best of your knowledge so that similar issues can be prevented in future. For cherry-picks to only Beta / Experimental, these sections can be ignored.
-- type: textarea
-  id: summary
-  attributes:
-    label: Summary
-    description: A summary of the problem and its root cause(s).
-    placeholder: |
-      For Stable or LTS cherry-picks, provide answers to questions like:
-      - What is the bug being fixed?
-      - What are its root cause(s)?
-      - Could it have been detected by error reports, error / performance graphs, or CI checks?
-      If details are as yet unknown, put down "TODO" in this section and remember to fill it in later.
-- type: textarea
-  id: impact
-  attributes:
-    label: Impact
-    description: How users were impacted.
-    placeholder: |
-      For Stable or LTS cherry-picks, provide answers to questions like:
-      - Which users were affected? E.g. Users of Firefox version XXX.
-      - Roughly how many users? E.g. O(YYY) users.
-      - How were they affected? E.g. ZZZ feature did not work.
-      If details are as yet unknown, put down "TODO" in this section and remember to fill it in later.
-- type: textarea
-  id: action_items
-  attributes:
-    label: Action Items
-    description: What can be done to prevent this in future.
-    placeholder: |
-      For Stable or LTS cherry-picks, provide answers to questions like:
-      - How can this class of bugs be prevented in the future?
-      - How do we detect them sooner and mitigate their impact?
-      - How could we make the investigation of these issues easier?
-      If details are as yet unknown, put down "TODO" in this section and remember to fill it in later.
-- type: textarea
-  id: cherry_pick_progress
-  attributes:
-    label: Cherry-Pick Progress
-    description: Progress details for this cherry-pick.
-    value: |
-      <!-- Leave this section as it is for now. -->
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        Thanks for filling out this cherry-pick request.
+        - See AMP's [release schedule](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md) to learn about how releases work.
+        - See AMP's [release calendar](https://amp-release-calendar.appspot.com) for information about past releases (e.g. versions, dates, submission times, notes).
+        - See AMP's [code contribution docs](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks) for an overview of the cherry-pick process.
+  - type: input
+    id: issue
+    attributes:
+      label: Issue (P0 Bug)
+      description: The P0 bug that necessitates this cherry-pick. Remember to update the issue title with this info.
+      placeholder: 'e.g. #11111'
+    validations:
+      required: true
+  - type: input
+    id: pull_request
+    attributes:
+      label: Pull Request(s)
+      description: The PR(s) that fix the bug. Make sure they are merged and have passing [CI builds](https://app.circleci.com/pipelines/github/ampproject/amphtml?branch=main).
+      placeholder: 'e.g. #22222, #33333'
+    validations:
+      required: true
+  - type: input
+    id: release_tracker
+    attributes:
+      label: Release Tracker(s)
+      description: The [tracker issue(s)](https://github.com/ampproject/amphtml/labels/Type%3A%20Release) for the release to which the cherry-pick will be applied. Remember to update the issue title with this info.
+      placeholder: 'e.g. #44444, #55555'
+    validations:
+      required: true
+  - type: dropdown
+    id: channels
+    attributes:
+      label: Channels
+      description: The [release channels](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md#release-channels) to which the cherry-pick will be applied. Remember to update the issue labels with this info.
+      multiple: true
+      options:
+        - Beta / Experimental
+        - Stable
+        - LTS
+    validations:
+      required: true
+  - type: textarea
+    id: justification
+    attributes:
+      label: Justification
+      description: Why you believe this issue meets the [cherry-pick criteria](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks).
+      placeholder: Provide a specific rationale for why this fix cannot wait until the next Stable release.
+    validations:
+      required: true
+  - type: textarea
+    id: verification_steps
+    attributes:
+      label: Verification Steps
+      description: How the fix can be verified once the cherry-pick has been performed.
+      placeholder: Provide detailed steps to manually verify the changes in this cherry-pick. They will be run by a developer or a QA expert to ensure that the bug was indeed fixed.
+    validations:
+      required: true
+  - type: markdown
+    id: mini_postmortem
+    attributes:
+      value: |
+        ## Mini Postmortem
+        For cherry-picks to Stable or LTS, the following sections serve as a postmortem, and are meant to document things like the bug summary, its root causes, user impact, and action items. Fill in these sections to the best of your knowledge so that similar issues can be prevented in future. For cherry-picks to only Beta / Experimental, these sections can be ignored.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A summary of the problem and its root cause(s).
+      placeholder: |
+        For Stable or LTS cherry-picks, provide answers to questions like:
+        - What is the bug being fixed?
+        - What are its root cause(s)?
+        - Could it have been detected by error reports, error / performance graphs, or CI checks?
+        If details are as yet unknown, put down "TODO" in this section and remember to fill it in later.
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: How users were impacted.
+      placeholder: |
+        For Stable or LTS cherry-picks, provide answers to questions like:
+        - Which users were affected? E.g. Users of Firefox version XXX.
+        - Roughly how many users? E.g. O(YYY) users.
+        - How were they affected? E.g. ZZZ feature did not work.
+        If details are as yet unknown, put down "TODO" in this section and remember to fill it in later.
+  - type: textarea
+    id: action_items
+    attributes:
+      label: Action Items
+      description: What can be done to prevent this in future.
+      placeholder: |
+        For Stable or LTS cherry-picks, provide answers to questions like:
+        - How can this class of bugs be prevented in the future?
+        - How do we detect them sooner and mitigate their impact?
+        - How could we make the investigation of these issues easier?
+        If details are as yet unknown, put down "TODO" in this section and remember to fill it in later.
+  - type: textarea
+    id: cherry_pick_progress
+    attributes:
+      label: Cherry-Pick Progress
+      description: Progress details for this cherry-pick.
+      value: |
+        <!-- Leave this section as it is for now. -->
 
-      To be updated by @ampproject/release-on-duty as each stage is completed.
-      - [x] Cherry-pick request created
-      - [ ] Cherry-pick request approved
-      - [ ] New version released to Beta / Experimental channels
-      - [ ] New version released to Stable channel
-      - [ ] New version released to LTS channel
-      - [ ] Release tracker updated
-      - [ ] Cherry-pick completed
-- type: textarea
-  id: notifications
-  attributes:
-    label: Notifications
-    description: Add working groups or individuals you want to notify about this cherry-pick.
-    value: /cc @ampproject/release-on-duty @ampproject/wg-approvers @ampproject/cherry-pick-approvers
+        To be updated by @ampproject/release-on-duty as each stage is completed.
+        - [x] Cherry-pick request created
+        - [ ] Cherry-pick request approved
+        - [ ] New version released to Beta / Experimental channels
+        - [ ] New version released to Stable channel
+        - [ ] New version released to LTS channel
+        - [ ] Release tracker updated
+        - [ ] Cherry-pick completed
+  - type: textarea
+    id: notifications
+    attributes:
+      label: Notifications
+      description: Add working groups or individuals you want to notify about this cherry-pick.
+      value: /cc @ampproject/release-on-duty @ampproject/wg-approvers @ampproject/cherry-pick-approvers

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,36 +1,36 @@
 ---
 name: Feature Request
 description: Request a new feature in AMP.
-labels: "Type: Feature Request"
+labels: 'Type: Feature Request'
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      Thanks for filling out this feature request.
-      - Feature requests related to the [AMP](https://amp.dev) format and cache can be reported using the form below.
-      - Feature requests related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [support forum](https://wordpress.org/support/plugin/amp/) or at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
-      - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or at the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
-      - Questions about Google Search can be asked at Google's [Help Community](https://goo.gl/utQ1KZ).
-- type: textarea
-  id: description
-  attributes:
-    label: Description
-    description: A brief description of the feature request.
-    placeholder: Provide a clear and concise description of the new feature or change to an existing feature you'd like to see.
-  validations:
-    required: true
-- type: textarea
-  id: alternatives_considered
-  attributes:
-    label: Alternatives Considered
-    description: Alternatives to this feature request.
-    placeholder: Provide details around any alternative solutions or features you've considered.
-  validations:
-    required: true
-- type: textarea
-  id: additional_context
-  attributes:
-    label: Additional Context
-    description: Other relevant context.
-    placeholder: Add any other context about your feature request here. E.g. paste a screenshot, or provide a link.
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        Thanks for filling out this feature request.
+        - Feature requests related to the [AMP](https://amp.dev) format and cache can be reported using the form below.
+        - Feature requests related to the [AMP WordPress Plugin](https://wordpress.org/plugins/amp/) can be reported at the [support forum](https://wordpress.org/support/plugin/amp/) or at the [`amp-wp`](https://github.com/ampproject/amp-wp/issues) repository.
+        - Questions about AMP uage can be asked at the [`#using-amp`](https://amphtml.slack.com/archives/C9HPA6HGB) Slack channel or at the [`amp-html`](http://stackoverflow.com/questions/tagged/amp-html) tag at Stack Overflow.
+        - Questions about Google Search can be asked at Google's [Help Community](https://goo.gl/utQ1KZ).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the feature request.
+      placeholder: Provide a clear and concise description of the new feature or change to an existing feature you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives_considered
+    attributes:
+      label: Alternatives Considered
+      description: Alternatives to this feature request.
+      placeholder: Provide details around any alternative solutions or features you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Other relevant context.
+      placeholder: Add any other context about your feature request here. E.g. paste a screenshot, or provide a link.

--- a/.github/ISSUE_TEMPLATE/intent-to-deprecate.yml
+++ b/.github/ISSUE_TEMPLATE/intent-to-deprecate.yml
@@ -3,55 +3,55 @@ name: Intent-to-Deprecate (I2D)
 description: Propose that an existing AMP feature be deprecated.
 labels: INTENT TO DEPRECATE
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      Thanks for creating this Intent-to-Deprecate (I2D) issue.
-      - See AMP's [versioning and deprecations policy](https://github.com/ampproject/amphtml/blob/main/docs/spec/amp-versioning-policy.md) for instructions on how to fill out this I2D template and how to get help.
-      - If the feature can be removed immediately after deprecation, add the "INTENT TO REMOVE" label to this issue.
-      - Otherwise, file a separate Intent-to-Remove (I2R) when the feature is ready for removal.
-- type: textarea
-  id: summary
-  attributes:
-    label: Summary
-    description: A brief description of the feature to be deprecated.
-    placeholder: Provide the detailed removal plan if the feature is ready for immediate removal after deprecation. Otherwise provide an initial plan for removing the deprecated feature and file a separate Intent-to-Remove (I2R) issue after this issue is approved.
-  validations:
-    required: true
-- type: textarea
-  id: motivation
-  attributes:
-    label: Motivation
-    description: The rationale behind this deprecation.
-    placeholder: Explain why this feature needs to be deprecated and eventually removed.
-  validations:
-    required: true
-- type: textarea
-  id: impact
-  attributes:
-    label: Impact on Existing Users
-    description: How this will affect existing users.
-    placeholder: Explain how the removal of this feature will affect sites that currently use AMP. If available, provide the estimated usage of this feature.
-  validations:
-    required: true
-- type: textarea
-  id: alternative_implementation
-  attributes:
-    label: Alternative Implementation
-    description: Alternative implementation suggestions for developers using AMP.
-    placeholder: Explain how developers using AMP can achieve similar functionality after the feature you are deprecating is removed.
-  validations:
-    required: true
-- type: textarea
-  id: additional_context
-  attributes:
-    label: Additional Context
-    description: Any other relevant context.
-    placeholder: Add any other context that may help people understand your I2D. E.g. paste a screenshot, or provide a link.
-- type: textarea
-  id: notifications
-  attributes:
-    label: Notifications
-    description: Add working groups or individuals you want to notify about this I2D.
-    value: /cc @ampproject/wg-approvers
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        Thanks for creating this Intent-to-Deprecate (I2D) issue.
+        - See AMP's [versioning and deprecations policy](https://github.com/ampproject/amphtml/blob/main/docs/spec/amp-versioning-policy.md) for instructions on how to fill out this I2D template and how to get help.
+        - If the feature can be removed immediately after deprecation, add the "INTENT TO REMOVE" label to this issue.
+        - Otherwise, file a separate Intent-to-Remove (I2R) when the feature is ready for removal.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief description of the feature to be deprecated.
+      placeholder: Provide the detailed removal plan if the feature is ready for immediate removal after deprecation. Otherwise provide an initial plan for removing the deprecated feature and file a separate Intent-to-Remove (I2R) issue after this issue is approved.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: The rationale behind this deprecation.
+      placeholder: Explain why this feature needs to be deprecated and eventually removed.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact on Existing Users
+      description: How this will affect existing users.
+      placeholder: Explain how the removal of this feature will affect sites that currently use AMP. If available, provide the estimated usage of this feature.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative_implementation
+    attributes:
+      label: Alternative Implementation
+      description: Alternative implementation suggestions for developers using AMP.
+      placeholder: Explain how developers using AMP can achieve similar functionality after the feature you are deprecating is removed.
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other relevant context.
+      placeholder: Add any other context that may help people understand your I2D. E.g. paste a screenshot, or provide a link.
+  - type: textarea
+    id: notifications
+    attributes:
+      label: Notifications
+      description: Add working groups or individuals you want to notify about this I2D.
+      value: /cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/intent-to-implement.yml
+++ b/.github/ISSUE_TEMPLATE/intent-to-implement.yml
@@ -3,54 +3,54 @@ name: Intent-to-Implement (I2I)
 description: Propose a significant feature or change to AMP.
 labels: INTENT TO IMPLEMENT
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      Thanks for creating this Intent-to-Implement (I2I) issue.
-      - See AMP's [code contribution guide](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md) for instructions on how to fill out this I2I form and how to get help.
-      - Note that if you are implementing a minor change or fix, you likely do not need to file an I2I.
-      - If you haven't already done so, sign AMP's [Contributor License Agreement (CLA)](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#contributor-license-agreement).
-      - A signed CLA is not required to submit this I2I or to create a PR, but is required before code can be merged.
-- type: textarea
-  id: summary
-  attributes:
-    label: Summary
-    description: A brief description of the feature being implemented.
-    placeholder: Provide a brief description of the feature you are planning on implementing.
-  validations:
-    required: true
-- type: textarea
-  id: design_doc
-  attributes:
-    label: Design Document
-    description: Document that describes the feature's design.
-    placeholder: Provide a link to your design document once you have one. You do not need a design document to file this I2I.
-- type: textarea
-  id: motivation
-  attributes:
-    label: Motivation
-    description: The rationale behind this feature.
-    placeholder: Explain why AMP needs this change. It may be useful to describe what AMP developers/users are forced to do without it. When possible, include links to back up your claims.
-  validations:
-    required: true
-- type: textarea
-  id: alternative_solutions
-  attributes:
-    label: Alternative Solutions
-    description: Alternative solutions for developers using AMP.
-    placeholder: Provide a clear and concise description of any alternative solutions or features you've considered.
-  validations:
-    required: true
-- type: textarea
-  id: launch_tracker
-  attributes:
-    label: Launch Tracker
-    description: A tracker for the project's status.
-    placeholder: Provide a link to the launch tracker for this work here if applicable. A template with instructions can be found at bit.ly/amp-launch-tracker.
-- type: textarea
-  id: notifications
-  attributes:
-    label: Notifications
-    description: Add working groups or individuals you want to notify about this I2I, including a code reviewer once you have found one. See [here](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md) for help.
-    value: /cc @ampproject/wg-approvers
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        Thanks for creating this Intent-to-Implement (I2I) issue.
+        - See AMP's [code contribution guide](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md) for instructions on how to fill out this I2I form and how to get help.
+        - Note that if you are implementing a minor change or fix, you likely do not need to file an I2I.
+        - If you haven't already done so, sign AMP's [Contributor License Agreement (CLA)](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#contributor-license-agreement).
+        - A signed CLA is not required to submit this I2I or to create a PR, but is required before code can be merged.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief description of the feature being implemented.
+      placeholder: Provide a brief description of the feature you are planning on implementing.
+    validations:
+      required: true
+  - type: textarea
+    id: design_doc
+    attributes:
+      label: Design Document
+      description: Document that describes the feature's design.
+      placeholder: Provide a link to your design document once you have one. You do not need a design document to file this I2I.
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: The rationale behind this feature.
+      placeholder: Explain why AMP needs this change. It may be useful to describe what AMP developers/users are forced to do without it. When possible, include links to back up your claims.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative_solutions
+    attributes:
+      label: Alternative Solutions
+      description: Alternative solutions for developers using AMP.
+      placeholder: Provide a clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: launch_tracker
+    attributes:
+      label: Launch Tracker
+      description: A tracker for the project's status.
+      placeholder: Provide a link to the launch tracker for this work here if applicable. A template with instructions can be found at bit.ly/amp-launch-tracker.
+  - type: textarea
+    id: notifications
+    attributes:
+      label: Notifications
+      description: Add working groups or individuals you want to notify about this I2I, including a code reviewer once you have found one. See [here](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md) for help.
+      value: /cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/intent-to-remove.yml
+++ b/.github/ISSUE_TEMPLATE/intent-to-remove.yml
@@ -3,53 +3,53 @@ name: Intent-to-Remove (I2R)
 description: Propose a rollout plan for the removal of a deprecated feature.
 labels: INTENT TO REMOVE
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      Thanks for creating this Intent-to-Remove (I2R) issue.
-      - See AMP's [versioning and deprecations policy](https://github.com/ampproject/amphtml/blob/main/docs/spec/amp-versioning-policy.md) for instructions on how to fill out this I2R template and how to get help.
-      - This I2R issue should be created after the Intent-to-Deprecate (I2D) issue for the feature was approved.
-- type: textarea
-  id: summary
-  attributes:
-    label: Summary
-    description: A brief description of the feature being removed.
-    placeholder: Provide a brief description of the feature you are planning on removing.
-  validations:
-    required: true
-- type: textarea
-  id: i2d_issue
-  attributes:
-    label: Intent-to-Deprecate (I2D) Issue
-    description: A link to the I2D issue.
-    placeholder: Provide a link to the I2D issue you filed to deprecate this feature.
-  validations:
-    required: true
-- type: textarea
-  id: rollout_plan
-  attributes:
-    label: Rollout Plan
-    description: Steps to remove the feature.
-    placeholder: Provide details for the steps you will use to remove this previously deprecated feature.
-  validations:
-    required: true
-- type: textarea
-  id: alternative_implementation
-  attributes:
-    label: Alternative Implementation
-    description: Alternative implementation suggestions for developers using AMP.
-    placeholder: Explain how developers using AMP can achieve similar functionality after the feature you are deprecating is removed.
-  validations:
-    required: true
-- type: textarea
-  id: additional_context
-  attributes:
-    label: Additional Context
-    description: Any other relevant context.
-- type: textarea
-  id: notifications
-  attributes:
-    label: Notifications
-    description: Add working groups or individuals you want to notify about this I2I.
-    value: /cc @ampproject/wg-approvers
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        Thanks for creating this Intent-to-Remove (I2R) issue.
+        - See AMP's [versioning and deprecations policy](https://github.com/ampproject/amphtml/blob/main/docs/spec/amp-versioning-policy.md) for instructions on how to fill out this I2R template and how to get help.
+        - This I2R issue should be created after the Intent-to-Deprecate (I2D) issue for the feature was approved.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief description of the feature being removed.
+      placeholder: Provide a brief description of the feature you are planning on removing.
+    validations:
+      required: true
+  - type: textarea
+    id: i2d_issue
+    attributes:
+      label: Intent-to-Deprecate (I2D) Issue
+      description: A link to the I2D issue.
+      placeholder: Provide a link to the I2D issue you filed to deprecate this feature.
+    validations:
+      required: true
+  - type: textarea
+    id: rollout_plan
+    attributes:
+      label: Rollout Plan
+      description: Steps to remove the feature.
+      placeholder: Provide details for the steps you will use to remove this previously deprecated feature.
+    validations:
+      required: true
+  - type: textarea
+    id: alternative_implementation
+    attributes:
+      label: Alternative Implementation
+      description: Alternative implementation suggestions for developers using AMP.
+      placeholder: Explain how developers using AMP can achieve similar functionality after the feature you are deprecating is removed.
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other relevant context.
+  - type: textarea
+    id: notifications
+    attributes:
+      label: Notifications
+      description: Add working groups or individuals you want to notify about this I2I.
+      value: /cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/intent-to-ship.yml
+++ b/.github/ISSUE_TEMPLATE/intent-to-ship.yml
@@ -3,63 +3,63 @@ name: Intent-to-Ship (I2S)
 description: Propose the launch of an already implemented significant feature or change to AMP.
 labels: INTENT TO SHIP
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      Thanks for creating this Intent-to-Ship (I2S) issue.
-      - See AMP's [code contribution guide](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md) for instructions on how to fill out this I2I form and how to get help.
-      - Note that if you are shipping a minor feature or change, you likely do not need to file an I2I.
-      - Typically, issues that require an I2S issue also required an Intent-to-implement (I2I) issue.
-- type: textarea
-  id: summary
-  attributes:
-    label: Summary
-    description: A brief description of the feature being shipped.
-    placeholder: Provide a brief description of the feature you have implemented and are planning on shipping.
-  validations:
-    required: true
-- type: textarea
-  id: i2i_issue
-  attributes:
-    label: Intent-to-Implement (I2I) Issue
-    description: A link to the I2I issue.
-    placeholder: Provide a link to the I2I issue you filed for this feature or change.
-  validations:
-    required: true
-- type: textarea
-  id: experiments
-  attributes:
-    label: Experiment(s) to Enable
-    description: A list of experiments to enable.
-    placeholder: Provide a list of the experiment(s) that should be enabled to launch your feature.
-  validations:
-    required: true
-- type: textarea
-  id: required_release
-  attributes:
-    label: Release Tracking Issue
-    description: AMP release containing the implementation of this feature.
-    placeholder: "Provide a link to the \"Type: Release\" issue for the release that contains all of the changes necessary for your launch."
-  validations:
-    required: true
-- type: textarea
-  id: demo_instructions
-  attributes:
-    label: Demo Instructions
-    description: How to demo the feature.
-    placeholder: Provide instructions for how to demonstrate the feature. E.g. a link to an example page that uses the feature.
-  validations:
-    required: true
-- type: textarea
-  id: additional_context
-  attributes:
-    label: Additional Context
-    description: Other relevant context.
-    placeholder: Add any other information that may be relevant in determining if your feature can ship.
-- type: textarea
-  id: notifications
-  attributes:
-    label: Notifications
-    description: Add working groups or individuals you want to notify about this I2S, including the code reviewer you worked with on the I2I.
-    value: /cc @ampproject/wg-approvers
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        Thanks for creating this Intent-to-Ship (I2S) issue.
+        - See AMP's [code contribution guide](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md) for instructions on how to fill out this I2I form and how to get help.
+        - Note that if you are shipping a minor feature or change, you likely do not need to file an I2I.
+        - Typically, issues that require an I2S issue also required an Intent-to-implement (I2I) issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A brief description of the feature being shipped.
+      placeholder: Provide a brief description of the feature you have implemented and are planning on shipping.
+    validations:
+      required: true
+  - type: textarea
+    id: i2i_issue
+    attributes:
+      label: Intent-to-Implement (I2I) Issue
+      description: A link to the I2I issue.
+      placeholder: Provide a link to the I2I issue you filed for this feature or change.
+    validations:
+      required: true
+  - type: textarea
+    id: experiments
+    attributes:
+      label: Experiment(s) to Enable
+      description: A list of experiments to enable.
+      placeholder: Provide a list of the experiment(s) that should be enabled to launch your feature.
+    validations:
+      required: true
+  - type: textarea
+    id: required_release
+    attributes:
+      label: Release Tracking Issue
+      description: AMP release containing the implementation of this feature.
+      placeholder: 'Provide a link to the "Type: Release" issue for the release that contains all of the changes necessary for your launch.'
+    validations:
+      required: true
+  - type: textarea
+    id: demo_instructions
+    attributes:
+      label: Demo Instructions
+      description: How to demo the feature.
+      placeholder: Provide instructions for how to demonstrate the feature. E.g. a link to an example page that uses the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Other relevant context.
+      placeholder: Add any other information that may be relevant in determining if your feature can ship.
+  - type: textarea
+    id: notifications
+    attributes:
+      label: Notifications
+      description: Add working groups or individuals you want to notify about this I2S, including the code reviewer you worked with on the I2I.
+      value: /cc @ampproject/wg-approvers

--- a/.github/ISSUE_TEMPLATE/release-tracker.yml
+++ b/.github/ISSUE_TEMPLATE/release-tracker.yml
@@ -1,102 +1,102 @@
 ---
 name: Release Tracker
 description: Track a new AMP release.
-labels: "Type: Release"
+labels: 'Type: Release'
 title: "\U0001F684 Tracking issue for release VERSION"
 body:
-- type: markdown
-  id: header
-  attributes:
-    value: |
-      This is AMP's release tracker form, meant to be used by on-duty engineers.
-      - See AMP's [release schedule](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md) to learn about how releases work.
-      - See AMP's [release calendar](https://amp-release-calendar.appspot.com) for information about past releases (e.g. versions, dates, submission times, notes).
-      - See AMP's [pre-release documentation](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md#beta-and-experimental-channels) to learn how to test changes in the Experimental channel.
-      - If you find a bug in this release, file a [bug report](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type%3A+Bug&template=bug-report.yml).
-      - If you believe a bug should be fixed as part of this release, request a [cherry-pick](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks).
-      - For updates that may be of interest to the community (e.g. bug fixes, delayed releases), post a comment to this issue.
-- type: input
-  id: release_version
-  attributes:
-    label: Release Version
-    description: The version of the release being tracked, in the format YYMMDDHHMMXXX.
-    placeholder: e.g. 2105150310000
-  validations:
-    required: true
-- type: input
-  id: previous_release_version
-  attributes:
-    label: Previous Release Version
-    description: The version of the previous stable channel release, in the format YYMMDDHHMMXXX. Copy it from [here](https://github.com/ampproject/amphtml/releases/latest).
-    placeholder: e.g. 2105072136000
-  validations:
-    required: true
-- type: textarea
-  id: release_progress
-  attributes:
-    label: Release Progress
-    description: Progress details for this release.
-    value: |
-      <!-- Replace VERSION with the contents of the "Release Version" field. -->
-      <!-- Replace PREVIOUS_VERSION with the contents of the "Previous Release Version" field. -->
-      <!-- After creating this issue, check the appropriate checkbox at each stage and replace CL_SUBMIT_TIME with the "Submitted" time from the promotion CL. -->
+  - type: markdown
+    id: header
+    attributes:
+      value: |
+        This is AMP's release tracker form, meant to be used by on-duty engineers.
+        - See AMP's [release schedule](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md) to learn about how releases work.
+        - See AMP's [release calendar](https://amp-release-calendar.appspot.com) for information about past releases (e.g. versions, dates, submission times, notes).
+        - See AMP's [pre-release documentation](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md#beta-and-experimental-channels) to learn how to test changes in the Experimental channel.
+        - If you find a bug in this release, file a [bug report](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type%3A+Bug&template=bug-report.yml).
+        - If you believe a bug should be fixed as part of this release, request a [cherry-pick](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks).
+        - For updates that may be of interest to the community (e.g. bug fixes, delayed releases), post a comment to this issue.
+  - type: input
+    id: release_version
+    attributes:
+      label: Release Version
+      description: The version of the release being tracked, in the format YYMMDDHHMMXXX.
+      placeholder: e.g. 2105150310000
+    validations:
+      required: true
+  - type: input
+    id: previous_release_version
+    attributes:
+      label: Previous Release Version
+      description: The version of the previous stable channel release, in the format YYMMDDHHMMXXX. Copy it from [here](https://github.com/ampproject/amphtml/releases/latest).
+      placeholder: e.g. 2105072136000
+    validations:
+      required: true
+  - type: textarea
+    id: release_progress
+    attributes:
+      label: Release Progress
+      description: Progress details for this release.
+      value: |
+        <!-- Replace VERSION with the contents of the "Release Version" field. -->
+        <!-- Replace PREVIOUS_VERSION with the contents of the "Previous Release Version" field. -->
+        <!-- After creating this issue, check the appropriate checkbox at each stage and replace CL_SUBMIT_TIME with the "Submitted" time from the promotion CL. -->
 
-      This issue tracks release [VERSION](https://github.com/ampproject/amphtml/releases/tag/VERSION). See [new commits](https://github.com/ampproject/amphtml/compare/PREVIOUS_VERSION...VERSION) since the previous Stable channel release.
+        This issue tracks release [VERSION](https://github.com/ampproject/amphtml/releases/tag/VERSION). See [new commits](https://github.com/ampproject/amphtml/compare/PREVIOUS_VERSION...VERSION) since the previous Stable channel release.
 
-      - [ ] Release VERSION promoted to Experimental and Beta (opt-in) channels (CL_SUBMIT_TIME)
-      - [ ] Release VERSION promoted to Experimental and Beta (1% traffic) channels (CL_SUBMIT_TIME)
-      - [ ] Release VERSION promoted to Stable channel (CL_SUBMIT_TIME)
-  validations:
-    required: true
-- type: textarea
-  id: lts_release
-  attributes:
-    label: LTS Release
-    description: Details for the LTS promotion if necessary.
-    value: |
-      <!-- Replace VERSION with the contents of the "Release Version" field. -->
-      <!-- After creating this issue, check the checkbox and replace CL_SUBMIT_TIME with the the "Submitted" time from the promotion CL. -->
+        - [ ] Release VERSION promoted to Experimental and Beta (opt-in) channels (CL_SUBMIT_TIME)
+        - [ ] Release VERSION promoted to Experimental and Beta (1% traffic) channels (CL_SUBMIT_TIME)
+        - [ ] Release VERSION promoted to Stable channel (CL_SUBMIT_TIME)
+    validations:
+      required: true
+  - type: textarea
+    id: lts_release
+    attributes:
+      label: LTS Release
+      description: Details for the LTS promotion if necessary.
+      value: |
+        <!-- Replace VERSION with the contents of the "Release Version" field. -->
+        <!-- After creating this issue, check the checkbox and replace CL_SUBMIT_TIME with the the "Submitted" time from the promotion CL. -->
 
-      - [ ] Release VERSION promoted to LTS channel (CL_SUBMIT_TIME)
-- type: markdown
-  id: lts_release_instructions
-  attributes:
-    value: |
-      On the second Monday of each month, the current Stable channel version will be promoted to the LTS channel.
-      - Releases promoted to Stable channel on the first Tuesday of a given month are promoted to LTS channel on the second Monday of the same month.
-      - Releases promoted to Stable channel on the second, third, fourth, or fifth Tuesday of a given month are not LTS release candidates.
+        - [ ] Release VERSION promoted to LTS channel (CL_SUBMIT_TIME)
+  - type: markdown
+    id: lts_release_instructions
+    attributes:
+      value: |
+        On the second Monday of each month, the current Stable channel version will be promoted to the LTS channel.
+        - Releases promoted to Stable channel on the first Tuesday of a given month are promoted to LTS channel on the second Monday of the same month.
+        - Releases promoted to Stable channel on the second, third, fourth, or fifth Tuesday of a given month are not LTS release candidates.
 
-      Based on the above, if this release must be promoted to LTS, fill out the "LTS Release" section.
-- type: input
-  id: cherry_pick_version
-  attributes:
-    label: Cherry-Pick Release Version
-    description: The updated cherry-pick release version if necessary, in the format YYMMDDHHMMXXX.
-    placeholder: e.g. 2105150310001
-- type: markdown
-  id: cherry_pick_instructions
-  attributes:
-    value: |
-      Sometimes, a bug in a release necessitates that a fix be cherry-picked before the release can progress. If this is the case, follow the instructions in the [cherry-picks documentation](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks) and fill out this section.
-- type: textarea
-  id: cherry_picks
-  attributes:
-    label: Cherry-Picks
-    description: Details for cherry-picks if necessary.
-    value: |
-      <!-- Replace CP_VERSION with the contents of the "Cherry-Pick Release Version" field. -->
-      <!-- Replace CP_ISSUE with one or more cherry-pick issue numbers. -->
-      <!-- After creating this issue, check the appropriate checkbox at each stage and replace CL_SUBMIT_TIME with the "Submitted" time from the promotion CL. -->
+        Based on the above, if this release must be promoted to LTS, fill out the "LTS Release" section.
+  - type: input
+    id: cherry_pick_version
+    attributes:
+      label: Cherry-Pick Release Version
+      description: The updated cherry-pick release version if necessary, in the format YYMMDDHHMMXXX.
+      placeholder: e.g. 2105150310001
+  - type: markdown
+    id: cherry_pick_instructions
+    attributes:
+      value: |
+        Sometimes, a bug in a release necessitates that a fix be cherry-picked before the release can progress. If this is the case, follow the instructions in the [cherry-picks documentation](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md#Cherry-picks) and fill out this section.
+  - type: textarea
+    id: cherry_picks
+    attributes:
+      label: Cherry-Picks
+      description: Details for cherry-picks if necessary.
+      value: |
+        <!-- Replace CP_VERSION with the contents of the "Cherry-Pick Release Version" field. -->
+        <!-- Replace CP_ISSUE with one or more cherry-pick issue numbers. -->
+        <!-- After creating this issue, check the appropriate checkbox at each stage and replace CL_SUBMIT_TIME with the "Submitted" time from the promotion CL. -->
 
-      A cherry-pick release [CP_VERSION](https://github.com/ampproject/amphtml/releases/tag/CP_VERSION) was created with cherry-pick(s) #CP_ISSUE.
+        A cherry-pick release [CP_VERSION](https://github.com/ampproject/amphtml/releases/tag/CP_VERSION) was created with cherry-pick(s) #CP_ISSUE.
 
-      - [ ] Release CP_VERSION promoted to Experimental and Beta (opt-in) channels (CL_SUBMIT_TIME)
-      - [ ] Release CP_VERSION promoted to Experimental and Beta (1% traffic) channels (CL_SUBMIT_TIME)
-      - [ ] Release CP_VERSION promoted to Stable channel (CL_SUBMIT_TIME)
-      - [ ] Release CP_VERSION promoted to LTS channel (CL_SUBMIT_TIME)
-- type: textarea
-  id: notifications
-  attributes:
-    label: Notifications
-    description: Add working groups or individuals you want to notify about this release.
-    value: /cc @ampproject/release-on-duty
+        - [ ] Release CP_VERSION promoted to Experimental and Beta (opt-in) channels (CL_SUBMIT_TIME)
+        - [ ] Release CP_VERSION promoted to Experimental and Beta (1% traffic) channels (CL_SUBMIT_TIME)
+        - [ ] Release CP_VERSION promoted to Stable channel (CL_SUBMIT_TIME)
+        - [ ] Release CP_VERSION promoted to LTS channel (CL_SUBMIT_TIME)
+  - type: textarea
+    id: notifications
+    attributes:
+      label: Notifications
+      description: Add working groups or individuals you want to notify about this release.
+      value: /cc @ampproject/release-on-duty

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,6 +28,5 @@ validator/**/dist
 validator/export
 
 # Files and directories explicitly ignored by prettier
-.github/ISSUE_TEMPLATE/**
 **/package*.json
 **/node_modules/**

--- a/.prettierrc
+++ b/.prettierrc
@@ -25,16 +25,6 @@
     {
       "files": [".prettierrc", ".renovaterc.json", "*.json"],
       "options": {"parser": "json"}
-    },
-    {
-      "files": [
-        ".circleci/config.yml",
-        ".codecov.yml",
-        ".github/workflows/continuous-integration-workflow.yml",
-        ".lando.yml",
-        ".lgtm.yml"
-      ],
-      "options": {"parser": "yaml"}
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,14 +7,7 @@
 
     // Enable JSON auto-formatting for these files.
     ".prettierrc": "json",
-    ".renovaterc.json": "json",
-
-    // Enable YAML auto-formatting for these files.
-    ".circleci/config.yml": "yaml",
-    ".codecov.yml": "yaml",
-    ".github/workflows/continuous-integration-workflow.yml": "yaml",
-    ".lando.yml": "yaml",
-    ".lgtm.yml": "yaml"
+    ".renovaterc.json": "json"
   },
 
   // Auto-fix JS files with ESLint using amphtml's custom settings. Needs

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -158,18 +158,14 @@ const presubmitGlobs = [
  * 2. Make sure it is listed in .vscode/settings.json (for auto-fix-on-save)
  */
 const prettifyGlobs = [
-  '.circleci/config.yml',
-  '.codecov.yml',
-  '.lando.yml',
-  '.lgtm.yml',
   '.prettierrc',
   '.renovaterc.json',
-  '.circleci/config.yml',
   '.vscode/settings.json',
   '.github/workflows/continuous-integration-workflow.yml',
   '**/*.json',
   '**/OWNERS',
   '**/*.md',
+  '**/*.yml',
 ];
 
 /**


### PR DESCRIPTION
This is a follow up to #34400, which migrated all issue templates to yaml forms.

**PR Highlights:**
- Enable prettier-auto formatting for all `.yml` files (`.gitignore` contents are still ignored)
- Enable VSCode auto-formatting for `.yml` files
- Remove superfluous per-file associations in `.prettierrc` and `.vscode/settings.json`
- Include `.yml` files in the `amp prettify` CI check (`--fix` will work during local dev)
- Apply auto-fixes to all files in `.github/ISSUE_TEMPLATE/` (separate commit)