### PR TITLE
🐛 [no-signing] fix ads using amp-gwd-animation

### DIFF
--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -63,6 +63,7 @@ const EXTENSION_ALLOWLIST = map({
   'amp-fit-text': true,
   'amp-font': true,
   'amp-form': true,
+  'amp-gwd-animation': true,
   'amp-img': true,
   'amp-layout': true,
   'amp-lightbox': true,


### PR DESCRIPTION
Was not added originally as it is not in our docs for allowed extensions for a4a. I assume this is because it is not a public facing extension.

cc/ @zombifier 