### PR TITLE
🚮 Sweep experiments older than 2020-11-29

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -7,7 +7,6 @@
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
   "dfp-render-on-idle-cwv-exp": 1,
-  "expand-json-targeting": 1,
   "flexAdSlots": 0.05,
   "flexible-bitrate": 0.1,
   "ios-fixed-no-transfer": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -6,7 +6,6 @@
   "adsense-ad-size-optimization": 1,
   "doubleclickSraExp": 0.01,
   "doubleclickSraReportExcludedBlock": 0.1,
-  "expand-json-targeting": 1,
   "flexAdSlots": 0.05,
   "flexible-bitrate": 0.1,
   "ios-fixed-no-transfer": 0,

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -170,11 +170,6 @@ export const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/27189',
   },
   {
-    id: 'expand-json-targeting',
-    name: 'Allow CLIENT_ID in doubleclick json targeting feature',
-    spec: 'https://github.com/ampproject/amphtml/issues/25190',
-  },
-  {
     id: 'auto-ads-layout-callback',
     name: 'Move ads placement into layoutCallback',
     spec: 'https://github.com/ampproject/amphtml/issues/27068',


### PR DESCRIPTION
Sweep experiments last flipped globally up to 2020-11-29:

- (2020-08-14, 77ced1de0) `expand-json-targeting`: 1
