### PR TITLE
Use latest scripts when publishing Bento components

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -40,13 +40,13 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Get latest scripts
         run: |
-          wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/build-npm-binaries.js" -O build-npm-binaries.js
-          wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/write-package-files.js" -O write-package-files.js
+          wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/build-npm-binaries.js" -O ./build-system/npm-publish/build-npm-binaries.js
+          wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/write-package-files.js" -O ./build-system/npm-publish/write-package-files.js
       - name: Build package
         run: |
           npm install
-          node build-npm-binaries.js ${{ matrix.extension }}
-          node write-package-files.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
+          node ./build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
+          node ./build-system/npm-publish/write-package-files.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
       - name: Publish v1
         run: npm publish ./extensions/${{ matrix.extension }}/1.0 --access public --tag ${{ github.event.inputs.tag }}
         env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -38,11 +38,15 @@ jobs:
         with:
           check-latest: true
           registry-url: https://registry.npmjs.org
+      - name: Get latest scripts
+        run: |
+          wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/build-npm-binaries.js" -O build-npm-binaries.js
+          wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/write-package-files.js" -O write-package-files.js
       - name: Build package
         run: |
           npm install
-          node ./build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
-          node ./build-system/npm-publish/write-package-files.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
+          node build-npm-binaries.js ${{ matrix.extension }}
+          node write-package-files.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
       - name: Publish v1
         run: npm publish ./extensions/${{ matrix.extension }}/1.0 --access public --tag ${{ github.event.inputs.tag }}
         env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,7 +23,7 @@ jobs:
           EXTENSIONS=$(node ./build-system/npm-publish/get-extensions.js)
           echo "::set-output name=extensions::{\"include\":${EXTENSIONS}}"
   publish:
-    if: github.repository == 'estherkim/amphtml'
+    if: github.repository == 'ampproject/amphtml'
     environment: NPM_TOKEN #TODO: change environment name in repo settings
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,7 +23,7 @@ jobs:
           EXTENSIONS=$(node ./build-system/npm-publish/get-extensions.js)
           echo "::set-output name=extensions::{\"include\":${EXTENSIONS}}"
   publish:
-    if: github.repository == 'ampproject/amphtml'
+    if: github.repository == 'estherkim/amphtml'
     environment: NPM_TOKEN #TODO: change environment name in repo settings
     needs: setup
     runs-on: ubuntu-latest


### PR DESCRIPTION
This overwrites the Node scripts with latest, so that we don't have to wait for PRs with those changes to make a release cut.