### PR TITLE
Notify wg-amp4email as OWNERS for extension spec changes

### DIFF
--- a/extensions/amp-accordion/OWNERS
+++ b/extensions/amp-accordion/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-accordion/OWNERS
+++ b/extensions/amp-accordion/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-anim/OWNERS
+++ b/extensions/amp-anim/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-anim/OWNERS
+++ b/extensions/amp-anim/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-autocomplete/OWNERS
+++ b/extensions/amp-autocomplete/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-autocomplete/OWNERS
+++ b/extensions/amp-autocomplete/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-bind/OWNERS
+++ b/extensions/amp-bind/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-bind/OWNERS
+++ b/extensions/amp-bind/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'choumx'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-carousel/OWNERS
+++ b/extensions/amp-carousel/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-carousel/OWNERS
+++ b/extensions/amp-carousel/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-fit-text/OWNERS
+++ b/extensions/amp-fit-text/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-fit-text/OWNERS
+++ b/extensions/amp-fit-text/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-form/OWNERS
+++ b/extensions/amp-form/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-form/OWNERS
+++ b/extensions/amp-form/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-image-lightbox/OWNERS
+++ b/extensions/amp-image-lightbox/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-image-lightbox/OWNERS
+++ b/extensions/amp-image-lightbox/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-lightbox/OWNERS
+++ b/extensions/amp-lightbox/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-lightbox/OWNERS
+++ b/extensions/amp-lightbox/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-list/OWNERS
+++ b/extensions/amp-list/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-performance'}, {name: 'choumx'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-list/OWNERS
+++ b/extensions/amp-list/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-mustache/OWNERS
+++ b/extensions/amp-mustache/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-performance'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-mustache/OWNERS
+++ b/extensions/amp-mustache/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-selector/OWNERS
+++ b/extensions/amp-selector/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-selector/OWNERS
+++ b/extensions/amp-selector/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-sidebar/OWNERS
+++ b/extensions/amp-sidebar/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }

--- a/extensions/amp-sidebar/OWNERS
+++ b/extensions/amp-sidebar/OWNERS
@@ -6,5 +6,11 @@
     {
       owners: [{name: 'ampproject/wg-components'}],
     },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
+    },
   ],
 }

--- a/extensions/amp-timeago/OWNERS
+++ b/extensions/amp-timeago/OWNERS
@@ -4,7 +4,13 @@
 {
   rules: [
     {
-      owners: [{name: 'edhollinghurst'}],
+      owners: [{name: 'edhollinghurst'}, {name: 'wg-components'}],
+    },
+    {
+      pattern: 'validator-*.protoascii',
+      owners: [
+        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
+      ],
     },
   ],
 }

--- a/extensions/amp-timeago/OWNERS
+++ b/extensions/amp-timeago/OWNERS
@@ -8,9 +8,7 @@
     },
     {
       pattern: 'validator-*.protoascii',
-      owners: [
-        {name: 'ampproject/wg-amp4email', notify: true, requestReviews: false},
-      ],
+      owners: [{name: 'ampproject/wg-amp4email', notify: true}],
     },
   ],
 }


### PR DESCRIPTION
This change applies to all components that are valid in the email format which live in `extensions/`. Note: `amp-img` and `amp-layout` are maintained in the general spec. cc/ @ampproject/wg-amp4email 