### PR TITLE
Track flexible-bitrate experiment through CSI pipeline.

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -430,12 +430,6 @@ export class AmpStory extends AMP.BaseElement {
       this.element.removeChild(node);
     });
 
-    if (isExperimentOn(this.win, 'flexible-bitrate')) {
-      Services.performanceFor(this.win).addEnabledExperiment(
-        'flexible-bitrate'
-      );
-    }
-
     if (isExperimentOn(this.win, 'amp-story-branching')) {
       this.registerAction('goToPage', (invocation) => {
         const {args} = invocation;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -430,6 +430,12 @@ export class AmpStory extends AMP.BaseElement {
       this.element.removeChild(node);
     });
 
+    if (isExperimentOn(this.win, 'flexible-bitrate')) {
+      Services.performanceFor(this.win).addEnabledExperiment(
+        'flexible-bitrate'
+      );
+    }
+
     if (isExperimentOn(this.win, 'amp-story-branching')) {
       this.registerAction('goToPage', (invocation) => {
         const {args} = invocation;

--- a/extensions/amp-video/0.1/flexible-bitrate.js
+++ b/extensions/amp-video/0.1/flexible-bitrate.js
@@ -15,6 +15,7 @@
  */
 
 import {DomBasedWeakRef} from '../../../src/core/dom/weakref';
+import {Services} from '../../../src/services';
 import {childElement, childElementsByTag} from '../../../src/dom';
 import {dev, devAssert} from '../../../src/log';
 import {isExperimentOn} from '../../../src/experiments';
@@ -53,6 +54,11 @@ export function getBitrateManager(win) {
   if (instance) {
     return instance;
   }
+
+  if (isExperimentOn(win, 'flexible-bitrate')) {
+    Services.performanceFor(win).addEnabledExperiment('flexible-bitrate');
+  }
+
   return (instance = new BitrateManager(win));
 }
 

--- a/extensions/amp-video/0.1/test/test-amp-video.js
+++ b/extensions/amp-video/0.1/test/test-amp-video.js
@@ -19,6 +19,7 @@ import {Services} from '../../../../src/services';
 import {VideoEvents} from '../../../../src/video-interface';
 import {VisibilityState} from '../../../../src/core/constants/visibility-state';
 import {dispatchCustomEvent} from '../../../../src/dom';
+import {installPerformanceService} from '../../../../src/service/performance-impl';
 import {installResizeObserverStub} from '../../../../testing/resize-observer-stub';
 import {listenOncePromise} from '../../../../src/event-helper';
 import {toggleExperiment} from '../../../../src/experiments';
@@ -40,6 +41,7 @@ describes.realWin(
       doc = win.document;
       timer = Services.timerFor(win);
 
+      installPerformanceService(win);
       resizeObserverStub = installResizeObserverStub(env.sandbox, win);
     });
 


### PR DESCRIPTION
Send the `flexible-bitrate` with the enabled experiments so it can be used to filter the CSI dashboards.