### PR TITLE
✨ [bento][npm] Update file naming from mjs to module

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -25,6 +25,7 @@ const {
   doBuildJs,
   endBuildStep,
   maybeToEsmName,
+  npmMaybeToEsmName,
   mkdirSync,
   watchDebounceDelay,
 } = require('./helpers');
@@ -615,8 +616,8 @@ function buildBinaries(extDir, binaries, options) {
       entryPoint,
       `${extDir}/dist`,
       Object.assign(options, {
-        toName: maybeToEsmName(`${name}.max.js`),
-        minifiedName: maybeToEsmName(`${name}.js`),
+        toName: npmMaybeToEsmName(`${name}.max.js`),
+        minifiedName: npmMaybeToEsmName(`${name}.js`),
         latestName: '',
         outputFormat: esm ? 'esm' : 'cjs',
         wrapper: '',

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -25,8 +25,8 @@ const {
   doBuildJs,
   endBuildStep,
   maybeToEsmName,
-  npmMaybeToEsmName,
   mkdirSync,
+  npmMaybeToEsmName,
   watchDebounceDelay,
 } = require('./helpers');
 const {

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -25,8 +25,8 @@ const {
   doBuildJs,
   endBuildStep,
   maybeToEsmName,
+  maybeToNpmEsmName,
   mkdirSync,
-  npmMaybeToEsmName,
   watchDebounceDelay,
 } = require('./helpers');
 const {
@@ -616,8 +616,8 @@ function buildBinaries(extDir, binaries, options) {
       entryPoint,
       `${extDir}/dist`,
       Object.assign(options, {
-        toName: npmMaybeToEsmName(`${name}.max.js`),
-        minifiedName: npmMaybeToEsmName(`${name}.js`),
+        toName: maybeToNpmEsmName(`${name}.max.js`),
+        minifiedName: maybeToNpmEsmName(`${name}.js`),
         latestName: '',
         outputFormat: esm ? 'esm' : 'cjs',
         wrapper: '',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -480,9 +480,9 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
     watchedTargets.set(entryPoint, {
       rebuild: async () => {
         const time = Date.now();
-        const {
-          rebuild,
-        } = /** @type {Required<esbuild.BuildResult>} */ (buildResult);
+        const {rebuild} = /** @type {Required<esbuild.BuildResult>} */ (
+          buildResult
+        );
 
         const buildPromise = rebuild()
           .then(() =>
@@ -873,8 +873,8 @@ module.exports = {
   compileUnminifiedJs,
   maybePrintCoverageMessage,
   maybeToEsmName,
-  npmMaybeToEsmName,
   mkdirSync,
+  npmMaybeToEsmName,
   printConfigHelp,
   printNobuildHelp,
   watchDebounceDelay,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -292,6 +292,14 @@ function maybeToEsmName(name) {
 }
 
 /**
+ * @param {string} name
+ * @return {string}
+ */
+function npmMaybeToEsmName(name) {
+  return argv.esm ? name.replace(/\.js$/, '.module.js') : name;
+}
+
+/**
  * Minifies a given JavaScript file entry point.
  * @param {string} srcDir
  * @param {string} srcFilename
@@ -472,9 +480,9 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
     watchedTargets.set(entryPoint, {
       rebuild: async () => {
         const time = Date.now();
-        const {rebuild} = /** @type {Required<esbuild.BuildResult>} */ (
-          buildResult
-        );
+        const {
+          rebuild,
+        } = /** @type {Required<esbuild.BuildResult>} */ (buildResult);
 
         const buildPromise = rebuild()
           .then(() =>
@@ -503,9 +511,8 @@ async function compileUnminifiedJs(srcDir, srcFilename, destDir, options) {
 async function compileJsWithEsbuild(srcDir, srcFilename, destDir, options) {
   const startTime = Date.now();
   const entryPoint = path.join(srcDir, srcFilename);
-  const destFilename = maybeToEsmName(
-    options.minify ? options.minifiedName : options.toName
-  );
+  const fileName = options.minify ? options.minifiedName : options.toName;
+  const destFilename = options.npm ? fileName : maybeToEsmName(fileName);
   const destFile = path.join(destDir, destFilename);
 
   if (watchedTargets.has(entryPoint)) {
@@ -866,6 +873,7 @@ module.exports = {
   compileUnminifiedJs,
   maybePrintCoverageMessage,
   maybeToEsmName,
+  npmMaybeToEsmName,
   mkdirSync,
   printConfigHelp,
   printNobuildHelp,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -295,7 +295,7 @@ function maybeToEsmName(name) {
  * @param {string} name
  * @return {string}
  */
-function npmMaybeToEsmName(name) {
+function maybeToNpmEsmName(name) {
   return argv.esm ? name.replace(/\.js$/, '.module.js') : name;
 }
 
@@ -873,8 +873,8 @@ module.exports = {
   compileUnminifiedJs,
   maybePrintCoverageMessage,
   maybeToEsmName,
+  maybeToNpmEsmName,
   mkdirSync,
-  npmMaybeToEsmName,
   printConfigHelp,
   printNobuildHelp,
   watchDebounceDelay,


### PR DESCRIPTION
Update naming of generated files for NPM publishing.

Instead of using `.mjs`, we will go with `.module.js` since `create-react-app` does not support `.mjs` format.