### PR TITLE
🏗 Shorten copyright comments in esm and non-esm minified output

### DIFF
--- a/build-system/babel-config/post-closure-config.js
+++ b/build-system/babel-config/post-closure-config.js
@@ -24,16 +24,17 @@ const argv = require('minimist')(process.argv.slice(2));
  */
 function getPostClosureConfig() {
   const postClosurePlugins = [
+    argv.esm || argv.sxg
+      ? './build-system/babel-plugins/babel-plugin-const-transformer'
+      : null,
+    argv.esm || argv.sxg
+      ? './build-system/babel-plugins/babel-plugin-transform-remove-directives'
+      : null,
+    argv.esm || argv.sxg
+      ? './build-system/babel-plugins/babel-plugin-transform-stringish-literals'
+      : null,
     './build-system/babel-plugins/babel-plugin-transform-minified-comments',
-  ];
-
-  if (argv.esm || argv.sxg) {
-    postClosurePlugins.push(
-      './build-system/babel-plugins/babel-plugin-const-transformer',
-      './build-system/babel-plugins/babel-plugin-transform-remove-directives',
-      './build-system/babel-plugins/babel-plugin-transform-stringish-literals'
-    );
-  }
+  ].filter(Boolean);
 
   return {
     compact: false,

--- a/build-system/babel-config/post-closure-config.js
+++ b/build-system/babel-config/post-closure-config.js
@@ -18,20 +18,23 @@
 const argv = require('minimist')(process.argv.slice(2));
 
 /**
- * Gets the config for post-closure babel transforms run during `amp dist --esm`.
+ * Gets the config for post-closure babel transforms run during `amp dist`.
  *
  * @return {!Object}
  */
 function getPostClosureConfig() {
-  if (!argv.esm && !argv.sxg) {
-    return {};
+  const postClosurePlugins = [
+    './build-system/babel-plugins/babel-plugin-transform-minified-comments',
+  ];
+
+  if (argv.esm || argv.sxg) {
+    postClosurePlugins.push(
+      './build-system/babel-plugins/babel-plugin-const-transformer',
+      './build-system/babel-plugins/babel-plugin-transform-remove-directives',
+      './build-system/babel-plugins/babel-plugin-transform-stringish-literals'
+    );
   }
 
-  const postClosurePlugins = [
-    './build-system/babel-plugins/babel-plugin-const-transformer',
-    './build-system/babel-plugins/babel-plugin-transform-remove-directives',
-    './build-system/babel-plugins/babel-plugin-transform-stringish-literals',
-  ];
   return {
     compact: false,
     inputSourceMap: false,

--- a/build-system/babel-plugins/babel-plugin-transform-minified-comments/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-minified-comments/index.js
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+/**
+ * Shortens a comment block by removing line breaks and consecutive whitespaces.
+ * @param {Array<Object>} comments
+ * @return {Array<Object>}
+ */
+function formatComments(comments) {
+  return comments.map((comment) => ({
+    ...comment,
+    value: comment.value.replace(/\n/g, ' ').replace(/\s+/g, ' '),
+  }));
+}
+
 // Ensure comments in minified build output is minimal.
 module.exports = function () {
   return {
@@ -21,21 +33,13 @@ module.exports = function () {
       Statement(path) {
         const {node} = path;
         const {trailingComments} = node;
-        if (!trailingComments || trailingComments.length <= 0) {
-          return;
+        if (trailingComments?.length) {
+          node.trailingComments = formatComments(trailingComments);
+          const next = path.getNextSibling();
+          if (next.node) {
+            next.node.leadingComments = null;
+          }
         }
-
-        const next = path.getNextSibling();
-        if (!next) {
-          return;
-        }
-
-        node.trailingComments = null;
-        const formattedComments = (trailingComments || []).map((comment) => ({
-          ...comment,
-          value: comment.value.replace(/\n +/g, `\n`),
-        }));
-        next.addComments('leading', formattedComments);
       },
     },
   };

--- a/build-system/babel-plugins/babel-plugin-transform-minified-comments/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-minified-comments/index.js
@@ -14,18 +14,6 @@
  * limitations under the License.
  */
 
-/**
- * Shortens a comment block by removing line breaks and consecutive whitespaces.
- * @param {Array<Object>} comments
- * @return {Array<Object>}
- */
-function formatComments(comments) {
-  return comments.map((comment) => ({
-    ...comment,
-    value: comment.value.replace(/\n/g, ' ').replace(/\s+/g, ' '),
-  }));
-}
-
 // Ensure comments in minified build output is minimal.
 module.exports = function () {
   return {
@@ -34,9 +22,12 @@ module.exports = function () {
         const {node} = path;
         const {trailingComments} = node;
         if (trailingComments?.length) {
-          node.trailingComments = formatComments(trailingComments);
+          node.trailingComments = trailingComments.map((comment) => ({
+            ...comment,
+            value: comment.value.replace(/\s+/g, ' '),
+          }));
           const next = path.getNextSibling();
-          if (next.node) {
+          if (next?.node) {
             next.node.leadingComments = null;
           }
         }

--- a/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses-tabs/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses-tabs/input.js
@@ -19,5 +19,6 @@ const Gd={PRERENDER:"prerender",VISIBLE:"visible",HIDDEN:"hidden",PAUSED:"paused
 	Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
 	Use of this source code is governed by a BSD-style
 	license that can be found in the LICENSE file or at
-	https://developers.google.com/open-source/licenses/bsd */
+	https://developers.google.com/open-source/licenses/bsd
+	*/
   let Hd;

--- a/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses-tabs/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses-tabs/output.js
@@ -20,10 +20,6 @@ const Gd = {
   PAUSED: "paused",
   INACTIVE: "inactive"
 };
+/* Copyright (c) 2014 The Polymer Project Authors. All rights reserved. Use of this source code is governed by a BSD-style license that can be found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd */
 
-/*
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
-Use of this source code is governed by a BSD-style
-license that can be found in the LICENSE file or at
-https://developers.google.com/open-source/licenses/bsd */
 let Hd;

--- a/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses/input.js
@@ -19,5 +19,6 @@ const Gd={PRERENDER:"prerender",VISIBLE:"visible",HIDDEN:"hidden",PAUSED:"paused
   Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
   Use of this source code is governed by a BSD-style
   license that can be found in the LICENSE file or at
-  https://developers.google.com/open-source/licenses/bsd */
+  https://developers.google.com/open-source/licenses/bsd
+  */
   let Hd;

--- a/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-minified-comments/test/fixtures/transform/licenses/output.js
@@ -20,10 +20,6 @@ const Gd = {
   PAUSED: "paused",
   INACTIVE: "inactive"
 };
+/* Copyright (c) 2014 The Polymer Project Authors. All rights reserved. Use of this source code is governed by a BSD-style license that can be found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd */
 
-/*
-Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
-Use of this source code is governed by a BSD-style
-license that can be found in the LICENSE file or at
-https://developers.google.com/open-source/licenses/bsd */
 let Hd;

--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -78,6 +78,11 @@ async function terserMinify(code, filename) {
  * @return {Promise<void>}
  */
 async function postClosureBabel(file) {
+  if (path.extname(file) === '.map') {
+    debug(CompilationLifecycles['complete'], file);
+    return;
+  }
+
   debug(CompilationLifecycles['closured-pre-babel'], file);
   /** @type {?babel.TransformOptions} */
   const babelOptions = babel.loadOptions({caller: {name: 'post-closure'}});

--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -73,16 +73,11 @@ async function terserMinify(code, filename) {
 
 /**
  * Apply Babel Transforms on output from Closure Compuler, then cleanup added
- * space with Terser. Used only in esm mode.
+ * space with Terser.
  * @param {string} file
  * @return {Promise<void>}
  */
 async function postClosureBabel(file) {
-  if ((!argv.esm && !argv.sxg) || path.extname(file) === '.map') {
-    debug(CompilationLifecycles['complete'], file);
-    return;
-  }
-
   debug(CompilationLifecycles['closured-pre-babel'], file);
   /** @type {?babel.TransformOptions} */
   const babelOptions = babel.loadOptions({caller: {name: 'post-closure'}});

--- a/third_party/webcomponentsjs/ShadowCSS.js
+++ b/third_party/webcomponentsjs/ShadowCSS.js
@@ -3,7 +3,8 @@
 * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
 * Use of this source code is governed by a BSD-style
 * license that can be found in the LICENSE file or at
-* https://developers.google.com/open-source/licenses/bsd */
+* https://developers.google.com/open-source/licenses/bsd
+*/
 
 /*
   This is a limited shim for ShadowDOM css styling.


### PR DESCRIPTION
**PR Highlights:**
- Updates `transform-minified-comments` to remove newline characters and multi-whitespaces from comments
- Fixes bug that was resulting in duplicate comments
- Runs the plugin after closure compilation in esm and non-esm modes (running it before closure has no effect)
- Updates logic used to trigger `post-closure` transforms
- Updates expected output in `amp babel-plugin-tests`

**Screenshots:**

**Before:**

![image](https://user-images.githubusercontent.com/26553114/120380453-30679880-c2ef-11eb-8153-4b95a38557d5.png)
![image](https://user-images.githubusercontent.com/26553114/120380420-25146d00-c2ef-11eb-9f18-f2910cd59328.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/120380625-66a51800-c2ef-11eb-98a4-12d1ee888855.png)
![image](https://user-images.githubusercontent.com/26553114/120380651-71f84380-c2ef-11eb-9660-24e28642dac7.png)


Addresses https://github.com/ampproject/amphtml/pull/34628#issuecomment-852158829
