### PR TITLE
🏗 Skip NPM checks while type-checking build-system

### DIFF
--- a/build-system/common/update-packages.js
+++ b/build-system/common/update-packages.js
@@ -269,12 +269,13 @@ function updatePackages() {
  * 2. During local development, do an incremental install if necessary.
  * 3. Since install scripts can be async, `await` the process object.
  * 4. Since script output is noisy, capture and print the stderr if needed.
- * 5. During CI, make sure that the package files were correctly updated.
+ * 5. During CI, if not skipped, ensure package files were correctly updated.
  *
  * @param {string} dir
+ * @param {boolean=} skipNpmChecks
  * @return {Promise<void>}
  */
-async function updateSubpackages(dir) {
+async function updateSubpackages(dir, skipNpmChecks = false) {
   const results = checkDependencies.sync({packageDir: dir});
   const relativeDir = path.relative(process.cwd(), dir);
   if (results.depsWereOk) {
@@ -289,7 +290,7 @@ async function updateSubpackages(dir) {
       throw new Error('Installation failed');
     }
   }
-  if (isCiBuild()) {
+  if (isCiBuild() && !skipNpmChecks) {
     runNpmChecks(dir);
   }
 }

--- a/build-system/tasks/check-build-system.js
+++ b/build-system/tasks/check-build-system.js
@@ -22,11 +22,13 @@ const {updateSubpackages} = require('../common/update-packages');
 
 /**
  * Helper that updates build-system subpackages so their types can be verified.
+ * Skips NPM checks during CI (already done while running each task).
  */
 async function updateBuildSystemSubpackages() {
   const packageFiles = globby.sync('build-system/tasks/*/package.json');
   for (const packageFile of packageFiles) {
-    await updateSubpackages(path.dirname(packageFile));
+    const packageDir = path.dirname(packageFile);
+    await updateSubpackages(packageDir, /* skipNpmChecks */ true);
   }
 }
 


### PR DESCRIPTION
#34525 made it so that all build-system subpackages are installed before type-checking the directory. 

This PR skips running NPM checks for those subpackages during type-checking because this is already done while running the individual tasks. Doing so should shave off several seconds of running time.

