### PR TITLE
Video cache for amp-video[src].

### DIFF
--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -129,8 +129,8 @@ function replaceSrcWithSourceElement(videoEl, win) {
 
   // Remove all existing sources as they are never supposed to play for a video
   // that has a src, cf https://html.spec.whatwg.org/#concept-media-load-algorithm
-  const sourceEls = toArray(videoEl.querySelectorAll('source'));
-  sourceEls.forEach((el) => removeElement(el));
+  const sourceEls = videoEl.querySelectorAll('source');
+  iterateCursor(sourceEls, (el) => removeElement(el));
 
   videoEl.insertBefore(sourceEl, videoEl.firstChild);
 }

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -48,7 +48,7 @@ export function fetchCachedSources(videoEl, win) {
   }
   const {canonicalUrl, sourceUrl} = Services.documentInfoForDoc(win.document);
   const servicePromise = Services.cacheUrlServicePromiseForDoc(videoEl);
-  replaceSrcWithSourceElement(videoEl, win);
+  maybeReplaceSrcWithSourceElement(videoEl, win);
   const videoUrl = resolveRelativeUrl(selectVideoSource(videoEl), sourceUrl);
   return servicePromise
     .then((service) => service.createCacheUrl(videoUrl))
@@ -106,13 +106,12 @@ function applySourcesToVideo(videoEl, sources) {
 }
 
 /**
- * Moves the src attribute to a source element to enable playing from multiple
- * sources: the cached ones and the fallback initial src.
+ * If present, moves the src attribute to a source element to enable playing
+ * from multiple sources: the cached ones and the fallback initial src.
  * @param {!Element} videoEl
  * @param {!Window} win
- * @return {!Promise}
  */
-function replaceSrcWithSourceElement(videoEl, win) {
+function maybeReplaceSrcWithSourceElement(videoEl, win) {
   if (!videoEl.hasAttribute('src')) {
     return;
   }
@@ -127,6 +126,7 @@ function replaceSrcWithSourceElement(videoEl, win) {
 
   // Remove the src attr so the source children can play.
   videoEl.removeAttribute('src');
+  videoEl.removeAttribute('type');
 
   // Remove all existing sources as they are never supposed to play for a video
   // that has a src, cf https://html.spec.whatwg.org/#concept-media-load-algorithm

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -18,6 +18,7 @@ import {Services} from '../../../src/services';
 import {addParamsToUrl, resolveRelativeUrl} from '../../../src/url';
 import {
   createElementWithAttributes,
+  iterateCursor,
   matches,
   removeElement,
 } from '../../../src/dom';

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -39,7 +39,7 @@ export function fetchCachedSources(videoEl, win) {
     !extensionScriptInNode(win, 'amp-cache-url', '0.1') ||
     !(
       videoEl.getAttribute('src') ||
-      videoEl.querySelector('source[src]').getAttribute('src')
+      videoEl.querySelector('source[src]')?.getAttribute('src')
     )
   ) {
     user().error('AMP-VIDEO', 'Video cache not properly configured');


### PR DESCRIPTION
Enable the video cache for `amp-video[src]` configurations.