### PR TITLE
♻️ Refactor `replaceUrls`

### DIFF
--- a/build-system/tasks/pr-deploy-bot-utils.js
+++ b/build-system/tasks/pr-deploy-bot-utils.js
@@ -60,8 +60,7 @@ function getBaseUrl() {
 async function replace(filePath) {
   const data = await fs.readFile(filePath, 'utf8');
   const hostName = getBaseUrl();
-  const inabox = false;
-  const result = replaceUrlsAppUtil('compiled', data, hostName, inabox);
+  const result = replaceUrlsAppUtil('compiled', data, hostName);
 
   await fs.writeFile(filePath, result, 'utf8');
 }


### PR DESCRIPTION
1. `.js/.mjs` files under `dist/` match the CDN URLs when `--compiled`, so we simplify with a catch-all pattern.

2. `inabox` argument was removed. Its logic was extracted into the separate function `toInaboxDocument`:

   - Callers now pass the result of `toInaboxDocument` when needed.

   - An existing pattern on `replaceUrls` already matches the input's script URL without a condition for `inabox`.

3. RTV modes can short-circuit.