### PR TITLE
♻️ amp-auto-lightbox exported methods unused outside

### DIFF
--- a/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/amp-auto-lightbox.js
@@ -191,7 +191,7 @@ const srcsetWidthRe = /\s+([0-9]+)w(,|[\S\s]*$)/g;
  * @return {number} -1 if no srcset, or if srcset is defined by dpr instead of
  *   width. (This value is useful for comparisons, see getMaxNaturalDimensions.)
  */
-export function getMaxWidthFromSrcset(img) {
+function getMaxWidthFromSrcset(img) {
   let max = -1;
 
   const srcsetAttr = img.getAttribute('srcset');
@@ -216,7 +216,7 @@ export function getMaxWidthFromSrcset(img) {
  * @param {!Element} img
  * @return {{naturalWidth: number, naturalHeight: number}}
  */
-export function getMaxNaturalDimensions(img) {
+function getMaxNaturalDimensions(img) {
   const {naturalHeight, naturalWidth} = img;
   const ratio = naturalWidth / naturalHeight;
   const maxWidthFromSrcset = getMaxWidthFromSrcset(img);


### PR DESCRIPTION
Removed export for methods that are not used outside the current module in `amp-auto-lightbox`.