### PR TITLE
🐛 Fixed broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,5 @@ AMP is an open source project, and we'd love your help making it better!
 
 -   [AMP's release documentation](docs/release-schedule.md) provides details on how and when AMP releases new versions, including [how to know when a change is live in a release](https://github.com/ampproject/amphtml/blob/main/docs/release-schedule.md#determining-if-your-change-is-in-a-release).
 -   [AMP's roadmap](https://amp.dev/community/roadmap) provides details on some of the significant projects we are working on.
--   The [AMP meta repository](https://github.com/ampproject/meta) has information _about_ the AMP open source project, including AMP's [governance](https://github.com/ampproject/meta/blob/main/docs/governance.md).
+-   The [AMP meta repository](https://github.com/ampproject/meta) has information _about_ the AMP open source project, including AMP's [governance](https://github.com/ampproject/meta/blob/main/GOVERNANCE.md).
 -   [AMP's code of conduct](https://github.com/ampproject/meta/blob/main/CODE_OF_CONDUCT.md) documents how all members, committers and volunteers in the community are required to act. AMP strives for a positive and growing project community that provides a safe environment for everyone.


### PR DESCRIPTION
Changed README link for AMP's Governance from https://github.com/ampproject/meta/blob/main/docs/governance.md to https://github.com/ampproject/meta/blob/main/GOVERNANCE.md

Fixes #34706
