### PR TITLE
🏗 Switch name of renovate bot for owners check

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -40,7 +40,7 @@
     },
     {
       pattern: '**/package{,-lock}.json',
-      owners: [{name: 'renovate-bot'}],
+      owners: [{name: 'renovate[bot]'}],
     },
     {
       pattern: '**/OWNERS',

--- a/OWNERS
+++ b/OWNERS
@@ -40,7 +40,7 @@
     },
     {
       pattern: '**/package{,-lock}.json',
-      owners: [{name: 'renovate[bot]'}],
+      owners: [{name: 'renovate'}],
     },
     {
       pattern: '**/OWNERS',


### PR DESCRIPTION
In order to get auto-submit working for low-risk package upgrades, we're switching from the `forking-renovate` app (creates PRs from a fork) to the `renovate` app (creates PRs on the main repo).

Since the new app uses a slightly different committer ID, we need an owners config change.

**Example:**

**PR:** https://github.com/ampproject/amphtml/pull/34673
**Owners check run:** https://github.com/ampproject/amphtml/pull/34673/checks?check_run_id=2737953772
**Commit info:** https://github.com/ampproject/amphtml/pull/34673/commits

Partial fix for #33959