### PR TITLE
Skip failing amp-base-carousel:0.1 e2e test

### DIFF
--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -49,7 +49,7 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should render correctly', async function () {
+    it.skip('should render correctly', async function () {
       this.timeout(testTimeout);
       const el = await getScrollingElement(controller);
 


### PR DESCRIPTION
Related to #24195

Note: [This test appears to be failing consistently on Circle CI ](https://app.circleci.com/pipelines/github/ampproject/amphtml/9854/workflows/e0bd0a95-2391-49cf-b7ce-2ad4e236b4af/jobs/152844)but I could not get it to fail on local runs. 