### PR TITLE
🏗  🚀 Update circleci fail_fast logic to mark workflows as failed rather than canceled

### DIFF
--- a/.circleci/cancel_running_jobs.js
+++ b/.circleci/cancel_running_jobs.js
@@ -2,6 +2,7 @@ const request = require('request');
 
 const CIRCLE_WORKFLOW_ID = process.env.CIRCLE_WORKFLOW_ID || '972a46ec-a0cd-47b0-a4d2-9fad83486c51';
 const CIRCLE_TOKEN = process.env.CIRCLE_TOKEN;
+const CIRCLE_JOB = process.env.CIRCLE_JOB;
 
 function get(url) {
   return new Promise((resolve, reject) => {
@@ -44,7 +45,7 @@ async function cancelAllRunningJobs() {
   console.log('failed', jobs.items.filter(job => job.status === 'failed').length);
   console.log('canceled', jobs.items.filter(job => job.status === 'canceled').length);
   console.log('running', jobs.items.filter(job => job.status === 'running').length);
-  jobs.items.filter(job => job.status === 'running').forEach(job => {
+  jobs.items.filter(job => job.status === 'running' && job.name !== CIRCLE_JOB).forEach(job => {
     console.log(`Canceling job ${job.job_number}`);
     post(`https://circleci.com/api/v2/project/github/ampproject/amphtml/job/${job.job_number}/cancel?circle-token=${CIRCLE_TOKEN}`);
   })

--- a/.circleci/cancel_running_jobs.js
+++ b/.circleci/cancel_running_jobs.js
@@ -1,0 +1,53 @@
+const request = require('request');
+
+const CIRCLE_WORKFLOW_ID = process.env.CIRCLE_WORKFLOW_ID || '972a46ec-a0cd-47b0-a4d2-9fad83486c51';
+const CIRCLE_TOKEN = process.env.CIRCLE_TOKEN;
+
+function get(url) {
+  return new Promise((resolve, reject) => {
+    request
+      .get({
+        method: 'GET',
+        url,
+      }, (err, _res, body) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(JSON.parse(body));
+      });
+  });
+}
+
+function post(url) {
+  return new Promise((resolve, reject) => {
+    url = new URL(url);
+    request({
+      method: 'POST',
+      url,
+    },
+      (err, _res, body) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(body);
+      }
+    );
+  });
+}
+
+async function cancelAllRunningJobs() {
+  const jobs = await get(
+    `https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/job?circle-token=${CIRCLE_TOKEN}`
+  );
+  // DO_NOT_SUBMIT
+  console.log(jobs);
+  console.log('failed', jobs.items.filter(job => job.status === 'failed').length);
+  console.log('canceled', jobs.items.filter(job => job.status === 'canceled').length);
+  console.log('running', jobs.items.filter(job => job.status === 'running').length);
+  jobs.items.filter(job => job.status === 'running').forEach(job => {
+    console.log(`Canceling job ${job.job_number}`);
+    post(`https://circleci.com/api/v2/project/github/ampproject/amphtml/job/${job.job_number}/cancel?circle-token=${CIRCLE_TOKEN}`);
+  })
+}
+
+cancelAllRunningJobs();

--- a/.circleci/fail_fast.sh
+++ b/.circleci/fail_fast.sh
@@ -69,6 +69,5 @@ fi
 
 # For PR builds, cancel when the first job fails.
 echo $(RED "Canceling PR build because a job failed.")
-curl -X POST \
---header "Content-Type: application/json" \
-"https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel?circle-token=${CIRCLE_TOKEN}"
+DIRECTORY=`dirname $0`
+node "$DIRECTORY/cancel_running_jobs.js"

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -39,39 +39,42 @@ const options = {
  * @param {Array<string>} filesToLint
  */
 async function runLinter(filesToLint) {
-  logLocalDev(green('Starting linter...'));
-  const eslint = new ESLint(options);
-  const results = {
-    errorCount: 0,
-    warningCount: 0,
-  };
-  const fixedFiles = {};
-  for (const file of filesToLint) {
-    const text = fs.readFileSync(file, 'utf-8');
-    const lintResult = await eslint.lintText(text, {filePath: file});
-    const result = lintResult[0];
-    results.errorCount += result.errorCount;
-    results.warningCount += result.warningCount;
-    const formatter = await eslint.loadFormatter('stylish');
-    const resultText = formatter
-      .format(lintResult)
-      .replace(`${process.cwd()}/`, '')
-      .trim();
-    if (resultText.length) {
-      logOnSameLine(resultText);
-    }
-    if (argv.fix) {
-      await ESLint.outputFixes(lintResult);
-    }
-    logOnSameLineLocalDev(green('Linted: ') + file);
-    if (options.fix && result.output) {
-      const status =
-        result.errorCount == 0 ? green('Fixed: ') : yellow('Partially fixed: ');
-      logOnSameLine(status + cyan(file));
-      fixedFiles[file] = status;
-    }
-  }
-  summarizeResults(results, fixedFiles);
+  // DO_NOT_SUBMIT
+  log(red('Triggering fast fail'));
+  process.exitCode = 1;
+  // logLocalDev(green('Starting linter...'));
+  // const eslint = new ESLint(options);
+  // const results = {
+  //   errorCount: 0,
+  //   warningCount: 0,
+  // };
+  // const fixedFiles = {};
+  // for (const file of filesToLint) {
+  //   const text = fs.readFileSync(file, 'utf-8');
+  //   const lintResult = await eslint.lintText(text, {filePath: file});
+  //   const result = lintResult[0];
+  //   results.errorCount += result.errorCount;
+  //   results.warningCount += result.warningCount;
+  //   const formatter = await eslint.loadFormatter('stylish');
+  //   const resultText = formatter
+  //     .format(lintResult)
+  //     .replace(`${process.cwd()}/`, '')
+  //     .trim();
+  //   if (resultText.length) {
+  //     logOnSameLine(resultText);
+  //   }
+  //   if (argv.fix) {
+  //     await ESLint.outputFixes(lintResult);
+  //   }
+  //   logOnSameLineLocalDev(green('Linted: ') + file);
+  //   if (options.fix && result.output) {
+  //     const status =
+  //       result.errorCount == 0 ? green('Fixed: ') : yellow('Partially fixed: ');
+  //     logOnSameLine(status + cyan(file));
+  //     fixedFiles[file] = status;
+  //   }
+  // }
+  // summarizeResults(results, fixedFiles);
 }
 
 /**


### PR DESCRIPTION
We have been using CircleCIs fail_fast system to cancel workflows as soon as a job fails. Unfortunately this results in the workflow being marked as canceled. CircleCI seems to have added a new api to cancel a running job (not the whole workflow) so I am updating the fast_fail logic to cancel all remaining jobs instead. This should allow the workflow to terminate naturally and display a "Failed" status.

Example of failed job showing as "Canceled"
![image](https://user-images.githubusercontent.com/78179109/119580772-ee31da80-bd75-11eb-939e-68b7a77eece5.png)


<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
