### PR TITLE
📖 Add explicit mention of working groups as owners

### DIFF
--- a/docs/contributing-code.md
+++ b/docs/contributing-code.md
@@ -171,6 +171,7 @@ These guidelines are specific to the amphtml repository. Other ampproject repos 
     -   When creating a new directory (such as when creating a new AMP extension) the author of the pull request should designate themselves as an Owner of that directory.
     -   Owners of an area may approve other Owners at or below their area of expertise following the normal PR process. To request becoming an Owner create a PR adding yourself to the appropriate OWNERS file and assign/cc a current Owner for that directory.
 -   The list of Owners for a directory can be found in the [OWNERS](https://github.com/ampproject/amphtml/search?o=asc&q=filename%3A"OWNERS"&s=indexed) file in the directory or a parent directory.
+-   Please note that some Owners may be relevant regardless of code location and therefore may include one or more [AMP Working Groups](https://amp.dev/community/governance/#working-groups), such as the groups for [Security & Privacy](https://amp.dev/community/working-groups/security-privacy/) and [Components](https://amp.dev/community/working-groups/components), which can provide guidance on web accessibility.
 
 ## Cherry-picks
 


### PR DESCRIPTION
This PR is a copy of #30137:
> Based on a conversation with @nainar on email, pointing out that there are already mechanisms in place to make sure accessibility is considered as part of any code/submission review (and indeed, seeing that `wg-ui-and-a11y` is set as owner in most of the OWNER files), it may be worth explicitly mentioning this for further visibility/clarity.

Note that because `wg-components` no longer contains `a11y` in the name, I also added a clause about the group being a relevant resource for web accessibility considerations in the documentation.

/to @rcebulko who approved the original PR
/cc @TetraLogicalHelpdesk 