### PR TITLE
🏗 Don't type-check server transform output

### DIFF
--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -25,7 +25,8 @@ const SERVER_TRANSFORM_PATH = 'build-system/server/new-server/transforms';
 const CONFIG_PATH = `${SERVER_TRANSFORM_PATH}/tsconfig.json`;
 
 /**
- * Builds the new server by converting typescript transforms to JS
+ * Builds the new server by converting typescript transforms to JS. This JS
+ * output is not type-checked as part of `amp check-build-system`.
  * @return {Promise<void>}
  */
 async function buildNewServer() {
@@ -41,6 +42,7 @@ async function buildNewServer() {
     entryPoints,
     outdir: path.join(SERVER_TRANSFORM_PATH, 'dist'),
     bundle: false,
+    banner: {js: '// @ts-nocheck'},
     tsconfig: CONFIG_PATH,
     format: 'cjs',
   });

--- a/build-system/tasks/coverage-map/index.js
+++ b/build-system/tasks/coverage-map/index.js
@@ -97,11 +97,8 @@ async function autoScroll(page) {
  * @return {Promise<void>}
  */
 async function htmlTransform() {
-  const {
-    // @ts-ignore
-    transform,
-    // @ts-ignore
-  } = require('../../server/new-server/transforms/dist/transform');
+  // @ts-ignore
+  const {transform} = require('../../server/new-server/transforms/dist/transform'); // prettier-ignore
   log('Transforming', cyan(`${inputHtml}`) + '...');
   const transformed = await transform(`examples/${inputHtml}`);
   const transformedName = `transformed.${inputHtml}`;

--- a/build-system/tasks/coverage-map/index.js
+++ b/build-system/tasks/coverage-map/index.js
@@ -98,8 +98,8 @@ async function autoScroll(page) {
  */
 async function htmlTransform() {
   const {
-    transform,
     // @ts-ignore
+    transform,
   } = require('../../server/new-server/transforms/dist/transform');
   log('Transforming', cyan(`${inputHtml}`) + '...');
   const transformed = await transform(`examples/${inputHtml}`);

--- a/build-system/tasks/coverage-map/index.js
+++ b/build-system/tasks/coverage-map/index.js
@@ -100,6 +100,7 @@ async function htmlTransform() {
   const {
     // @ts-ignore
     transform,
+    // @ts-ignore
   } = require('../../server/new-server/transforms/dist/transform');
   log('Transforming', cyan(`${inputHtml}`) + '...');
   const transformed = await transform(`examples/${inputHtml}`);


### PR DESCRIPTION
With this, `amp check-build-system` will return zero type errors even when the server transforms have been built locally.