### PR TITLE
🏗 Add `importAssertions` to jscodeshift parser config

### DIFF
--- a/build-system/test-configs/jscodeshift/parser-config.json
+++ b/build-system/test-configs/jscodeshift/parser-config.json
@@ -20,6 +20,7 @@
     "exportNamespaceFrom",
     "functionBind",
     "functionSent",
+    "importAssertions",
     "importMeta",
     "logicalAssignment",
     "nullishCoalescingOperator",


### PR DESCRIPTION
Required for parsing files that import JSON. I thought this was already present, but memory may be failing me.
