### PR TITLE
Use isModeDevelopment for validator integration

### DIFF
--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -33,7 +33,7 @@ export function maybeValidate(win) {
     return;
   }
   let validator = false;
-  if (isModeDevelopment(this.win)) {
+  if (isModeDevelopment(win)) {
     const hash = parseQueryString(
       win.location['originalHash'] || win.location.hash
     );

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {getMode} from './mode';
+import {getMode, isModeDevelopment} from './mode';
 import {loadPromise} from './event-helper';
 import {parseQueryString} from './core/types/string/url';
 import {urls} from './config';
@@ -33,7 +33,7 @@ export function maybeValidate(win) {
     return;
   }
   let validator = false;
-  if (getMode().development) {
+  if (isModeDevelopment(this.win)) {
     const hash = parseQueryString(
       win.location['originalHash'] || win.location.hash
     );

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -23,7 +23,8 @@ import {loadScript, maybeValidate} from '../../src/validator-integration';
 
 describes.fakeWin('validator-integration', {}, (env) => {
   let loadScriptStub;
-  let modeStub;
+  let getModeStub;
+  let isModeDevelopmentStub;
   let win;
   describe('maybeValidate', () => {
     beforeEach(() => {
@@ -31,31 +32,36 @@ describes.fakeWin('validator-integration', {}, (env) => {
       loadScriptStub = env.sandbox
         .stub(eventHelper, 'loadPromise')
         .returns(Promise.resolve());
-      modeStub = env.sandbox.stub(mode, 'getMode');
+      getModeStub = env.sandbox.stub(mode, 'getMode');
+      isModeDevelopmentStub = env.sandbox.stub(mode, 'isModeDevelopment');
     });
 
     it('should not load validator script if not in dev mode', () => {
-      modeStub.returns({development: false});
+      getModeStub.returns({});
+      isModeDevelopmentStub.returns(false);
       maybeValidate(win);
       expect(loadScriptStub).not.to.have.been.called;
     });
 
     it('should not load validator script if bypassed', () => {
-      modeStub.returns({development: true, test: true});
+      getModeStub.returns({test: true});
+      isModeDevelopmentStub.returns(true);
       win.location = 'https://www.example.com/#development=1&validate=0';
       maybeValidate(win);
       expect(loadScriptStub).not.to.have.been.called;
     });
 
     it('should load validator script if dev mode', () => {
-      modeStub.returns({development: true});
+      getModeStub.returns({});
+      isModeDevelopmentStub.returns(true);
       loadScriptStub.returns(Promise.resolve());
       maybeValidate(win);
       expect(loadScriptStub).to.have.been.called;
     });
 
     it('should load WebAssembly validator', () => {
-      modeStub.returns({development: true, test: true});
+      getModeStub.returns({test: true});
+      isModeDevelopmentStub.returns(true);
       win.location = 'https://www.example.com/#development=1';
       maybeValidate(win);
       expect(loadScriptStub).to.have.been.calledWith(


### PR DESCRIPTION
Fixes #34501

#34372 introduce `isModeDevelopment` so that development can be determined in module runtime (v0.mjs). Use this for validator integration instead of `getMode().development`.