### PR TITLE
Adding Tail as rtc vendor

### DIFF
--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -149,6 +149,7 @@ The `errorReportingUrl` property is optional. The only available macros are ERRO
 -   Rubicon
 -   Salesforce
 -   T13
+-   Tail
 -   The Ozone Project
 -   Yieldbot
 -   Yieldlab

--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -43,6 +43,7 @@ To use RTC, you must meet the following requirements:
 -   Rubicon
 -   Salesforce
 -   T13
+-   Tail
 -   The Ozone Project
 -   Yieldbot
 -   Yieldlab

--- a/src/service/real-time-config/callout-vendors.js
+++ b/src/service/real-time-config/callout-vendors.js
@@ -243,6 +243,11 @@ const RTC_VENDORS = jsonConfiguration({
     macros: ['TAG_ID', 'CONSENT_STRING', 'ACCOUNT_ID'],
     disableKeyAppend: true,
   },
+  tail: {
+    url: 'https://ACCOUNT_ID.seg.t.tailtarget.com/amp',
+    macros: ['ACCOUNT_ID'],
+    disableKeyAppend: true,
+  },
 });
 
 // DO NOT MODIFY: Setup for tests


### PR DESCRIPTION
Changes to add Tail as rtc vendor to enable Publishers to use Tail (https://tail.digital/) data with doubleclick ad unit.