### PR TITLE
🏗 Update task-level subpackages before task code can be loaded

### DIFF
--- a/build-system/common/update-packages.js
+++ b/build-system/common/update-packages.js
@@ -269,15 +269,13 @@ function updatePackages() {
  *
  * 1. During CI, do a clean install.
  * 2. During local development, do an incremental install if necessary.
- * 3. Since install scripts can be async, `await` the process object.
- * 4. Since script output is noisy, capture and print the stderr if needed.
- * 5. During CI, if not skipped, ensure package files were correctly updated.
+ * 3. Since script output is noisy, capture and print the stderr if needed.
+ * 4. During CI, if not skipped, ensure package files were correctly updated.
  *
  * @param {string} dir
  * @param {boolean=} skipNpmChecks
- * @return {Promise<void>}
  */
-async function updateSubpackages(dir, skipNpmChecks = false) {
+function updateSubpackages(dir, skipNpmChecks = false) {
   const results = checkDependencies.sync({packageDir: dir});
   const relativeDir = path.relative(process.cwd(), dir);
   if (results.depsWereOk) {
@@ -286,7 +284,7 @@ async function updateSubpackages(dir, skipNpmChecks = false) {
   } else {
     const installCmd = isCiBuild() ? 'npm ci' : 'npm install';
     log('Running', cyan(installCmd), 'in', cyan(relativeDir) + '...');
-    const output = await getOutput(`${installCmd} --prefix ${dir}`);
+    const output = getOutput(`${installCmd} --prefix ${dir}`);
     if (output.status !== 0) {
       log(red('ERROR:'), output.stderr);
       throw new Error('Installation failed');

--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -76,32 +76,36 @@ function startAtRepoRoot() {
 }
 
 /**
- * Updates task-specific subpackages if there are any.
- * @param {string} taskSourceFilePath
- * @return {Promise<void>}
+ * 1. Updates root-level packages during local development. (Skipped during CI
+ *    because they're guaranteed to be fresh.)
+ * 2. Updates task-level subpackages if a package.json file exists in the task
+ *    directory.
+ * @param {string} taskSourceFileName
  */
-async function maybeUpdateSubpackages(taskSourceFilePath) {
+function ensureUpdatedPackages(taskSourceFileName) {
+  if (!isCiBuild()) {
+    updatePackages();
+  }
+  const taskSourceFilePath = getTaskSourceFilePath(taskSourceFileName);
   const packageFile = path.join(taskSourceFilePath, 'package.json');
-  const hasSubpackages = await fs.pathExists(packageFile);
+  const hasSubpackages = fs.pathExistsSync(packageFile);
   if (hasSubpackages) {
-    await updateSubpackages(taskSourceFilePath);
+    updateSubpackages(taskSourceFilePath);
   }
 }
 
 /**
  * Runs an AMP task with logging and timing after installing its subpackages.
  * @param {string} taskName
- * @param {string} taskSourceFileName
  * @param {TaskFuncDef} taskFunc
  * @return {Promise<void>}
  */
-async function runTask(taskName, taskSourceFileName, taskFunc) {
+async function runTask(taskName, taskFunc) {
   const taskFile = path.relative(os.homedir(), 'amp.js');
   log('Using task file', magenta(taskFile));
   const start = Date.now();
   try {
     log(`Starting '${cyan(taskName)}'...`);
-    await maybeUpdateSubpackages(getTaskSourceFilePath(taskSourceFileName));
     await taskFunc();
     log('Finished', `'${cyan(taskName)}'`, 'after', magenta(getTime(start)));
   } catch (err) {
@@ -183,8 +187,6 @@ function createTask(
   const isInvokedTask = argv._.includes(taskName); // `amp <task>`
   const isDefaultTask =
     argv._.length === 0 && taskName == 'default' && !isHelpTask; // `amp`
-  const isTaskLevelHelp =
-    (isInvokedTask || isDefaultTask) && argv.hasOwnProperty('help'); // `amp <task> --help`
 
   if (isHelpTask) {
     const taskFunc = getTaskFunc(taskSourceFileName, taskFuncName);
@@ -193,9 +195,7 @@ function createTask(
   }
   if (isInvokedTask || isDefaultTask) {
     startAtRepoRoot();
-    if (!isTaskLevelHelp && !isCiBuild()) {
-      updatePackages();
-    }
+    ensureUpdatedPackages(taskSourceFileName);
     const taskFunc = getTaskFunc(taskSourceFileName, taskFuncName);
     const task = commander.command(taskName, {isDefault: isDefaultTask});
     task.description(green(taskFunc.description));
@@ -207,7 +207,7 @@ function createTask(
     }
     task.action(async () => {
       validateUsage(task, taskName, taskFunc);
-      await runTask(taskName, taskSourceFileName, taskFunc);
+      await runTask(taskName, taskFunc);
     });
   }
 }

--- a/build-system/tasks/check-build-system.js
+++ b/build-system/tasks/check-build-system.js
@@ -22,13 +22,13 @@ const {updateSubpackages} = require('../common/update-packages');
 
 /**
  * Helper that updates build-system subpackages so their types can be verified.
- * Skips NPM checks during CI (already done while running each task).
+ * Skips npm checks during CI (already done while running each task).
  */
-async function updateBuildSystemSubpackages() {
+function updateBuildSystemSubpackages() {
   const packageFiles = globby.sync('build-system/tasks/*/package.json');
   for (const packageFile of packageFiles) {
     const packageDir = path.dirname(packageFile);
-    await updateSubpackages(packageDir, /* skipNpmChecks */ true);
+    updateSubpackages(packageDir, /* skipNpmChecks */ true);
   }
 }
 
@@ -36,8 +36,8 @@ async function updateBuildSystemSubpackages() {
  * Performs type checking on the /build-system directory using TypeScript.
  * Configuration is defined in /build-system/tsconfig.json.
  */
-async function checkBuildSystem() {
-  await updateBuildSystemSubpackages();
+function checkBuildSystem() {
+  updateBuildSystemSubpackages();
   log('Checking types in', cyan('build-system') + '...');
   execOrThrow(
     'npx -p typescript tsc --project ./build-system/tsconfig.json',


### PR DESCRIPTION
**Background:**

In #33452, we introduced automatic subpackage installation for `amp` tasks (see #33141). It turns out we're still loading task code before installation can happen. This can break during first run if a task does not lazy-require its packages. See [example failure logs](https://app.circleci.com/pipelines/github/ampproject/amphtml/10381/workflows/5567fe9e-9c11-4d42-b51e-77f694c8510d/jobs/162101).

**PR Highlights:**
- Perform subpackage installation in `amp-task-runner.js` before task code can be loaded
- Fix incorrect assumption that `updateSubpackages()` is async (it uses the synchronous `spawnSync()` under the covers)
- Update call-sites where `await` is no longer needed

With this, there's no need for tasks to lazy-require their packages (unless it's for performance considerations).

**Screenshots:**

**Before:**

![image](https://user-images.githubusercontent.com/26553114/120537119-eba53580-c3b2-11eb-940c-88b7c4cae53f.png)

**After:**

![image](https://user-images.githubusercontent.com/26553114/120537169-f9f35180-c3b2-11eb-981d-0c5b9d85f520.png)


Prerequisite for #34653