### PR TITLE
Force inabox to use legacy ini load measurement

### DIFF
--- a/src/inabox/utils.js
+++ b/src/inabox/utils.js
@@ -16,7 +16,7 @@
 
 import {Services} from '../services';
 import {createCustomEvent} from '../event-helper.js';
-import {whenContentIniLoad} from '../ini-load';
+import {whenContentIniLoadMeasure} from '../ini-load';
 
 /**
  * Registers ini-load listener that will fire custom 'amp-ini-load' event
@@ -27,7 +27,7 @@ import {whenContentIniLoad} from '../ini-load';
 export function registerIniLoadListener(ampdoc) {
   const {win} = ampdoc;
   const root = ampdoc.getRootNode();
-  whenContentIniLoad(
+  whenContentIniLoadMeasure(
     ampdoc,
     win,
     Services.viewportForDoc(ampdoc).getLayoutRect(

--- a/src/ini-load.js
+++ b/src/ini-load.js
@@ -53,15 +53,13 @@ export function whenContentIniLoad(
 }
 
 /**
- * A legacy way using direct measurement.
+ * A legacy way using direct measurement. Used by inabox runtime.
  *
  * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
  * @param {!Window} hostWin
  * @param {!./layout-rect.LayoutRectDef} rect
  * @param {boolean=} opt_prerenderableOnly signifies if we are in prerender mode.
  * @return {!Promise}
- * @visibleForTesting
- * TODO(#31915): remove, once launched.
  */
 export function whenContentIniLoadMeasure(
   elementOrAmpDoc,

--- a/src/ini-load.js
+++ b/src/ini-load.js
@@ -53,7 +53,8 @@ export function whenContentIniLoad(
 }
 
 /**
- * A legacy way using direct measurement. Used by inabox runtime.
+ * A legacy way using direct measurement.
+ * Used by inabox runtime, and will be moved there after #31915.
  *
  * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc
  * @param {!Window} hostWin

--- a/test/unit/inabox/test-utils.js
+++ b/test/unit/inabox/test-utils.js
@@ -41,7 +41,7 @@ describes.realWin('inabox-utils', {}, (env) => {
     iniLoadDeferred = new Deferred();
 
     env.sandbox
-      .stub(IniLoad, 'whenContentIniLoad')
+      .stub(IniLoad, 'whenContentIniLoadMeasure')
       .returns(iniLoadDeferred.promise);
     env.sandbox
       .stub(Services, 'viewportForDoc')


### PR DESCRIPTION
Inabox runtime wants to keep using the legacy ini load measurement mechanism since the new one is causing some regressions there.