### PR TITLE
♻️ Opinary Ads: fix whitespace issue for AMS integration

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -888,7 +888,9 @@ const adConfig = jsonConfiguration({
     renderStartImplemented: true,
   },
 
-  'opinary': {},
+  'opinary': {
+    renderStartImplemented: true,
+  },
 
   'outbrain': {
     renderStartImplemented: true,

--- a/ads/vendors/opinary.md
+++ b/ads/vendors/opinary.md
@@ -25,7 +25,7 @@ The automated matching system is an algorithm developed by Opinary which matches
 ```html
 <amp-embed
   width="500"
-  height="500"
+  height="1"
   type="opinary"
   layout="intrinsic"
   data-client="test-success"

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -1530,7 +1530,7 @@
   </div>
 
   <h2>Opinary</h2>
-  <amp-embed width="500" height="500" type="opinary" layout="intrinsic" data-client="test-success">
+  <amp-embed width="500" height="1" type="opinary" layout="intrinsic" data-client="test-success">
   </amp-embed>
 
   <h2>Outbrain widget</h2>


### PR DESCRIPTION
Opinary AMP integration only supported the "automatic matching", where the Opinary algorithm decided what polls to show - sometimes it decided to do not to show any poll 

Regarding information in the documentation:
_If no ad is available for the slot, AMP attempts to collapse the amp-ad element (that is, set to display: none). AMP determines that this operation can be performed without affecting the user's scroll position. If the ad is in the current viewport, the ad will not be collapsed because it affects the user's scroll position; however, if the ad is outside of the current viewport, it will be collapsed._

Sometimes it keeps reserved space even any poll is displayed and is it problematic for publishers, in that case, we decided to reverse logic and we could reserve 1px height and in a case, we have a poll, try to expand it to 500x500 -  in that case the risk for the client is much lower.

CC @torbenbrodt 
