### PR TITLE
♿  Add lang="en" to relevant snippets in `build-system/`

### DIFF
--- a/build-system/server/app-index/amphtml-helpers.js
+++ b/build-system/server/app-index/amphtml-helpers.js
@@ -71,7 +71,7 @@ const AmpDoc = ({body, canonical, css, head}) => {
   assert(canonical);
   return html`
     <!DOCTYPE html>
-    <html ⚡>
+    <html ⚡ lang="en">
       <head>
         <title>AMP Dev Server</title>
         <meta charset="utf-8" />

--- a/build-system/server/server-a4a-template.html
+++ b/build-system/server/server-a4a-template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A4A Envelope</title>

--- a/build-system/tasks/make-extension/template/classic/examples/amp-__component_name_hyphenated__.html
+++ b/build-system/tasks/make-extension/template/classic/examples/amp-__component_name_hyphenated__.html
@@ -14,7 +14,7 @@
   limitations under the license.
 -->
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <!-- prettier-ignore -->
   <head>
     <meta charset="utf-8">

--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/test/__validator__-amp-__component_name_hyphenated__.html
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/test/__validator__-amp-__component_name_hyphenated__.html
@@ -14,7 +14,7 @@
   limitations under the license.
 -->
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <!-- prettier-ignore -->
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
This PR is a partial copy of #31208, which adds `lang="en"` to relevant code snippets in this codebase. Instead of copying the PR file-for-file, I decided to break this change up into a few root directories for ease of review and less likelihood of falling behind to merge conflicts.

Original PR description:
> Suggested changes and additions based on the TetraLogical accessibility review commissioned by @nainar / @caroqliu
>
> x-ref ampproject/amp.dev#4972

/cc @TetraLogicalHelpdesk 