### PR TITLE
🏗 Auto-format dev dashboard tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -30,7 +30,6 @@ validator/export
 # Files and directories explicitly ignored by eslint
 build-system/babel-plugins/**/fixtures/**/*.js
 build-system/babel-plugins/**/fixtures/**/*.mjs
-build-system/server/app-index/test/*.js
 build-system/tasks/make-extension/template/**/*
 build-system/tasks/visual-diff/snippets/*.js
 extensions/amp-a4a/0.1/test/testdata/**

--- a/build-system/server/app-index/test/helpers.js
+++ b/build-system/server/app-index/test/helpers.js
@@ -17,17 +17,14 @@
 const {expect} = require('chai');
 const {JSDOM} = require('jsdom');
 
-
-const parseHtmlChunk = htmlStr => {
-  const {body} = (new JSDOM(htmlStr)).window.document;
+const parseHtmlChunk = (htmlStr) => {
+  const {body} = new JSDOM(htmlStr).window.document;
   expect(body.children).to.have.length(1);
   return body.firstElementChild;
 };
 
-
-const boundAttrRe = attr =>
+const boundAttrRe = (attr) =>
   new RegExp(`\\[${attr}\\]=(("[^"]+")|('[^']+')|([^\\s\\>]+))`);
-
 
 // JSDom doesn't parse attributes whose names don't follow the spec, so
 // our only way to test [attr] values is via regex.
@@ -37,13 +34,11 @@ const getBoundAttr = ({outerHTML}, attr) => {
     return;
   }
   const [, valuePart] = match;
-  if (valuePart.charAt(0) == '"' ||
-      valuePart.charAt(0) == '\'') {
+  if (valuePart.charAt(0) == '"' || valuePart.charAt(0) == "'") {
     return valuePart.substring(1, valuePart.length - 1);
   }
   return valuePart;
-}
-
+};
 
 const expectValidAmphtml = (validator, string) => {
   const {errors: errorsAndWarnings, status} = validator.validateString(string);
@@ -54,7 +49,6 @@ const expectValidAmphtml = (validator, string) => {
   expect(errors).to.deep.equal([]);
   expect(status).to.equal('PASS');
 };
-
 
 module.exports = {
   expectValidAmphtml,

--- a/build-system/server/app-index/test/test-amphtml-helpers.js
+++ b/build-system/server/app-index/test/test-amphtml-helpers.js
@@ -16,27 +16,23 @@
 
 const amphtmlValidator = require('amphtml-validator');
 
-const {expect} = require('chai');
 const {expectValidAmphtml, parseHtmlChunk} = require('./helpers');
+const {expect} = require('chai');
 const {html} = require('../html');
 const {JSDOM} = require('jsdom');
 
 const {
-  addRequiredExtensionsToHead,
   AmpDoc,
   AmpState,
+  addRequiredExtensionsToHead,
   ampStateKey,
   containsExpr,
   ternaryExpr,
 } = require('../amphtml-helpers');
 
-
 describe('devdash', () => {
-
   describe('AMPHTML helpers', () => {
-
     describe('AmpDoc', () => {
-
       it('fails without args', () => {
         expect(() => AmpDoc()).to.throw;
       });
@@ -45,18 +41,22 @@ describe('devdash', () => {
         expect(() => AmpDoc({})).to.throw;
       });
 
-      it('creates valid doc with min required fields', async() => {
-        expectValidAmphtml(await amphtmlValidator.getInstance(), AmpDoc({
-          canonical: '/',
-        }));
+      it('creates valid doc with min required fields', async () => {
+        expectValidAmphtml(
+          await amphtmlValidator.getInstance(),
+          AmpDoc({
+            canonical: '/',
+          })
+        );
       }).timeout(5000);
 
-      it('creates valid doc with set fields', async() => {
-        expectValidAmphtml(await amphtmlValidator.getInstance(), AmpDoc({
-          canonical: '/',
-          css: 'body { font-family:sans-serif; } ',
-          head: html`
-            <script type="application/ld+json">
+      it('creates valid doc with set fields', async () => {
+        expectValidAmphtml(
+          await amphtmlValidator.getInstance(),
+          AmpDoc({
+            canonical: '/',
+            css: 'body { font-family:sans-serif; } ',
+            head: html` <script type="application/ld+json">
               {
                 "@context": "http://schema.org",
                 "@type": "NewsArticle",
@@ -87,18 +87,19 @@ describe('devdash', () => {
                 }
               }
             </script>`,
-          body: html`<div>Hola</div>`,
-        }));
+            body: html`<div>Hola</div>`,
+          })
+        );
       }).timeout(5000);
     });
 
     describe('ampStateKey', () => {
       it('concats arguments', () => {
         expect(ampStateKey('foo', 'bar')).to.equal('foo.bar');
-        expect(ampStateKey('tacos', 'al', 'pastor'))
-            .to.equal('tacos.al.pastor');
+        expect(ampStateKey('tacos', 'al', 'pastor')).to.equal(
+          'tacos.al.pastor'
+        );
       });
-
     });
 
     describe('ternaryExpr', () => {
@@ -109,13 +110,15 @@ describe('devdash', () => {
 
     describe('containsExpr', () => {
       it('creates expression with literals', () => {
-        expect(containsExpr('\'a\'', '\'b\'', '\'c\'', '\'d\''))
-            .to.equal('\'a\'.indexOf(\'b\') > -1 ? \'c\' : \'d\'');
+        expect(containsExpr("'a'", "'b'", "'c'", "'d'")).to.equal(
+          "'a'.indexOf('b') > -1 ? 'c' : 'd'"
+        );
       });
 
       it('creates expression with vars', () => {
-        expect(containsExpr('a', 'b', 'c', 'd'))
-            .to.equal('a.indexOf(b) > -1 ? c : d');
+        expect(containsExpr('a', 'b', 'c', 'd')).to.equal(
+          'a.indexOf(b) > -1 ? c : d'
+        );
       });
     });
 
@@ -132,16 +135,18 @@ describe('devdash', () => {
 
         const {firstElementChild} = root;
         expect(firstElementChild.tagName).to.equal('SCRIPT');
-        expect(firstElementChild.getAttribute('type'))
-            .to.equal('application/json');
+        expect(firstElementChild.getAttribute('type')).to.equal(
+          'application/json'
+        );
       });
 
       it('renders json object', () => {
         const id = 'whatever';
         const state = {foo: 'bar', baz: {yes: 'no'}};
 
-        const {textContent} =
-            parseHtmlChunk(AmpState(id, state)).firstElementChild;
+        const {textContent} = parseHtmlChunk(
+          AmpState(id, state)
+        ).firstElementChild;
 
         expect(JSON.parse(textContent)).to.deep.equal(state);
       });
@@ -150,8 +155,9 @@ describe('devdash', () => {
         const id = 'whatever';
         const state = 'foo';
 
-        const {textContent} =
-            parseHtmlChunk(AmpState(id, state)).firstElementChild;
+        const {textContent} = parseHtmlChunk(
+          AmpState(id, state)
+        ).firstElementChild;
 
         expect(JSON.parse(textContent)).to.equal(state);
       });
@@ -160,41 +166,44 @@ describe('devdash', () => {
         const id = 'whatever';
         const state = ['foo', 'bar', 'baz'];
 
-        const {textContent} =
-            parseHtmlChunk(AmpState(id, state)).firstElementChild;
+        const {textContent} = parseHtmlChunk(
+          AmpState(id, state)
+        ).firstElementChild;
 
         expect(JSON.parse(textContent)).to.deep.equal(state);
       });
     });
 
     describe('addRequiredExtensionsToHead', () => {
-
       function containsExtension(scripts, expectedExtension) {
-        return scripts.some(s =>
-          s.getAttribute('custom-element') == expectedExtension &&
-          s.getAttribute('custom-template') == null);
+        return scripts.some(
+          (s) =>
+            s.getAttribute('custom-element') == expectedExtension &&
+            s.getAttribute('custom-template') == null
+        );
       }
 
       function containsTemplate(scripts, expectedTemplate) {
-        return scripts.some(s =>
-          s.getAttribute('custom-template') == expectedTemplate &&
-          s.getAttribute('custom-extension') == null);
+        return scripts.some(
+          (s) =>
+            s.getAttribute('custom-template') == expectedTemplate &&
+            s.getAttribute('custom-extension') == null
+        );
       }
 
       it('renders ok', () => {
-        const rawStr = html`
-          <html>
-            <head></head>
-            <body>
-              <amp-foo foo="bar"></amp-foo>
-            </body>
-          </html>`;
+        // eslint-disable-next-line local/html-template
+        const rawStr = html` <html>
+          <head></head>
+          <body>
+            <amp-foo foo="bar"></amp-foo>
+          </body>
+        </html>`;
 
         expect(new JSDOM(addRequiredExtensionsToHead(rawStr))).to.be.ok;
       });
 
       it('adds mixed', () => {
-
         const expectedExtensions = [
           'amp-foo',
           'amp-bar',
@@ -205,97 +214,103 @@ describe('devdash', () => {
 
         const expectedTemplates = ['amp-mustache'];
 
-        const rawStr = html`
-          <html>
-            <head></head>
-            <body>
-              <amp-foo foo="bar"></amp-foo>
-              <amp-foo foo="bar"></amp-foo>
-              <amp-foo foo="bar"></amp-foo>
+        // eslint-disable-next-line local/html-template
+        const rawStr = html` <html>
+          <head></head>
+          <body>
+            <amp-foo foo="bar"></amp-foo>
+            <amp-foo foo="bar"></amp-foo>
+            <amp-foo foo="bar"></amp-foo>
+            <div>
+              <amp-bar></amp-bar>
               <div>
-                <amp-bar></amp-bar>
-                <div>
-                  <amp-foo-bar-baz many="1" attributes="2">
-                    Text content
-                  </amp-foo-bar-baz>
-                </div>
-                <input>
-                <amp-state id="myState"></amp-state>
-                <template type="amp-mustache"></template>
+                <amp-foo-bar-baz many="1" attributes="2">
+                  Text content
+                </amp-foo-bar-baz>
               </div>
-            </body>
-          </html>`;
+              <input />
+              <amp-state id="myState"></amp-state>
+              <template type="amp-mustache"></template>
+            </div>
+          </body>
+        </html>`;
 
-        const {document} =
-            (new JSDOM(addRequiredExtensionsToHead(rawStr))).window;
+        const {document} = new JSDOM(addRequiredExtensionsToHead(rawStr))
+          .window;
 
-        const scripts =
-            Array.from(document.head.getElementsByTagName('script'));
+        const scripts = Array.from(
+          document.head.getElementsByTagName('script')
+        );
 
         expect(scripts).to.have.length(
-            expectedExtensions.length + expectedTemplates.length);
+          expectedExtensions.length + expectedTemplates.length
+        );
 
-        scripts.forEach(script => {
+        scripts.forEach((script) => {
           expect(script.getAttribute('src')).to.be.ok;
           expect(script.getAttribute('async')).to.equal('');
         });
 
-        expectedExtensions.forEach(expectedScript => {
-          expect(scripts).to.satisfy(scripts =>
-            containsExtension(scripts, expectedScript))
+        expectedExtensions.forEach((expectedScript) => {
+          expect(scripts).to.satisfy((scripts) =>
+            containsExtension(scripts, expectedScript)
+          );
         });
 
-        expectedTemplates.forEach(expectedScript => {
-          expect(scripts).to.satisfy(scripts =>
-            containsTemplate(scripts, expectedScript))
+        expectedTemplates.forEach((expectedScript) => {
+          expect(scripts).to.satisfy((scripts) =>
+            containsTemplate(scripts, expectedScript)
+          );
         });
       });
 
       it('adds extensions', () => {
-
         const expected = ['amp-foo', 'amp-bar', 'amp-foo-bar-baz'];
 
-        const rawStr = html`
-          <html>
-            <head></head>
-            <body>
-              <amp-foo foo="bar"></amp-foo>
-              <amp-foo foo="bar"></amp-foo>
-              <amp-foo foo="bar"></amp-foo>
+        // eslint-disable-next-line local/html-template
+        const rawStr = html` <html>
+          <head></head>
+          <body>
+            <amp-foo foo="bar"></amp-foo>
+            <amp-foo foo="bar"></amp-foo>
+            <amp-foo foo="bar"></amp-foo>
+            <div>
+              <amp-bar></amp-bar>
               <div>
-                <amp-bar></amp-bar>
-                <div>
-                  <amp-foo-bar-baz many="1" attributes="2">
-                    Text content
-                  </amp-foo-bar-baz>
-                </div>
+                <amp-foo-bar-baz many="1" attributes="2">
+                  Text content
+                </amp-foo-bar-baz>
               </div>
-            </body>
-          </html>`;
+            </div>
+          </body>
+        </html>`;
 
-        const {document} =
-            (new JSDOM(addRequiredExtensionsToHead(rawStr))).window;
+        const {document} = new JSDOM(addRequiredExtensionsToHead(rawStr))
+          .window;
 
-        const scripts =
-            Array.from(document.head.getElementsByTagName('script'));
+        const scripts = Array.from(
+          document.head.getElementsByTagName('script')
+        );
 
         expect(scripts).to.have.length(expected.length);
 
-        scripts.forEach(script => {
-          expect(script.getAttribute('src')).to.be.ok
+        scripts.forEach((script) => {
+          expect(script.getAttribute('src')).to.be.ok;
           expect(script.getAttribute('async')).to.equal('');
           expect(script.getAttribute('custom-template')).to.be.null;
         });
 
-        expected.forEach(expectedScript => {
-          expect(scripts).to.satisfy(scripts =>
-            containsExtension(scripts, expectedScript));
+        expected.forEach((expectedScript) => {
+          expect(scripts).to.satisfy((scripts) =>
+            containsExtension(scripts, expectedScript)
+          );
         });
       });
 
       it('adds template', () => {
         const expected = 'amp-mustache';
 
+        // eslint-disable-next-line local/html-template
         const rawStr = html`
           <html>
             <head></head>
@@ -309,8 +324,8 @@ describe('devdash', () => {
             </body>
           </html>`;
 
-        const {document} =
-            (new JSDOM(addRequiredExtensionsToHead(rawStr))).window;
+        const {document} = new JSDOM(addRequiredExtensionsToHead(rawStr))
+          .window;
 
         const scripts = document.head.getElementsByTagName('script');
 
@@ -325,19 +340,18 @@ describe('devdash', () => {
       });
 
       it('adds <amp-form> per <form>', () => {
-
         const expected = 'amp-form';
 
-        const rawStr = html`
-          <html>
-            <head></head>
-            <body>
-              <form action="whatever.com"></form>
-            </body>
-          </html>`;
+        // eslint-disable-next-line local/html-template
+        const rawStr = html` <html>
+          <head></head>
+          <body>
+            <form action="whatever.com"></form>
+          </body>
+        </html>`;
 
-        const {document} =
-            (new JSDOM(addRequiredExtensionsToHead(rawStr))).window;
+        const {document} = new JSDOM(addRequiredExtensionsToHead(rawStr))
+          .window;
 
         const scripts = document.head.getElementsByTagName('script');
 
@@ -352,21 +366,20 @@ describe('devdash', () => {
       });
 
       it('adds <amp-form> per <input>', () => {
-
         const expected = 'amp-form';
 
-        const rawStr = html`
-          <html>
-            <head></head>
-            <body>
-              <input>
-              <input>
-              <input>
-            </body>
-          </html>`;
+        // eslint-disable-next-line local/html-template
+        const rawStr = html` <html>
+          <head></head>
+          <body>
+            <input />
+            <input />
+            <input />
+          </body>
+        </html>`;
 
-        const {document} =
-            (new JSDOM(addRequiredExtensionsToHead(rawStr))).window;
+        const {document} = new JSDOM(addRequiredExtensionsToHead(rawStr))
+          .window;
 
         const scripts = document.head.getElementsByTagName('script');
 
@@ -381,19 +394,18 @@ describe('devdash', () => {
       });
 
       it('adds <amp-form> per <select>', () => {
-
         const expected = 'amp-form';
 
-        const rawStr = html`
-          <html>
-            <head></head>
-            <body>
-              <select></select>
-            </body>
-          </html>`;
+        // eslint-disable-next-line local/html-template
+        const rawStr = html` <html>
+          <head></head>
+          <body>
+            <select></select>
+          </body>
+        </html>`;
 
-        const {document} =
-            (new JSDOM(addRequiredExtensionsToHead(rawStr))).window;
+        const {document} = new JSDOM(addRequiredExtensionsToHead(rawStr))
+          .window;
 
         const scripts = document.head.getElementsByTagName('script');
 
@@ -406,8 +418,6 @@ describe('devdash', () => {
         expect(script.getAttribute('async')).to.equal('');
         expect(script.getAttribute('custom-element')).to.equal(expected);
       });
-
     });
   });
-
 });

--- a/build-system/server/app-index/test/test-file-list.js
+++ b/build-system/server/app-index/test/test-file-list.js
@@ -18,17 +18,16 @@ const {expect} = require('chai');
 const {FileList} = require('../file-list');
 const {getBoundAttr, parseHtmlChunk} = require('./helpers');
 
-
 describe('devdash', () => {
-
   describe('FileList', () => {
-
     it('wraps', () => {
-      const root = parseHtmlChunk(FileList({
-        basepath: 'basepath',
-        fileSet: [],
-        selectModePrefix: '/',
-      }));
+      const root = parseHtmlChunk(
+        FileList({
+          basepath: 'basepath',
+          fileSet: [],
+          selectModePrefix: '/',
+        })
+      );
 
       expect(root.className).to.equal('file-list-container');
 
@@ -38,11 +37,13 @@ describe('devdash', () => {
     });
 
     it('creates amp-list', () => {
-      const root = parseHtmlChunk(FileList({
-        basepath: 'basepath',
-        fileSet: [],
-        selectModePrefix: '/',
-      }));
+      const root = parseHtmlChunk(
+        FileList({
+          basepath: 'basepath',
+          fileSet: [],
+          selectModePrefix: '/',
+        })
+      );
 
       const {length} = root.getElementsByTagName('amp-list');
       expect(length).to.equal(1);
@@ -51,11 +52,13 @@ describe('devdash', () => {
     it('creates placeholder inside amp-list with rendered data', () => {
       const fileSet = ['foo.bar', 'tacos.al.pastor'];
 
-      const root = parseHtmlChunk(FileList({
-        fileSet,
-        basepath: 'basepath',
-        selectModePrefix: '/',
-      }));
+      const root = parseHtmlChunk(
+        FileList({
+          fileSet,
+          basepath: 'basepath',
+          selectModePrefix: '/',
+        })
+      );
 
       const els = root.querySelectorAll('amp-list > [placeholder]');
 
@@ -75,11 +78,13 @@ describe('devdash', () => {
       const fileSet = ['asada.html', 'adobada.html', 'pastor.html'];
       const basepath = '/examples/';
 
-      const root = parseHtmlChunk(FileList({
-        fileSet,
-        basepath,
-        selectModePrefix: '/',
-      }));
+      const root = parseHtmlChunk(
+        FileList({
+          fileSet,
+          basepath,
+          selectModePrefix: '/',
+        })
+      );
 
       const els = root.querySelectorAll('amp-list [role=listitem] > a[href]');
 
@@ -95,11 +100,13 @@ describe('devdash', () => {
       const fileSet = ['asada.html', 'adobada.html', 'pastor.html'];
       const basepath = '/potato/';
 
-      const root = parseHtmlChunk(FileList({
-        fileSet,
-        basepath,
-        selectModePrefix: '/',
-      }));
+      const root = parseHtmlChunk(
+        FileList({
+          fileSet,
+          basepath,
+          selectModePrefix: '/',
+        })
+      );
 
       const els = root.querySelectorAll('amp-list [role=listitem] > a[href]');
 
@@ -116,11 +123,13 @@ describe('devdash', () => {
       const notBound = ['chabbuddy.g', 'dj.beats', 'mc.grindah'];
       const basepath = '/examples/';
 
-      const root = parseHtmlChunk(FileList({
-        fileSet: [...bound, ...notBound],
-        basepath,
-        selectModePrefix: '/',
-      }));
+      const root = parseHtmlChunk(
+        FileList({
+          fileSet: [...bound, ...notBound],
+          basepath,
+          selectModePrefix: '/',
+        })
+      );
 
       const els = root.querySelectorAll('amp-list [role=listitem] > a[href]');
 
@@ -138,7 +147,5 @@ describe('devdash', () => {
         expect(el.getAttribute('href')).to.equal(basepath + expectedHref);
       });
     });
-
   });
-
 });

--- a/build-system/server/app-index/test/test-html.js
+++ b/build-system/server/app-index/test/test-html.js
@@ -17,18 +17,15 @@
 const {expect} = require('chai');
 const {html, joinFragments} = require('../html');
 
-
 describe('devdash', () => {
   describe('html helpers', () => {
     describe('joinFragments', () => {
-
       it('joins simple fragments', () => {
         expect(joinFragments(['a', 'b', 'c'])).to.equal('abc');
       });
       it('joins mapped fragments', () => {
-        expect(joinFragments([1, 2, 3], a => a + 1)).to.equal('234');
+        expect(joinFragments([1, 2, 3], (a) => a + 1)).to.equal('234');
       });
-
     });
 
     describe('html', () => {
@@ -37,8 +34,9 @@ describe('devdash', () => {
       });
 
       it('concatenates interpolated args', () => {
-        expect(html`quesadilla ${'de'} chicharrón ${'con'} queso`)
-            .to.equal('quesadilla de chicharrón con queso');
+        // eslint-disable-next-line local/html-template
+        const interpolated = html`quesadilla ${'de'} chicharrón ${'con'} queso`;
+        expect(interpolated).to.equal('quesadilla de chicharrón con queso');
       });
     });
   });

--- a/build-system/server/app-index/test/test-self.js
+++ b/build-system/server/app-index/test/test-self.js
@@ -17,20 +17,12 @@
 const amphtmlValidator = require('amphtml-validator');
 const fs = require('fs');
 const path = require('path');
+const {expectValidAmphtml, getBoundAttr, parseHtmlChunk} = require('./helpers');
 const {expect} = require('chai');
-const {
-  expectValidAmphtml,
-  getBoundAttr,
-  parseHtmlChunk,
-} = require('./helpers');
-
 
 describe('devdash', () => {
-
   describe('Test helpers', () => {
-
     describe('parseHtmlChunk', () => {
-
       it('returns firstElementChild', () => {
         const {tagName} = parseHtmlChunk('<my-tag></my-tag>');
         expect(tagName).to.equal(tagName);
@@ -47,11 +39,9 @@ describe('devdash', () => {
       it('fails on empty string', () => {
         expect(() => parseHtmlChunk('')).to.throw;
       });
-
     });
 
     describe('getBoundAttr', () => {
-
       it('returns bound attr set with other bound attrs', () => {
         const fakeEl = {outerHTML: '<div myHref=no [y]=b [myHref]=a></div>'};
         expect(getBoundAttr(fakeEl, 'myHref')).to.equal('a');
@@ -94,29 +84,29 @@ describe('devdash', () => {
       });
 
       it('returns value with double quote', () => {
-        const fakeEl = {outerHTML: '<div [foo]=\'ab"cd ef\'></div>'};
+        const fakeEl = {outerHTML: "<div [foo]='ab\"cd ef'></div>"};
         expect(getBoundAttr(fakeEl, 'foo')).to.equal('ab"cd ef');
       });
 
       it('returns value with single quote', () => {
         const fakeEl = {outerHTML: '<div [foo]="ab\'cd ef"></div>'};
-        expect(getBoundAttr(fakeEl, 'foo')).to.equal('ab\'cd ef');
+        expect(getBoundAttr(fakeEl, 'foo')).to.equal("ab'cd ef");
       });
-
     });
 
     describe('expectValidAmphtml', () => {
-
-      it('passes with minimum valid doc', async() => {
-        const validDocPath = path.join(__dirname,
-            '../../../../validator/testdata/feature_tests/minimum_valid_amp.html');
+      it('passes with minimum valid doc', async () => {
+        const validDocPath = path.join(
+          __dirname,
+          '../../../../validator/testdata/feature_tests/minimum_valid_amp.html'
+        );
 
         const validDoc = fs.readFileSync(validDocPath).toString();
 
         expectValidAmphtml(await amphtmlValidator.getInstance(), validDoc);
       });
 
-      it('fails with invalid doc', async() => {
+      it('fails with invalid doc', async () => {
         const invalidDoc = '<html 😻></html>';
 
         const validator = await amphtmlValidator.getInstance();
@@ -135,9 +125,6 @@ describe('devdash', () => {
         };
         expectValidAmphtml(mockValidator, 'any string');
       });
-
     });
-
   });
-
 });

--- a/build-system/server/app-index/test/test-template.js
+++ b/build-system/server/app-index/test/test-template.js
@@ -20,25 +20,26 @@ const {expectValidAmphtml} = require('./helpers');
 const {renderTemplate} = require('../template');
 
 describe('template', () => {
-
   describe('renderTemplate', () => {
-
-    it('renders valid doc', async() => {
-      expectValidAmphtml(await amphtmlValidator.getInstance(), renderTemplate({
-        basepath: '/examples/',
-        css: 'body{}',
-        isMainPage: true,
-        fileSet: ['tacos.al.pastor'],
-        serveMode: 'default',
-        selectModePrefix: '/',
-      }));
+    it('renders valid doc', async () => {
+      expectValidAmphtml(
+        await amphtmlValidator.getInstance(),
+        renderTemplate({
+          basepath: '/examples/',
+          css: 'body{}',
+          isMainPage: true,
+          fileSet: ['tacos.al.pastor'],
+          serveMode: 'default',
+          selectModePrefix: '/',
+        })
+      );
     });
 
-    it('renders valid doc with empty/default values', async() => {
-      expectValidAmphtml(await amphtmlValidator.getInstance(),
-          renderTemplate());
+    it('renders valid doc with empty/default values', async () => {
+      expectValidAmphtml(
+        await amphtmlValidator.getInstance(),
+        renderTemplate()
+      );
     });
-
   });
-
 });

--- a/build-system/server/app-index/test/test.js
+++ b/build-system/server/app-index/test/test.js
@@ -20,13 +20,10 @@ const {serveIndexForTesting} = require('../index');
 const NOOP = () => {};
 
 describe('devdash', () => {
-
   describe('express middleware', () => {
-
-    it('renders HTML', async() => {
+    it('renders HTML', async () => {
       const renderedHtml = await serveIndexForTesting({url: '/'}, {end: NOOP});
       expect(renderedHtml).to.be.ok;
     });
-
   });
 });


### PR DESCRIPTION
These tests were added in #18796, but weren't auto-formatted or linted at the time. While investigating https://github.com/ampproject/amphtml/pull/34451#issuecomment-848221679, I found it useful to have auto-formatting and inline lint checks.
