### PR TITLE
🏗 Enable auto-merge for all devDependency upgrades that pass CI

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -10,6 +10,7 @@
   "dependencyDashboard": true,
   "prBodyColumns": ["Package", "Update", "Type", "Change", "Package file"],
   "prBodyNotes": [
+    "See all other Renovate PRs on the [Dependency Dashboard](https://github.com/ampproject/amphtml/issues/34671)",
     "<details>",
     "<summary>How to resolve breaking changes</summary>",
     "This PR may introduce breaking changes that require manual intervention. In such cases, you will need to check out this branch, fix the cause of the breakage, and commit the fix to ensure a green CI build. To check out and update this PR, follow the steps below:",
@@ -20,14 +21,12 @@
     {
       "groupName": "subpackage devDependencies",
       "matchPaths": ["**/*"],
-      "major": {"automerge": false, "assignAutomerge": false},
       "automerge": true,
       "assignAutomerge": true
     },
     {
       "groupName": "build-system devDependencies",
       "matchPaths": ["build-system/**"],
-      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra"],
       "automerge": true,
       "assignAutomerge": true
@@ -35,7 +34,6 @@
     {
       "groupName": "validator devDependencies",
       "matchPaths": ["validator/**"],
-      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: caching"],
       "automerge": true,
       "assignAutomerge": true
@@ -48,7 +46,6 @@
     {
       "groupName": "core devDependencies",
       "matchFiles": ["package.json"],
-      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra"],
       "automerge": true,
       "assignAutomerge": true
@@ -57,7 +54,6 @@
       "groupName": "linting devDependencies",
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\b(prettier|eslint)\\b"],
-      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra"],
       "automerge": true,
       "assignAutomerge": true
@@ -75,7 +71,6 @@
       "groupName": "esbuild devDependencies",
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\besbuild\\b"],
-      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra", "WG: performance"],
       "automerge": true,
       "assignAutomerge": true
@@ -85,7 +80,6 @@
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["devDependencies"],
-      "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: bento", "WG: components", "WG: performance"],
       "automerge": true,
       "assignAutomerge": true


### PR DESCRIPTION
**PR Highlights:**
- Add a link to all PRs pointing to the [dev dashboard](https://github.com/ampproject/amphtml/issues/34671)
- Enable auto-merge for all devDependency upgrades ([worked well](https://github.com/ampproject/amp-github-apps/pulls?q=is%3Apr+author%3Aapp%2Frenovate+sort%3Aupdated-desc+is%3Aclosed) for the `amp-github-apps` repo)

**Notes:**
- With this, we will see less noise from version upgrades
- Major version updates will still be tested in a separate group (default renovate behavior)
- Runtime dependencies will still need manual review / merge.
