### PR TITLE
✨ Add `latest` version to `amp-cache-url` extension spec

### DIFF
--- a/extensions/amp-cache-url/validator-amp-cache-url.protoascii
+++ b/extensions/amp-cache-url/validator-amp-cache-url.protoascii
@@ -20,6 +20,7 @@ tags: {  # amp-cache-url
   extension_spec: {
     name: "amp-cache-url"
     version: "0.1"
+    version: "latest"
     requires_usage: NONE
   }
   attr_lists: "common-extension-attrs"


### PR DESCRIPTION
In looking at the new validator spec for `amp-cache-url` (added in #33611), it appears that `latest` was omitted:

https://github.com/ampproject/amphtml/blob/39cf9c2f5e73c921218ddf6a69c7c96e2f590822/extensions/amp-cache-url/validator-amp-cache-url.protoascii#L20-L23

Nevertheless, `latest` and `0.1` are both valid script URLs:

https://cdn.ampproject.org/v0/amp-cache-url-0.1.js
https://cdn.ampproject.org/v0/amp-cache-url-latest.js

For consistency with other 132 extension specs, it seems `latest` should be allowed as well. Granted, now that `amp-cache-url` is auto-imported at runtime (#34588), this seems less necessary.