### PR TITLE
🏗 Enable type-checking for `performance` and `get-zindex`

### DIFF
--- a/build-system/global.d.ts
+++ b/build-system/global.d.ts
@@ -21,12 +21,21 @@ declare global {
       install: Function;
     };
     AMP: Function[];
-    viewer?: {
+    viewer: {
       receivedMessages?: number;
     };
     __coverage__: any;
+    longTasks: PerformanceEntry[];
+    cumulativeLayoutShift: number;
+    largestContentfulPaint: number;
+    measureStarted: number;
   }
 
+  interface PerformanceEntry {
+    loadTime: number;
+    renderTime: number;
+    value: number;
+  }
   interface Error {
     status?: string;
   }

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -91,6 +91,7 @@ function createTable(filesData) {
     const entry = Array.isArray(filesData[filename])
       ? filesData[filename]
       : Object.entries(filesData[filename]).sort(sortedByEntryKey);
+    // @ts-ignore
     for (const [context, zIndex] of entry) {
       rows.push([`\`${context}\``, zIndex, `[${filename}](/${filename})`]);
     }

--- a/build-system/tasks/get-zindex/jscodeshift/collect-zindex.js
+++ b/build-system/tasks/get-zindex/jscodeshift/collect-zindex.js
@@ -17,8 +17,8 @@
 const zIndexRegExp = /^z-?index$/i;
 
 /**
- * @param {Node} node
- * @return {string}
+ * @param {*} node
+ * @return {string|undefined}
  */
 function getCallExpressionZIndexValue(node) {
   for (let i = 1; i < node.arguments.length; i++) {
@@ -35,8 +35,8 @@ function getCallExpressionZIndexValue(node) {
 }
 
 /**
- * @param {string} file
- * @param {Node} node
+ * @param {*} file
+ * @param {*} node
  * @return {string}
  */
 function source(file, node) {
@@ -45,8 +45,8 @@ function source(file, node) {
 }
 
 /**
- * @param {string} file
- * @param {string} path
+ * @param {*} file
+ * @param {*} path
  * @return {string}
  */
 function chainId(file, path) {

--- a/build-system/tasks/performance/ads-handler.js
+++ b/build-system/tasks/performance/ads-handler.js
@@ -26,7 +26,6 @@ const EXAMPLE_AD_URL =
  * instead.
  * @param {!Array<function>} handlersList
  * @param {string} version
- * @return {boolean}
  */
 function setupAdRequestHandler(handlersList, version) {
   handlersList.push((interceptedRequest) => {

--- a/build-system/tasks/performance/analytics-handler.js
+++ b/build-system/tasks/performance/analytics-handler.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const puppeteer = require('puppeteer'); // eslint-disable-line no-unused-vars
+
 /**
  *
  * @param {!Array<function>} handlersList
@@ -80,7 +82,7 @@ function setupAnalyticsHandler(handlersList, handlerOptions, resolve) {
  * Matches intercepted request with special analytics parameter
  * and records first outgoing analytics request, using callback.
  * Abort all requests, to not ping real servers.
- * @param {Request} interceptedRequest
+ * @param {puppeteer.HTTPRequest} interceptedRequest
  * @param {string} analyticsParam
  * @param {!Function} requestCallback
  * @return {!Promise<boolean>}

--- a/build-system/tasks/performance/copy-images.js
+++ b/build-system/tasks/performance/copy-images.js
@@ -16,6 +16,7 @@
 
 const fs = require('fs');
 const {CONTROL, maybeCopyImageToCache, urlToCachePath} = require('./helpers');
+const {JSDOM} = require('jsdom');
 
 /**
  * Lookup URL from cache. Inspect tags that could use images.
@@ -26,7 +27,6 @@ const {CONTROL, maybeCopyImageToCache, urlToCachePath} = require('./helpers');
 async function copyImagesFromTags(url) {
   const cachePath = urlToCachePath(url, CONTROL);
   const document = fs.readFileSync(cachePath);
-  const {JSDOM} = await import('jsdom'); // Lazy-imported to speed up task loading.
   const dom = new JSDOM(document);
 
   copyImagesFromAmpImg(url, dom);
@@ -37,7 +37,7 @@ async function copyImagesFromTags(url) {
  * Copy locally stored images found in the amp-img tags
  * from src and srcset to cache.
  *
- * @param {url} url
+ * @param {string} url
  * @param {JSDOM} dom
  */
 function copyImagesFromAmpImg(url, dom) {
@@ -61,7 +61,7 @@ function copyImagesFromAmpImg(url, dom) {
  * Copy locally stored images found in the amp-video tags
  * from artwork to cache.
  *
- * @param {url} url
+ * @param {string} url
  * @param {JSDOM} dom
  */
 function copyImagesFromAmpVideo(url, dom) {

--- a/build-system/tasks/performance/helpers.js
+++ b/build-system/tasks/performance/helpers.js
@@ -142,7 +142,7 @@ function maybeCopyImageToCache(configUrl, src) {
 
   touchDirs();
 
-  const filename = src.split('/').pop();
+  const filename = src.split('/').pop() ?? '';
   const destPath = path.join(IMG_CACHE_PATH, filename);
 
   if (!fs.existsSync(destPath)) {

--- a/build-system/tasks/performance/index.js
+++ b/build-system/tasks/performance/index.js
@@ -22,20 +22,22 @@ const loadConfig = require('./load-config');
 const rewriteAnalyticsTags = require('./rewrite-analytics-tags');
 const rewriteScriptTags = require('./rewrite-script-tags');
 const runTests = require('./run-tests');
+const {css} = require('../css');
 const {printReport} = require('./print-report');
 
 /**
- * @return {!Promise}
+ * @return {!Promise<void>}
  */
 async function performance() {
-  let resolver;
+  let resolver = (..._) => {}; // eslint-disable-line no-unused-vars
   const deferred = new Promise((resolverIn) => {
     resolver = resolverIn;
   });
 
-  const config = new loadConfig();
+  const config = loadConfig();
   const urls = Object.keys(config.urlToHandlers);
   const urlsAndAdsUrls = urls.concat(config.adsUrls || []);
+  await css();
   await cacheDocuments(urlsAndAdsUrls);
   await compileScripts(urlsAndAdsUrls);
   await copyLocalImages(urlsAndAdsUrls);

--- a/build-system/tasks/performance/load-config.js
+++ b/build-system/tasks/performance/load-config.js
@@ -33,7 +33,7 @@ const PATH = './config.json';
  */
 function loadConfig() {
   const file = fs.readFileSync(path.join(__dirname, PATH));
-  const config = JSON.parse(file);
+  const config = JSON.parse(file.toString());
   // Create mapping of url to handlers for ease of use later
   config.urlToHandlers = config.handlers.reduce((mapping, handlerOptions) => {
     if (argv.url && handlerOptions.handlerName === 'defaultHandler') {
@@ -41,7 +41,7 @@ function loadConfig() {
     }
     handlerOptions.urls.forEach((url) => {
       if (mapping[url]) {
-        throw new Error('All urls must be unique: %s.', url);
+        throw new Error(`All urls must be unique: ${url}.`);
       }
       mapping[url] = handlerOptions;
     });

--- a/build-system/tasks/performance/measure-documents.js
+++ b/build-system/tasks/performance/measure-documents.js
@@ -15,7 +15,8 @@
  */
 
 const argv = require('minimist')(process.argv.slice(2));
-const fs = require('fs');
+const fs = require('fs-extra');
+const puppeteer = require('puppeteer');
 const {
   CDN_URL,
   CONTROL,
@@ -35,23 +36,13 @@ const {cyan, green} = require('../../common/colors');
 const {log} = require('../../common/logging');
 const {setupAdRequestHandler} = require('./ads-handler');
 
-// Require Puppeteer dynamically to prevent throwing error during CI
-let puppeteer;
-
-/**
- * Lazy-requires the puppeteer module.
- */
-function requirePuppeteer_() {
-  puppeteer = require('puppeteer');
-}
-
 /**
  * Setup measurement on page before navigating to the URL. Performance
  * observers need to be initialized before content begins to load to take
  * measurements.
  *
- * @param {puppeteer.page} page
- * @return {Promise} Resolves when script is evaluated
+ * @param {puppeteer.Page} page
+ * @return {Promise<void>} Resolves when script is evaluated
  */
 const setupMeasurement = (page) =>
   page.evaluateOnNewDocument(() => {
@@ -88,7 +79,7 @@ const setupMeasurement = (page) =>
 /**
  * Intecepts requests for default extensions made by runtime and returns a
  * cached version.
- * @param {Request} interceptedRequest
+ * @param {puppeteer.HTTPRequest} interceptedRequest
  * @param {string} version
  * @return {!Promise<boolean>}
  */
@@ -138,7 +129,7 @@ function setupDelayBasedOnHandlerOptions(handlerOptions) {
 /**
  * Evaluate script on the page to collect and calculate metrics
  *
- * @param {Puppeteer.page} page
+ * @param {puppeteer.Page} page
  * @return {Promise<object>} Resolves with page load metrics
  */
 const readMetrics = (page) =>
@@ -148,7 +139,7 @@ const readMetrics = (page) =>
     /**
      *
      * @param {string} name
-     * @return {nuber}
+     * @return {number}
      */
     function getMetric(name) {
       const entry = entries.find((entry) => entry.name === name);
@@ -202,7 +193,7 @@ function setupDefaultHandlers(handlersList, version) {
  *
  * @param {!Array<function>} handlersList
  * @param {?Object} handlerOptions
- * @param {!Puppeteer.page} page
+ * @param {!puppeteer.Page} page
  * @param {!function} resolve
  * @param {string} version
  */
@@ -234,7 +225,7 @@ async function setupAdditionalHandlers(
  * handlers respond/abort the request.
  *
  * @param {!Array<function>} handlersList
- * @param {Puppeteer.page} page
+ * @param {puppeteer.Page} page
  */
 function startRequestListener(handlersList, page) {
   page.on('request', async (interceptedRequest) => {
@@ -253,7 +244,7 @@ function startRequestListener(handlersList, page) {
  * Return metrics based on handler
  *
  * @param {?Object} handlerOptions
- * @param {Puppeteer.page} page
+ * @param {puppeteer.Page} page
  * @return {!Promise<!Object>}
  */
 async function addHandlerMetric(handlerOptions, page) {
@@ -278,7 +269,7 @@ function writeMetrics(url, version, metrics) {
   let results = {};
 
   if (fs.existsSync(RESULTS_PATH)) {
-    results = JSON.parse(fs.readFileSync(RESULTS_PATH));
+    results = fs.readJson(RESULTS_PATH);
   }
 
   if (!results[url]) {
@@ -297,7 +288,7 @@ function writeMetrics(url, version, metrics) {
  * @param {string} url
  * @param {string} version "control" or "experiment"
  * @param {!Object} config
- * @return {Promise}
+ * @return {Promise<void>}
  */
 async function measureDocument(url, version, config) {
   const browser = await puppeteer.launch({
@@ -349,11 +340,9 @@ async function measureDocument(url, version, config) {
  *
  * @param {!Array<string>} urls
  * @param {!Object} config
- * @return {Promise} Fulfills when all URLs have been measured
+ * @return {Promise<void>} Fulfills when all URLs have been measured
  */
 async function measureDocuments(urls, config) {
-  requirePuppeteer_();
-
   try {
     fs.unlinkSync(RESULTS_PATH);
   } catch {} // file does not exist (first run)

--- a/build-system/tasks/performance/rewrite-analytics-tags.js
+++ b/build-system/tasks/performance/rewrite-analytics-tags.js
@@ -93,7 +93,7 @@ async function alterAnalyticsTags(url, version, extraUrlParams) {
  * Rewrite analytics configs for each document
  * downloaded from the analytics or ads handler urls
  * @param {?Object} handlers
- * @return {Promise}
+ * @return {Promise<void[]>}
  */
 async function rewriteAnalyticsConfig(handlers) {
   const handlerPromises = [];

--- a/build-system/tasks/performance/rewrite-script-tags.js
+++ b/build-system/tasks/performance/rewrite-script-tags.js
@@ -92,7 +92,7 @@ async function useRemoteScripts(url) {
 /**
  * Download default extensions that are not explicility stated by script tags in
  * the HTML.
- * @return {Promise}
+ * @return {Promise<string[]>}
  */
 async function downloadDefaultExtensions() {
   return Promise.all(
@@ -108,7 +108,7 @@ async function downloadDefaultExtensions() {
  * Rewrite script tags for each document downloaded from the urls
  *
  * @param {!Array<string>} urls
- * @return {Promise}
+ * @return {Promise<void[]>}
  */
 async function rewriteScriptTags(urls) {
   await downloadDefaultExtensions();

--- a/build-system/tasks/performance/test-suite.js
+++ b/build-system/tasks/performance/test-suite.js
@@ -22,7 +22,7 @@ const {getReport} = require('./print-report');
 const DEFAULT_THRESHOLD = 1.05;
 const THRESHOLD = argv.threshold ? argv.threshold + 1 : DEFAULT_THRESHOLD;
 
-const {urlToHandlers} = new loadConfig();
+const {urlToHandlers} = loadConfig();
 const reports = getReport(Object.keys(urlToHandlers));
 
 reports.forEach((report) => {

--- a/build-system/test-configs/jscodeshift/index.js
+++ b/build-system/test-configs/jscodeshift/index.js
@@ -34,10 +34,10 @@ const jscodeshift = (args = [], opts) => getOutput(command(args), opts);
 
 /**
  * @param {Array<string>} args
- * @param {Object} opts
+ * @param {Object=} opts
  * @return {ReturnType<execScriptAsync>}
  */
-const jscodeshiftAsync = (args = [], opts) =>
+const jscodeshiftAsync = (args = [], opts = {}) =>
   execScriptAsync(command(args), opts);
 
 const stripColors = (str) => str.replace(/\x1B[[(?);]{0,2}(;?\d)*./g, '');

--- a/build-system/tsconfig.json
+++ b/build-system/tsconfig.json
@@ -23,17 +23,13 @@
   "files": ["./global.d.ts"],
   "include": ["./**/*.js"],
   "exclude": [
-    // Directories that do not need type-checking.
     "./**/node_modules/**",
     "./**/test/**/*.js",
-    "./**/*.test.js",
+    "./**/*test*.js",
     "./babel-plugins/**/*.js",
     "./eslint-rules/**/*.js",
     "./externs/**/*.js",
     "./tasks/make-extension/template/**/*.js",
-    "./tasks/performance/cache/**/*.js",
-
-    // Directories that need code fixes before type-checking can be enabled.
-    "./tasks/get-zindex/**/*.js"
+    "./tasks/performance/cache/**/*.js"
   ]
 }

--- a/build-system/tsconfig.json
+++ b/build-system/tsconfig.json
@@ -31,9 +31,9 @@
     "./eslint-rules/**/*.js",
     "./externs/**/*.js",
     "./tasks/make-extension/template/**/*.js",
+    "./tasks/performance/cache/**/*.js",
 
     // Directories that need code fixes before type-checking can be enabled.
-    "./tasks/get-zindex/**/*.js",
-    "./tasks/performance/**/*.js"
+    "./tasks/get-zindex/**/*.js"
   ]
 }


### PR DESCRIPTION
**PR Highlights:**
- Enable type-checking for `build-system/tasks/performance/`
- Enable type-checking for `build-system/tasks/get-zindex`
- Convert lazy requires to regular requires (okay because subpackage deps are now auto-installed)
- Add a few typedefs, fix a few type errors

With this, there are zero pending directories for which type-checking needs to be enabled.

**Future work:**
- Reintroduce performance tests to CI. See https://github.com/ampproject/amphtml/issues/12128#issuecomment-701669210. /cc @erwinmombay 

Fixes #28387
