### PR TITLE
📖 Make a few bug report fields optional

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -39,7 +39,7 @@ body:
     id: browsers
     attributes:
       label: Browser(s) Affected
-      description: Specify which browser(s) are affected. Select one or more options below.
+      description: If applicable, specify which browser(s) are affected. Select one or more options below.
       multiple: true
       options:
         - Chrome
@@ -47,29 +47,21 @@ body:
         - Safari
         - Edge
         - UC Browser
-    validations:
-      required: true
   - type: input
     id: operating_systems
     attributes:
       label: OS(s) Affected
-      description: If applicable, specify which operating system(s) are affected. Otherwise just put down 'n/a'.
+      description: If applicable, specify which operating system(s) are affected.
       placeholder: e.g. Android 11
-    validations:
-      required: true
   - type: input
     id: devices
     attributes:
       label: Device(s) Affected
-      description: If applicable, specify which device(s) are affected. Otherwise just put down 'n/a'.
+      description: If applicable, specify which device(s) are affected.
       placeholder: e.g. Pixel 3
-    validations:
-      required: true
   - type: input
     id: version
     attributes:
       label: AMP Version Affected
-      description: If applicable, specify which version is affected, in the format YYMMDDHHMMXXX. Otherwise just put down 'latest'.
+      description: If applicable, specify which version is affected, in the format YYMMDDHHMMXXX.
       placeholder: e.g. 2101280515000
-    validations:
-      required: true


### PR DESCRIPTION
**Background:**

We use AMP's default [bug report template](https://github.com/ampproject/amphtml/issues/new?assignees=&labels=Type%3A+Bug&template=bug-report.yml) for two broad purposes:
1. To receive bug reports about the AMP runtime + components from internal and external contributors
2. To receive bug reports / track tasks related to the non-runtime internals of AMP (e.g. infrastructure)

- For case 1, it's valuable to have info like browser, OS, device, and AMP version.
- For case 2, this info is mostly irrelevant.

**Options to address this:**

- Make the fields optional, with the expectation that they will still be filled out for case 1.
- Let the fields remain mandatory, and add a different "infrastructure bug report" template for case 2.

This PR implements the first option. Advantages are simplicity and less friction. Is there a compelling reason to go with the second option?

**Screenshot:**

![image](https://user-images.githubusercontent.com/26553114/119576353-95b70900-bd86-11eb-97e6-c9efe0072944.png)
