### PR TITLE
📖 Add bug report fields for OSs and Devices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -39,7 +39,7 @@ body:
     id: browsers
     attributes:
       label: Browser(s) Affected
-      description: Select one or more browser(s).
+      description: Specify which browser(s) are affected. Select one or more options below.
       multiple: true
       options:
         - Chrome
@@ -50,10 +50,26 @@ body:
     validations:
       required: true
   - type: input
+    id: operating_systems
+    attributes:
+      label: OS(s) Affected
+      description: If applicable, specify which operating system(s) are affected. Otherwise just put down 'all'.
+      placeholder: e.g. Android 11
+    validations:
+      required: true
+  - type: input
+    id: devices
+    attributes:
+      label: Device(s) Affected
+      description: If applicable, specify which device(s) are affected. Otherwise just put down 'all'.
+      placeholder: e.g. Pixel 3
+    validations:
+      required: true
+  - type: input
     id: version
     attributes:
       label: AMP Version Affected
-      description: If applicable, indicate a version in the format YYMMDDHHMMXXX. Otherwise just put down 'latest'.
+      description: If applicable, specify which version is affected, in the format YYMMDDHHMMXXX. Otherwise just put down 'latest'.
       placeholder: e.g. 2101280515000
     validations:
       required: true


### PR DESCRIPTION
This PR adds two new fields to the bug report template.

<img width="942" alt="Screen Shot 2021-05-25 at 11 20 17 AM" src="https://user-images.githubusercontent.com/26553114/119524001-3be51d80-bd4b-11eb-9e17-d21441a2c025.png">
