### PR TITLE
Validator Rollup

### DIFF
--- a/validator/js/engine/htmlparser-interface.js
+++ b/validator/js/engine/htmlparser-interface.js
@@ -261,12 +261,13 @@ const ParsedHtmlTag = class {
 
   /**
    * Tests if this is an async script tag.
+   * @param {string} src
    * @return {boolean}
    * @private
    */
-  isAsyncScriptTag_() {
+  isAsyncScriptTag_(src) {
     return this.upperName() == 'SCRIPT' && 'async' in this.attrsByKey() &&
-        'src' in this.attrsByKey();
+        src !== null;
   }
 
   /**
@@ -276,7 +277,7 @@ const ParsedHtmlTag = class {
   isAmpRuntimeScript() {
     const src = this.getAttrValueOrNull_('src');
     if (src === null) return false;
-    return this.isAsyncScriptTag_() && !this.isExtensionScript() &&
+    return this.isAsyncScriptTag_(src) && !this.isExtensionScript() &&
         this.isAmpCacheDomain_(src) &&
         (src.endsWith('/v0.js') || src.endsWith('/v0.mjs') ||
          src.endsWith('/v0.mjs?f=sxg'));
@@ -292,10 +293,10 @@ const ParsedHtmlTag = class {
     // https://cdn.ampproject.org/lts/v0/amp-ad-0.1.js
     const src = this.getAttrValueOrNull_('src');
     if (src === null) return false;
-    const ltsScriptSrcRegex = new RegExp(
-        '^https://cdn\\.ampproject\\.org/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$',
-        'i');
-    return this.isAsyncScriptTag_() && ltsScriptSrcRegex.test(src);
+    const ltsScriptPathRegex =
+        new RegExp('/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
+    return this.isAsyncScriptTag_(src) && this.isAmpCacheDomain_(src) &&
+        ltsScriptPathRegex.test(src);
   }
 
   /**
@@ -310,11 +311,10 @@ const ParsedHtmlTag = class {
     if (type === null) return false;
     const src = this.getAttrValueOrNull_('src');
     if (src === null) return false;
-    const moduleScriptSrcRegex = new RegExp(
-        '^https://cdn\\.ampproject\\.org/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$',
-        'i');
-    return this.isAsyncScriptTag_() && (type == 'module') &&
-        moduleScriptSrcRegex.test(src);
+    const moduleScriptPathRegex =
+        new RegExp('/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$', 'i');
+    return this.isAsyncScriptTag_(src) && (type == 'module') &&
+        this.isAmpCacheDomain_(src) && moduleScriptPathRegex.test(src);
   }
 
   /**
@@ -327,11 +327,10 @@ const ParsedHtmlTag = class {
     // https://cdn.ampproject.org/v0/amp-ad-0.1.js
     const src = this.getAttrValueOrNull_('src');
     if (src === null) return false;
-    const nomoduleScriptSrcRegex = new RegExp(
-        '^https://cdn\\.ampproject\\.org/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$',
-        'i');
-    return this.isAsyncScriptTag_() && 'nomodule' in this.attrsByKey() &&
-        nomoduleScriptSrcRegex.test(src);
+    const nomoduleScriptPathRegex =
+        new RegExp('/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
+    return this.isAsyncScriptTag_(src) && 'nomodule' in this.attrsByKey() &&
+        this.isAmpCacheDomain_(src) && nomoduleScriptPathRegex.test(src);
   }
 
   /**
@@ -346,11 +345,10 @@ const ParsedHtmlTag = class {
     if (type === null) return false;
     const src = this.getAttrValueOrNull_('src');
     if (src === null) return false;
-    const moduleLtsScriptSrcRegex = new RegExp(
-        '^https://cdn\\.ampproject\\.org/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$',
-        'i');
-    return this.isAsyncScriptTag_() && (type == 'module') &&
-        moduleLtsScriptSrcRegex.test(src);
+    const moduleLtsScriptPathRegex =
+        new RegExp('lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$', 'i');
+    return this.isAsyncScriptTag_(src) && (type == 'module') &&
+        this.isAmpCacheDomain_(src) && moduleLtsScriptPathRegex.test(src);
   }
 
   /**
@@ -363,11 +361,10 @@ const ParsedHtmlTag = class {
     // https://cdn.ampproject.org/lts/v0/amp-ad-0.1.js
     const src = this.getAttrValueOrNull_('src');
     if (src === null) return false;
-    const nomoduleLtsScriptSrcRegex = new RegExp(
-        '^https://cdn\\.ampproject\\.org/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$',
-        'i');
-    return this.isAsyncScriptTag_() && 'nomodule' in this.attrsByKey() &&
-        nomoduleLtsScriptSrcRegex.test(src);
+    const nomoduleLtsScriptPathRegex =
+        new RegExp('/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
+    return this.isAsyncScriptTag_(src) && 'nomodule' in this.attrsByKey() &&
+        this.isAmpCacheDomain_(src) && nomoduleLtsScriptPathRegex.test(src);
   }
 };
 exports.ParsedHtmlTag = ParsedHtmlTag;

--- a/validator/testdata/transformed_feature_tests/script_amp_onerror_js.html
+++ b/validator/testdata/transformed_feature_tests/script_amp_onerror_js.html
@@ -1,0 +1,37 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests the validity of the script tag for early styling on fast failure
+  to load v0.js. See GitHub #22543.
+-->
+<!doctype html>
+<html ⚡ transformed="google;v=1">
+<head>
+  <meta charset="utf-8">
+  <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+  <meta name="viewport" content="width=device-width">
+  <script async src=https://cdn.ampproject.org/v0.js></script>
+
+  <!-- Valid -->
+  <script amp-onerror>document.querySelector("script[src*='/v0.js']").onerror=function(){document.querySelector('style[amp-boilerplate]').textContent=''}</script>
+
+  <link rel="canonical" href="./regular-html-version.html">
+</head>
+<body>
+Hello, world.
+</body>
+</html>

--- a/validator/testdata/transformed_feature_tests/script_amp_onerror_js.out
+++ b/validator/testdata/transformed_feature_tests/script_amp_onerror_js.out
@@ -1,0 +1,38 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests the validity of the script tag for early styling on fast failure
+|    to load v0.js. See GitHub #22543.
+|  -->
+|  <!doctype html>
+|  <html ⚡ transformed="google;v=1">
+|  <head>
+|    <meta charset="utf-8">
+|    <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+|    <meta name="viewport" content="width=device-width">
+|    <script async src=https://cdn.ampproject.org/v0.js></script>
+|
+|    <!-- Valid -->
+|    <script amp-onerror>document.querySelector("script[src*='/v0.js']").onerror=function(){document.querySelector('style[amp-boilerplate]').textContent=''}</script>
+|
+|    <link rel="canonical" href="./regular-html-version.html">
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/testdata/transformed_feature_tests/script_amp_onerror_js_fail.html
+++ b/validator/testdata/transformed_feature_tests/script_amp_onerror_js_fail.html
@@ -1,0 +1,37 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  This tests the validity of the script tag for early styling on fast failure
+  to load v0.js. See GitHub #22543.
+-->
+<!doctype html>
+<html ⚡ transformed="google;v=1">
+<head>
+  <meta charset="utf-8">
+  <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+  <meta name="viewport" content="width=device-width">
+  <script async src=https://cdn.ampproject.org/v0.js></script>
+
+  <!-- Invalid: cdata does not match exactly -->
+  <script amp-onerror>document.querySelector("script[src*='/v0.js']").onerror=function(){document.querySelector('style[amp-boilerplate]').textContent=' '}</script>
+
+  <link rel="canonical" href="./regular-html-version.html">
+</head>
+<body>
+Hello, world.
+</body>
+</html>

--- a/validator/testdata/transformed_feature_tests/script_amp_onerror_js_fail.out
+++ b/validator/testdata/transformed_feature_tests/script_amp_onerror_js_fail.out
@@ -1,0 +1,40 @@
+FAIL
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    This tests the validity of the script tag for early styling on fast failure
+|    to load v0.js. See GitHub #22543.
+|  -->
+|  <!doctype html>
+|  <html ⚡ transformed="google;v=1">
+|  <head>
+|    <meta charset="utf-8">
+|    <style amp-runtime i-amphtml-version=123456789012345>.omitted-for-brevity{}</style>
+|    <meta name="viewport" content="width=device-width">
+|    <script async src=https://cdn.ampproject.org/v0.js></script>
+|
+|    <!-- Invalid: cdata does not match exactly -->
+|    <script amp-onerror>document.querySelector("script[src*='/v0.js']").onerror=function(){document.querySelector('style[amp-boilerplate]').textContent=' '}</script>
+>>   ^~~~~~~~~
+transformed_feature_tests/script_amp_onerror_js_fail.html:30:2 The mandatory text inside tag 'script amp-onerror' is missing or incorrect.
+|
+|    <link rel="canonical" href="./regular-html-version.html">
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3383,9 +3383,14 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
   cdata: {
-    mandatory_cdata: "[].slice.call(document.querySelectorAll(\"script[src*='/v0.js'],script[src*='/v0.mjs']\")).forEach(function(s){s.onerror=function(){document.querySelector('style[amp-boilerplate]').textContent=''}})"
+    # Only valid if contents are exactly either of these:
+    # [].slice.call(document.querySelectorAll("script[src*='/v0.js'],script[src*='/v0.mjs']")).forEach(function(s){s.onerror=function(){document.querySelector('style[amp-boilerplate]').textContent=''}})
+    # document.querySelector("script[src*='/v0.js']").onerror=function(){document.querySelector('style[amp-boilerplate]').textContent=''}
+    cdata_regex: "\\[]\\.slice\\.call\\(document\\.querySelectorAll\\(\"script\\[src\\*='\\/v0\\.js'],script\\[src\\*='\\/v0\\.mjs']\"\\)\\)\\.forEach\\(function\\(s\\){s\\.onerror=function\\(\\){document\\.querySelector\\('style\\[amp-boilerplate]'\\)\\.textContent=''}}\\)|"
+                 "document\\.querySelector\\(\"script\\[src\\*='\\/v0\\.js']\"\\)\\.onerror=function\\(\\){document\\.querySelector\\('style\\[amp-boilerplate]'\\)\\.textContent=''}"
   }
 }
+
 # Enables early styling on fast failure to load v0.js. See GitHub #22543.
 tags: {
   html_format: AMP


### PR DESCRIPTION
 - cl/376850642 Allow both onerror cdata contents for Transformed AMP.
 - cl/376841625 Extract AMP Cache Domain validation, part 2
