### PR TITLE
🏗 Enable type-checking for `build-system/tasks/visual-diff`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -31,7 +31,6 @@ validator/export
 build-system/babel-plugins/**/fixtures/**/*.js
 build-system/babel-plugins/**/fixtures/**/*.mjs
 build-system/tasks/make-extension/template/**/*
-build-system/tasks/visual-diff/snippets/*.js
 examples/amp-script/todomvc.ssr.js
 examples/amp-script/vue-todomvc.js
 extensions/amp-a4a/0.1/test/testdata/**

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const puppeteer = require('puppeteer'); // eslint-disable-line no-unused-vars
 const {cyan, green, red, yellow} = require('../../common/colors');
 const {log: logBase} = require('../../common/logging');
 
@@ -33,6 +34,14 @@ const HTML_ESCAPE_CHARS = {
   '`': '&#x60;',
 };
 const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
+
+/**
+ * @typedef {{
+ *  visible?: boolean,
+ *  hidden?: boolean,
+ * }}
+ */
+let VisibilityDef;
 
 /**
  * Escapes a string of HTML elements to HTML entities.
@@ -169,8 +178,8 @@ async function waitForPageLoad(page, testName) {
  *
  * @param {!puppeteer.Page} page page to check the visibility of elements in.
  * @param {string} selector CSS selector for elements to wait on.
- * @param {!Object} options with key 'visible' OR 'hidden' set to true.
- * @return {boolean} true if the expectation is met before the timeout.
+ * @param {!VisibilityDef} options with key 'visible' OR 'hidden' set to true.
+ * @return {Promise<boolean>} true if the expectation is met before the timeout.
  * @throws {Error} if the expectation is not met before the timeout, throws an
  *    error with the message value set to the CSS selector.
  */
@@ -237,7 +246,7 @@ async function waitForElementVisibility(page, selector, options) {
  *
  * @param {!puppeteer.Page} page page to check the existence of the selector in.
  * @param {string} selector CSS selector.
- * @return {boolean} true if the element exists before the timeout.
+ * @return {Promise<boolean>} true if the element exists before the timeout.
  * @throws {Error} if the element does not exist before the timeout, throws an
  *    error with the message value set to the CSS selector.
  */
@@ -256,7 +265,7 @@ async function waitForSelectorExistence(page, selector) {
 /**
  * Returns a Promise that resolves after the specified number of milliseconds.
  * @param {number} ms
- * @return {Promise}
+ * @return {Promise<void>}
  */
 async function sleep(ms) {
   return new Promise((res) => setTimeout(res, ms));

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -19,7 +19,6 @@ const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs');
 const JSON5 = require('json5');
 const path = require('path');
-const Percy = require('@percy/core');
 const percySnapshot = require('@percy/puppeteer');
 const puppeteer = require('puppeteer');
 const {
@@ -42,6 +41,7 @@ const {
 } = require('../../common/git');
 const {buildRuntime} = require('../../common/utils');
 const {cyan, yellow} = require('../../common/colors');
+const {default: Percy} = require('@percy/core');
 const {isCiBuild} = require('../../common/ci');
 const {startServer, stopServer} = require('../serve');
 
@@ -133,7 +133,7 @@ let TestErrorDef;
  *  interactive_tests: string,
  *  no_base_test: boolean,
  *  flaky: boolean,
- *  tests_: Object<string,Function>,
+ *  tests_: Object<string, Function>,
  * }}
  */
 let WebpageDef;
@@ -190,7 +190,6 @@ async function launchPercyAgent(browserFetcher) {
     return;
   }
 
-  // @ts-ignore Type mismatch in library
   const percy = await Percy.start({
     token: process.env.PERCY_TOKEN,
     loglevel: argv.percy_agent_debug ? 'debug' : 'info',
@@ -774,7 +773,6 @@ async function visualDiff() {
   try {
     await performVisualTests(browserFetcher);
   } finally {
-    // @ts-ignore Type mismatch in library
     await percy?.stop();
   }
   exitCtrlcHandler(handlerProcess);

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -19,6 +19,7 @@ const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs');
 const JSON5 = require('json5');
 const path = require('path');
+const Percy = require('@percy/core');
 const percySnapshot = require('@percy/puppeteer');
 const puppeteer = require('puppeteer');
 const {
@@ -41,7 +42,6 @@ const {
 } = require('../../common/git');
 const {buildRuntime} = require('../../common/utils');
 const {cyan, yellow} = require('../../common/colors');
-const {default: Percy} = require('@percy/core');
 const {isCiBuild} = require('../../common/ci');
 const {startServer, stopServer} = require('../serve');
 
@@ -190,6 +190,7 @@ async function launchPercyAgent(browserFetcher) {
     return;
   }
 
+  // @ts-ignore Type mismatch in library
   const percy = await Percy.start({
     token: process.env.PERCY_TOKEN,
     loglevel: argv.percy_agent_debug ? 'debug' : 'info',
@@ -773,6 +774,7 @@ async function visualDiff() {
   try {
     await performVisualTests(browserFetcher);
   } finally {
+    // @ts-ignore Type mismatch in library
     await percy?.stop();
   }
   exitCtrlcHandler(handlerProcess);

--- a/build-system/tasks/visual-diff/package-lock.json
+++ b/build-system/tasks/visual-diff/package-lock.json
@@ -127,14 +127,22 @@
       "version": "14.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
       "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/puppeteer": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.3.tgz",
+      "integrity": "sha512-3nE8YgR9DIsgttLW+eJf6mnXxq8Ge+27m5SU3knWmrlfl6+KOG0Bf9f7Ua7K+C4BnaTMAh3/UpySqdAYvrsvjg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yauzl": {
       "version": "2.9.1",

--- a/build-system/tasks/visual-diff/package.json
+++ b/build-system/tasks/visual-diff/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@percy/core": "1.0.0-beta.52",
     "@percy/puppeteer": "2.0.0",
+    "@types/puppeteer": "5.4.3",
     "puppeteer": "10.0.0"
   }
 }

--- a/build-system/tasks/visual-diff/snippets/freeze-canvas-image.js
+++ b/build-system/tasks/visual-diff/snippets/freeze-canvas-image.js
@@ -1,12 +1,30 @@
-// This file is executed via Puppeteer's page.evaluate on a document to copy the
-// current image data of the canvas to an attribute so that it will be passed in the
-// snapshots to Percy.
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview This file is executed via Puppeteer's page.evaluate on a
+ * document to copy the current image data of the canvas to an attribute so that
+ * it will be passed in the snapshots to Percy.
+ */
 
 const canvases = document.querySelectorAll('canvas');
 canvases.forEach((canvas) => {
   const img = document.createElement('img');
-  img.style.width = '100%';
-  img.style.height = '100%';
+  img.style.width = '100%'; // eslint-disable-line local/no-style-property-setting
+  img.style.height = '100%'; // eslint-disable-line local/no-style-property-setting
   img.setAttribute('src', canvas.toDataURL());
   canvas.replaceWith(img);
 });

--- a/build-system/tasks/visual-diff/snippets/freeze-form-values.js
+++ b/build-system/tasks/visual-diff/snippets/freeze-form-values.js
@@ -1,14 +1,31 @@
-// This file is executed via Puppeteer's page.evaluate on a document to copy the
-// values of forms into their attributes, so that they will be passed in the
-// snapshots to Percy.
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-for (const form of document.forms) {
-  for (const formElement of form.elements) {
-    switch (formElement.tagName) {
+/**
+ * @fileoverview This file is executed via Puppeteer's page.evaluate on a
+ * document to copy the values of forms into their attributes, so that they will
+ * be passed in the snapshots to Percy.
+ */
+
+for (const form of Array.from(document.forms)) {
+  for (const element of Array.from(form.elements)) {
+    switch (element.tagName) {
       case 'INPUT':
-        // Need to update this? Look at
-        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#Properties
-        // for inspiration.
+        // Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
+        const formElement = /** @type {!HTMLInputElement} */ (element);
         switch (formElement.type) {
           case 'file':
           case 'hidden':
@@ -18,9 +35,9 @@ for (const form of document.forms) {
           case 'checkbox':
           case 'radio':
             if (formElement.checked) {
-                formElement.setAttribute('checked', '');
+              formElement.setAttribute('checked', '');
             } else {
-                formElement.removeAttribute('checked');
+              formElement.removeAttribute('checked');
             }
             break;
 
@@ -30,7 +47,9 @@ for (const form of document.forms) {
         break;
 
       case 'SELECT':
-        for (const optionElement of formElement.options) {
+        // Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement
+        const selectElement = /** @type {!HTMLSelectElement} */ (element);
+        for (const optionElement of Array.from(selectElement.options)) {
           if (optionElement.selected) {
             optionElement.setAttribute('selected', '');
           } else {
@@ -40,7 +59,9 @@ for (const form of document.forms) {
         break;
 
       case 'TEXTAREA':
-        formElement.textContent = formElement.value;
+        // Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLTextAreaElement
+        const textElement = /** @type {!HTMLTextAreaElement} */ (element);
+        textElement.textContent = textElement.value;
         break;
     }
   }

--- a/build-system/tasks/visual-diff/snippets/iframe-wrapper.js
+++ b/build-system/tasks/visual-diff/snippets/iframe-wrapper.js
@@ -1,11 +1,30 @@
-// This file is executed via Puppeteer's page.evaluate on a document to wrap it
-// with an <iframe>, so that we can perform viewport-constrained visual diff
-// tests.
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-// The following strings will be replaced at execution time:
-// * __WIDTH__ and __HEIGHT__ with the viewport's size from the visual test's config.
-// * __PERCY_CSS__ with Percy-specific CSS.
+/**
+ * @fileoverview This file is executed via Puppeteer's page.evaluate on a
+ * document to wrap it with an <iframe>, so that we can perform
+ * viewport-constrained visual diff tests.
+ *
+ * The following strings will be replaced at execution time:
+ * 1. __WIDTH__ and __HEIGHT__ with the viewport's size from the test's config.
+ * 2. __PERCY_CSS__ with Percy-specific CSS.
+ */
 
+// eslint-disable-next-line no-useless-concat
 if ('__PERCY_CSS__' !== '__' + 'PERCY_CSS' + '__') {
   const style = document.createElement('style');
   style.setAttribute('data-percy-specific-css', '');
@@ -13,10 +32,11 @@ if ('__PERCY_CSS__' !== '__' + 'PERCY_CSS' + '__') {
   document.body.appendChild(style);
 }
 
-const pageContents = document.documentElement.outerHTML;
+const pageContents = document.documentElement.outerHTML; // eslint-disable-line local/no-forbidden-terms
 
-const metaCharset = document.querySelector('head meta[charset]')
-    || document.createElement('meta');
+const metaCharset =
+  document.querySelector('head meta[charset]') ||
+  document.createElement('meta');
 if (!metaCharset.hasAttribute('charset')) {
   metaCharset.setAttribute('charset', 'utf-8');
 }
@@ -31,10 +51,12 @@ while (document.body.firstChild) {
 }
 
 const iframe = document.createElement('iframe');
-iframe.width = __WIDTH__;
-iframe.height = __HEIGHT__;
+// @ts-ignore
+iframe.width = __WIDTH__; // eslint-disable-line no-undef
+// @ts-ignore
+iframe.height = __HEIGHT__; // eslint-disable-line no-undef
 iframe.srcdoc = pageContents;
 document.body.appendChild(iframe);
 
-document.body.style.margin = '0';
-iframe.style.border = '0';
+document.body.style.margin = '0'; // eslint-disable-line local/no-style-property-setting
+iframe.style.border = '0'; // eslint-disable-line local/no-style-property-setting

--- a/build-system/tasks/visual-diff/snippets/remove-amp-scripts.js
+++ b/build-system/tasks/visual-diff/snippets/remove-amp-scripts.js
@@ -1,6 +1,26 @@
-// This file is executed via Puppeteer's page.evaluate on a document to remove
-// all <script> tags that import AMP pages. This makes for cleaner diffs and
-// prevents "double-execution" of AMP scripts when enableJavaScript=true.
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-document.head.querySelectorAll("script[src]")
-    .forEach(node => node./*OK*/remove());
+/**
+ * @fileoverview This file is executed via Puppeteer's page.evaluate on a
+ * document to remove all <script> tags that import AMP pages. This makes for
+ * cleaner diffs and prevents "double-execution" of AMP scripts when
+ * enableJavaScript=true.
+ */
+
+document.head
+  .querySelectorAll('script[src]')
+  .forEach((node) => node./*OK*/ remove());

--- a/build-system/tsconfig.json
+++ b/build-system/tsconfig.json
@@ -34,7 +34,6 @@
 
     // Directories that need code fixes before type-checking can be enabled.
     "./tasks/get-zindex/**/*.js",
-    "./tasks/performance/**/*.js",
-    "./tasks/visual-diff/**/*.js"
+    "./tasks/performance/**/*.js"
   ]
 }


### PR DESCRIPTION
**PR Highlights:**
- Enable type-checking for `build-system/tasks/visual-diff/`
- Convert lazy requires to regular requires (okay because subpackage deps are now auto-installed)
- Enable linting / auto-formatting for `build-system/tasks/visual-diff/snippets/`
- Add a few typedefs, fix a few type errors