### PR TITLE
🏗 Update instructions to resolve breaking changes during package upgrades

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -13,7 +13,7 @@
     "<details>",
     "<summary>How to resolve breaking changes</summary>",
     "This PR may introduce breaking changes that require manual intervention. In such cases, you will need to check out this branch, fix the cause of the breakage, and commit the fix to ensure a green CI build. To check out and update this PR, follow the steps below:",
-    "```sh\n# Check out the PR branch (these steps are from GitHub)\ngit checkout -b renovate-bot-{{{branchName}}} main\ngit pull https://github.com/renovate-bot/amphtml.git {{{branchName}}}\n\n# Directly make fixes and commit them\namp lint --fix # For lint errors in JS files\namp prettify --fix # For prettier errors in non-JS files\n# Edit source code in case of new compiler warnings / errors\n\n# Push the changes to the branch\ngit push git@github.com:renovate-bot/amphtml.git renovate-bot-{{{branchName}}}:{{{branchName}}}\n```",
+    "```sh\n# Check out the PR branch\ngit checkout -b {{{branchName}}} main\ngit pull https://github.com/ampproject/amphtml.git {{{branchName}}}\n\n# Directly make fixes and commit them\namp lint --fix # For lint errors in JS files\namp prettify --fix # For prettier errors in non-JS files\n# Edit source code in case of new compiler warnings / errors\n\n# Push the changes to the branch\ngit push git@github.com:ampproject/amphtml.git {{{branchName}}}:{{{branchName}}}\n```",
     "</details>"
   ],
   "packageRules": [


### PR DESCRIPTION
We just switched from the `forking-renovate` app (creates PRs from a fork) to the `renovate` app (creates PRs on the main repo).

This PR updates the instructions for resolving breaking changes. We no longer need the `renovate-bot-` prefix for the branch name, and PR branches are now created on `ampproject/amphtml`. I've verified that the new instructions work.
