### PR TITLE
🏗 Enforce JSDoc across `build-system/` for complete type-checking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -271,6 +271,7 @@ module.exports = {
         'extensions/**/test-e2e/*.js',
         'ads/**/test/**/*.js',
         'testing/**/*.js',
+        'build-system/**/test/*.js',
       ],
       'rules': {
         'require-jsdoc': 0,

--- a/build-system/.eslintrc.js
+++ b/build-system/.eslintrc.js
@@ -47,6 +47,5 @@ module.exports = {
     'local/no-module-exports': 0,
     'local/no-rest': 0,
     'local/no-spread': 0,
-    'require-jsdoc': 0,
   },
 };

--- a/build-system/OWNERS
+++ b/build-system/OWNERS
@@ -10,5 +10,9 @@
       pattern: '{package.json,package-lock.json}',
       owners: [{name: 'ampproject/wg-infra', requestReviews: false}],
     },
+    {
+      pattern: 'tsconfig.json',
+      owners: [{name: 'rileyajones', notify: true}],
+    },
   ],
 }

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -61,6 +61,10 @@ module.exports = function ({template, types: t}) {
     return filename.endsWith('.jss.js');
   }
 
+  /**
+   * @param {string} name
+   * @return {string>}
+   */
   function classnameId(name) {
     return `\$${name}`;
   }
@@ -238,6 +242,11 @@ module.exports = function ({template, types: t}) {
     );
   }
 
+  /**
+   * @param {Path} importDeclaration
+   * @param {string} name
+   * @return {string}
+   */
   function getImportIdentifier(importDeclaration, name) {
     return addNamed(
       importDeclaration,

--- a/build-system/babel-plugins/babel-plugin-transform-jss/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-jss/index.js
@@ -63,7 +63,7 @@ module.exports = function ({template, types: t}) {
 
   /**
    * @param {string} name
-   * @return {string>}
+   * @return {string}
    */
   function classnameId(name) {
     return `\$${name}`;

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -44,6 +44,13 @@ function getEsbuildBabelPlugin(
     transformCache = new TransformCache('.babel-cache', '.js');
   }
 
+  /**
+   * @param {string} filename
+   * @param {string} contents
+   * @param {string} hash
+   * @param {Object} babelOptions
+   * @return {Promise}
+   */
   async function transformContents(filename, contents, hash, babelOptions) {
     if (enableCache) {
       const cached = transformCache.get(hash);

--- a/build-system/common/update-packages.js
+++ b/build-system/common/update-packages.js
@@ -201,7 +201,9 @@ function patchShadowDom() {
 
   writeIfUpdated(patchedName, file);
 }
-
+/**
+ * Adds a missing export statement to the preact module.
+ */
 function patchPreact() {
   fs.ensureDirSync('node_modules/preact/dom');
   const file = `export { render, hydrate } from 'preact';`;

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -79,6 +79,9 @@ async function closureCompile(
   // Rate limit closure compilation to MAX_PARALLEL_CLOSURE_INVOCATIONS
   // concurrent processes.
   return new Promise(function (resolve, reject) {
+    /**
+     * Kicks off the first closure invocation.
+     */
     function start() {
       inProgress++;
       compile(
@@ -97,6 +100,9 @@ async function closureCompile(
       );
     }
 
+    /**
+     * Keeps track of the invocation count.
+     */
     function next() {
       if (!queue.length) {
         return;
@@ -110,6 +116,9 @@ async function closureCompile(
   });
 }
 
+/**
+ * Cleans up the placeholder directories for fake build modules.
+ */
 function cleanupBuildDir() {
   del.sync('build/fake-module');
   del.sync('build/patched-module');
@@ -441,6 +450,9 @@ async function compile(
   }
 }
 
+/**
+ * Indicates the current closure concurrency and how to override it.
+ */
 function printClosureConcurrency() {
   log(
     green('Using up to'),

--- a/build-system/compile/helpers.js
+++ b/build-system/compile/helpers.js
@@ -21,10 +21,15 @@ const path = require('path');
 const {getBabelOutputDir} = require('./pre-closure-babel');
 const {VERSION: internalRuntimeVersion} = require('./internal-version');
 
+/**
+ * Computes the base url for sourcemaps. Custom sourcemap URLs have placeholder
+ * {version} that should be replaced with the actual version. Also, ensures
+ * that a trailing slash exists.
+ * @param {Object} options
+ * @return {string}
+ */
 function getSourceMapBase(options) {
   if (argv.sourcemap_url) {
-    // Custom sourcemap URLs have placeholder {version} that should be
-    // replaced with the actual version. Also, ensure trailing slash exists.
     return String(argv.sourcemap_url)
       .replace(/\{version\}/g, internalRuntimeVersion)
       .replace(/([^/])$/, '$1/');
@@ -35,6 +40,10 @@ function getSourceMapBase(options) {
   return `https://raw.githubusercontent.com/ampproject/amphtml/${internalRuntimeVersion}/`;
 }
 
+/**
+ * Updates all filepaths in the sourcemap output.
+ * @param {Object} sourcemaps
+ */
 function updatePaths(sourcemaps) {
   const babelOutputDir = getBabelOutputDir();
   sourcemaps.sources = sourcemaps.sources.map((source) =>
@@ -47,6 +56,12 @@ function updatePaths(sourcemaps) {
   }
 }
 
+/**
+ * Writes the sourcemap output to disk.
+ * @param {string} sourcemapsFile
+ * @param {Object} options
+ * @return {Promise<void>}
+ */
 async function writeSourcemaps(sourcemapsFile, options) {
   const sourcemaps = await fs.readJson(sourcemapsFile);
   updatePaths(sourcemaps);

--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -31,6 +31,10 @@ module.exports = {
     // greatly speeds up this rule.
     const fileContent = {};
 
+    /**
+     * @param {string} filename
+     * @return {string}
+     */
     function readFileContent(filename) {
       try {
         return (
@@ -42,6 +46,10 @@ module.exports = {
       }
     }
 
+    /**
+     * @param {Object} fixer
+     * @param {Node} node
+     */
     function* removeFromArray(fixer, node) {
       const {text} = context.getSourceCode();
       let {start} = node;

--- a/build-system/pr-check/bundle-size.js
+++ b/build-system/pr-check/bundle-size.js
@@ -25,12 +25,18 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'bundle-size.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   timedExecOrDie('amp dist --noconfig --esm');
   timedExecOrDie('amp dist --noconfig');
   timedExecOrDie('amp bundle-size --on_push_build');
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME)) {
     timedExecOrDie('amp dist --noconfig --esm');

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -26,6 +26,9 @@ const {timedExecOrDie} = require('./utils');
 
 const jobName = 'checks.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   timedExecOrDie('amp presubmit');
   timedExecOrDie('amp check-invalid-whitespaces');
@@ -53,6 +56,7 @@ function pushBuildWorkflow() {
 }
 
 /**
+ * Steps to run during PR builds.
  * @return {Promise<void>}
  */
 async function prBuildWorkflow() {

--- a/build-system/pr-check/cross-browser-tests.js
+++ b/build-system/pr-check/cross-browser-tests.js
@@ -98,7 +98,9 @@ function runUnitTestsForPlatform() {
       );
   }
 }
-
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   runUnitTestsForPlatform();
   timedExecOrDie('amp dist --fortesting');
@@ -106,6 +108,7 @@ function pushBuildWorkflow() {
 }
 
 /**
+ * Steps to run during PR builds.
  * @return {Promise<void>}
  */
 async function prBuildWorkflow() {

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -29,6 +29,9 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'e2e-tests.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   try {
     timedExecOrThrow(
@@ -44,6 +47,9 @@ function pushBuildWorkflow() {
   }
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.E2E_TEST)) {
     timedExecOrDie('amp e2e --nobuild --headless --compiled');

--- a/build-system/pr-check/experiment-build.js
+++ b/build-system/pr-check/experiment-build.js
@@ -31,6 +31,9 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = `${experiment}-build.js`;
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   // Note that if config is invalid, this build would have been skipped by CircleCI.
   const config = getExperimentConfig(experiment);
@@ -39,6 +42,9 @@ function pushBuildWorkflow() {
   storeExperimentBuildToWorkspace(experiment);
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (
     buildTargetsInclude(

--- a/build-system/pr-check/experiment-tests.js
+++ b/build-system/pr-check/experiment-tests.js
@@ -58,12 +58,18 @@ function runExperimentTests(config) {
   }
 }
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   // Note that if config is invalid, this build would have been skipped by CircleCI.
   const config = getExperimentConfig(experiment);
   runExperimentTests(config);
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (
     buildTargetsInclude(

--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -29,11 +29,17 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'module-build.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   timedExecOrDie('amp dist --esm --fortesting');
   storeModuleBuildToWorkspace();
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   // TODO(#31102): This list must eventually match the same buildTargets check
   // found in pr-check/nomodule-build.js as we turn on the systems that

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -27,6 +27,9 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'module-tests.js';
 
+/**
+ * Adds a canary or prod config string to all esm and non-esm minified targets.
+ */
 function prependConfig() {
   const targets = MINIFIED_TARGETS.flatMap((target) => [
     `dist/${target}.js`,
@@ -37,11 +40,17 @@ function prependConfig() {
   );
 }
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   prependConfig();
   timedExecOrDie('amp integration --nobuild --compiled --headless --esm');
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     prependConfig();

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -37,12 +37,16 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'nomodule-build.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   timedExecOrDie('amp dist --fortesting');
   storeNomoduleBuildToWorkspace();
 }
 
 /**
+ * Steps to run during PR builds.
  * @return {Promise<void>}
  */
 async function prBuildWorkflow() {

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -31,6 +31,9 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'nomodule-tests.js';
 
+/**
+ * Adds a canary or prod config string to all non-esm minified targets.
+ */
 function prependConfig() {
   const targets = MINIFIED_TARGETS.flatMap((target) => [
     `dist/${target}.js`,
@@ -40,6 +43,9 @@ function prependConfig() {
   );
 }
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   prependConfig();
   try {
@@ -56,6 +62,9 @@ function pushBuildWorkflow() {
   }
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     prependConfig();

--- a/build-system/pr-check/performance-tests.js
+++ b/build-system/pr-check/performance-tests.js
@@ -24,6 +24,9 @@ const {timedExecOrDie} = require('./utils');
 
 const jobName = 'performance-tests.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   timedExecOrDie('amp performance --nobuild --quiet --headless');
 }

--- a/build-system/pr-check/unit-tests.js
+++ b/build-system/pr-check/unit-tests.js
@@ -29,6 +29,9 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'unit-tests.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   try {
     timedExecOrThrow(
@@ -48,6 +51,9 @@ function pushBuildWorkflow() {
   }
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
     timedExecOrDie('amp unit --headless --local_changes');

--- a/build-system/pr-check/unminified-build.js
+++ b/build-system/pr-check/unminified-build.js
@@ -29,11 +29,17 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'unminified-build.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   timedExecOrDie('amp build --fortesting');
   storeUnminifiedBuildToWorkspace();
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     timedExecOrDie('amp build --fortesting');

--- a/build-system/pr-check/unminified-tests.js
+++ b/build-system/pr-check/unminified-tests.js
@@ -29,6 +29,9 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'unminified-tests.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   try {
     timedExecOrThrow(
@@ -48,6 +51,9 @@ function pushBuildWorkflow() {
   }
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
     timedExecOrDie('amp integration --nobuild --headless --coverage');

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -25,12 +25,18 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'validator-tests.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   timedExecOrDie('amp validator-webui');
   timedExecOrDie('amp validator');
   timedExecOrDie('amp validator-cpp');
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   if (
     !buildTargetsInclude(

--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -26,11 +26,17 @@ const {Targets, buildTargetsInclude} = require('./build-targets');
 
 const jobName = 'visual-diff-tests.js';
 
+/**
+ * Steps to run during push builds.
+ */
 function pushBuildWorkflow() {
   process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
   timedExecOrDie('amp visual-diff --nobuild --main');
 }
 
+/**
+ * Steps to run during PR builds.
+ */
 function prBuildWorkflow() {
   process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
   if (buildTargetsInclude(Targets.RUNTIME, Targets.VISUAL_DIFF)) {

--- a/build-system/server/app-index/test/test-amphtml-helpers.js
+++ b/build-system/server/app-index/test/test-amphtml-helpers.js
@@ -34,11 +34,11 @@ describe('devdash', () => {
   describe('AMPHTML helpers', () => {
     describe('AmpDoc', () => {
       it('fails without args', () => {
-        expect(() => AmpDoc()).to.throw;
+        expect(() => AmpDoc()).to.throw();
       });
 
       it('fails without min required fields', () => {
-        expect(() => AmpDoc({})).to.throw;
+        expect(() => AmpDoc({})).to.throw();
       });
 
       it('creates valid doc with min required fields', async () => {

--- a/build-system/server/app-index/test/test-self.js
+++ b/build-system/server/app-index/test/test-self.js
@@ -29,15 +29,15 @@ describe('devdash', () => {
       });
 
       it('fails with multiple children', () => {
-        expect(() => parseHtmlChunk('<a></a><a></a>')).to.throw;
+        expect(() => parseHtmlChunk('<a></a><a></a>')).to.throw();
       });
 
       it('fails with text node as content', () => {
-        expect(() => parseHtmlChunk('text content')).to.throw;
+        expect(() => parseHtmlChunk('text content')).to.throw();
       });
 
       it('fails on empty string', () => {
-        expect(() => parseHtmlChunk('')).to.throw;
+        expect(() => parseHtmlChunk('')).to.throw();
       });
     });
 
@@ -113,7 +113,7 @@ describe('devdash', () => {
 
         expect(() => {
           expectValidAmphtml(validator, invalidDoc);
-        }).to.throw;
+        }).to.throw();
       });
 
       it('ignores errors with severity ≠ ERROR', () => {

--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -49,6 +49,9 @@ async function buildNewServer() {
   endBuildStep('Built', 'AMP Server', startTime);
 }
 
+/**
+ * Checks all types in the generated output after running server transforms.
+ */
 function typecheckNewServer() {
   const cmd = `npx -p typescript tsc --noEmit -p ${CONFIG_PATH}`;
   const result = exec(cmd, {'stdio': ['inherit', 'inherit', 'pipe']});

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -407,9 +407,11 @@ function describeEnv(factory) {
       spec.browsers = ['chrome'];
     }
 
+    /**
+     * Initializes the describe object for all applicable browsers.
+     */
     function createBrowserDescribe() {
       const allowedBrowsers = getAllowedBrowsers();
-
       spec.browsers
         .filter((x) => allowedBrowsers.has(x))
         .forEach((browserName) => {

--- a/build-system/tasks/e2e/expect.js
+++ b/build-system/tasks/e2e/expect.js
@@ -22,11 +22,15 @@ let installed;
 let lastExpectError;
 let networkLogger;
 
+/**
+ * Clears previous expected error state.
+ */
 function clearLastExpectError() {
   lastExpectError = null;
 }
 
 /**
+ * Retrieves the expected error state.
  * @return {?Error}
  */
 function getLastExpectError() {

--- a/build-system/tasks/e2e/repl.js
+++ b/build-system/tasks/e2e/repl.js
@@ -67,7 +67,6 @@ function installRepl(global, env) {
 
   /**
    * Continues execution while debugging.
-   * @return {void}
    */
   function replContinue() {
     if (!replResolve) {

--- a/build-system/tasks/e2e/repl.js
+++ b/build-system/tasks/e2e/repl.js
@@ -65,6 +65,10 @@ function installRepl(global, env) {
     return replPromise;
   };
 
+  /**
+   * Continues execution while debugging.
+   * @return {void}
+   */
   function replContinue() {
     if (!replResolve) {
       return;
@@ -81,6 +85,9 @@ function installRepl(global, env) {
   }
 }
 
+/**
+ * Ends the debugging session.
+ */
 function uninstallRepl() {
   delete global.repl;
 }

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -675,6 +675,7 @@ class SeleniumWebDriverController {
   }
 
   /**
+   * Shutdown the driver.
    * @return {void}
    */
   dispose() {

--- a/build-system/tasks/e2e/selenium-webdriver-controller.js
+++ b/build-system/tasks/e2e/selenium-webdriver-controller.js
@@ -655,6 +655,9 @@ class SeleniumWebDriverController {
     this.shadowRoot_ = shadowRootBody;
   }
 
+  /**
+   * @return {Promise<void>}
+   */
   async switchToLight() {
     this.shadowRoot_ = null;
   }
@@ -671,6 +674,9 @@ class SeleniumWebDriverController {
     return this.evaluate(() => document.documentElement);
   }
 
+  /**
+   * @return {void}
+   */
   dispose() {
     return this.driver.quit();
   }

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -396,7 +396,8 @@ async function doBuildExtension(extensions, extension, options) {
 }
 
 /**
- * Watches for non-JS changes within an extensions directory to trigger recompilation.
+ * Watches for non-JS changes within an extensions directory to trigger
+ * recompilation.
  *
  * @param {string} extDir
  * @param {string} name
@@ -413,6 +414,9 @@ async function watchExtension(
   hasCss,
   options
 ) {
+  /**
+   * Steps to run when a watched file is modified.
+   */
   function watchFunc() {
     buildExtension(name, version, latestVersion, hasCss, {
       ...options,

--- a/build-system/tasks/get-zindex/jscodeshift/collect-zindex.js
+++ b/build-system/tasks/get-zindex/jscodeshift/collect-zindex.js
@@ -16,6 +16,10 @@
 
 const zIndexRegExp = /^z-?index$/i;
 
+/**
+ * @param {Node} node
+ * @return {string}
+ */
 function getCallExpressionZIndexValue(node) {
   for (let i = 1; i < node.arguments.length; i++) {
     const argument = node.arguments[i];
@@ -30,11 +34,21 @@ function getCallExpressionZIndexValue(node) {
   }
 }
 
+/**
+ * @param {string} file
+ * @param {Node} node
+ * @return {string}
+ */
 function source(file, node) {
   const {end, start} = node;
   return file.source.substr(start, end - start);
 }
 
+/**
+ * @param {string} file
+ * @param {string} path
+ * @return {string}
+ */
 function chainId(file, path) {
   let propertyChain = '';
   let at = path;

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -556,6 +556,10 @@ async function compileJsWithEsbuild(srcDir, srcFilename, destDir, options) {
     await finishBundle(srcFilename, destDir, destFilename, options, time);
   }
 
+  /**
+   * Generates a plugin to remap the dependencies of a JS bundle.
+   * @return {Object}
+   */
   function remapDependenciesPlugin() {
     const remapDependencies = {__proto__: null, ...options.remapDependencies};
     const external = options.externalDependencies;
@@ -666,6 +670,11 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
     watch(deps).on('change', debounce(watchFunc, watchDebounceDelay));
   }
 
+  /**
+   * Actually performs the steps to compile the entry point.
+   * @param {Object} options
+   * @return {Promise<void>}
+   */
   async function doCompileJs(options) {
     const buildResult = options.minify
       ? compileMinifiedJs(srcDir, srcFilename, destDir, options)

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -39,6 +39,10 @@ class Runner extends RuntimeTestRunner {
   }
 }
 
+/**
+ * Entry point for the `amp integration` task.
+ * @return {Promise<void>}
+ */
 async function integration() {
   maybePrintArgvMessages();
 

--- a/build-system/tasks/markdown-toc/index.js
+++ b/build-system/tasks/markdown-toc/index.js
@@ -164,6 +164,10 @@ async function overrideTocGlob(cwd) {
   return result;
 }
 
+/**
+ * Entry point for the `amp markdown-toc` task.
+ * @return {Promise<void>}
+ */
 async function markdownToc() {
   const result = await overrideTocGlob('.');
   let errored = false;

--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -38,6 +38,9 @@ const {setupAdRequestHandler} = require('./ads-handler');
 // Require Puppeteer dynamically to prevent throwing error during CI
 let puppeteer;
 
+/**
+ * Lazy-requires the puppeteer module.
+ */
 function requirePuppeteer_() {
   puppeteer = require('puppeteer');
 }

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -130,6 +130,9 @@ const CHANNEL_CONFIGS = {
   '25': {type: 'experimentC', configBase: 'prod'}, // Spec name: 'inabox-experimentC'
 };
 
+/**
+ * Prints a separator line so logs are easy to read.
+ */
 function logSeparator_() {
   log('---\n\n');
 }

--- a/build-system/tsconfig.json
+++ b/build-system/tsconfig.json
@@ -29,7 +29,7 @@
     "./tasks/coverage-map/*",
     "./tasks/create-golden-css/*",
     "./tasks/css/*",
-    "./tasks/e2e/*", // 152 remaining type errors.
+    "./tasks/e2e/*",
     "./tasks/get-zindex/*",
     "./tasks/markdown-toc/*",
     // "./tasks/performance/*", // 35 remaining type errors.
@@ -44,15 +44,11 @@
   "exclude": [
     "**/node_modules",
     "**/*.test.js",
-    "tasks/dep-check.js", // JSDoc private used inside a function confuses TS.
-    "tasks/runtime-test/runtime-test-base.js", // TS does not like Object.assign.
     "common/check-package-manager.js",
     "server/app-index/test/test-html.js",
     "server/app-index/test/test-amphtml-helpers.js",
     "server/new-server/**/*",
-    "server/typescript-compile.js",
-    "test-configs/dep-check-config.js",
-    "tasks/e2e/helper.js",
+    "tasks/dep-check.js", // JSDoc private used inside a function confuses TS.
     "tasks/get-zindex/*"
   ]
 }


### PR DESCRIPTION
**PR Highlights:**
- Enable the `require-jsdoc` lint rule across `build-system/` (except test directories)
- Add missing JSDoc annotations so `build-system/` is fully documented
- Fix types so that `amp check-build-system` returns zero errors
- Clean up stale entries in `tsconfig.json`
- Add a code owner for future changes to `tsconfig.json`

Addresses https://github.com/ampproject/amphtml/pull/34586#discussion_r640796424
Follow up to #34544
Fixes #28387