### PR TITLE
♿ Apply `lang="en"` to relevant snippets in `examples/`

### DIFF
--- a/examples/3q-player.amp.html
+++ b/examples/3q-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>3Q AMP Example</title>

--- a/examples/accordion.amp.html
+++ b/examples/accordion.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">

--- a/examples/alp.amp.html
+++ b/examples/alp.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>ALP examples</title>

--- a/examples/amp-3d-gltf.amp.html
+++ b/examples/amp-3d-gltf.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-3d-gltf example</title>

--- a/examples/amp-action-macro.html
+++ b/examples/amp-action-macro.html
@@ -5,7 +5,7 @@
 -->
 <!-- -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-ad-template.amp.html
+++ b/examples/amp-ad-template.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>Amp Ad Common Example/Debug</title>

--- a/examples/amp-ad/a4a-fullwidth.amp.html
+++ b/examples/amp-ad/a4a-fullwidth.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AdSense full-width ad examples</title>

--- a/examples/amp-ad/a4a-multisize.amp.html
+++ b/examples/amp-ad/a4a-multisize.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP A4A examples</title>

--- a/examples/amp-ad/a4a.amp.html
+++ b/examples/amp-ad/a4a.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP A4A examples</title>

--- a/examples/amp-ad/ads-legacy.amp.html
+++ b/examples/amp-ad/ads-legacy.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/examples/amp-ad/ads.amp.esm.html
+++ b/examples/amp-ad/ads.amp.esm.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/examples/amp-ad/adsense.amp.html
+++ b/examples/amp-ad/adsense.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Adsense examples</title>

--- a/examples/amp-ad/adzerk.amp.html
+++ b/examples/amp-ad/adzerk.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Adzerk examples</title>

--- a/examples/amp-ad/doubleclick-multisize.amp.html
+++ b/examples/amp-ad/doubleclick-multisize.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>Multi-size Ad Requests with DoubleClick Examples</title>

--- a/examples/amp-ad/doubleclick-remote-html.html
+++ b/examples/amp-ad/doubleclick-remote-html.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Doubleclick Example using custom remote.html on page</title>

--- a/examples/amp-ad/doubleclick-rtc.amp.html
+++ b/examples/amp-ad/doubleclick-rtc.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Doubleclick RTC Example</title>

--- a/examples/amp-ad/doubleclick-safeframe.html
+++ b/examples/amp-ad/doubleclick-safeframe.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Doubleclick Safeframe Example</title>

--- a/examples/amp-ad/doubleclick-targeting-macro.html
+++ b/examples/amp-ad/doubleclick-targeting-macro.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Doubleclick JSON targeting macro Example</title>

--- a/examples/amp-ad/doubleclick-usdrud.html
+++ b/examples/amp-ad/doubleclick-usdrud.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Doubleclick Example with UseSameDomainRenderingUntilDeprecated</title>

--- a/examples/amp-ad/doubleclick-vanilla.amp.html
+++ b/examples/amp-ad/doubleclick-vanilla.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Doubleclick Basic Example</title>

--- a/examples/amp-ad/sticky.html
+++ b/examples/amp-ad/sticky.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Ad examples</title>

--- a/examples/amp-addthis.amp.html
+++ b/examples/amp-addthis.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-addthis example</title>

--- a/examples/amp-autocomplete-bind.html
+++ b/examples/amp-autocomplete-bind.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html amp>
+<html amp lang="en">
   <head>
     <meta charset="utf-8">
     <title>autocomplete and bind testing</title>

--- a/examples/amp-autocomplete-testing.html
+++ b/examples/amp-autocomplete-testing.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html amp>
+<html amp lang="en">
   <head>
     <meta charset="utf-8">
     <title>autocomplete testing</title>

--- a/examples/amp-byside-content.amp.html
+++ b/examples/amp-byside-content.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>BySide Content example</title>

--- a/examples/amp-consent/amp-consent-3p-postmessage.html
+++ b/examples/amp-consent/amp-consent-3p-postmessage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>amp-video-iframe</title>

--- a/examples/amp-consent/amp-consent-amp-ad.amp.html
+++ b/examples/amp-consent/amp-consent-amp-ad.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>My AMP Page</title>

--- a/examples/amp-consent/amp-consent-client.html
+++ b/examples/amp-consent/amp-consent-client.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent GEO Test</title>

--- a/examples/amp-consent/amp-consent-cmp.html
+++ b/examples/amp-consent/amp-consent-cmp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-consent/amp-consent-geo.html
+++ b/examples/amp-consent/amp-consent-geo.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent GEO in Iframe Test</title>

--- a/examples/amp-consent/amp-consent-iframe.amp.html
+++ b/examples/amp-consent/amp-consent-iframe.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>AMP Consent CMP Vendors</title>

--- a/examples/amp-consent/amp-consent-server.html
+++ b/examples/amp-consent/amp-consent-server.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent GEO Test</title>

--- a/examples/amp-consent/cmp-vendors.amp.html
+++ b/examples/amp-consent/cmp-vendors.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>AMP Consent CMP Vendors</title>

--- a/examples/amp-date-countdown.amp.html
+++ b/examples/amp-date-countdown.amp.html
@@ -11,7 +11,7 @@
   limitations under the license.
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-date-countdown example</title>

--- a/examples/amp-date-display.amp.html
+++ b/examples/amp-date-display.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-date-display example</title>

--- a/examples/amp-delight-player.amp.html
+++ b/examples/amp-delight-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="./regular-html-version.html">

--- a/examples/amp-embedly-card.amp.html
+++ b/examples/amp-embedly-card.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-embedly-card example</title>

--- a/examples/amp-fit-text.amp.html
+++ b/examples/amp-fit-text.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
     <meta charset="utf-8">

--- a/examples/amp-form-initialization-test.html
+++ b/examples/amp-form-initialization-test.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <title>amp-form initialization test</title>

--- a/examples/amp-fx-float-in.html
+++ b/examples/amp-fx-float-in.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-geo.amp.html
+++ b/examples/amp-geo.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-geo example</title>

--- a/examples/amp-gist.amp.html
+++ b/examples/amp-gist.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-gist example</title>

--- a/examples/amp-google-assistant-assistjs.amp.html
+++ b/examples/amp-google-assistant-assistjs.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-google-assistant-assistjs example</title>

--- a/examples/amp-imgur.amp.html
+++ b/examples/amp-imgur.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-imgur example</title>

--- a/examples/amp-install-serviceworker.amp.html
+++ b/examples/amp-install-serviceworker.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-install-serviceworker example</title>

--- a/examples/amp-layout-intrinsic.amp.html
+++ b/examples/amp-layout-intrinsic.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Intrinsic layout example</title>

--- a/examples/amp-layout.amp.html
+++ b/examples/amp-layout.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-layout example</title>

--- a/examples/amp-lightbox.amp.html
+++ b/examples/amp-lightbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Scrollable lightbox</title>

--- a/examples/amp-link-rewriter.html
+++ b/examples/amp-link-rewriter.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-link-rewriter example</title>

--- a/examples/amp-list-layout-container.amp.html
+++ b/examples/amp-list-layout-container.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-list-protocol-adapters.html
+++ b/examples/amp-list-protocol-adapters.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-list-with-form.amp.html
+++ b/examples/amp-list-with-form.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-list.amp.html
+++ b/examples/amp-list.amp.html
@@ -5,7 +5,7 @@
 -->
 <!-- -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-list.state.html
+++ b/examples/amp-list.state.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-mathml.amp.html
+++ b/examples/amp-mathml.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-mathml example</title>

--- a/examples/amp-minute-media-player.amp.html
+++ b/examples/amp-minute-media-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-minute-media-player example</title>

--- a/examples/amp-mowplayer.amp.html
+++ b/examples/amp-mowplayer.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-mowplayer example</title>

--- a/examples/amp-next-page.amp.html
+++ b/examples/amp-next-page.amp.html
@@ -14,7 +14,7 @@
   limitations under the license.
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/amp-orientation-observer-3d-parallax.amp.html
+++ b/examples/amp-orientation-observer-3d-parallax.amp.html
@@ -1,4 +1,4 @@
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-orientation-observer-amp-3d-gltf.amp.html
+++ b/examples/amp-orientation-observer-amp-3d-gltf.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-orientation-observer-panorama.amp.html
+++ b/examples/amp-orientation-observer-panorama.amp.html
@@ -1,4 +1,4 @@
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-orientation-observer-scroll.amp.html
+++ b/examples/amp-orientation-observer-scroll.amp.html
@@ -1,4 +1,4 @@
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-orientation-observer.amp.html
+++ b/examples/amp-orientation-observer.amp.html
@@ -1,4 +1,4 @@
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-position-observer.amp.html
+++ b/examples/amp-position-observer.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-rate-limited.amp.html
+++ b/examples/amp-rate-limited.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Rate Limited Input Examples in AMP</title>

--- a/examples/amp-riddle-quiz.amp.html
+++ b/examples/amp-riddle-quiz.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-riddle-quiz example</title>

--- a/examples/amp-script/example.amp.html
+++ b/examples/amp-script/example.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="self.html" />

--- a/examples/amp-script/example.sandboxed.amp.html
+++ b/examples/amp-script/example.sandboxed.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="self.html" />

--- a/examples/amp-script/todomvc.amp.html
+++ b/examples/amp-script/todomvc.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="self.html" />

--- a/examples/amp-sidebar-autoscroll.amp.html
+++ b/examples/amp-sidebar-autoscroll.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>responsive sidebar with autofocus</title>

--- a/examples/amp-skimlinks.html
+++ b/examples/amp-skimlinks.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Skimlinks Example</title>

--- a/examples/amp-smartlinks.html
+++ b/examples/amp-smartlinks.html
@@ -15,7 +15,7 @@
 	Valid amp-smartlinks tag
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
 	<meta charset="utf-8">
 	<link rel="canonical" href="./regular-html-version.html">

--- a/examples/amp-story/advance-after-background-audio.html
+++ b/examples/amp-story/advance-after-background-audio.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="robots" content="none">

--- a/examples/amp-story/amp-audio.html
+++ b/examples/amp-story/amp-audio.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <meta name="robots" content="none">

--- a/examples/amp-story/amp-story-360.html
+++ b/examples/amp-story/amp-story-360.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-story-360 Example</title>

--- a/examples/amp-story/amp-story-animation.html
+++ b/examples/amp-story/amp-story-animation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>amp-animation inside amp-story</title>

--- a/examples/amp-story/amp-story-auto-ads.html
+++ b/examples/amp-story/amp-story-auto-ads.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html amp>
+<html amp lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-story</title>

--- a/examples/amp-story/amp-story-panning-media.html
+++ b/examples/amp-story/amp-story-panning-media.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-story-panning-media example</title>

--- a/examples/amp-story/animations-presets.html
+++ b/examples/amp-story/animations-presets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html amp>
+<html amp lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-story/animations-sequence.html
+++ b/examples/amp-story/animations-sequence.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html amp>
+<html amp lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-story</title>

--- a/examples/amp-story/cta-layer-outlink.html
+++ b/examples/amp-story/cta-layer-outlink.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-story/quiz.html
+++ b/examples/amp-story/quiz.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-story-interactive-quiz example</title>

--- a/examples/amp-story/text-background-color.html
+++ b/examples/amp-story/text-background-color.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-story/visual-effects.html
+++ b/examples/amp-story/visual-effects.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/amp-subscriptions-google/amp-subscriptions-contribution.amp.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions-contribution.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>subscriptions example</title>

--- a/examples/amp-subscriptions-google/amp-subscriptions-iframe.amp.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions-iframe.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>subscriptions example</title>

--- a/examples/amp-subscriptions-google/amp-subscriptions-metering-gaa-bail.amp.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions-metering-gaa-bail.amp.html
@@ -8,7 +8,7 @@
   (amp-subscriptions-google)
 -->
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Showcase with subscription entitlements that grant</title>

--- a/examples/amp-subscriptions-google/amp-subscriptions-metering-gaa.amp.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions-metering-gaa.amp.html
@@ -5,7 +5,7 @@
   (amp-subscriptions-google)
 -->
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Showcase with GAA metering entitlements that grant</title>

--- a/examples/amp-subscriptions-google/amp-subscriptions-metering-laa.amp.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions-metering-laa.amp.html
@@ -5,7 +5,7 @@
   (amp-subscriptions-google)
 -->
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Showcase with LAA metering entitlements that grant</title>

--- a/examples/amp-subscriptions-google/amp-subscriptions-smartbox.amp.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions-smartbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>subscriptions example</title>

--- a/examples/amp-subscriptions-google/amp-subscriptions.amp.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>subscriptions example</title>

--- a/examples/amp-subscriptions-rtp.amp.html
+++ b/examples/amp-subscriptions-rtp.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>subscriptions example</title>

--- a/examples/amp-subscriptions.rtc.amp.html
+++ b/examples/amp-subscriptions.rtc.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>subscriptions example</title>

--- a/examples/amp-tiktok.amp.html
+++ b/examples/amp-tiktok.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>amp-tiktok example</title>

--- a/examples/amp-timeago.amp.html
+++ b/examples/amp-timeago.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-timeago example</title>

--- a/examples/amp-video-iframe-videojs.html
+++ b/examples/amp-video-iframe-videojs.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-video-iframe</title>

--- a/examples/amp-video-iframe.html
+++ b/examples/amp-video-iframe.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-video-iframe</title>

--- a/examples/amp-video-iframe/consent.html
+++ b/examples/amp-video-iframe/consent.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>amp-video-iframe with amp-consent</title>

--- a/examples/amp-video.amp.html
+++ b/examples/amp-video.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/amp-video/multi-bitrate/multi-bitrate.html
+++ b/examples/amp-video/multi-bitrate/multi-bitrate.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Multi bitrate</title>

--- a/examples/amp-web-push.amp.html
+++ b/examples/amp-web-push.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-web-push example</title>

--- a/examples/amp-yotpo.amp.html
+++ b/examples/amp-yotpo.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-yotpo example</title>

--- a/examples/amp-youtube.amp.html
+++ b/examples/amp-youtube.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/analytics-error-reporting.amp.html
+++ b/examples/analytics-error-reporting.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Errors for User Error Report</title>

--- a/examples/analytics-html-attr.amp.html
+++ b/examples/analytics-html-attr.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>3P AMP Analytics Example</title>

--- a/examples/analytics-iframe-transport.amp.html
+++ b/examples/analytics-iframe-transport.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>3P AMP Analytics Example</title>

--- a/examples/analytics-in-creative-measurement.amp.html
+++ b/examples/analytics-in-creative-measurement.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Analytics In-Creative Measurement Test</title>

--- a/examples/analytics-notification-with-geo.amp.html
+++ b/examples/analytics-notification-with-geo.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/analytics-notification.amp.html
+++ b/examples/analytics-notification.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/analytics-reportWhen.amp.html
+++ b/examples/analytics-reportWhen.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics reportWhen</title>

--- a/examples/analytics-scrollDepth.amp.html
+++ b/examples/analytics-scrollDepth.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics reportWhen</title>

--- a/examples/analytics-varGroups.amp.html
+++ b/examples/analytics-varGroups.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics varGroups</title>

--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/examples/analytics-visibility.amp.html
+++ b/examples/analytics-visibility.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/examples/analytics.amp.html
+++ b/examples/analytics.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/examples/anim-worklet.amp.html
+++ b/examples/anim-worklet.amp.html
@@ -12,7 +12,7 @@
 -->
 
 <!doctype html>
-<html amp>
+<html amp lang="en">
   <head>
     <meta charset="utf-8">
     <link rel="canonical" href="anim-worklet.amp.html">

--- a/examples/animations.amp.html
+++ b/examples/animations.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Animations Examples</title>

--- a/examples/apester-media.amp.html
+++ b/examples/apester-media.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Apester Media Smart Unit</title>

--- a/examples/article-access-iframe.amp.html
+++ b/examples/article-access-iframe.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/article-access-laterpay.amp.html
+++ b/examples/article-access-laterpay.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/article-access-multiple.amp.html
+++ b/examples/article-access-multiple.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/article-access-poool.amp.html
+++ b/examples/article-access-poool.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/article-access.amp.html
+++ b/examples/article-access.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/article-fade-in.amp.html
+++ b/examples/article-fade-in.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with fade-in animations</title>

--- a/examples/article-fixed-header.amp.html
+++ b/examples/article-fixed-header.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/article-fly-in.amp.html
+++ b/examples/article-fly-in.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with fly-in animations</title>

--- a/examples/article-invalid-presets.amp.html
+++ b/examples/article-invalid-presets.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with fade-in animations</title>

--- a/examples/article-parallax.amp.html
+++ b/examples/article-parallax.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with parallax title</title>

--- a/examples/article-super-short.amp.html
+++ b/examples/article-super-short.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum</title>

--- a/examples/article-with-lightbox-2.0-gallery.amp.html
+++ b/examples/article-with-lightbox-2.0-gallery.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/article.amp.html
+++ b/examples/article.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/audio-bind.amp.html
+++ b/examples/audio-bind.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-audio amp-bind</title>

--- a/examples/audio-nodisplay.amp.html
+++ b/examples/audio-nodisplay.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-audio nodisplay</title>

--- a/examples/autocomplete.amp.html
+++ b/examples/autocomplete.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/bento.amp.html
+++ b/examples/bento.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Bento example</title>

--- a/examples/beopinion.amp.html
+++ b/examples/beopinion.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>BeOpinion examples</title>

--- a/examples/beopinion.article.amp.html
+++ b/examples/beopinion.article.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/bind/basic.amp.html
+++ b/examples/bind/basic.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Basic</title>

--- a/examples/bind/carousels.amp.html
+++ b/examples/bind/carousels.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Carousels</title>

--- a/examples/bind/details.amp.html
+++ b/examples/bind/details.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Details</title>

--- a/examples/bind/ecommerce.amp.html
+++ b/examples/bind/ecommerce.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: E-commerce</title>

--- a/examples/bind/errors.amp.html
+++ b/examples/bind/errors.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Errors</title>

--- a/examples/bind/forms.amp.html
+++ b/examples/bind/forms.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Forms Examples in AMP</title>

--- a/examples/bind/game.amp.html
+++ b/examples/bind/game.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Game</title>

--- a/examples/bind/iframe.amp.html
+++ b/examples/bind/iframe.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: iframe</title>

--- a/examples/bind/list.amp.html
+++ b/examples/bind/list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Lists</title>

--- a/examples/bind/live-list.amp.html
+++ b/examples/bind/live-list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Live-list</title>

--- a/examples/bind/macros.amp.html
+++ b/examples/bind/macros.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Basic</title>

--- a/examples/bind/performance.amp.html
+++ b/examples/bind/performance.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Performance</title>

--- a/examples/bind/sandbox.amp.html
+++ b/examples/bind/sandbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Sandbox</title>

--- a/examples/bind/svgimage.amp.html
+++ b/examples/bind/svgimage.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: svg</title>

--- a/examples/bind/title.amp.html
+++ b/examples/bind/title.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title [text]="'amp-bind: Title (' + myState.count + ')'">amp-bind: Title</title>

--- a/examples/bind/video.amp.html
+++ b/examples/bind/video.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: Video</title>

--- a/examples/bind/xhr.amp.html
+++ b/examples/bind/xhr.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind: XHR</title>

--- a/examples/bodymovin-animation.amp.html
+++ b/examples/bodymovin-animation.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Bodymovin Animation examples</title>

--- a/examples/brid-player.amp.html
+++ b/examples/brid-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Brid.tv Player Example</title>

--- a/examples/brightcove.amp.html
+++ b/examples/brightcove.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Brightcove Player Example</title>

--- a/examples/browsi-analytics.amp.html
+++ b/examples/browsi-analytics.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/examples/browsi-prediction.amp.html
+++ b/examples/browsi-prediction.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/examples/carousel-v1.amp.html
+++ b/examples/carousel-v1.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP #0</title>

--- a/examples/carousel.amp.html
+++ b/examples/carousel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/connatix-player.amp.html
+++ b/examples/connatix-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-connatix-player example</title>

--- a/examples/csa.amp.html
+++ b/examples/csa.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>CSA example</title>

--- a/examples/csp.amp.html
+++ b/examples/csp.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP CSP</title>

--- a/examples/dailymotion.amp.html
+++ b/examples/dailymotion.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Dailymotion examples</title>

--- a/examples/date-picker.amp.html
+++ b/examples/date-picker.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Date Picker Example</title>

--- a/examples/doubleload.amp.html
+++ b/examples/doubleload.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/everything.amp.esm.html
+++ b/examples/everything.amp.esm.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/everything.amp.html
+++ b/examples/everything.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/experiment-1.0.amp.html
+++ b/examples/experiment-1.0.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-experiment</title>

--- a/examples/experiment.amp.html
+++ b/examples/experiment.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-experiment</title>

--- a/examples/facebook.amp.html
+++ b/examples/facebook.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Facebook examples</title>

--- a/examples/fake-ad.amp.html
+++ b/examples/fake-ad.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Fake Ad Network Test</title>

--- a/examples/fluid.amp.html
+++ b/examples/fluid.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>DoubleClick with Fluid Example</title>

--- a/examples/font.amp.html
+++ b/examples/font.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Font example</title>

--- a/examples/forms.amp.html
+++ b/examples/forms.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Forms Examples in AMP</title>

--- a/examples/gfk-sensic-analytics.amp.html
+++ b/examples/gfk-sensic-analytics.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>GfK (Sensic) Media Analytics</title>

--- a/examples/gfycat.amp.html
+++ b/examples/gfycat.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Gfycat examples</title>

--- a/examples/gwd.amp.html
+++ b/examples/gwd.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-gwd-animation</title>

--- a/examples/ima-video.amp.html
+++ b/examples/ima-video.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>IMA examples</title>

--- a/examples/image-lightbox.amp.html
+++ b/examples/image-lightbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
 <meta charset="utf-8">
 <title>Sample document</title>

--- a/examples/image-slider.amp.html
+++ b/examples/image-slider.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-image-slider example</title>

--- a/examples/img.amp.html
+++ b/examples/img.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/instagram.amp.html
+++ b/examples/instagram.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Instagram examples</title>

--- a/examples/izlesene.amp.html
+++ b/examples/izlesene.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Izlesene examples</title>

--- a/examples/jwplayer.amp.html
+++ b/examples/jwplayer.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>JWPlayer AMP Example</title>

--- a/examples/kaltura.amp.html
+++ b/examples/kaltura.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Kaltura Player Example</title>

--- a/examples/layout-flex-item.amp.html
+++ b/examples/layout-flex-item.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/lightbox-gallery.amp.html
+++ b/examples/lightbox-gallery.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <link rel="canonical" href="https://amp.dev/documentation/examples/components/amp-lightbox-gallery/index.html">

--- a/examples/linkers.html
+++ b/examples/linkers.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Linker</title>

--- a/examples/live-blog-non-floating-button.amp.html
+++ b/examples/live-blog-non-floating-button.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/live-blog.amp.html
+++ b/examples/live-blog.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/live-list-update-reverse.amp.html
+++ b/examples/live-list-update-reverse.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/live-list-update.amp.html
+++ b/examples/live-list-update.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/live-list.amp.html
+++ b/examples/live-list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/loads-windowcontext-creative-https.html
+++ b/examples/loads-windowcontext-creative-https.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
         <meta charset="utf-8">
     <title>window.context Example</title>

--- a/examples/loads-windowcontext-creative.html
+++ b/examples/loads-windowcontext-creative.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
         <meta charset="utf-8">
     <title>window.context Example</title>

--- a/examples/lots-of-images.amp.html
+++ b/examples/lots-of-images.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="self.html" />

--- a/examples/masking-trim.amp.html
+++ b/examples/masking-trim.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Input masking examples in AMP</title>

--- a/examples/masking.amp.html
+++ b/examples/masking.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Input masking examples in AMP</title>

--- a/examples/megaphone.amp.html
+++ b/examples/megaphone.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Megaphone examples</title>

--- a/examples/nexxtv-player.amp.html
+++ b/examples/nexxtv-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Nexxtv Player Example</title>

--- a/examples/o2player.amp.html
+++ b/examples/o2player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>O2Player examples</title>

--- a/examples/old-boilerplate.amp.html
+++ b/examples/old-boilerplate.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Twitter examples</title>

--- a/examples/onetap.amp.html
+++ b/examples/onetap.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Google One Tap Example</title>

--- a/examples/openx.amp.html
+++ b/examples/openx.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>OpenX examples</title>

--- a/examples/pinterest.amp.html
+++ b/examples/pinterest.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Pinterest examples</title>

--- a/examples/playbuzz.amp.html
+++ b/examples/playbuzz.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>playbuzz examples</title>

--- a/examples/powr-player.amp.html
+++ b/examples/powr-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Powr Player Example</title>

--- a/examples/reach-player.amp.html
+++ b/examples/reach-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Reach-Player Example</title>

--- a/examples/recaptcha.amp.html
+++ b/examples/recaptcha.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-recaptcha example</title>

--- a/examples/reddit.amp.html
+++ b/examples/reddit.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Reddit examples</title>

--- a/examples/refresh.amp.html
+++ b/examples/refresh.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>DoubleClick with Refresh Example</title>

--- a/examples/released.amp.html
+++ b/examples/released.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Released AMP components</title>

--- a/examples/responsive-menu.amp.html
+++ b/examples/responsive-menu.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP responsive menu example</title>

--- a/examples/responsive.amp.html
+++ b/examples/responsive.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/runtime/article.html
+++ b/examples/runtime/article.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Article</title>

--- a/examples/runtime/images.html
+++ b/examples/runtime/images.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>images test</title>

--- a/examples/runtime/list-always.html
+++ b/examples/runtime/list-always.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>images test</title>

--- a/examples/selector.amp.html
+++ b/examples/selector.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/sidebar-nested-menu.html
+++ b/examples/sidebar-nested-menu.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP nested menu example</title>

--- a/examples/sidebar.amp.html
+++ b/examples/sidebar.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/soundcloud.amp.html
+++ b/examples/soundcloud.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Soundcloud examples</title>

--- a/examples/springboard-player.amp.html
+++ b/examples/springboard-player.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Springboard Player Example</title>

--- a/examples/standalone.amp.html
+++ b/examples/standalone.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Standalone Demo</title>

--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Hide/Show/Toggle Examples in AMP</title>

--- a/examples/sticky.ads.0.1.amp.html
+++ b/examples/sticky.ads.0.1.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Sticky Ad Test</title>

--- a/examples/sticky.ads.amp.html
+++ b/examples/sticky.ads.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Sticky Ad Test</title>

--- a/examples/travel-lb.amp.html
+++ b/examples/travel-lb.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Travel date picker example</title>

--- a/examples/travel.amp.html
+++ b/examples/travel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Travel date picker example</title>

--- a/examples/twitter.amp.html
+++ b/examples/twitter.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Twitter examples</title>

--- a/examples/user-notification.amp.html
+++ b/examples/user-notification.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/valueimpression.amp.html
+++ b/examples/valueimpression.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/video-animation-sync.html
+++ b/examples/video-animation-sync.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/viewer-cid.amp.html
+++ b/examples/viewer-cid.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/examples/vimeo.amp.html
+++ b/examples/vimeo.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Vimeo examples</title>

--- a/examples/vine.amp.html
+++ b/examples/vine.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Vine examples</title>

--- a/examples/viqeo.amp.html
+++ b/examples/viqeo.amp.html
@@ -14,7 +14,7 @@
   limitations under the license.
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Viqeo examples</title>

--- a/examples/visual-tests/amp-accordion/amp-accordion.html
+++ b/examples/visual-tests/amp-accordion/amp-accordion.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/visual-tests/amp-autocomplete/amp-autocomplete.amp.html
+++ b/examples/visual-tests/amp-autocomplete/amp-autocomplete.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-autocomplete examples</title>

--- a/examples/visual-tests/amp-carousel/amp-carousel-slides.html
+++ b/examples/visual-tests/amp-carousel/amp-carousel-slides.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-carousel</title>

--- a/examples/visual-tests/amp-carousel/amp-carousel.html
+++ b/examples/visual-tests/amp-carousel/amp-carousel.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-carousel</title>

--- a/examples/visual-tests/amp-date-picker/amp-date-picker.amp.html
+++ b/examples/visual-tests/amp-date-picker/amp-date-picker.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-list examples</title>

--- a/examples/visual-tests/amp-form/amp-form.amp.html
+++ b/examples/visual-tests/amp-form/amp-form.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Form</title>

--- a/examples/visual-tests/amp-layout/amp-layout.amp.html
+++ b/examples/visual-tests/amp-layout/amp-layout.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-layout example</title>

--- a/examples/visual-tests/amp-lightbox-gallery.html
+++ b/examples/visual-tests/amp-lightbox-gallery.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/visual-tests/amp-list/amp-list.amp.html
+++ b/examples/visual-tests/amp-list/amp-list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-list examples</title>

--- a/examples/visual-tests/amp-mega-menu/amp-mega-menu-with-list.amp.html
+++ b/examples/visual-tests/amp-mega-menu/amp-mega-menu-with-list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/visual-tests/amp-mega-menu/amp-mega-menu.amp.html
+++ b/examples/visual-tests/amp-mega-menu/amp-mega-menu.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/visual-tests/amp-selector.amp.html
+++ b/examples/visual-tests/amp-selector.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Selector</title>

--- a/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ol.amp.html
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ol.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ul.amp.html
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar-ul.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/visual-tests/amp-sidebar/amp-sidebar.amp.html
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/examples/visual-tests/amp-sticky-ad/amp-sticky-ad.amp.html
+++ b/examples/visual-tests/amp-sticky-ad/amp-sticky-ad.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/examples/visual-tests/amp-story/amp-story-360-image.html
+++ b/examples/visual-tests/amp-story/amp-story-360-image.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-story-360 Visual Diff</title>

--- a/examples/visual-tests/amp-story/amp-story-dev-tools.html
+++ b/examples/visual-tests/amp-story/amp-story-dev-tools.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-story-interactive-quiz example</title>

--- a/examples/visual-tests/amp-story/amp-story-interactive-quiz-sizing-positioning.html
+++ b/examples/visual-tests/amp-story/amp-story-interactive-quiz-sizing-positioning.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-story-interactive-quiz example</title>

--- a/examples/visual-tests/amp-user-notification/amp-user-notification.amp.html
+++ b/examples/visual-tests/amp-user-notification/amp-user-notification.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/visual-tests/amp-video-docking/ltr.html
+++ b/examples/visual-tests/amp-video-docking/ltr.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-video-docking visual test</title>

--- a/examples/visual-tests/amp-video-docking/rtl.html
+++ b/examples/visual-tests/amp-video-docking/rtl.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-video-docking visual test</title>

--- a/examples/visual-tests/amp-video-docking/slot.html
+++ b/examples/visual-tests/amp-video-docking/slot.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-video-docking visual test</title>

--- a/examples/visual-tests/amphtml-ads/amp-fie-adchoices.html
+++ b/examples/visual-tests/amphtml-ads/amp-fie-adchoices.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMPHTML Ad FIE test</title>

--- a/examples/visual-tests/amphtml-ads/amp-fie-static.html
+++ b/examples/visual-tests/amphtml-ads/amp-fie-static.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMPHTML Ad FIE test</title>

--- a/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html
+++ b/examples/visual-tests/amphtml-ads/resource/amp-ads-fallback.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMPHTML Ad FIE test</title>

--- a/examples/visual-tests/article-access.amp/article-access.amp.html
+++ b/examples/visual-tests/article-access.amp/article-access.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/visual-tests/article-fade-in.amp.html
+++ b/examples/visual-tests/article-fade-in.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with fade-in animations</title>

--- a/examples/visual-tests/article.amp/article.amp.html
+++ b/examples/visual-tests/article.amp/article.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/examples/visual-tests/css.amp/css.amp.html
+++ b/examples/visual-tests/css.amp/css.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>CSS example</title>

--- a/examples/visual-tests/font.amp.404/font.amp.html
+++ b/examples/visual-tests/font.amp.404/font.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Font example</title>

--- a/examples/visual-tests/video/rotate-to-fullscreen.html
+++ b/examples/visual-tests/video/rotate-to-fullscreen.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Rotate to fullscreen</title>

--- a/examples/viz-vega.amp.html
+++ b/examples/viz-vega.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Vega Visualization examples</title>

--- a/examples/vk.amp.html
+++ b/examples/vk.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-vk example</title>

--- a/examples/youtube.amp.html
+++ b/examples/youtube.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>AMP #0</title>


### PR DESCRIPTION
This PR is a partial copy of #31208, which adds `lang="en"` to relevant code snippets in this codebase. Instead of copying the PR file-for-file, I decided to break this change up into a few root directories for ease of review and less likelihood of falling behind to merge conflicts. 

Original PR description:
> Suggested changes and additions based on the TetraLogical accessibility review commissioned by @nainar / @caroqliu
>
> x-ref ampproject/amp.dev#4972

Others in the series: #34757 #34758
/cc @TetraLogicalHelpdesk 