### PR TITLE
🏗 Speculative fix for puppeteer disconnections

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -105,9 +105,6 @@ const SNAPSHOT_ERROR_SNIPPET = fs.readFileSync(
   'utf8'
 );
 
-// Browser instance that runs all visual tests.
-let browser_;
-
 /**
  * @typedef {{
  *  name: string,
@@ -245,14 +242,7 @@ async function launchBrowser(browserFetcher) {
     executablePath: browserFetcher.revisionInfo(PUPPETEER_CHROMIUM_REVISION)
       .executablePath,
   };
-
-  try {
-    browser_ = await puppeteer.launch(browserOptions);
-  } catch (error) {
-    log('fatal', error);
-  }
-
-  return browser_;
+  return await puppeteer.launch(browserOptions);
 }
 
 /**


### PR DESCRIPTION
Puppeteer is frequently stalling / complaining about a browser disconnection during visual tests.

![image](https://user-images.githubusercontent.com/26553114/120865831-c3593a80-c55c-11eb-9c5b-dc53932c7085.png)


**Example builds:** [1](https://app.circleci.com/pipelines/github/ampproject/amphtml/10653/workflows/88ff5e62-c953-43f4-92b9-0c559f57b9e4/jobs/166860), [2](https://app.circleci.com/pipelines/github/ampproject/amphtml/10619/workflows/e7469b42-a362-42cf-8290-550ad1c0aef7/jobs/166269), [3](https://app.circleci.com/pipelines/github/ampproject/amphtml/10635/workflows/8a6991c2-8e7b-4dec-9420-df8e768f2475/jobs/166619)

The root cause is as yet unknown, but might be due to recent changes to puppeteer.

This PR is a speculative fix. Instead of using a global variable for the puppeteer instance, we directly `await` and return the result of `puppeteer.launch()`, as recommended by the "Usage" section of the dev docs at https://pptr.dev.

