### PR TITLE
✨ Add Mediasquare to RTC callout-vendors for amp-ad

### DIFF
--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -142,6 +142,7 @@ The `errorReportingUrl` property is optional. The only available macros are ERRO
 -   NewsPassID
 -   Lotame
 -   Media.net
+-   Mediasquare
 -   Nexx360.io
 -   OpenX
 -   PubMatic OpenWrap

--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -37,6 +37,7 @@ To use RTC, you must meet the following requirements:
 -   Newspassid
 -   Lotame
 -   Media.net
+-   Mediasquare
 -   OpenX
 -   PubMatic OpenWrap
 -   Purch

--- a/src/service/real-time-config/callout-vendors.js
+++ b/src/service/real-time-config/callout-vendors.js
@@ -248,6 +248,12 @@ const RTC_VENDORS = jsonConfiguration({
     macros: ['ACCOUNT_ID'],
     disableKeyAppend: true,
   },
+  mediasquare: {
+    url:
+      'https://pbs-front.mediasquare.fr/msq_prebid?owner=OWNER&code=CODE&sizes=ATTR(data-multi-size)&adunit=ATTR(data-slot)&referer=HREF&gdpr_consent=CONSENT_STRING',
+    macros: ['OWNER', 'CODE', 'CONSENT_STRING'],
+    disableKeyAppend: true,
+  },
 });
 
 // DO NOT MODIFY: Setup for tests


### PR DESCRIPTION
Add Mediasquare to the list of RTC callout-vendors in order to be able to add Mediasquare in the rtc-config attribute of amp-ad tags.
Add Mediasquare to the list of supported vendors in extensions/amp-a4a/rtc-documentation.md and extensions/amp-a4a/rtc-publisher-implementation-guide.md