### PR TITLE
🏗 Optimize linting during PR builds

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -32,6 +32,8 @@ build-system/babel-plugins/**/fixtures/**/*.js
 build-system/babel-plugins/**/fixtures/**/*.mjs
 build-system/tasks/make-extension/template/**/*
 build-system/tasks/visual-diff/snippets/*.js
+examples/amp-script/todomvc.ssr.js
+examples/amp-script/vue-todomvc.js
 extensions/amp-a4a/0.1/test/testdata/**
 src/purifier/noop.js
 testing/local-amp-chrome-extension/**

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -56,6 +56,7 @@ const Targets = {
   INTEGRATION_TEST: 'INTEGRATION_TEST',
   INVALID_WHITESPACES: 'INVALID_WHITESPACES',
   LINT: 'LINT',
+  LINT_RULES: 'LINT_RULES',
   OWNERS: 'OWNERS',
   PACKAGE_UPGRADE: 'PACKAGE_UPGRADE',
   PRESUBMIT: 'PRESUBMIT',
@@ -238,6 +239,9 @@ const targetMatchers = {
       file == 'build-system/tasks/lint.js' ||
       file.startsWith('build-system/test-configs')
     );
+  },
+  [Targets.LINT_RULES]: (file) => {
+    return file.endsWith('.eslintrc.js') || file == 'package.json';
   },
   [Targets.OWNERS]: (file) => {
     return isOwnersFile(file) || file == 'build-system/tasks/check-owners.js';

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -70,7 +70,9 @@ async function prBuildWorkflow() {
     timedExecOrDie('amp validate-html-fixtures');
   }
 
-  if (buildTargetsInclude(Targets.LINT)) {
+  if (buildTargetsInclude(Targets.LINT_RULES)) {
+    timedExecOrDie('amp lint');
+  } else if (buildTargetsInclude(Targets.LINT)) {
     timedExecOrDie('amp lint --local_changes');
   }
 

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -71,7 +71,7 @@ async function prBuildWorkflow() {
   }
 
   if (buildTargetsInclude(Targets.LINT)) {
-    timedExecOrDie('amp lint');
+    timedExecOrDie('amp lint --local_changes');
   }
 
   if (buildTargetsInclude(Targets.PRETTIFY)) {

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -63,7 +63,9 @@ async function prCheck() {
     runCheck('amp validate-html-fixtures --local_changes');
   }
 
-  if (buildTargetsInclude(Targets.LINT)) {
+  if (buildTargetsInclude(Targets.LINT_RULES)) {
+    runCheck('amp lint');
+  } else if (buildTargetsInclude(Targets.LINT)) {
     runCheck('amp lint --local_changes');
   }
 


### PR DESCRIPTION
**Background:**

During PR checks, we run `amp lint` against the entire repo. This is a long and time-consuming process primarily due to `prettier`, as can be seen by running `TIMING=1 amp lint`.

```
Rule                              |  Time (ms) | Relative
:---------------------------------|-----------:|--------:
prettier/prettier                 | 105048.078 |    78.9%
jsdoc/check-types                 |   7343.111 |     5.5%
jsdoc/check-tag-names             |   6639.867 |     5.0%
local/no-forbidden-terms          |   1453.448 |     1.1%
jsdoc/require-param               |    953.783 |     0.7%
local/closure-type-primitives     |    903.859 |     0.7%
google-camelcase/google-camelcase |    780.167 |     0.6%
jsdoc/check-param-names           |    767.958 |     0.6%
jsdoc/require-returns             |    622.634 |     0.5%
no-redeclare                      |    513.069 |     0.4%
```

**This PR optimizes linting during CI:**

- For most PRs (`Targets.LINT`), run `amp lint --local_changes` during CI
- For PRs that touch lint rules or repo-root packages (`Targets.LINT_RULES`), lint all files during CI
- For `main` branch builds, continue linting all files in the repo

With this, the average PR will see lint checks take a few seconds instead of a few minutes.

**Bonus fixes:**
- Ignore `examples/amp-script/{todomvc.ssr|vue-todomvc}.js`, which are large already-minified files
- Disregard ignored files while tallying error / warning counts

**Before (all files):**

![image](https://user-images.githubusercontent.com/26553114/119745114-79d16700-be5b-11eb-8339-c7009376bf78.png)

**After (`--local_changes`):**

![image](https://user-images.githubusercontent.com/26553114/119745141-881f8300-be5b-11eb-9539-3dd12b170ab0.png)

Implements https://github.com/ampproject/amphtml/pull/34544#discussion_r640038883