### PR TITLE
🖍 Add `min--moz-device-pixel-ratio` and `max--moz-device-pixel-ratio` media features to CSS validator spec

### DIFF
--- a/validator/validator-css.protoascii
+++ b/validator/validator-css.protoascii
@@ -838,6 +838,8 @@ tags: {  # <style amp-custom>, [AMP]
            feature: 'min-device-pixel-ratio'
            feature: 'max-device-pixel-ratio2'
            feature: 'min-device-pixel-ratio2'
+           feature: 'min--moz-device-pixel-ratio'
+           feature: 'max--moz-device-pixel-ratio'
          }
       }
       at_rule_spec: { name: 'page' }


### PR DESCRIPTION
In the past few days the WordPress AMP plugin has been getting topics about Search Console reporting a warning for a CSS syntax error:

https://wordpress.org/support/topic/amp-css-syntax-error-in-tag-style-amp-custom-2/
https://wordpress.org/support/topic/css-syntax-error-in-tag-style-amp-custom-11/
https://wordpress.org/support/topic/css-syntax-error-in-tag-style-amp-custom-12/

For example:

![search-console](https://user-images.githubusercontent.com/134745/119600536-192f2500-bd9c-11eb-8cab-ec712b652f40.png)

The offending CSS code looks like this:

```css
@media only screen and (-webkit-min-device-pixel-ratio: 1.5),
       only screen and (min--moz-device-pixel-ratio: 1.5), 
       only screen and (min-resolution: 240dpi) 
{
	div.googleplay a.apptitle {
		background: url(../img/googleplay-small.png);
	}
}
```

Both the JS and C++ validators are reporting:

> CSS syntax error in tag 'style amp-custom' - disallowed media feature 'min--moz-device-pixel-ratio'

The fix appears to simply be to add both `min--moz-device-pixel-ratio` and `max--moz-device-pixel-ratio` to the list of non-standard media types and features commonly seen. These two features were used in Firefox 16 and older [according to MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/-moz-device-pixel-ratio).