### PR TITLE
🏗 Do not import task modules during `amp --help`

### DIFF
--- a/build-system/tasks/analytics-vendor-configs.js
+++ b/build-system/tasks/analytics-vendor-configs.js
@@ -92,4 +92,4 @@ module.exports = {
   analyticsVendorConfigs,
 };
 
-analyticsVendorConfigs.description = 'Compile analytics vendor configs to dist';
+analyticsVendorConfigs.description = 'Compile all analytics vendor configs';

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -44,8 +44,8 @@ module.exports = {
   ava,
 };
 
-ava.description = "Runs ava tests for AMP's tasks";
+ava.description = "Run ava tests for AMP's tasks";
 
 ava.flags = {
-  'watch': 'Watches for changes',
+  'watch': 'Watch for changes',
 };

--- a/build-system/tasks/babel-plugin-tests.js
+++ b/build-system/tasks/babel-plugin-tests.js
@@ -56,4 +56,4 @@ module.exports = {
 };
 
 babelPluginTests.description =
-  "Runs the Jest based tests for AMP's custom babel plugins.";
+  "Run the Jest based tests for AMP's custom babel plugins";

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -90,18 +90,18 @@ module.exports = {
 
 /* eslint "google-camelcase/google-camelcase": 0 */
 
-build.description = 'Builds the AMP library';
+build.description = 'Build the AMP library';
 build.flags = {
-  config: 'Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-  fortesting: 'Builds the AMP library for local testing',
-  extensions: 'Builds only the listed extensions.',
-  extensions_from: 'Builds only the extensions from the listed AMP(s).',
-  noextensions: 'Builds with no extensions.',
-  core_runtime_only: 'Builds only the core runtime.',
-  coverage: 'Adds code coverage instrumentation to JS files using istanbul.',
-  version_override: 'Overrides the version written to AMP_CONFIG',
-  watch: 'Watches for changes in files, re-builds when detected',
+  config: 'Set the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  fortesting: 'Build the AMP library for local testing',
+  extensions: 'Build only the listed extensions',
+  extensions_from: 'Build only the extensions from the listed AMP(s)',
+  noextensions: 'Build with no extensions',
+  core_runtime_only: 'Build only the core runtime',
+  coverage: 'Add code coverage instrumentation to JS files using istanbul',
+  version_override: 'Override the version written to AMP_CONFIG',
+  watch: 'Watch for changes in files, re-builds when detected',
   esm: 'Do not transpile down to ES5',
   define_experiment_constant:
-    'Builds runtime with the EXPERIMENT constant set to true',
+    'Build runtime with the EXPERIMENT constant set to true',
 };

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -276,13 +276,12 @@ module.exports = {
 };
 
 bundleSize.description =
-  'Checks if the minified AMP binary has exceeded its size cap';
+  'Check if minified AMP binaries have exceeded their size caps';
 bundleSize.flags = {
   'on_push_build':
     'Store bundle sizes in the AMP build artifacts repo for main branch builds',
   'on_pr_build': 'Report the bundle sizes for this pull request to GitHub',
   'on_skipped_build':
-    "Set the status of this pull request's bundle " +
-    'size check in GitHub to `skipped`',
-  'on_local_build': 'Compute bundle sizes for the locally built runtime',
+    "Set the status of a PR's bundle size check in GitHub to skipped",
+  'on_local_build': 'Compute bundle sizes for the locally built AMP binaries',
 };

--- a/build-system/tasks/caches-json.js
+++ b/build-system/tasks/caches-json.js
@@ -53,4 +53,4 @@ module.exports = {
   cachesJson,
 };
 
-cachesJson.description = 'Check that caches.json contains all expected caches.';
+cachesJson.description = 'Check that caches.json contains all expected caches';

--- a/build-system/tasks/check-analytics-vendors-list.js
+++ b/build-system/tasks/check-analytics-vendors-list.js
@@ -98,8 +98,9 @@ module.exports = {
   checkAnalyticsVendorsList,
 };
 
-checkAnalyticsVendorsList.description = `Checks or updates list on ${filepath}`;
+checkAnalyticsVendorsList.description =
+  'Check the list of vendors in analytics-vendors-list.md';
 
 checkAnalyticsVendorsList.flags = {
-  'fix': 'Write to file',
+  'fix': 'Update the list and write results to file',
 };

--- a/build-system/tasks/check-asserts.js
+++ b/build-system/tasks/check-asserts.js
@@ -84,4 +84,4 @@ module.exports = {
 };
 
 checkAsserts.description =
-  "Checks amp.js and v0.js to validate that assertions are DCE'd correctly";
+  "Check amp.js and v0.js to validate that assertions are DCE'd correctly";

--- a/build-system/tasks/check-build-system.js
+++ b/build-system/tasks/check-build-system.js
@@ -47,7 +47,7 @@ function checkBuildSystem() {
 }
 
 checkBuildSystem.description =
-  'Check source code in build-system/ for JS type errors.';
+  'Check source code in build-system/ for JS type errors';
 
 module.exports = {
   checkBuildSystem,

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -77,4 +77,4 @@ module.exports = {
 };
 
 checkExactVersions.description =
-  'Checks that all package.json files in the repo use exact versions.';
+  'Check all package.json files in the repo to make sure they use exact versions';

--- a/build-system/tasks/check-invalid-whitespaces.js
+++ b/build-system/tasks/check-invalid-whitespaces.js
@@ -59,10 +59,10 @@ function checkInvalidWhitespaces() {
 }
 
 checkInvalidWhitespaces.description =
-  'Checks different types of files for invalid whitespaces.';
+  'Check multiple types of non-JS source files for invalid whitespaces';
 checkInvalidWhitespaces.flags = {
-  'files': 'Checks just the specified files',
-  'local_changes': 'Checks just the files changed in the local branch',
+  'files': 'Check just the specified files',
+  'local_changes': 'Check just the files changed in the local branch',
 };
 
 module.exports = {

--- a/build-system/tasks/check-links.js
+++ b/build-system/tasks/check-links.js
@@ -177,8 +177,8 @@ module.exports = {
   checkLinks,
 };
 
-checkLinks.description = 'Detects dead links in markdown files';
+checkLinks.description = 'Check markdown files for dead links';
 checkLinks.flags = {
-  'files': 'Checks only the specified files',
-  'local_changes': 'Checks just the files changed in the local branch',
+  'files': 'Check only the specified files',
+  'local_changes': 'Check just the files changed in the local branch',
 };

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -112,8 +112,8 @@ module.exports = {
   checkOwners,
 };
 
-checkOwners.description = 'Checks all OWNERS files in the repo for correctness';
+checkOwners.description = 'Check all OWNERS files in the repo for correctness';
 checkOwners.flags = {
-  'files': 'Checks only the specified OWNERS files',
-  'local_changes': 'Checks just the OWNERS files changed in the local branch',
+  'files': 'Check only the specified OWNERS files',
+  'local_changes': 'Check just the OWNERS files changed in the local branch',
 };

--- a/build-system/tasks/check-renovate-config.js
+++ b/build-system/tasks/check-renovate-config.js
@@ -101,4 +101,4 @@ module.exports = {
 };
 
 checkRenovateConfig.description =
-  'Checks the Renovate config file for correctness';
+  'Check the Renovate config file for correctness';

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -186,7 +186,7 @@ module.exports = {
 };
 
 checkSourcemaps.description =
-  'Checks sourcemaps generated during minified compilation for correctness.';
+  'Check sourcemaps generated during minified compilation for correctness';
 checkSourcemaps.flags = {
-  'nobuild': 'Skips building the runtime (checks previously built code)',
+  'nobuild': 'Skip building the runtime (checks previously built code)',
 };

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -334,12 +334,11 @@ module.exports = {
 };
 
 /* eslint "google-camelcase/google-camelcase": 0 */
-
 checkTypes.description = 'Check source code for JS type errors';
 checkTypes.flags = {
-  closure_concurrency: 'Sets the number of concurrent invocations of closure',
-  debug: 'Outputs the file contents during compilation lifecycles',
+  closure_concurrency: 'Set the number of concurrent invocations of closure',
+  debug: 'Output the file contents during compilation lifecycles',
   targets: 'Comma-delimited list of targets to type-check',
   warning_level:
-    "Optionally sets closure's warning level to one of [quiet, default, verbose]",
+    "Optionally set closure's warning level to one of [quiet, default, verbose]",
 };

--- a/build-system/tasks/check-video-interface-list.js
+++ b/build-system/tasks/check-video-interface-list.js
@@ -80,8 +80,9 @@ module.exports = {
   checkVideoInterfaceList,
 };
 
-checkVideoInterfaceList.description = `Checks or updates 3rd party video player list on ${filepath}`;
+checkVideoInterfaceList.description =
+  'Check 3rd party video player list in amp-video-interface.md';
 
 checkVideoInterfaceList.flags = {
-  'fix': 'Write to file',
+  'fix': 'Update the list and write results to file',
 };

--- a/build-system/tasks/cherry-pick.js
+++ b/build-system/tasks/cherry-pick.js
@@ -136,10 +136,10 @@ async function cherryPick() {
 
 module.exports = {cherryPick};
 
-cherryPick.description = 'Cherry-picks one or more commits onto a new branch';
+cherryPick.description = 'Cherry-pick one or more commits onto a new branch';
 cherryPick.flags = {
   'commits': 'Comma-delimited list of commit SHAs to cherry-pick',
-  'push': 'If set, will push the created branch to the remote',
-  'remote': 'Remote to refresh tags from (default: origin)',
+  'push': 'If set, push the created branch to the remote',
+  'remote': 'Remote ref to refresh tags from (default: origin)',
   'onto': '13-digit AMP version to cherry-pick onto',
 };

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -83,10 +83,9 @@ module.exports = {
   clean,
 };
 
-clean.description = 'Cleans up various cache and output directories';
+clean.description = 'Clean up various cache and output directories';
 clean.flags = {
-  'dry_run': 'Does a dry run without actually deleting anything',
-  'include_subpackages':
-    'Also cleans up inner node_modules package directories',
-  'exclude': 'Comma separated list of directories to exclude from deletion',
+  'dry_run': 'Do a dry run without actually deleting anything',
+  'include_subpackages': 'Also clean up inner node_modules package directories',
+  'exclude': 'Comma-separated list of directories to exclude from deletion',
 };

--- a/build-system/tasks/codecov-upload.js
+++ b/build-system/tasks/codecov-upload.js
@@ -80,4 +80,4 @@ module.exports = {
 };
 
 codecovUpload.description =
-  'Uploads code coverage reports to codecov.io during CI builds.';
+  'Upload code coverage reports to codecov.io during CI';

--- a/build-system/tasks/compile-jison.js
+++ b/build-system/tasks/compile-jison.js
@@ -91,4 +91,5 @@ module.exports = {
   compileJison,
 };
 
-compileJison.description = 'Use jison to create parsers';
+compileJison.description =
+  'Precompile jison parsers for use during the main build';

--- a/build-system/tasks/coverage-map/index.js
+++ b/build-system/tasks/coverage-map/index.js
@@ -169,15 +169,15 @@ module.exports = {
 };
 
 coverageMap.description =
-  'Generates a code coverage heat map for v0.js via source map explorer';
+  'Generate a code-coverage heat map for v0.js via source map explorer';
 
 coverageMap.flags = {
   json: 'JSON output filename [default: out.json]',
   inputhtml: 'Input HTML file under "examples/" [default: everything.amp.html]',
   outputhtml: 'Output HTML file [default: out.html]',
-  nobuild: 'Skips dist build.',
+  nobuild: 'Skip building the runtime',
   port: 'Port number for AMP server [default: 8000]',
   file: 'Output file(s) relative to dist/. Accepts .js, .mjs, and wildcards. [default: v0.js]',
-  esm: 'Generate coverage in ESM mode. Triggers an extra HTML transformation.',
-  sxg: 'Generate in SxG mode. Triggers an extra HTML transformation.',
+  esm: 'Generate coverage in ESM mode (triggers an extra HTML transformation)',
+  sxg: 'Generate in SxG mode (triggers an extra HTML transformation)',
 };

--- a/build-system/tasks/css/index.js
+++ b/build-system/tasks/css/index.js
@@ -160,4 +160,4 @@ module.exports = {
   cssEntryPoints,
 };
 
-css.description = 'Recompile css to build directory';
+css.description = 'Compile all css files to the build directory';

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -63,27 +63,25 @@ module.exports = {
 /* eslint "google-camelcase/google-camelcase": 0 */
 
 defaultTask.description =
-  'Starts the dev server, lazily builds JS and extensions when requested, and watches them for changes';
+  'Start the dev server, lazily build JS when requested, and watch for changes';
 defaultTask.flags = {
-  compiled: 'Compiles and serves minified binaries',
+  compiled: 'Compile and serve minified binaries',
   pseudo_names:
-    'Compiles with readable names. ' +
-    'Great for profiling and debugging production code.',
+    'Compile with readable names (useful while profiling / debugging production code)',
   pretty_print:
-    'Outputs compiled code with whitespace. ' +
-    'Great for debugging production code.',
-  fortesting: 'Compiles production binaries for local testing',
-  noconfig: 'Compiles production binaries without applying AMP_CONFIG',
-  config: 'Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-  closure_concurrency: 'Sets the number of concurrent invocations of closure',
-  extensions: 'Pre-builds the given extensions, lazily builds the rest.',
+    'Output compiled code with whitespace (useful while profiling / debugging production code)',
+  fortesting: 'Compile production binaries for local testing',
+  noconfig: 'Compile production binaries without applying AMP_CONFIG',
+  config: 'Set the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  closure_concurrency: 'Set the number of concurrent invocations of closure',
+  extensions: 'Pre-build the given extensions, lazily builds the rest.',
   extensions_from:
-    'Pre-builds the extensions used by the provided example page.',
-  full_sourcemaps: 'Includes source code content in sourcemaps',
-  version_override: 'Overrides the version written to AMP_CONFIG',
-  host: 'Host to serve the project on. localhost by default.',
-  port: 'Port to serve the project on. 8000 by default.',
-  https: 'Use https server. http by default.',
+    'Pre-build the extensions used by the provided example page.',
+  full_sourcemaps: 'Include source code content in sourcemaps',
+  version_override: 'Override the version written to AMP_CONFIG',
+  host: 'Host to serve the project on [default: localhost]',
+  port: 'Port to serve the project on [default: 8000]',
+  https: 'Use https',
   define_experiment_constant:
-    'Builds runtime with the EXPERIMENT constant set to true',
+    'Build runtime with the EXPERIMENT constant set to true',
 };

--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -333,4 +333,4 @@ module.exports = {
   depCheck,
 };
 
-depCheck.description = 'Runs a dependency check on each module';
+depCheck.description = 'Run a dependency check on each module';

--- a/build-system/tasks/dev-dashboard-tests.js
+++ b/build-system/tasks/dev-dashboard-tests.js
@@ -55,4 +55,4 @@ module.exports = {
   devDashboardTests,
 };
 
-devDashboardTests.description = 'Runs all the dev dashboard tests';
+devDashboardTests.description = 'Run all the dev dashboard tests';

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -378,35 +378,33 @@ module.exports = {
 /* eslint "google-camelcase/google-camelcase": 0 */
 
 dist.description =
-  'Compiles AMP production binaries and applies AMP_CONFIG to runtime files';
+  'Compile AMP production binaries and apply AMP_CONFIG to runtime files';
 dist.flags = {
   pseudo_names:
-    'Compiles with readable names. ' +
-    'Great for profiling and debugging production code.',
+    'Compile with readable names (useful while profiling / debugging production code)',
   pretty_print:
-    'Outputs compiled code with whitespace. ' +
-    'Great for debugging production code.',
-  fortesting: 'Compiles production binaries for local testing',
-  noconfig: 'Compiles production binaries without applying AMP_CONFIG',
-  config: 'Sets the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
-  coverage: 'Instruments compiled code for collecting coverage information',
-  extensions: 'Builds only the listed extensions.',
-  extensions_from: 'Builds only the extensions from the listed AMP(s).',
-  noextensions: 'Builds with no extensions.',
-  core_runtime_only: 'Builds only the core runtime.',
-  full_sourcemaps: 'Includes source code content in sourcemaps',
-  sourcemap_url: 'Sets a custom sourcemap URL with placeholder {version}',
-  type: 'Points sourcemap to fetch files from the correct GitHub tag',
-  esm: 'Does not transpile down to ES5',
+    'Output compiled code with whitespace (useful while profiling / debugging production code)',
+  fortesting: 'Compile production binaries for local testing',
+  noconfig: 'Compile production binaries without applying AMP_CONFIG',
+  config: 'Set the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
+  coverage: 'Instrument compiled code for collecting coverage information',
+  extensions: 'Build only the listed extensions',
+  extensions_from: 'Build only the extensions from the listed AMP(s)',
+  noextensions: 'Build with no extensions',
+  core_runtime_only: 'Build only the core runtime',
+  full_sourcemaps: 'Include source code content in sourcemaps',
+  sourcemap_url: 'Set a custom sourcemap URL with placeholder {version}',
+  type: 'Point sourcemap to fetch files from the correct GitHub tag',
+  esm: 'Do not transpile down to ES5',
   version_override: 'Override the version written to AMP_CONFIG',
-  watch: 'Watches for changes in files, re-compiles when detected',
-  closure_concurrency: 'Sets the number of concurrent invocations of closure',
-  debug: 'Outputs the file contents during compilation lifecycles',
+  watch: 'Watch for changes in files, re-compiles when detected',
+  closure_concurrency: 'Set the number of concurrent invocations of closure',
+  debug: 'Output the file contents during compilation lifecycles',
   define_experiment_constant:
-    'Builds runtime with the EXPERIMENT constant set to true',
+    'Build runtime with the EXPERIMENT constant set to true',
   sanitize_vars_for_diff:
-    'Sanitize the output to diff build results. Requires --pseudo_names',
-  sxg: 'Outputs the compiled code for the SxG build',
+    'Sanitize the output to diff build results (requires --pseudo_names)',
+  sxg: 'Output the compiled code for the SxG build',
   warning_level:
-    "Optionally sets closure's warning level to one of [quiet, default, verbose]",
+    "Optionally set closure's warning level to one of [quiet, default, verbose]",
 };

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -221,25 +221,24 @@ module.exports = {
   e2e,
 };
 
-e2e.description = 'Runs e2e tests';
+e2e.description = 'Run e2e tests';
 e2e.flags = {
   'browsers':
-    'Run only the specified browser tests. Options are ' +
-    '`chrome`, `firefox`, `safari`.',
+    'Run tests on the specified browser (options are `chrome`, `firefox`, `safari`)',
   'config':
-    'Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
-  'core_runtime_only': 'Builds only the core runtime.',
-  'nobuild': 'Skips building the runtime via `amp (build|dist) --fortesting`',
+    'Set the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
+  'core_runtime_only': 'Build only the core runtime.',
+  'nobuild': 'Skip building the runtime via `amp (build|dist) --fortesting`',
   'define_experiment_constant':
-    'Transforms tests with the EXPERIMENT constant set to true',
+    'Transform tests with the EXPERIMENT constant set to true',
   'experiment': 'Experiment being tested (used for status reporting)',
-  'extensions': 'Builds only the listed extensions.',
-  'compiled': 'Runs tests against minified JS',
+  'extensions': 'Build only the listed extensions.',
+  'compiled': 'Run tests against minified JS',
   'files': 'Run tests found in a specific path (ex: **/test-e2e/*.js)',
-  'testnames': 'Lists the name of each test being run',
-  'watch': 'Watches for changes in files, runs corresponding test(s)',
-  'headless': 'Runs the browser in headless mode',
-  'debug': 'Prints debugging information while running tests',
+  'testnames': 'List the name of each test being run',
+  'watch': 'Watch for changes in files, runs corresponding test(s)',
+  'headless': 'Run the browser in headless mode',
+  'debug': 'Print debugging information while running tests',
   'report': 'Write test result report to a local file',
   'coverage': 'Collect coverage data from instrumented code',
 };

--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -120,11 +120,10 @@ module.exports = {
   firebase,
 };
 
-firebase.description = 'Generates firebase folder for deployment';
+firebase.description = 'Generate build artificats for deployment to firebase';
 firebase.flags = {
   'file': 'File to deploy to firebase as index.html',
   'compiled': 'Deploy from minified files',
-  'nobuild': 'Skips the amp build|dist step.',
-  'fortesting':
-    'Expects an env var AMP_TESTING_HOST and writes this to AMP_CONFIG',
+  'nobuild': 'Skip the amp build|dist step.',
+  'fortesting': 'Read the AMP_TESTING_HOST env var and write it to AMP_CONFIG',
 };

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -255,8 +255,8 @@ module.exports = {
 };
 
 getZindex.description =
-  'Runs through all css files of project to gather z-index values';
+  'Run through all css files in the repo to gather z-index values';
 
 getZindex.flags = {
-  'fix': 'Write to file',
+  'fix': 'Write the results to file',
 };

--- a/build-system/tasks/integration.js
+++ b/build-system/tasks/integration.js
@@ -58,32 +58,31 @@ module.exports = {
   integration,
 };
 
-integration.description = 'Runs integration tests';
+integration.description = 'Run integration tests';
 integration.flags = {
-  'chrome_canary': 'Runs tests on Chrome Canary',
-  'chrome_flags': 'Uses the given flags to launch Chrome',
-  'compiled': 'Runs tests against minified JS',
+  'chrome_canary': 'Run tests on Chrome Canary',
+  'chrome_flags': 'Use the given flags to launch Chrome',
+  'compiled': 'Run tests against minified JS',
   'config':
-    'Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
+    'Set the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
   'coverage': 'Run tests in code coverage mode',
   'debug':
-    'Allow debug statements by auto opening devtools. NOTE: This only ' +
-    'works in non headless mode.',
-  'edge': 'Runs tests on Edge',
-  'esm': 'Runs against module(esm) build',
+    "Allow debug statements by auto opening devtools (doesn't work in non-headless mode)",
+  'edge': 'Run tests on Edge',
+  'esm': 'Run against module(esm) build',
   'define_experiment_constant':
-    'Transforms tests with the EXPERIMENT constant set to true',
+    'Transform tests with the EXPERIMENT constant set to true',
   'experiment': 'Experiment being tested (used for status reporting)',
-  'firefox': 'Runs tests on Firefox',
-  'files': 'Runs tests for specific files',
-  'grep': 'Runs tests that match the pattern',
+  'firefox': 'Run tests on Firefox',
+  'files': 'Run tests for specific files',
+  'grep': 'Run tests that match the pattern',
   'headless': 'Run tests in a headless Chrome window',
-  'ie': 'Runs tests on IE',
-  'nobuild': 'Skips build step',
+  'ie': 'Run tests on IE',
+  'nobuild': 'Skip build step',
   'nohelp': 'Silence help messages that are printed prior to test run',
   'report': 'Write test result report to a local file',
-  'safari': 'Runs tests on Safari',
-  'testnames': 'Lists the name of each test being run',
+  'safari': 'Run tests on Safari',
+  'testnames': 'List the name of each test being run',
   'verbose': 'With logging enabled',
-  'watch': 'Watches for changes in files, runs corresponding test(s)',
+  'watch': 'Watch for changes in files, runs corresponding test(s)',
 };

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -149,9 +149,9 @@ module.exports = {
   lint,
 };
 
-lint.description = 'Runs eslint checks against JS files';
+lint.description = 'Run lint checks against JS files using eslint';
 lint.flags = {
-  'fix': 'Fixes simple lint errors (spacing etc)',
-  'files': 'Lints just the specified files',
-  'local_changes': 'Lints just the files changed in the local branch',
+  'fix': 'Fix all errors that can be auto-fixed (e.g. spacing)',
+  'files': 'Lint just the specified files',
+  'local_changes': 'Lint just the files changed in the local branch',
 };

--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -450,16 +450,16 @@ module.exports = {
   writeFromTemplateDir,
 };
 
-makeExtension.description = 'Create an extension skeleton';
+makeExtension.description = 'Create the skeleton for a new extension';
 makeExtension.flags = {
-  name: 'The name of the extension. The prefix `amp-*` is added if necessary',
-  cleanup: 'Undo file changes before exiting. This is useful alongside --test',
+  name: 'Name of the extension (the amp-* prefix is added if necessary)',
+  cleanup: 'Undo file changes before exiting (useful with --test)',
   bento: 'Generate a Bento component',
   nocss:
-    'Exclude extension-specific CSS. (If specifying --bento, JSS is still generated unless combined with --nojss)',
-  nojss: 'Exclude extension-specific JSS when specifying --bento.',
+    'Exclude extension-specific CSS (JSS is generated for --bento unless combined with --nojss)',
+  nojss: 'Exclude extension-specific JSS (used with --bento)',
   test: 'Build and test the generated extension',
-  version: 'Sets the version number (default: 0.1; or 1.0 with --bento)',
+  version: 'Set the version number (default: 0.1; or 1.0 with --bento)',
   overwrite:
-    'Overwrites existing files at the destination, if present. Otherwise skips them',
+    'Overwrite existing files at the destination if present, otherwise skip',
 };

--- a/build-system/tasks/markdown-toc/index.js
+++ b/build-system/tasks/markdown-toc/index.js
@@ -199,8 +199,8 @@ module.exports = {
 };
 
 markdownToc.description =
-  'Finds Markdown files that contain table of contents and updates them.';
+  'Update all markdown files that contain a table of contents';
 
 markdownToc.flags = {
-  'fix': 'Write to file',
+  'fix': 'Update the list and write results to file',
 };

--- a/build-system/tasks/performance-urls.js
+++ b/build-system/tasks/performance-urls.js
@@ -57,5 +57,4 @@ module.exports = {
   performanceUrls,
 };
 
-performanceUrls.description =
-  "Check validity of performance task config's urls";
+performanceUrls.description = 'Validite config urls for the performance task';

--- a/build-system/tasks/performance/index.js
+++ b/build-system/tasks/performance/index.js
@@ -49,16 +49,16 @@ async function performance() {
   return deferred;
 }
 
-performance.description = 'Runs web performance test on current branch';
+performance.description = 'Run web performance tests';
 
 performance.flags = {
   'devtools': 'Run with devtools open',
-  'headless': 'Run chromium headless',
-  'nobuild': 'Does not compile minified runtime before running tests',
+  'headless': 'Run on chromium headless',
+  'nobuild': 'Do not compile minified runtime before running tests',
   'threshold':
-    'Fraction by which metrics are allowed to increase. Number between 0.0 and 1.0',
-  'quiet': 'Does not log progress per page',
-  'url': 'Page to test. Overrides urls set in config.json',
+    'Fraction by which metrics are allowed to increase (number between 0.0 and 1.0)',
+  'quiet': 'Do not log progress per page',
+  'url': 'Page to test (overrides urls set in config.json)',
 };
 
 module.exports = {

--- a/build-system/tasks/pr-check.js
+++ b/build-system/tasks/pr-check.js
@@ -146,7 +146,7 @@ module.exports = {
   prCheck,
 };
 
-prCheck.description = 'Runs a subset of the CI checks against local changes.';
+prCheck.description = 'Run almost all CI checks against the local branch';
 prCheck.flags = {
-  'nobuild': 'Skips building the runtime via `amp dist`.',
+  'nobuild': 'Skip building the runtime',
 };

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -306,21 +306,19 @@ module.exports = {
   valueOrDefault,
 };
 
-prependGlobal.description = 'Prepends a json config to a target file';
+prependGlobal.description = 'Prepend a json config to a target file';
 prependGlobal.flags = {
-  'target': 'Comma separated list of files to prepend the json config to.',
+  'target': 'Comma-separated list of files to prepend the json config to',
   'canary':
-    'Prepend the default canary config. ' +
-    'Takes in an optional value for a custom canary config source.',
+    'Prepend the default canary config (takes an optional value for a custom config source)',
   'prod':
-    'Prepend the default prod config. ' +
-    'Takes in an optional value for a custom prod config source.',
-  'local_dev': 'Enables runtime to be used for local development.',
+    'Prepend the default prod config (takes an optional value for a custom config source)',
+  'local_dev': 'Enable the runtime to be used for local development',
   'branch':
-    'Get config source from the given branch. Uses the main branch by default.',
+    'Get config source from the given branch (uses the main branch by default)',
   'local_branch':
-    "Don't switch branches and use the config from the local branch.",
-  'fortesting': 'Force the config to return true for getMode().test',
+    'Use the config from the local branch (does not switch branches)',
+  'fortesting': 'Enable local testing by setting getMode().test to true',
   'derandomize':
-    'Rounds all experiment percentages to 0 or 1, whichever is closest.',
+    'Round all experiment percentages to 0 or 1, whichever is closest',
 };

--- a/build-system/tasks/prettify.js
+++ b/build-system/tasks/prettify.js
@@ -160,9 +160,9 @@ module.exports = {
 };
 
 prettify.description =
-  'Checks several non-JS files in the repo for formatting using prettier';
+  'Check several non-JS files in the repo for formatting using prettier';
 prettify.flags = {
-  'files': 'Checks only the specified files',
-  'local_changes': 'Checks just the files changed in the local branch',
-  'fix': 'Fixes formatting errors',
+  'files': 'Check only the specified files',
+  'local_changes': 'Check just the files changed in the local branch',
+  'fix': 'Fix all auto-fixable formatting errors',
 };

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -499,13 +499,13 @@ module.exports = {
   release,
 };
 
-release.description = 'Generates a release build';
+release.description = 'Generate a release build';
 release.flags = {
   'output_dir':
     'Directory path to emplace release files (defaults to "./release")',
   'flavor':
-    'Limit this release build to a single flavor. Can be used to split the release work between multiple build machines.',
+    'Limit this release build to a single flavor (can be used to split the release work across multiple build machines)',
   'esm':
     // TODO(danielrozenberg): remove undefined case when the release automation platform explicitly handles it.
-    'True to compile with --esm, false to compile without; Do not set to compile both.',
+    'Compile with --esm if true, without --esm if false, and with + without --esm if left unset',
 };

--- a/build-system/tasks/serve.js
+++ b/build-system/tasks/serve.js
@@ -245,10 +245,10 @@ module.exports = {
 
 /* eslint "google-camelcase/google-camelcase": 0 */
 
-serve.description = 'Starts a webserver at the project root directory';
+serve.description = 'Start a webserver at the project root directory';
 serve.flags = {
   host: 'Hostname or IP address to bind to (default: localhost)',
-  port: 'Specifies alternative port (default: 8000)',
+  port: 'Specify alternative port (default: 8000)',
   https: 'Use HTTPS server',
   quiet: "Run in quiet mode and don't log HTTP requests",
   cache: 'Make local resources cacheable by the browser',
@@ -258,6 +258,5 @@ serve.flags = {
   cdn: 'Serve current prod JS',
   rtv: 'Serve JS from the RTV provided',
   coverage:
-    'Serve instrumented code to collect coverage info; use ' +
-    '--coverage=live to auto-report coverage on page unload',
+    'Serve instrumented code to collect coverage info (use --coverage=live to auto-report coverage on page unload)',
 };

--- a/build-system/tasks/server-tests.js
+++ b/build-system/tasks/server-tests.js
@@ -208,4 +208,4 @@ module.exports = {
   serverTests,
 };
 
-serverTests.description = "Runs tests for the AMP server's custom transforms";
+serverTests.description = "Run tests for the AMP server's custom transforms";

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -115,12 +115,12 @@ module.exports = {
   storybook,
 };
 
-storybook.description = 'Isolated testing and development for AMP components.';
+storybook.description =
+  'Set up isolated development and testing for AMP components';
 
 storybook.flags = {
-  'build':
-    'Builds a static web application, as described in https://storybook.js.org/docs/react/workflows/publish-storybook',
+  'build': 'Build a static web application (see https://storybook.js.org/docs)',
   'storybook_env':
-    "Set environment(s) to run Storybook, either 'amp', 'preact' or a list as 'amp,preact'",
-  'storybook_port': 'Set port from which to run the Storybook dashboard.',
+    "Environment(s) to run Storybook (either 'amp', 'preact' or a list as 'amp,preact')",
+  'storybook_port': 'Port from which to run the Storybook dashboard',
 };

--- a/build-system/tasks/sweep-experiments/index.js
+++ b/build-system/tasks/sweep-experiments/index.js
@@ -542,12 +542,12 @@ module.exports = {
 };
 
 sweepExperiments.description =
-  'Sweep experiments whose configuration is too old, or specified with --experiment.';
+  'Remove outdated experiments from the AMP config';
 
 sweepExperiments.flags = {
   'days_ago':
-    'How old experiment configuration flips must be for an experiment to be removed. Default is 365 days. This is ignored when using --experiment.',
+    'Age at which experiments are removed (default: 365 days, unless using --experiment)',
   'dry_run':
-    "Don't write, but only list the experiments that would be removed by this command.",
-  'experiment': 'Remove a specific experiment id.',
+    'List experiments that will be removed without actually removing them',
+  'experiment': 'Remove a specific experiment id, no matter what its age is',
 };

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -139,4 +139,5 @@ module.exports = {
   testReportUpload,
 };
 
-testReportUpload.description = 'Sends test results to test result database';
+testReportUpload.description =
+  'Send results from a test run to the AMP test result database';

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -64,23 +64,23 @@ module.exports = {
   unit,
 };
 
-unit.description = 'Runs unit tests';
+unit.description = 'Run unit tests';
 unit.flags = {
-  'chrome_canary': 'Runs tests on Chrome Canary',
-  'chrome_flags': 'Uses the given flags to launch Chrome',
+  'chrome_canary': 'Run tests on Chrome Canary',
+  'chrome_flags': 'Use the given flags to launch Chrome',
   'coverage': 'Run tests in code coverage mode',
-  'edge': 'Runs tests on Edge',
-  'firefox': 'Runs tests on Firefox',
-  'files': 'Runs tests for specific files',
-  'grep': 'Runs tests that match the pattern',
+  'edge': 'Run tests on Edge',
+  'firefox': 'Run tests on Firefox',
+  'files': 'Run tests for specific files',
+  'grep': 'Run tests that match the pattern',
   'headless': 'Run tests in a headless Chrome window',
   'ie': 'Runs tests on IE',
   'local_changes':
     'Run unit tests directly affected by the files changed in the local branch',
   'nohelp': 'Silence help messages that are printed prior to test run',
   'report': 'Write test result report to a local file',
-  'safari': 'Runs tests on Safari',
-  'testnames': 'Lists the name of each test being run',
-  'verbose': 'With logging enabled',
-  'watch': 'Watches for changes in files, runs corresponding test(s)',
+  'safari': 'Run tests on Safari',
+  'testnames': 'List the name of each test being run',
+  'verbose': 'Enable logging',
+  'watch': 'Watch for changes in files, runs corresponding test(s)',
 };

--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -103,15 +103,16 @@ async function validateHtmlFixtures() {
   await runCheck(filesToCheck);
 }
 
-validateHtmlFixtures.description =
-  'Makes sure that HTML fixtures used during tests contain valid AMPHTML.';
-validateHtmlFixtures.flags = {
-  'files': 'Checks just the specified files',
-  'include_skipped':
-    'Include skipped files while validating (can be used with --local_changes)',
-  'local_changes': 'Checks just the files changed in the local branch',
-};
-
 module.exports = {
   validateHtmlFixtures,
+};
+
+validateHtmlFixtures.description =
+  'Make sure that HTML fixtures used during tests contain valid AMPHTML';
+
+validateHtmlFixtures.flags = {
+  'files': 'Check just the specified files',
+  'include_skipped':
+    'Include skipped files while validating (can be used with --local_changes)',
+  'local_changes': 'Check just the files changed in the local branch',
 };

--- a/build-system/tasks/validator.js
+++ b/build-system/tasks/validator.js
@@ -71,15 +71,15 @@ module.exports = {
   validatorWebui,
 };
 
-validator.description = 'Builds and tests the AMP validator.';
+validator.description = 'Build and tests the AMP validator';
 validator.flags = {
-  'update_tests': 'Updates validation test output files',
+  'update_tests': 'Update validation test output files',
 };
 
-validatorCpp.description = 'Builds and tests the AMP C++ validator.';
+validatorCpp.description = 'Build and tests the AMP C++ validator';
 // TODO(antiphoton): Add the ability to update validation test output files.
 
-validatorWebui.description = 'Builds and tests the AMP validator web UI.';
+validatorWebui.description = 'Build and test the AMP validator web UI';
 validatorWebui.flags = {
-  'update_tests': 'Updates validation test output files',
+  'update_tests': 'Update validator web UI test output files',
 };

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -866,21 +866,21 @@ module.exports = {
   visualDiff,
 };
 
-visualDiff.description = 'Runs the AMP visual diff tests.';
+visualDiff.description = 'Run the AMP visual diff tests';
 visualDiff.flags = {
-  'main': 'Includes a blank snapshot (baseline for skipped builds)',
-  'empty': 'Creates a dummy Percy build with only a blank snapshot',
+  'main': 'Include a blank snapshot (baseline for skipped builds)',
+  'empty': 'Create a dummy Percy build with only a blank snapshot',
   'config':
-    'Sets the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
-  'chrome_debug': 'Prints debug info from Chrome',
-  'webserver_debug': 'Prints debug info from the local amp webserver',
-  'percy_agent_debug': 'Prints debug info from the @percy/agent instance',
-  'debug': 'Sets all debugging flags',
-  'verbose': 'Prints verbose log statements',
-  'grep': 'Runs tests that match the pattern',
+    'Set the runtime\'s AMP_CONFIG to one of "prod" (default) or "canary"',
+  'chrome_debug': 'Print debug info from Chrome',
+  'webserver_debug': 'Print debug info from the local amp webserver',
+  'percy_agent_debug': 'Print debug info from the @percy/agent instance',
+  'debug': 'Set all debugging flags',
+  'verbose': 'Print verbose log statements',
+  'grep': 'Run tests that match the pattern',
   'percy_token': 'Override the PERCY_TOKEN environment variable',
   'percy_branch': 'Override the PERCY_BRANCH environment variable',
   'percy_disabled':
-    'Disables Percy integration (for testing local changes only)',
+    'Disable Percy integration (for testing local changes only)',
   'nobuild': 'Skip build',
 };

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-sort-destructure-keys": "1.3.5",
     "eslint-plugin-sort-imports-es6-autofix": "0.6.0",
     "eslint-plugin-sort-requires": "2.1.0",
+    "esprima": "4.0.1",
     "event-stream": "4.0.1",
     "events": "3.3.0",
     "express": "4.17.1",


### PR DESCRIPTION
There are two problems with `amp --help`, the default help task:

1. When certain tasks' subpackages are not installed, their description text cannot be extracted.

![image](https://user-images.githubusercontent.com/26553114/120867795-ae7ea600-c560-11eb-81a6-80c962900bc3.png)

2. When subpackages are installed, it takes a while to load all modules, dependencies, etc. before extracting description text.

<img width="1142" alt="Screen Shot 2021-06-07 at 1 10 48 PM" src="https://user-images.githubusercontent.com/26553114/121061416-d3a62b00-c791-11eb-8fa3-9db90b73fc92.png">

This PR uses `esprima` (already present in `node_modules`) to tokenize each task file and extract the description text if present. This means tasks' subpackages needn't be installed until the task is run, and the modules needn't be loaded during `amp --help`. With this, `amp --help` runs ~10x faster with identical output.

<img width="1138" alt="Screen Shot 2021-06-07 at 1 06 17 PM" src="https://user-images.githubusercontent.com/26553114/121060957-44991300-c791-11eb-9201-25eba544c936.png">

**Bonus fix:** Clean up all task descriptions and flag descriptions to use the same tense and punctuation.

Follow up to #34655