### PR TITLE
🏗 Fix several suppressed type-check errors in `build-system`

### DIFF
--- a/build-system/babel-config/eslint-config.js
+++ b/build-system/babel-config/eslint-config.js
@@ -38,9 +38,7 @@ function getEslintConfig() {
 }
 
 /**
- * @return {{
- *  manipulateOptions: {Function(_opts: *, parserOpts: *): void}
- * }}
+ * @return {{manipulateOptions(_opts: *, parserOpts: *): void}}
  */
 function enableSyntax() {
   return {

--- a/build-system/common/check-package-manager.js
+++ b/build-system/common/check-package-manager.js
@@ -63,7 +63,7 @@ ${yellow('For detailed instructions, see')} ${cyan(setupInstructionsUrl)}`;
 /**
  * Formats the text to appear red
  *
- * @param {string} text
+ * @param {*} text
  * @return {string}
  */
 function red(text) {
@@ -72,7 +72,7 @@ function red(text) {
 /**
  * Formats the text to appear cyan
  *
- * @param {string} text
+ * @param {*} text
  * @return {string}
  */
 function cyan(text) {
@@ -81,7 +81,7 @@ function cyan(text) {
 /**
  * Formats the text to appear green
  *
- * @param {string} text
+ * @param {*} text
  * @return {string}
  */
 function green(text) {
@@ -90,7 +90,7 @@ function green(text) {
 /**
  * Formats the text to appear yellow
  *
- * @param {string} text
+ * @param {*} text
  * @return {string}
  */
 function yellow(text) {
@@ -103,7 +103,7 @@ function yellow(text) {
  * package manager being used is determined.
  **/
 function ensureNpm() {
-  if (!process.env.npm_execpath.includes('npm')) {
+  if (!process.env.npm_execpath?.includes('npm')) {
     console.log(npmInfoMessage);
     process.exit(1);
   }
@@ -112,7 +112,7 @@ function ensureNpm() {
 /**
  * Check the node version and print a warning if it is not the latest LTS.
  *
- * @return {Promise}
+ * @return {Promise<void>}
  **/
 function checkNodeVersion() {
   const nodeVersion = getStdout('node --version').trim();

--- a/build-system/common/exec.js
+++ b/build-system/common/exec.js
@@ -21,8 +21,8 @@
 
 const childProcess = require('child_process');
 const {log} = require('./logging');
+const {red} = require('./colors');
 const {spawnProcess} = require('./process');
-const {yellow} = require('./colors');
 
 const shellCmd = process.platform == 'win32' ? 'cmd' : '/bin/bash';
 
@@ -90,7 +90,7 @@ function execWithError(cmd) {
 function execOrThrow(cmd, msg) {
   const p = exec(cmd, {'stdio': ['inherit', 'inherit', 'pipe']});
   if (p.status && p.status != 0) {
-    log(yellow('ERROR:'), msg);
+    log(red('ERROR:'), msg);
     const error = new Error(p.stderr);
     error.status = p.status;
     throw error;

--- a/build-system/global.d.ts
+++ b/build-system/global.d.ts
@@ -12,11 +12,14 @@ declare global {
   }
 
   interface EslintContext {
-    report: (val: any) => void;
+    report: Function;
   }
 
   interface Window {
-    queryXpath: (xpath: string, root: unknown /** Puppeteer.ElementHandle */) => unknown[] | null;
+    queryXpath: Function;
+    wgxpath: {
+      install: Function;
+    };
     AMP: Function[];
     viewer?: {
       receivedMessages?: number;

--- a/build-system/task-runner/amp-cli-runner.js
+++ b/build-system/task-runner/amp-cli-runner.js
@@ -32,11 +32,10 @@ const path = require('path');
  */
 function getRepoRoot() {
   const repoRootCmd = 'git rev-parse --show-toplevel';
-  const spawnOptions = {
+  const result = childProcess.spawnSync(repoRootCmd, {
     shell: process.platform == 'win32' ? 'cmd' : '/bin/bash',
     encoding: 'utf-8',
-  };
-  const result = childProcess.spawnSync(repoRootCmd, spawnOptions);
+  });
   return result.status == 0 ? result.stdout.trim() : undefined;
 }
 

--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -116,7 +116,7 @@ async function runTask(taskName, taskSourceFileName, taskFunc) {
  * @param {string} taskSourceFileName
  * @param {string=} taskFuncName
  */
-function handleInvalidTaskError(taskSourceFileName, taskFuncName = undefined) {
+function handleInvalidTaskError(taskSourceFileName, taskFuncName) {
   log(
     red('ERROR:'),
     'Could not find' + (taskFuncName ? ` ${cyan(taskFuncName + '()')} in` : ''),

--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -33,6 +33,14 @@ const {isCiBuild} = require('../common/ci');
 const {log} = require('../common/logging');
 
 /**
+ * @function {{
+ *  description: string,
+ *  flags?: Object,
+ * }}
+ */
+let TaskFuncDef;
+
+/**
  * Special-case constant that indicates if `amp --help` was invoked.
  */
 const isHelpTask = argv._.length == 0 && argv.hasOwnProperty('help');
@@ -84,7 +92,7 @@ async function maybeUpdateSubpackages(taskSourceFilePath) {
  * Runs an AMP task with logging and timing after installing its subpackages.
  * @param {string} taskName
  * @param {string} taskSourceFileName
- * @param {Function()} taskFunc
+ * @param {TaskFuncDef} taskFunc
  * @return {Promise<void>}
  */
 async function runTask(taskName, taskSourceFileName, taskFunc) {
@@ -106,9 +114,9 @@ async function runTask(taskName, taskSourceFileName, taskFunc) {
 /**
  * Prints an error if the task file and / or function are invalid, and exits.
  * @param {string} taskSourceFileName
- * @param {string?} taskFuncName
+ * @param {string=} taskFuncName
  */
-function handleInvalidTaskError(taskSourceFileName, taskFuncName) {
+function handleInvalidTaskError(taskSourceFileName, taskFuncName = undefined) {
   log(
     red('ERROR:'),
     'Could not find' + (taskFuncName ? ` ${cyan(taskFuncName + '()')} in` : ''),
@@ -145,7 +153,7 @@ function getTaskSourceFilePath(taskSourceFileName) {
  * Returns a task function after making sure it is valid.
  * @param {string} taskSourceFileName
  * @param {string} taskFuncName
- * @return {Function():any}
+ * @return {TaskFuncDef}
  */
 function getTaskFunc(taskSourceFileName, taskFuncName) {
   const taskSourceFilePath = getTaskSourceFilePath(taskSourceFileName);
@@ -208,7 +216,7 @@ function createTask(
  * Validates usage by examining task and flag invocation.
  * @param {Object} task
  * @param {string} taskName
- * @param {function} taskFunc
+ * @param {TaskFuncDef} taskFunc
  */
 function validateUsage(task, taskName, taskFunc) {
   const tasks = argv._;

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -322,7 +322,7 @@ function toArrayOrDefault(value, defaultValue) {
 /**
  * Flatten array of arrays if necessary.
  *
- * @param {Array<Array>|Array} arr
+ * @param {Array} arr
  * @return {!Array}
  */
 function flatten(arr) {

--- a/build-system/tasks/e2e/driver/query-xpath.js
+++ b/build-system/tasks/e2e/driver/query-xpath.js
@@ -40,8 +40,8 @@ const TEST_ID_ATTRIBUTE = 'data-i-amphtml-xpath-test-id';
  *
  * Precondition: wgxpath has been installed on the window object
  * @param {string} xpathString
- * @param {!Element} context
- * @return {?Array<!Element>}
+ * @param {!HTMLElement} context
+ * @return {?Array<!HTMLElement>}
  */
 function queryXpath(xpathString, context) {
   // Install https://github.com/google/wicked-good-xpath
@@ -95,13 +95,13 @@ function queryXpath(xpathString, context) {
     removeData(node);
   }
 
-  return elements.length ? elements : null;
+  return elements.length ? /** @type {Array<HTMLElement>} */ (elements) : null;
 }
 
 /**
  * Get the xpath test id data param
- * @param {!Element} node
- * @return {string}
+ * @param {!HTMLElement} node
+ * @return {string|undefined}
  */
 function getData(node) {
   return node.dataset[TEST_ID_PROPERTY];
@@ -109,16 +109,16 @@ function getData(node) {
 
 /**
  * Set the xpath test id data param
- * @param {!Element} node
+ * @param {!HTMLElement} node
  * @param {number} value
  */
 function setData(node, value) {
-  node.dataset[TEST_ID_PROPERTY] = value;
+  node.dataset[TEST_ID_PROPERTY] = value.toString();
 }
 
 /**
  * Remove the xpath test id data param.
- * @param {!Element} node
+ * @param {!HTMLElement} node
  */
 function removeData(node) {
   delete node.dataset[TEST_ID_PROPERTY];
@@ -126,8 +126,8 @@ function removeData(node) {
 
 /**
  * Create an iterator over the subtree of the given element.
- * @param {!Element} element
- * @return {!Iterable<!Element>}
+ * @param {!HTMLElement} element
+ * @return {!Iterable<!HTMLElement>}
  */
 function createElementIterator(element) {
   const document = element.ownerDocument;
@@ -140,7 +140,7 @@ function createElementIterator(element) {
 /**
  * Create an iterator from an XPathResult instance.
  * @param {!XPathResult} xpathResult
- * @return {!Iterable<!Element>}
+ * @return {!Iterable<!HTMLElement>}
  */
 function createXpathIterator(xpathResult) {
   return createCommonIterator(xpathResult, 'iterateNext');
@@ -149,6 +149,7 @@ function createXpathIterator(xpathResult) {
 /**
  * Create an iterator from an object with iterator-like behavior but a
  * different API name for the iteration method.
+ * @template T
  * @param {!NodeIterator|!XPathResult} iterator
  * @param {string} nextProperty
  * @return {!Iterable<T>}
@@ -164,8 +165,9 @@ function* createCommonIterator(iterator, nextProperty) {
  * Create an iterator from an existing iterator, which nests the original
  * value under the `item` property in the iteration object value and adds an
  * `index` property.
+ * @template T
  * @param {!Iterable<T>} iter
- * @return {!Iterable<{{item: T, index: number}}>}
+ * @return {!Iterable<{item: T, index: number}>}
  */
 function* createIndexedInterator(iter) {
   let index = 0;

--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -15,9 +15,9 @@
  */
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2), {string: ['version']});
 const del = require('del');
 const fs = require('fs-extra');
+const minimist = require('minimist');
 const objstr = require('obj-str');
 const path = require('path');
 const {cyan, green, red, yellow} = require('../../common/colors');
@@ -25,8 +25,40 @@ const {format} = require('./format');
 const {getOutput, getStdout} = require('../../common/process');
 const {log, logLocalDev, logWithoutTimestamp} = require('../../common/logging');
 
+const argv = minimist(process.argv.slice(2), {string: ['version']});
+
 const extensionBundlesJson =
   'build-system/compile/bundles.config.extensions.json';
+
+/**
+ * @typedef {{
+ *   bundleConfig: Object,
+ *   modified: !Array<string>,
+ *   created: !Array<string>,
+ * }}
+ */
+let MakeExtensionResultDef;
+
+/**
+ * @typedef {{
+ *   version?: (string|undefined),
+ *   bento?: (boolean|undefined),
+ *   name?: (string|undefined),
+ *   nocss?: (string|undefined),
+ *   nojss?: (string|undefined),
+ * }}
+ */
+let ArgsDef;
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   version: string,
+ *   latestVersion?: (string|undefined)
+ *   options?: ({hasCss: boolean}|undefined)
+ * }}
+ */
+let BundleDef;
 
 /**
  * Convert dash-case-name to PascalCaseName.
@@ -41,7 +73,7 @@ function dashToPascalCase(name) {
  * Replaces from a map of keys/values.
  * @param {string} inputText
  * @param {Object<string, string>} replacements
- * @return {function(string): string}
+ * @return {string}
  */
 const replace = (inputText, replacements) =>
   Object.keys(replacements).reduce(
@@ -73,7 +105,7 @@ const getTemplateDir = (template) =>
  * @param {string} templateDir
  * @param {Object<string, string>} replacements
  * @param {string=} destinationDir
- * @return {Array<string>}
+ * @return {Promise<Array<string>>}
  */
 async function writeFromTemplateDir(
   templateDir,
@@ -129,12 +161,7 @@ async function writeFromTemplateDir(
 /**
  * Inserts an extension entry into bundles.config.extensions.json
  *
- * @param {{
- *   name: string,
- *   version: string,
- *   latestVersion?: (string|undefined)
- *   options: ({hasCss: boolean}|undefined)
- * }} bundle
+ * @param {BundleDef} bundle
  * @param {string=} destination
  */
 async function insertExtensionBundlesConfig(
@@ -179,22 +206,9 @@ async function insertExtensionBundlesConfig(
 }
 
 /**
- * @typedef {{
- *   bundleConfig: Object,
- *   modified: !Array<string>,
- *   created: !Array<string>,
- * }}
- */
-let MakeExtensionResultDef;
-
-/**
  * @param {Array<string>} templateDirs
  * @param {string=} destinationDir
- * @param {{
- *   version: (string|undefined),
- *   bento: (boolean|undefined),
- *   name: (string|undefined),
- * }} options
+ * @param {ArgsDef|minimist.ParsedArgs} options
  * @return {Promise<?MakeExtensionResultDef>}
  */
 async function makeExtensionFromTemplates(
@@ -330,7 +344,7 @@ async function makeExtensionFromTemplates(
 }
 
 /**
- * @param {function(...*):?{modified: ?Array<string>, created: ?Array<string>}} fn
+ * @param {function():?{modified: ?Array<string>, created: ?Array<string>}} fn
  * @return {Promise}
  */
 async function affectsWorkingTree(fn) {
@@ -356,7 +370,7 @@ async function affectsWorkingTree(fn) {
  * Generates an extension with the given name and runs all unit tests located in
  * the generated extension directory.
  * @param {string} name
- * @return {!Promise{?string}} stderr if failing, null if passing
+ * @return {Promise<?string>} stderr if failing, null if passing
  */
 async function runExtensionTests(name) {
   for (const command of [
@@ -380,6 +394,7 @@ async function makeExtension() {
 
   const {bento, nocss, nojss} = argv;
 
+  // @ts-ignore
   const templateDirs = objstr({
     shared: true,
     bento,

--- a/build-system/tasks/storybook/amp-env/register.js
+++ b/build-system/tasks/storybook/amp-env/register.js
@@ -20,5 +20,5 @@ import {addons} from '@storybook/addons';
  * Register the AMP Storybook decorator addon
  */
 export function register() {
-  addons.register('amp/storybook');
+  addons.register('amp/storybook', () => {});
 }

--- a/build-system/tsconfig.json
+++ b/build-system/tsconfig.json
@@ -20,35 +20,21 @@
     "esModuleInterop": true,
     "declaration": true
   },
-  "include": [
-    "./*",
-    "./common/**/*.js",
-    "./server/**/*.js",
-    "./tasks/*",
-    "./tasks/bundle-size/*",
-    "./tasks/coverage-map/*",
-    "./tasks/create-golden-css/*",
-    "./tasks/css/*",
-    "./tasks/e2e/*",
-    "./tasks/get-zindex/*",
-    "./tasks/markdown-toc/*",
-    // "./tasks/performance/*", // 35 remaining type errors.
-    "./tasks/prepend-global/*",
-    "./tasks/release/*",
-    "./tasks/runtime-test/*",
-    "./tasks/storybook/*",
-    "./tasks/sweep-experiments/*",
-    // "./tasks/visual-diff/*", // 12 errors due to async imports.
-    "./test-configs/**/*"
-  ],
+  "files": ["./global.d.ts"],
+  "include": ["./**/*.js"],
   "exclude": [
-    "**/node_modules",
-    "**/*.test.js",
-    "common/check-package-manager.js",
-    "server/app-index/test/test-html.js",
-    "server/app-index/test/test-amphtml-helpers.js",
-    "server/new-server/**/*",
-    "tasks/dep-check.js", // JSDoc private used inside a function confuses TS.
-    "tasks/get-zindex/*"
+    // Directories that do not need type-checking.
+    "./**/node_modules/**",
+    "./**/test/**/*.js",
+    "./**/*.test.js",
+    "./babel-plugins/**/*.js",
+    "./eslint-rules/**/*.js",
+    "./externs/**/*.js",
+    "./tasks/make-extension/template/**/*.js",
+
+    // Directories that need code fixes before type-checking can be enabled.
+    "./tasks/get-zindex/**/*.js",
+    "./tasks/performance/**/*.js",
+    "./tasks/visual-diff/**/*.js"
   ]
 }


### PR DESCRIPTION
**PR Highlights:**
- Add a `files` section to `tsconfig.json` and reference `global.d.ts` (it wasn't being consumed earlier)
- Replace the `include` section of `tsconfig.json` with `./**/*.js` (so all JS files are checked by default)
- Trim the `exclude` section of `tsconfig.json` to only those directories that still need work
- Fix several type-check errors