### PR TITLE
🏗 Don't duplicate copyright comments in ESM output

### DIFF
--- a/build-system/babel-config/post-closure-config.js
+++ b/build-system/babel-config/post-closure-config.js
@@ -28,7 +28,6 @@ function getPostClosureConfig() {
   }
 
   const postClosurePlugins = [
-    './build-system/babel-plugins/babel-plugin-transform-minified-comments',
     './build-system/babel-plugins/babel-plugin-const-transformer',
     './build-system/babel-plugins/babel-plugin-transform-remove-directives',
     './build-system/babel-plugins/babel-plugin-transform-stringish-literals',


### PR DESCRIPTION
For ESM builds, the `transform-minified-comments` is run during the pre- and post- closure compilation passes, resulting in duplicate copyright comments in all binaries.

**For example:**

![image](https://user-images.githubusercontent.com/26553114/120324574-c8945c00-c2b4-11eb-94c2-bd08fb316bc7.png)

![image](https://user-images.githubusercontent.com/26553114/120324645-d9dd6880-c2b4-11eb-9d6f-dd64ff7c81b6.png)

This PR removes the plugin from the post-closure pass. With this, there's only one copy of the copyright comments.

**Question:** Is there any valid reason to run this plugin twice? If so, is there merit in the suggestion in https://github.com/ampproject/amphtml/pull/26779#discussion_r398302869?

![image](https://user-images.githubusercontent.com/26553114/120325472-abac5880-c2b5-11eb-9412-cc4c9853bb75.png)

![image](https://user-images.githubusercontent.com/26553114/120325498-b535c080-c2b5-11eb-89a2-1df34d032780.png)
