### PR TITLE
✨ [bento][npm] Support react modules in NPM Bento components

### DIFF
--- a/extensions/amp-accordion/1.0/package.json
+++ b/extensions/amp-accordion/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Accordion Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
-      ".": "./preact",
-      "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
-      },
-      "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
-      }
+    ".": "./preact",
+    "./preact": {
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
+    },
+    "./react": {
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
+    }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
       "type": "git",
       "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-accordion/1.0/react.js
+++ b/extensions/amp-accordion/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-accordion/1.0/react.js
+++ b/extensions/amp-accordion/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-base-carousel/1.0/package.json
+++ b/extensions/amp-base-carousel/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Base Carousel Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-base-carousel/1.0/react.js
+++ b/extensions/amp-base-carousel/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-base-carousel/1.0/react.js
+++ b/extensions/amp-base-carousel/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-date-countdown/1.0/package.json
+++ b/extensions/amp-date-countdown/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Date Countdown Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-date-countdown/1.0/react.js
+++ b/extensions/amp-date-countdown/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-date-countdown/1.0/react.js
+++ b/extensions/amp-date-countdown/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-date-display/1.0/package.json
+++ b/extensions/amp-date-display/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Date Display Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-date-display/1.0/react.js
+++ b/extensions/amp-date-display/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-date-display/1.0/react.js
+++ b/extensions/amp-date-display/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-fit-text/1.0/package.json
+++ b/extensions/amp-fit-text/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Fit Text Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-fit-text/1.0/react.js
+++ b/extensions/amp-fit-text/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-fit-text/1.0/react.js
+++ b/extensions/amp-fit-text/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-inline-gallery/1.0/package.json
+++ b/extensions/amp-inline-gallery/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Inline Gallery Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-inline-gallery/1.0/react.js
+++ b/extensions/amp-inline-gallery/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-inline-gallery/1.0/react.js
+++ b/extensions/amp-inline-gallery/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-instagram/1.0/package.json
+++ b/extensions/amp-instagram/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Instagram Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-instagram/1.0/react.js
+++ b/extensions/amp-instagram/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-instagram/1.0/react.js
+++ b/extensions/amp-instagram/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-lightbox/1.0/package.json
+++ b/extensions/amp-lightbox/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Lightbox Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-lightbox/1.0/react.js
+++ b/extensions/amp-lightbox/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-lightbox/1.0/react.js
+++ b/extensions/amp-lightbox/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-selector/1.0/package.json
+++ b/extensions/amp-selector/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Selector Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-selector/1.0/react.js
+++ b/extensions/amp-selector/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-selector/1.0/react.js
+++ b/extensions/amp-selector/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-stream-gallery/1.0/package.json
+++ b/extensions/amp-stream-gallery/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Stream Gallery Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-stream-gallery/1.0/react.js
+++ b/extensions/amp-stream-gallery/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-stream-gallery/1.0/react.js
+++ b/extensions/amp-stream-gallery/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-timeago/1.0/package.json
+++ b/extensions/amp-timeago/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Time Ago Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
-      ".": "./preact",
-      "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
-      },
-      "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
-      }
+    ".": "./preact",
+    "./preact": {
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
+    },
+    "./react": {
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
+    }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
       "type": "git",
       "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-timeago/1.0/react.js
+++ b/extensions/amp-timeago/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-timeago/1.0/react.js
+++ b/extensions/amp-timeago/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-twitter/1.0/package.json
+++ b/extensions/amp-twitter/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Twitter Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-twitter/1.0/react.js
+++ b/extensions/amp-twitter/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-twitter/1.0/react.js
+++ b/extensions/amp-twitter/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');

--- a/extensions/amp-youtube/1.0/package.json
+++ b/extensions/amp-youtube/1.0/package.json
@@ -4,20 +4,20 @@
   "description": "AMP Youtube Component",
   "author": "The AMP HTML Authors",
   "license": "Apache-2.0",
-  "main": "dist/component.js",
-  "module": "dist/component.mjs",
+  "main": "./dist/component.js",
+  "module": "./dist/component-preact.module.js",
   "exports": {
     ".": "./preact",
     "./preact": {
-      "import": "dist/component-preact.mjs",
-      "require": "dist/component-preact.js"
+      "import": "./dist/component-preact.module.js",
+      "require": "./dist/component-preact.js"
     },
     "./react": {
-      "import": "dist/component-react.mjs",
-      "require": "dist/component-react.js"
+      "import": "./dist/component-react.module.js",
+      "require": "./dist/component-react.js"
     }
   },
-  "files": ["dist/*"],
+  "files": ["dist/*", "react.js"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ampproject/amphtml.git",

--- a/extensions/amp-youtube/1.0/react.js
+++ b/extensions/amp-youtube/1.0/react.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+module.exports = require('./dist/component-react');

--- a/extensions/amp-youtube/1.0/react.js
+++ b/extensions/amp-youtube/1.0/react.js
@@ -15,4 +15,5 @@
  */
 
 /* eslint-env node */
+// eslint-disable-next-line local/no-module-exports
 module.exports = require('./dist/component-react');


### PR DESCRIPTION
Partial for: https://github.com/ampproject/amphtml/issues/34137

Update package.json files for existing bento components ready for NPM publishing.

Includes additional `react.js` file which is needed for react apps.