### PR TITLE
✨Support conversion tracking in amp-ad-exit

### DIFF
--- a/examples/amp-ad-exit-conversion.html
+++ b/examples/amp-ad-exit-conversion.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html amp4ads>
+<head>
+  <title>amp-ad-exit example with conversion tracking</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp4ads-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+  <script async custom-element="amp-ad-exit" src="https://cdn.ampproject.org/v0/amp-ad-exit-0.1.js"></script>
+  <style amp-custom>
+    .ad {
+      border: 1px solid black;
+      width: 280px;
+      height: 230px;
+      background: #fff;
+    }
+  </style>
+</head>
+<body>
+  <h1>amp-ad-exit with conversion tracking</h1>
+  <div class="ad">
+    <h1 on="tap:exit-api.exit(target='landingPage')" role="button">CLICK ON ME!</h1>
+  </div>
+  <amp-ad-exit id="exit-api">
+    <script type="application/json">
+      {
+        "targets": {
+          "landingPage": {
+            "finalUrl": "https://example.com",
+            "behaviors": {
+              "browserAdConversion" : {
+                "attributiondestination": "https://example.com",
+                "attributionsourceeventid": "EFnZ8GunL1xrwNTIHbXrvQ==",
+                "attributionreportto": "https://google.com"
+              }
+            }
+          }
+        }
+      }
+    </script>
+  </amp-ad-exit>
+</body>
+</html>

--- a/examples/amp-ad-exit-conversion.html
+++ b/examples/amp-ad-exit-conversion.html
@@ -19,7 +19,7 @@
 <body>
   <h1>amp-ad-exit with conversion tracking</h1>
   <div class="ad">
-    <h1 on="tap:exit-api.exit(target='landingPage')" role="button">CLICK ON ME!</h1>
+    <h1 on="tap:exit-api.exit(target='landingPage')" role="button" tabindex="1">CLICK ON ME!</h1>
   </div>
   <amp-ad-exit id="exit-api">
     <script type="application/json">

--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -88,6 +88,7 @@ export function createSecureFrame(win, title, height, width) {
       dict({
         // NOTE: It is possible for either width or height to be 'auto',
         // a non-numeric value.
+        'allow': `attribution-reporting 'src'`,
         'height': height,
         'width': width,
         'title': title,

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -114,6 +114,7 @@ describes.realWin('amp-a4a: no signing', {amp: true}, (env) => {
       'allow-forms allow-popups allow-popups-to-escape-sandbox ' +
         'allow-same-origin allow-scripts allow-top-navigation'
     );
+    expect(fie.getAttribute('allow')).to.equal(`attribution-reporting 'src'`);
     const cspMeta = fie.contentDocument.querySelector(
       'meta[http-equiv=Content-Security-Policy]'
     );

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -441,18 +441,17 @@ export class AmpAdExit extends AMP.BaseElement {
    * @return {?string}
    */
   getAttributionReportingValues_(adConversionData) {
-    if (!adConversionData) {
+    if (!adConversionData || !Object.keys(adConversionData)) {
       return;
-    }
-
-    const parts = [];
-    for (const key of Object.keys(adConversionData)) {
-      parts.push(`${key.toLowerCase()}=${adConversionData[key]}`);
     }
 
     // `noopener` is probably redundant here but left as defense in depth.
     // https://groups.google.com/a/chromium.org/g/blink-dev/c/FFX6VkvladY/m/QgaWHK6ZBAAJ
-    return parts.length ? 'noopener,' + parts.join(',') : undefined;
+    const parts = ['noopener'];
+    for (const key of Object.keys(adConversionData)) {
+      parts.push(`${key.toLowerCase()}=${adConversionData[key]}`);
+    }
+    return parts.join(',');
   }
 
   /**

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -97,6 +97,10 @@ export class AmpAdExit extends AMP.BaseElement {
 
     /** @private @const {!Object<string,string>} */
     this.expectedOriginToVendor_ = {};
+
+    /** @private @const {boolean} */
+    this.isAttributionReportingSupported_ =
+      this.detectAttributionReportingSupport();
   }
 
   /**
@@ -148,6 +152,7 @@ export class AmpAdExit extends AMP.BaseElement {
         .forEach((url) => this.pingTrackingUrl_(url));
     }
     const finalUrl = substituteVariables(target.finalUrl);
+    // TODO(wg-monetization): clean up unused HostServices.
     if (HostServices.isAvailable(this.getAmpDoc())) {
       HostServices.exitForDoc(this.getAmpDoc())
         .then((exitService) => exitService.openUrl(finalUrl))
@@ -165,7 +170,7 @@ export class AmpAdExit extends AMP.BaseElement {
         target.behaviors.clickTarget == '_top'
           ? '_top'
           : '_blank';
-      openWindowDialog(this.win, finalUrl, clickTarget);
+      openWindowDialog(this.win, finalUrl, clickTarget, target.windowFeatures);
     }
   }
 
@@ -380,6 +385,14 @@ export class AmpAdExit extends AMP.BaseElement {
             .filter(Boolean),
           behaviors: target['behaviors'] || {},
         };
+
+        if (this.isAttributionReportingSupported_) {
+          this.targets_[name]['windowFeatures'] =
+            this.getAttributionReportingValues_(
+              target?.behaviors?.browserAdConversion
+            );
+        }
+
         // Build a map of {vendor, origin} for 3p custom variables in the config
         for (const customVar in target['vars']) {
           if (!target['vars'][customVar].iframeTransportSignal) {
@@ -407,6 +420,39 @@ export class AmpAdExit extends AMP.BaseElement {
     }
 
     this.init3pResponseListener_();
+  }
+
+  /**
+   * Determine if `attribution-reporting` is supported by user-agent. Should only return
+   * true for Chrome 92+.
+   * @visibleForTesting
+   * @return {boolean}
+   */
+  detectAttributionReportingSupport() {
+    return this.win.document.featurePolicy
+      ?.features()
+      .includes('attribution-reporting');
+  }
+
+  /**
+   * Extracts the keys from the `browserAdConversion` data creates a
+   * string to be used as the `features` param for the `window.open()` call.
+   * @param {JsonObject} adConversionData
+   * @return {?string}
+   */
+  getAttributionReportingValues_(adConversionData) {
+    if (!adConversionData) {
+      return;
+    }
+
+    const parts = [];
+    for (const key of Object.keys(adConversionData)) {
+      parts.push(`${key.toLowerCase()}=${adConversionData[key]}`);
+    }
+
+    // `noopener` is probably redundant here but left as defense in depth.
+    // https://groups.google.com/a/chromium.org/g/blink-dev/c/FFX6VkvladY/m/QgaWHK6ZBAAJ
+    return parts.length ? 'noopener,' + parts.join(',') : undefined;
   }
 
   /**

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -17,6 +17,7 @@
 import {AmpAdExit} from '../amp-ad-exit';
 import {FilterType} from '../filters/filter';
 import {IFRAME_TRANSPORTS} from '../../../amp-analytics/0.1/iframe-transport-vendors';
+import {expect} from 'chai';
 import {installPlatformService} from '../../../../src/service/platform-impl';
 import {installTimerService} from '../../../../src/service/timer-impl';
 import {setParentWindow} from '../../../../src/service';
@@ -359,6 +360,42 @@ describes.realWin(
       expect(open).to.have.been.calledWith(
         EXIT_CONFIG.targets.clickTargetTest.finalUrl,
         '_top'
+      );
+    });
+
+    it('should enable attribution tracking when given `browserAdConversion`', async () => {
+      env.sandbox
+        .stub(AmpAdExit.prototype, 'detectAttributionReportingSupport')
+        .returns(true);
+      const openStub = env.sandbox.stub(win, 'open').returns(win);
+      const config = {
+        targets: {
+          landingPage: {
+            finalUrl: 'https://example.com',
+            behaviors: {
+              browserAdConversion: {
+                attributiondestination: 'https://example.com',
+                attributionsourceeventid: 'EFnZ8GunL1xrwNTIHbXrvQ==',
+                attributionreportto: 'https://google.com',
+              },
+            },
+          },
+        },
+      };
+      const el = await makeElementWithConfig(config);
+      const impl = await el.getImpl();
+
+      impl.executeAction({
+        method: 'exit',
+        args: {target: 'landingPage'},
+        event: makeClickEvent(1001),
+        satisfiesTrust: () => true,
+      });
+
+      expect(openStub).calledWithExactly(
+        'https://example.com',
+        '_blank',
+        'noopener,attributiondestination=https://example.com,attributionsourceeventid=EFnZ8GunL1xrwNTIHbXrvQ==,attributionreportto=https://google.com'
       );
     });
 

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -17,7 +17,6 @@
 import {AmpAdExit} from '../amp-ad-exit';
 import {FilterType} from '../filters/filter';
 import {IFRAME_TRANSPORTS} from '../../../amp-analytics/0.1/iframe-transport-vendors';
-import {expect} from 'chai';
 import {installPlatformService} from '../../../../src/service/platform-impl';
 import {installTimerService} from '../../../../src/service/timer-impl';
 import {setParentWindow} from '../../../../src/service';


### PR DESCRIPTION
Opts in browsers where 
```js
// Should be chrome 92+ only.
document.featurePolicy.features().includes('attribution-reporting') == true
```

Manually verified that `the window.open()` call results in a new "Active Source" using `chrome://conversion-internals/`
Steps to repro:
1. Use chrome version >= 92
2. Enable `#experimental-web-platform-features` at `chrome://flags`
3. Click on `examples/amp-ad-exit-conversion`
4. See new entry at `chrome://conversion-internals/`

cc/ @jshamble
