### PR TITLE
🏗 Make new typecheck targets simpler

### DIFF
--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -101,7 +101,8 @@ const getExtensionSrcPaths = () =>
  * about. This is a list of source files to include in type-checking. For any
  * glob pattern ending in *.js, externs are picked up following the same pattern
  * but ending in *.extern.js. Note this only applies to *.js globs, and not
- * specific filenames.
+ * specific filenames. If just an array of strings is provided instead of an
+ * object, it is treated as srcGlobs.
  *
  * @type {Object<string, Array<string>|Object|function():Object>}
  */

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -235,6 +235,7 @@ const TYPE_CHECK_TARGETS = {
 
 /**
  * Produces a list of extern glob patterns from a list of source glob patterns.
+ * ex. ['src/core/** /*.js'] => ['src/core/** /*.extern.js']
  * @param {!Array<string>} srcGlobs
  * @return {!Array<string>}
  */

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -160,9 +160,8 @@ const TYPE_CHECK_TARGETS = {
     externGlobs: ['build-system/externs/*.extern.js'],
   },
 
-  /*
-   * Ensures that all files in src and extensions pass the specified set of errors.
-   */
+  // Ensures that all files in src and extensions pass the specified set of
+  // errors.
   'low-bar': {
     entryPoints: ['src/amp.js'],
     extraGlobs: ['{src,extensions}/**/*.js'],
@@ -242,9 +241,11 @@ function externGlobsFromSrcGlobs(srcGlobs) {
  */
 async function typeCheck(targetName) {
   let target = TYPE_CHECK_TARGETS[targetName];
+  // Allow targets to be dynamically evaluated
   if (typeof target == 'function') {
     target = target();
   }
+  // Allow targets to be specified as just an array of source globs
   if (Array.isArray(target)) {
     target = {srcGlobs: target};
   }

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -115,30 +115,20 @@ const TYPE_CHECK_TARGETS = {
     srcGlobs: ['src/amp-story-player/**/*.js'],
     warningLevel: 'QUIET',
   },
-  'src-context': {
-    srcGlobs: ['src/context/**/*.js', ...CORE_SRCS_GLOBS],
-  },
-  'src-core': {
-    srcGlobs: CORE_SRCS_GLOBS,
-  },
-  'src-examiner': {
-    srcGlobs: ['src/examiner/**/*.js'],
-  },
-  'src-experiments': {
-    srcGlobs: ['src/experiments/**/*.js', ...CORE_SRCS_GLOBS],
-  },
+  'src-context': ['src/context/**/*.js', ...CORE_SRCS_GLOBS],
+  'src-core': CORE_SRCS_GLOBS,
+  'src-examiner': ['src/examiner/**/*.js'],
+  'src-experiments': ['src/experiments/**/*.js', ...CORE_SRCS_GLOBS],
   'src-inabox': {
     srcGlobs: ['src/inabox/**/*.js'],
     warningLevel: 'QUIET',
   },
-  'src-polyfills': {
-    srcGlobs: [
-      'src/polyfills/**/*.js',
-      // Exclude fetch its dependencies are cleaned up/extracted to core.
-      '!src/polyfills/fetch.js',
-      ...CORE_SRCS_GLOBS,
-    ],
-  },
+  'src-polyfills': [
+    'src/polyfills/**/*.js',
+    // Exclude fetch its dependencies are cleaned up/extracted to core.
+    '!src/polyfills/fetch.js',
+    ...CORE_SRCS_GLOBS,
+  ],
   'src-preact': {
     srcGlobs: ['src/preact/**/*.js', 'src/context/**/*.js', ...CORE_SRCS_GLOBS],
     warningLevel: 'QUIET',
@@ -254,6 +244,9 @@ async function typeCheck(targetName) {
   let target = TYPE_CHECK_TARGETS[targetName];
   if (typeof target == 'function') {
     target = target();
+  }
+  if (Array.isArray(target)) {
+    target = {srcGlobs: target};
   }
 
   if (!target) {

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -103,7 +103,7 @@ const getExtensionSrcPaths = () =>
  * but ending in *.extern.js. Note this only applies to *.js globs, and not
  * specific filenames.
  *
- * @type {Object<string, Object|function():Object>}
+ * @type {Object<string, Array<string>|Object|function():Object>}
  */
 const TYPE_CHECK_TARGETS = {
   // Below are targets containing individual directories which are fully passing


### PR DESCRIPTION
Currently, type-check targets added as part of #34096 require providing an object with `srcGlobs` and `externGlobs`. Since `externGlobs` almost always follows directly from `srcGlobs`, this PR makes it easier to add/enable typecheck targets by specifying just the source globs.