### PR TITLE
🖍 Prevent native `img` elements from being styled by `ampshared.css`

### DIFF
--- a/css/ampshared.css
+++ b/css/ampshared.css
@@ -68,7 +68,7 @@
 
 .i-amphtml-layout-responsive,
 [layout=responsive][width][height]:not(.i-amphtml-layout-responsive),
-[width][height][sizes]:not([layout]):not(.i-amphtml-layout-responsive),
+[width][height][sizes]:not(img):not([layout]):not(.i-amphtml-layout-responsive),
 [width][height][heights]:not([layout]):not(.i-amphtml-layout-responsive)
 {
   display: block;
@@ -282,7 +282,7 @@ i-amphtml-sizer {
  */
 .i-amphtml-notbuilt,
 [layout]:not(.i-amphtml-element),
-[width][height][sizes]:not([layout]):not(.i-amphtml-element),
+[width][height][sizes]:not(img):not([layout]):not(.i-amphtml-element),
 [width][height][heights]:not([layout]):not(.i-amphtml-element)
 {
   position: relative;
@@ -317,7 +317,7 @@ amp-img:not(.i-amphtml-element)[i-amphtml-ssr] > img.i-amphtml-fill-content
 /** Hide all text node children of non-container elements. */
 .i-amphtml-notbuilt:not(.i-amphtml-layout-container),
 [layout]:not([layout='container']):not(.i-amphtml-element),
-[width][height][sizes]:not([layout]):not(.i-amphtml-element),
+[width][height][sizes]:not(img):not([layout]):not(.i-amphtml-element),
 [width][height][heights]:not([layout]):not(.i-amphtml-element) {
   color: transparent !important;
   line-height: 0 !important;

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3810,11 +3810,13 @@ tags: {
   mandatory_parent: "amp-img (transformed)"
   attrs: { name: "alt" }
   attrs: { name: "attribution" }
+  attrs: { name: "height" }
   attrs: { name: "object-fit" }
   attrs: { name: "object-position" }
   attrs: { name: "referrerpolicy" }
   attrs: { name: "sizes" }
   attrs: { name: "title" }
+  attrs: { name: "width" }
   attr_lists: "mandatory-src-or-srcset"
   # SSR requires these explicit attributes
   attrs: {


### PR DESCRIPTION
Fixes #34402. As suggested by @jridgewell in https://github.com/ampproject/amphtml/issues/34402#issuecomment-843521657.

This will facilitate incorporating native `img` elements onto AMP pages (#30442).

This also allows `width` and `height` attributes on SSR'ed `amp-img > img` elements which can be supplied by an optimization layer, like Mod_Pagespeed (https://github.com/apache/incubator-pagespeed-mod/issues/2067).

Using test case: https://ampshared-img-styling-issues.glitch.me/

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/119195057-dafed200-ba38-11eb-9d17-4150bd0439c8.png) | ![image](https://user-images.githubusercontent.com/134745/119195165-08e41680-ba39-11eb-9dac-aa2d4b18a0ae.png)

