### PR TITLE
amp-lightbox-gallery: fix incorrect unlayout

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -360,10 +360,9 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     return this.mutateElement(() => {
       const {length} = this.elementsMetadata_[lightboxGroupId];
       this.maybeEnableMultipleItemControls_(length);
-      this.carousel_.getImpl().then((implementation) => {
-        implementation.unlayoutCallback();
-        toggle(this.carousel_, true);
-      });
+      const owners = Services.ownersForDoc(this.element);
+      owners./*OK*/ scheduleUnlayout(this.element, this.carousel_);
+      toggle(this.carousel_, true);
     });
   }
 


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/issues/34556

During the `showCarousel` flow, the gallery directly calls `unlayoutCallback` on its child carousel:
https://github.com/ampproject/amphtml/blob/b14fb62461438176936f8bd51e1e19271b88c7c1/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js#L353-L368

This is a problem, because `unlayoutCallback` is _not_ meant to be directly called, just like layoutCalback isn't either. It must be called by either Resources or Owners or else those systems develop undefined behavior.   In this case, it was leading to the carousel never being scheduled for layout again.

---

Note: there are still further issues here. For example, when any thumbnail but the first is clicked, an error is logged:
![Screen Shot 2021-06-08 at 9 18 21 AM](https://user-images.githubusercontent.com/4656974/121192024-85009b80-c83a-11eb-9262-4cc7867380f2.png)

AFAICT, this is due to an inefficiency where we have calls to layout/unlayout of the individual slides that are occurring by a quick "showSlide(0)" (initialization) --> "showSlide(selected)" call. Would be good to fix in a future PR