### PR TITLE
♿ Apply `lang="en"` to relevant snippets in `test/`

### DIFF
--- a/test/fixtures/3p-ad.html
+++ b/test/fixtures/3p-ad.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>We can render an ad</title>

--- a/test/fixtures/actions.html
+++ b/test/fixtures/actions.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Fixture: Actions</title>

--- a/test/fixtures/amp-pan-zoom.html
+++ b/test/fixtures/amp-pan-zoom.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Pan Zoom Demo</title>

--- a/test/fixtures/boilerplate-new-visibility.html
+++ b/test/fixtures/boilerplate-new-visibility.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Released AMP components</title>

--- a/test/fixtures/boilerplate-old-opacity.html
+++ b/test/fixtures/boilerplate-old-opacity.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Released AMP components</title>

--- a/test/fixtures/configuration.html
+++ b/test/fixtures/configuration.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/datepicker.html
+++ b/test/fixtures/datepicker.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Date Picker Example</title>

--- a/test/fixtures/doubleclick.html
+++ b/test/fixtures/doubleclick.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>We can render an ad</title>

--- a/test/fixtures/doubleload-module.html
+++ b/test/fixtures/doubleload-module.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/doubleload-nomodule.html
+++ b/test/fixtures/doubleload-nomodule.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/e2e/amp-accordion/amp-accordion.html
+++ b/test/fixtures/e2e/amp-accordion/amp-accordion.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-accordion</title>

--- a/test/fixtures/e2e/amp-accordion/single-expand.html
+++ b/test/fixtures/e2e/amp-accordion/single-expand.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-accordion</title>

--- a/test/fixtures/e2e/amp-animation/simple.html
+++ b/test/fixtures/e2e/amp-animation/simple.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Animations Examples</title>

--- a/test/fixtures/e2e/amp-autocomplete/amp-autocomplete-inline.amp.html
+++ b/test/fixtures/e2e/amp-autocomplete/amp-autocomplete-inline.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>amp-autocomplete examples</title>

--- a/test/fixtures/e2e/amp-autocomplete/amp-autocomplete.amp.html
+++ b/test/fixtures/e2e/amp-autocomplete/amp-autocomplete.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-autocomplete examples</title>

--- a/test/fixtures/e2e/amp-base-carousel/1.0/autoadvance.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/1.0/autoadvance.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/1.0/basic.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/1.0/basic.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/1.0/grouping-move-by-2.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/1.0/grouping-move-by-2.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/1.0/mixed-lengths-no-snap.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/1.0/mixed-lengths-no-snap.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Mixed lengths carousel, looping</title>

--- a/test/fixtures/e2e/amp-base-carousel/1.0/mixed-lengths.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/1.0/mixed-lengths.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Mixed lengths carousel, looping</title>

--- a/test/fixtures/e2e/amp-base-carousel/1.0/vertical.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/1.0/vertical.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Vertical Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/advance.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/advance.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/fixtures/e2e/amp-base-carousel/arrows-in-lightbox.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/arrows-in-lightbox.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP Lightbox Carousel With AMP Selector</title>

--- a/test/fixtures/e2e/amp-base-carousel/autoadvance-rtl.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/autoadvance-rtl.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/autoadvance.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/autoadvance.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/basic-rtl.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/basic-rtl.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/basic.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/basic.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/bind-slide.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/bind-slide.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Carousel with bound slide</title>

--- a/test/fixtures/e2e/amp-base-carousel/captions.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/captions.amp.html
@@ -1,6 +1,6 @@
 
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/custom-arrows.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/custom-arrows.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/default-attributes.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/default-attributes.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />

--- a/test/fixtures/e2e/amp-base-carousel/fixed-children.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/fixed-children.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/e2e/amp-base-carousel/grouping-autoadvance.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/grouping-autoadvance.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Auto advance with grouping</title>

--- a/test/fixtures/e2e/amp-base-carousel/grouping-looping.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/grouping-looping.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/grouping-move-by-2.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/grouping-move-by-2.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/grouping.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/grouping.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/hidden-controls.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/hidden-controls.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/initial-slide.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/initial-slide.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Initial index carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/mixed-lengths-no-snap.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/mixed-lengths-no-snap.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Mixed lengths carousel, looping</title>

--- a/test/fixtures/e2e/amp-base-carousel/mixed-lengths.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/mixed-lengths.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Mixed lengths carousel, looping</title>

--- a/test/fixtures/e2e/amp-base-carousel/multi-visible-single-advance.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/multi-visible-single-advance.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />

--- a/test/fixtures/e2e/amp-base-carousel/no-arrows.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/no-arrows.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>No arrows for mixed length</title>

--- a/test/fixtures/e2e/amp-base-carousel/non-looping-rtl.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/non-looping-rtl.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Non-Looping Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/non-looping.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/non-looping.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Non-Looping Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/peeking-sides-centered.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/peeking-sides-centered.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Peeking sides carousel, center aligned</title>

--- a/test/fixtures/e2e/amp-base-carousel/peeking-sides-start-aligned.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/peeking-sides-start-aligned.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Peeking sides carousel, start aligned</title>

--- a/test/fixtures/e2e/amp-base-carousel/related-items.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/related-items.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Related items config</title>

--- a/test/fixtures/e2e/amp-base-carousel/responsive.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/responsive.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Basic Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/snap-property.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/snap-property.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />

--- a/test/fixtures/e2e/amp-base-carousel/three-slides-rtl.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/three-slides-rtl.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Three slides</title>

--- a/test/fixtures/e2e/amp-base-carousel/three-slides.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/three-slides.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Three slides</title>

--- a/test/fixtures/e2e/amp-base-carousel/tweets.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/tweets.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Tweets Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/two-slides.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/two-slides.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Two slides</title>

--- a/test/fixtures/e2e/amp-base-carousel/vertical.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/vertical.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Vertical Carousel</title>

--- a/test/fixtures/e2e/amp-base-carousel/zero-index-slide.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/zero-index-slide.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-bind</title>

--- a/test/fixtures/e2e/amp-bind/bind-basic.html
+++ b/test/fixtures/e2e/amp-bind/bind-basic.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind : basic</title>

--- a/test/fixtures/e2e/amp-bind/bind-brightcove.html
+++ b/test/fixtures/e2e/amp-bind/bind-brightcove.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind : amp-brightcove</title>

--- a/test/fixtures/e2e/amp-bind/bind-form.html
+++ b/test/fixtures/e2e/amp-bind/bind-form.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind : amp-form</title>

--- a/test/fixtures/e2e/amp-bind/bind-iframe.html
+++ b/test/fixtures/e2e/amp-bind/bind-iframe.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind : amp-iframe</title>

--- a/test/fixtures/e2e/amp-bind/bind-live-list.html
+++ b/test/fixtures/e2e/amp-bind/bind-live-list.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind : amp-live-list</title>

--- a/test/fixtures/e2e/amp-bind/bind-video.html
+++ b/test/fixtures/e2e/amp-bind/bind-video.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind : amp-video</title>

--- a/test/fixtures/e2e/amp-bind/bind-youtube.html
+++ b/test/fixtures/e2e/amp-bind/bind-youtube.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-bind : amp-youtube</title>

--- a/test/fixtures/e2e/amp-carousel/0.1/document-height.html
+++ b/test/fixtures/e2e/amp-carousel/0.1/document-height.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP documentHeight test</title>

--- a/test/fixtures/e2e/amp-carousel/0.1/hidden-controls.amp.html
+++ b/test/fixtures/e2e/amp-carousel/0.1/hidden-controls.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Carousel 0.1</title>

--- a/test/fixtures/e2e/amp-carousel/0.1/slidescroll-autoplay.html
+++ b/test/fixtures/e2e/amp-carousel/0.1/slidescroll-autoplay.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Carousel 0.1</title>

--- a/test/fixtures/e2e/amp-carousel/0.2/amp-lightbox-carousel-selector.amp.html
+++ b/test/fixtures/e2e/amp-carousel/0.2/amp-lightbox-carousel-selector.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP Lightbox Carousel With AMP Selector</title>

--- a/test/fixtures/e2e/amp-carousel/0.2/responsive-slides.amp.html
+++ b/test/fixtures/e2e/amp-carousel/0.2/responsive-slides.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Responsive Carousel</title>

--- a/test/fixtures/e2e/amp-consent/amp-consent-basic-uses.amp.html
+++ b/test/fixtures/e2e/amp-consent/amp-consent-basic-uses.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent GEO Test</title>

--- a/test/fixtures/e2e/amp-consent/cmp-interaction.html
+++ b/test/fixtures/e2e/amp-consent/cmp-interaction.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/fixtures/e2e/amp-date-countdown/amp-date-countdown.html
+++ b/test/fixtures/e2e/amp-date-countdown/amp-date-countdown.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-date-countdown</title>

--- a/test/fixtures/e2e/amp-date-picker/blocked-dates.html
+++ b/test/fixtures/e2e/amp-date-picker/blocked-dates.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Date Picker Example</title>

--- a/test/fixtures/e2e/amp-fit-text/0.1/amp-fit-text.html
+++ b/test/fixtures/e2e/amp-fit-text/0.1/amp-fit-text.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
  <meta charset="utf-8">
  <title>AMP #0</title>

--- a/test/fixtures/e2e/amp-fit-text/1.0/amp-fit-text.html
+++ b/test/fixtures/e2e/amp-fit-text/1.0/amp-fit-text.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
  <meta charset="utf-8">
  <title>AMP #0</title>

--- a/test/fixtures/e2e/amp-form/custom-validation-reporting.html
+++ b/test/fixtures/e2e/amp-form/custom-validation-reporting.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <!-- prettier-ignore -->
   <head>
     <meta charset="utf-8">

--- a/test/fixtures/e2e/amp-lightbox/amp-lightbox-autocomplete.html
+++ b/test/fixtures/e2e/amp-lightbox/amp-lightbox-autocomplete.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-lightbox</title>

--- a/test/fixtures/e2e/amp-lightbox/amp-lightbox-gallery-launch.amp.html
+++ b/test/fixtures/e2e/amp-lightbox/amp-lightbox-gallery-launch.amp.html
@@ -5,7 +5,7 @@ The amp-lightbox-gallery component provides a "lightbox” experience for AMP co
 -->
 <!-- -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="/components/amp-lightbox-gallery/">

--- a/test/fixtures/e2e/amp-lightbox/amp-lightbox-with-carousel-0.2.amp.html
+++ b/test/fixtures/e2e/amp-lightbox/amp-lightbox-with-carousel-0.2.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="/components/amp-lightbox-gallery/">

--- a/test/fixtures/e2e/amp-lightbox/amp-lightbox.html
+++ b/test/fixtures/e2e/amp-lightbox/amp-lightbox.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-lightbox</title>

--- a/test/fixtures/e2e/amp-lightbox/custom-close-button.amp.html
+++ b/test/fixtures/e2e/amp-lightbox/custom-close-button.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-lightbox</title>

--- a/test/fixtures/e2e/amp-list/amp-list-function-load-more.html
+++ b/test/fixtures/e2e/amp-list/amp-list-function-load-more.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/test/fixtures/e2e/amp-list/amp-list-function-src.html
+++ b/test/fixtures/e2e/amp-list/amp-list-function-src.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/test/fixtures/e2e/amp-list/load-more-auto.amp.html
+++ b/test/fixtures/e2e/amp-list/load-more-auto.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/e2e/amp-list/load-more-manual.amp.html
+++ b/test/fixtures/e2e/amp-list/load-more-manual.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/e2e/amp-position-observer/scrollbound-animation.html
+++ b/test/fixtures/e2e/amp-position-observer/scrollbound-animation.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/fixtures/e2e/amp-position-observer/target-id.html
+++ b/test/fixtures/e2e/amp-position-observer/target-id.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/fixtures/e2e/amp-script/basic.amp.html
+++ b/test/fixtures/e2e/amp-script/basic.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="self.html" />

--- a/test/fixtures/e2e/amp-selector/amp-selector-tabs.html
+++ b/test/fixtures/e2e/amp-selector/amp-selector-tabs.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
 

--- a/test/fixtures/e2e/amp-sidebar/amp-sidebar-toolbar.html
+++ b/test/fixtures/e2e/amp-sidebar/amp-sidebar-toolbar.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-sidebar</title>

--- a/test/fixtures/e2e/amp-sidebar/amp-sidebar.html
+++ b/test/fixtures/e2e/amp-sidebar/amp-sidebar.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-sidebar</title>

--- a/test/fixtures/e2e/amp-social-share/amp-social-share.html
+++ b/test/fixtures/e2e/amp-social-share/amp-social-share.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>amp-social-share</title>

--- a/test/fixtures/e2e/amp-story-player/basic.amp.html
+++ b/test/fixtures/e2e/amp-story-player/basic.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <title>Story Player (AMP version)</title>
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/test/fixtures/e2e/amp-story-player/navigation.amp.html
+++ b/test/fixtures/e2e/amp-story-player/navigation.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <title>Story Player (AMP version)</title>
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/test/fixtures/e2e/amp-story-player/pre-rendering.amp.html
+++ b/test/fixtures/e2e/amp-story-player/pre-rendering.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <title>Story Player (AMP version)</title>
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/test/fixtures/e2e/amp-subscriptions-google/swg.amp.html
+++ b/test/fixtures/e2e/amp-subscriptions-google/swg.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>16 Top Spots for Hiking - The Scenic - USA</title>

--- a/test/fixtures/e2e/amp-video/analytics-triggers.html
+++ b/test/fixtures/e2e/amp-video/analytics-triggers.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <title>amp-video</title>
     <meta charset="utf-8" />

--- a/test/fixtures/e2e/amp-video/autoplay.html
+++ b/test/fixtures/e2e/amp-video/autoplay.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <title>amp-video</title>
   <meta charset="utf-8">

--- a/test/fixtures/errors.html
+++ b/test/fixtures/errors.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/images-ie.html
+++ b/test/fixtures/images-ie.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/overflow.html
+++ b/test/fixtures/overflow.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-iframe</title>

--- a/test/fixtures/placeholder.html
+++ b/test/fixtures/placeholder.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-video-iframe</title>

--- a/test/fixtures/released.html
+++ b/test/fixtures/released.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Released AMP components</title>

--- a/test/fixtures/script-load-extension-footer-v0-footer.html
+++ b/test/fixtures/script-load-extension-footer-v0-footer.html
@@ -1,6 +1,6 @@
 <!-- All scripts in head, extension loads first-->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/script-load-extension-head-v0-head.html
+++ b/test/fixtures/script-load-extension-head-v0-head.html
@@ -1,6 +1,6 @@
 <!-- All scripts in head, extension loads first-->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/script-load-extensions.html
+++ b/test/fixtures/script-load-extensions.html
@@ -1,6 +1,6 @@
 <!-- All scripts in head, extension loads first-->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/script-load-v0-footer-extension-footer.html
+++ b/test/fixtures/script-load-v0-footer-extension-footer.html
@@ -1,6 +1,6 @@
 <!-- All scripts in head, extension loads first-->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/script-load-v0-head-extension-footer.html
+++ b/test/fixtures/script-load-v0-head-extension-footer.html
@@ -1,6 +1,6 @@
 <!-- All scripts in head, extension loads first-->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/script-load-v0-head-extension-head.html
+++ b/test/fixtures/script-load-v0-head-extension-head.html
@@ -1,6 +1,6 @@
 <!-- All scripts in head, extension loads first-->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/fixtures/served/ampdoc-with-messaging.html
+++ b/test/fixtures/served/ampdoc-with-messaging.html
@@ -15,7 +15,7 @@
   Tests amp-viewer-integration.
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="amps.html" >

--- a/test/fixtures/shadow-dom-element-polyfill.html
+++ b/test/fixtures/shadow-dom-element-polyfill.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>We can render a shadow dom element</title>

--- a/test/fixtures/shadow-dom-element.html
+++ b/test/fixtures/shadow-dom-element.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>We can render a shadow dom element</title>

--- a/test/fixtures/video-players.html
+++ b/test/fixtures/video-players.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Video Players Tests</title>

--- a/test/fixtures/visibility-state.html
+++ b/test/fixtures/visibility-state.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Released AMP components</title>

--- a/test/manual/accessibility/aria-propagation.amp.html
+++ b/test/manual/accessibility/aria-propagation.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>AMP #0</title>

--- a/test/manual/ad-scrolling.amp.html
+++ b/test/manual/ad-scrolling.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/test/manual/always-serve-npa.amp.html
+++ b/test/manual/always-serve-npa.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Always Serve NPA Example</title>

--- a/test/manual/amp-accordion-integration.amp.html
+++ b/test/manual/amp-accordion-integration.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-accordion.amp.html
+++ b/test/manual/amp-accordion.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-ad-custom.amp.html
+++ b/test/manual/amp-ad-custom.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/test/manual/amp-ad-expose-container.html
+++ b/test/manual/amp-ad-expose-container.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/test/manual/amp-ad.amp.html
+++ b/test/manual/amp-ad.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-analytics-cookie-writer.html
+++ b/test/manual/amp-analytics-cookie-writer.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-analytics-in-fie.amp.html
+++ b/test/manual/amp-analytics-in-fie.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-analytics-visible-repeat.amp.html
+++ b/test/manual/amp-analytics-visible-repeat.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad visible repeat examples</title>

--- a/test/manual/amp-analytics/amp-analytics-multi-selector.html
+++ b/test/manual/amp-analytics/amp-analytics-multi-selector.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>Ad visible repeat examples</title>

--- a/test/manual/amp-analytics/analytics-fcp.html
+++ b/test/manual/amp-analytics/analytics-fcp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-analytics/analytics-linker.html
+++ b/test/manual/amp-analytics/analytics-linker.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-analytics/analytics-nav-timing.html
+++ b/test/manual/amp-analytics/analytics-nav-timing.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-analytics/analytics-nested.html
+++ b/test/manual/amp-analytics/analytics-nested.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-analytics/analytics-shadow-root-1.html
+++ b/test/manual/amp-analytics/analytics-shadow-root-1.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-analytics/analytics-shadow-root-2.html
+++ b/test/manual/amp-analytics/analytics-shadow-root-2.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-analytics/analytics-shadow.html
+++ b/test/manual/amp-analytics/analytics-shadow.html
@@ -1,6 +1,6 @@
 
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics in shadow Root</title>

--- a/test/manual/amp-analytics/core-web-vitals.html
+++ b/test/manual/amp-analytics/core-web-vitals.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-analytics/default-data-vars.html
+++ b/test/manual/amp-analytics/default-data-vars.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
 	<meta charset="utf-8">

--- a/test/manual/amp-analytics/variable-request-examples.html
+++ b/test/manual/amp-analytics/variable-request-examples.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
     <meta charset="utf-8">

--- a/test/manual/amp-analytics/variable-request-tester.html
+++ b/test/manual/amp-analytics/variable-request-tester.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
     <meta charset="utf-8">

--- a/test/manual/amp-anim.amp.html
+++ b/test/manual/amp-anim.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-animation/scrollbound-embeds.amp.html
+++ b/test/manual/amp-animation/scrollbound-embeds.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/manual/amp-audio.amp.html
+++ b/test/manual/amp-audio.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-bind-intersection-observer-polyfill.html
+++ b/test/manual/amp-bind-intersection-observer-polyfill.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-bind: Basic</title>

--- a/test/manual/amp-carousel-scroll-regression.amp.html
+++ b/test/manual/amp-carousel-scroll-regression.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-carousel-scroll-test.amp.html
+++ b/test/manual/amp-carousel-scroll-test.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-carousel.amp.html
+++ b/test/manual/amp-carousel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-carousel/0.1/slides.amp.html
+++ b/test/manual/amp-carousel/0.1/slides.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-carousel/0.2/slides.amp.html
+++ b/test/manual/amp-carousel/0.2/slides.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-close-or-navigate-target.amp.html
+++ b/test/manual/amp-close-or-navigate-target.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-close-or-navigate.amp.html
+++ b/test/manual/amp-close-or-navigate.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-consent/amp-consent-actions.html
+++ b/test/manual/amp-consent/amp-consent-actions.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent GEO Test</title>

--- a/test/manual/amp-consent/amp-consent-cmp-overlay.html
+++ b/test/manual/amp-consent/amp-consent-cmp-overlay.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/manual/amp-consent/amp-consent-granular-consent.html
+++ b/test/manual/amp-consent/amp-consent-granular-consent.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP Consent Granular Consent</title>

--- a/test/manual/amp-consent/amp-consent-inline-postPromptUI.html
+++ b/test/manual/amp-consent/amp-consent-inline-postPromptUI.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent GEO Test</title>

--- a/test/manual/amp-consent/amp-consent-syncing-cid-forwarding.amp.html
+++ b/test/manual/amp-consent/amp-consent-syncing-cid-forwarding.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Linker</title>

--- a/test/manual/amp-consent/amp-consent-syncing-cid-receiving.amp.html
+++ b/test/manual/amp-consent/amp-consent-syncing-cid-receiving.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/amp-consent/legacy_config_support/amp-consent-cmp.html
+++ b/test/manual/amp-consent/legacy_config_support/amp-consent-cmp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/manual/amp-consent/legacy_config_support/amp-consent-geo.html
+++ b/test/manual/amp-consent/legacy_config_support/amp-consent-geo.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent Test</title>

--- a/test/manual/amp-consent/legacy_config_support/amp-consent-iframe.amp.html
+++ b/test/manual/amp-consent/legacy_config_support/amp-consent-iframe.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent Test</title>

--- a/test/manual/amp-consent/legacy_config_support/amp-consent.amp.html
+++ b/test/manual/amp-consent/legacy_config_support/amp-consent.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Consent Test</title>

--- a/test/manual/amp-experiment-1.0.html
+++ b/test/manual/amp-experiment-1.0.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-experiment</title>

--- a/test/manual/amp-flying-carpet.amp.html
+++ b/test/manual/amp-flying-carpet.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-form-textarea-added.amp.html
+++ b/test/manual/amp-form-textarea-added.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Forms Examples in AMP</title>

--- a/test/manual/amp-form-textarea.amp.html
+++ b/test/manual/amp-form-textarea.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>Forms Examples in AMP</title>

--- a/test/manual/amp-gfycat.amp.html
+++ b/test/manual/amp-gfycat.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-iframe-animate-container.html
+++ b/test/manual/amp-iframe-animate-container.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-iframe-clicktoplay.html
+++ b/test/manual/amp-iframe-clicktoplay.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-iframe</title>

--- a/test/manual/amp-iframe-messaging.amp.html
+++ b/test/manual/amp-iframe-messaging.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-iframe</title>

--- a/test/manual/amp-iframe-resize.amp.html
+++ b/test/manual/amp-iframe-resize.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-iframe</title>

--- a/test/manual/amp-iframe.amp.html
+++ b/test/manual/amp-iframe.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-iframe</title>

--- a/test/manual/amp-ima-video.html
+++ b/test/manual/amp-ima-video.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>IMA examples</title>

--- a/test/manual/amp-image-lightbox.amp.html
+++ b/test/manual/amp-image-lightbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-image-slider.amp.html
+++ b/test/manual/amp-image-slider.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-image-slider example</title>

--- a/test/manual/amp-img-404.html
+++ b/test/manual/amp-img-404.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/test/manual/amp-img-fallback.amp.html
+++ b/test/manual/amp-img-fallback.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-img-sizes.amp.html
+++ b/test/manual/amp-img-sizes.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-img.amp.html
+++ b/test/manual/amp-img.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-inline-gallery/captions.html
+++ b/test/manual/amp-inline-gallery/captions.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/fixed-height.amp.html
+++ b/test/manual/amp-inline-gallery/fixed-height.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/pagination-and-thumbnails.amp.html
+++ b/test/manual/amp-inline-gallery/pagination-and-thumbnails.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/pagination-only-autoplay.amp.html
+++ b/test/manual/amp-inline-gallery/pagination-only-autoplay.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/pagination-only-many-slides.amp.html
+++ b/test/manual/amp-inline-gallery/pagination-only-many-slides.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/pagination-only-outset.amp.html
+++ b/test/manual/amp-inline-gallery/pagination-only-outset.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/pagination-only-remote-images.amp.html
+++ b/test/manual/amp-inline-gallery/pagination-only-remote-images.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/pagination-only-responsive.amp.html
+++ b/test/manual/amp-inline-gallery/pagination-only-responsive.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/pagination-only.amp.html
+++ b/test/manual/amp-inline-gallery/pagination-only.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-inline-gallery/rtl.amp.html
+++ b/test/manual/amp-inline-gallery/rtl.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>A Basic inline gallery</title>

--- a/test/manual/amp-instagram.amp.html
+++ b/test/manual/amp-instagram.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-install-serviceworker.amp.html
+++ b/test/manual/amp-install-serviceworker.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-twitter</title>

--- a/test/manual/amp-lightbox-carousel.amp.html
+++ b/test/manual/amp-lightbox-carousel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-lightbox-focus.amp.html
+++ b/test/manual/amp-lightbox-focus.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-lightbox</title>

--- a/test/manual/amp-lightbox-gallery-launch-captions.amp.html
+++ b/test/manual/amp-lightbox-gallery-launch-captions.amp.html
@@ -5,7 +5,7 @@ The amp-lightbox-gallery component provides a "lightbox” experience for AMP co
 -->
 <!-- -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="/components/amp-lightbox-gallery/">

--- a/test/manual/amp-lightbox-gallery.amp.html
+++ b/test/manual/amp-lightbox-gallery.amp.html
@@ -1,6 +1,6 @@
 
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <link rel="canonical" href="/components/amp-lightbox-gallery/">

--- a/test/manual/amp-lightbox.amp.html
+++ b/test/manual/amp-lightbox.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-linker-simple.amp.html
+++ b/test/manual/amp-linker-simple.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>AMP Linker Simple</title>

--- a/test/manual/amp-list/amp-list-resize-flex.amp.html
+++ b/test/manual/amp-list/amp-list-resize-flex.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-list/amp-list-resize.amp.html
+++ b/test/manual/amp-list/amp-list-resize.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-list/amp-list-with-ads.amp.html
+++ b/test/manual/amp-list/amp-list-with-ads.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-list/amp-list.amp.html
+++ b/test/manual/amp-list/amp-list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-list/infinite-scroll-1.amp.html
+++ b/test/manual/amp-list/infinite-scroll-1.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-list/infinite-scroll-fail.amp.html
+++ b/test/manual/amp-list/infinite-scroll-fail.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-list/load-more-refresh.amp.html
+++ b/test/manual/amp-list/load-more-refresh.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-list/load-more-state.amp.html
+++ b/test/manual/amp-list/load-more-state.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-mega-menu/amp-mega-menu-with-list.amp.html
+++ b/test/manual/amp-mega-menu/amp-mega-menu-with-list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-mega-menu</title>

--- a/test/manual/amp-mega-menu/amp-mega-menu.amp.html
+++ b/test/manual/amp-mega-menu/amp-mega-menu.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-mega-menu</title>

--- a/test/manual/amp-megaphone.amp.html
+++ b/test/manual/amp-megaphone.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-megaphone</title>

--- a/test/manual/amp-nested-menu/amp-nested-menu-with-list.amp.html
+++ b/test/manual/amp-nested-menu/amp-nested-menu-with-list.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-nested-menu/amp-nested-menu.amp.html
+++ b/test/manual/amp-nested-menu/amp-nested-menu.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-next-page/1.0/amp-next-page-v1.element-visibility.html
+++ b/test/manual/amp-next-page/1.0/amp-next-page-v1.element-visibility.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP next page element visibility examples</title>

--- a/test/manual/amp-next-page/1.0/amp-next-page.amp.html
+++ b/test/manual/amp-next-page/1.0/amp-next-page.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP next page examples</title>

--- a/test/manual/amp-next-page/1.0/amp-next-page.element-visibility.html
+++ b/test/manual/amp-next-page/1.0/amp-next-page.element-visibility.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP next page element visibility examples</title>

--- a/test/manual/amp-next-page/1.0/amp-next-page.script-templated-separator.amp.html
+++ b/test/manual/amp-next-page/1.0/amp-next-page.script-templated-separator.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP next page examples</title>

--- a/test/manual/amp-next-page/1.0/articles/article-long.html
+++ b/test/manual/amp-next-page/1.0/articles/article-long.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with parallax title</title>

--- a/test/manual/amp-next-page/1.0/articles/article-short.html
+++ b/test/manual/amp-next-page/1.0/articles/article-short.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with parallax title</title>

--- a/test/manual/amp-next-page/1.0/articles/article-with-fixed.html
+++ b/test/manual/amp-next-page/1.0/articles/article-with-fixed.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Article with parallax title</title>

--- a/test/manual/amp-next-page/1.0/articles/element-visibility-1.html
+++ b/test/manual/amp-next-page/1.0/articles/element-visibility-1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP next page element visibility examples</title>

--- a/test/manual/amp-next-page/1.0/articles/element-visibility-2.html
+++ b/test/manual/amp-next-page/1.0/articles/element-visibility-2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>AMP next page element visibility examples</title>

--- a/test/manual/amp-pan-zoom/amp-pan-zoom-carousel.amp.html
+++ b/test/manual/amp-pan-zoom/amp-pan-zoom-carousel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-pan-zoom/amp-pan-zoom-initial.amp.html
+++ b/test/manual/amp-pan-zoom/amp-pan-zoom-initial.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Pan Zoom Demo</title>

--- a/test/manual/amp-pan-zoom/amp-pan-zoom-integration.amp.html
+++ b/test/manual/amp-pan-zoom/amp-pan-zoom-integration.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Pan Zoom Demo</title>

--- a/test/manual/amp-pan-zoom/amp-pan-zoom-positioning.amp.html
+++ b/test/manual/amp-pan-zoom/amp-pan-zoom-positioning.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Pan Zoom Demo</title>

--- a/test/manual/amp-pan-zoom/amp-pan-zoom.amp.html
+++ b/test/manual/amp-pan-zoom/amp-pan-zoom.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Pan Zoom Demo</title>

--- a/test/manual/amp-pixel.amp.html
+++ b/test/manual/amp-pixel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-selector.amp.html
+++ b/test/manual/amp-selector.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-sidebar.amp.html
+++ b/test/manual/amp-sidebar.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-single-pass-compilation.html
+++ b/test/manual/amp-single-pass-compilation.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-slidescroll.amp.html
+++ b/test/manual/amp-slidescroll.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-soundcloud.amp.html
+++ b/test/manual/amp-soundcloud.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-soundcloud</title>

--- a/test/manual/amp-sticky-ad-collapse.amp.html
+++ b/test/manual/amp-sticky-ad-collapse.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Sticky Ad Test</title>

--- a/test/manual/amp-stream-gallery/basic.amp.html
+++ b/test/manual/amp-stream-gallery/basic.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-stream-gallery/custom-arrows.amp.html
+++ b/test/manual/amp-stream-gallery/custom-arrows.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-stream-gallery/outset-arrows-partial-count-approximate.amp.html
+++ b/test/manual/amp-stream-gallery/outset-arrows-partial-count-approximate.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-stream-gallery/outset-arrows-partial-count.amp.html
+++ b/test/manual/amp-stream-gallery/outset-arrows-partial-count.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-stream-gallery/outset-arrows.amp.html
+++ b/test/manual/amp-stream-gallery/outset-arrows.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-stream-gallery/responsive.amp.html
+++ b/test/manual/amp-stream-gallery/responsive.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-stream-gallery/rtl.amp.html
+++ b/test/manual/amp-stream-gallery/rtl.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-stream-gallery/spacing.amp.html
+++ b/test/manual/amp-stream-gallery/spacing.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Stream Gallery</title>

--- a/test/manual/amp-subscriptions-google/swg.amp.html
+++ b/test/manual/amp-subscriptions-google/swg.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <header>
   <meta charset="utf-8">
   <title>16 Top Spots for Hiking - The Scenic - USA</title>

--- a/test/manual/amp-truncate-text/even-more.amp.html
+++ b/test/manual/amp-truncate-text/even-more.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text always show expand</title>

--- a/test/manual/amp-truncate-text/expand-collapse.amp.html
+++ b/test/manual/amp-truncate-text/expand-collapse.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text truncated link</title>

--- a/test/manual/amp-truncate-text/full-width-button.amp.html
+++ b/test/manual/amp-truncate-text/full-width-button.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text full width button</title>

--- a/test/manual/amp-truncate-text/inline-block-compact.amp.html
+++ b/test/manual/amp-truncate-text/inline-block-compact.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text inline-block, compact</title>

--- a/test/manual/amp-truncate-text/inline-block-large.amp.html
+++ b/test/manual/amp-truncate-text/inline-block-large.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text inline-block, large</title>

--- a/test/manual/amp-truncate-text/inline-button.amp.html
+++ b/test/manual/amp-truncate-text/inline-button.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text example</title>

--- a/test/manual/amp-truncate-text/link-before-truncation.amp.html
+++ b/test/manual/amp-truncate-text/link-before-truncation.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text link before truncation</title>

--- a/test/manual/amp-truncate-text/link-truncated.amp.html
+++ b/test/manual/amp-truncate-text/link-truncated.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text truncated link</title>

--- a/test/manual/amp-truncate-text/no-overflow-element.amp.html
+++ b/test/manual/amp-truncate-text/no-overflow-element.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text no overflow element</title>

--- a/test/manual/amp-truncate-text/persistent-and-collapsed.amp.html
+++ b/test/manual/amp-truncate-text/persistent-and-collapsed.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text persistent and collapsed</title>

--- a/test/manual/amp-truncate-text/persistent.amp.html
+++ b/test/manual/amp-truncate-text/persistent.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text persistent button</title>

--- a/test/manual/amp-truncate-text/responsive-size.amp.html
+++ b/test/manual/amp-truncate-text/responsive-size.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text responsive size</title>

--- a/test/manual/amp-truncate-text/right-aligned-compact.amp.html
+++ b/test/manual/amp-truncate-text/right-aligned-compact.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text right aligned, compact</title>

--- a/test/manual/amp-truncate-text/right-aligned-large.amp.html
+++ b/test/manual/amp-truncate-text/right-aligned-large.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-truncate-text right aligned, large</title>

--- a/test/manual/amp-twitter-resize.amp.html
+++ b/test/manual/amp-twitter-resize.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Twitter examples</title>

--- a/test/manual/amp-twitter.amp.html
+++ b/test/manual/amp-twitter.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-twitter</title>

--- a/test/manual/amp-video-auto-fullscreen.amp.html
+++ b/test/manual/amp-video-auto-fullscreen.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-video.amp.html
+++ b/test/manual/amp-video.amp.html
@@ -3,7 +3,7 @@
   multiple extensions through the server task.
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-videoplayers-autoplay.html
+++ b/test/manual/amp-videoplayers-autoplay.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Video Autoplay</title>

--- a/test/manual/amp-vine.amp.html
+++ b/test/manual/amp-vine.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-youtube-carousel.amp.html
+++ b/test/manual/amp-youtube-carousel.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/amp-youtube.amp.html
+++ b/test/manual/amp-youtube.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/ampUserNotification-ampConsent.html
+++ b/test/manual/ampUserNotification-ampConsent.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Lorem Ipsum | PublisherName</title>

--- a/test/manual/analytics-batching.amp.html
+++ b/test/manual/analytics-batching.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/analytics-resource-timing.html
+++ b/test/manual/analytics-resource-timing.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics</title>

--- a/test/manual/analytics-script-target.html
+++ b/test/manual/analytics-script-target.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Analytics: amp-script target</title>

--- a/test/manual/analytics-user-error.amp.html
+++ b/test/manual/analytics-user-error.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>User Error</title>

--- a/test/manual/auto-lightbox/amp-list.html
+++ b/test/manual/auto-lightbox/amp-list.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/test/manual/auto-lightbox/mixed.html
+++ b/test/manual/auto-lightbox/mixed.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 
 <head>
   <meta charset="utf-8">

--- a/test/manual/autofocus-on-show.html
+++ b/test/manual/autofocus-on-show.html
@@ -14,7 +14,7 @@
   limitations under the license.
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Autofocus on show</title>

--- a/test/manual/error.amp.html
+++ b/test/manual/error.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Error messages</title>

--- a/test/manual/fakead3p.amp.html
+++ b/test/manual/fakead3p.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Ad examples</title>

--- a/test/manual/gallery.amp.html
+++ b/test/manual/gallery.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP #0</title>

--- a/test/manual/intersection.amp.html
+++ b/test/manual/intersection.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>amp-iframe</title>

--- a/test/manual/loaders.amp.html
+++ b/test/manual/loaders.amp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8" />
     <title>New Loaders</title>

--- a/test/manual/unavailable-font.amp.html
+++ b/test/manual/unavailable-font.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
   <meta charset="utf-8">
   <title>Font example</title>


### PR DESCRIPTION
This PR is a partial copy of #31208, which adds `lang="en"` to relevant code snippets in this codebase. Instead of copying the PR file-for-file, I decided to break this change up into a few root directories for ease of review and less likelihood of falling behind to merge conflicts.  /to @kristoferbaxter who approved the original PR

**Notably ignores one file in `test/unit` which appears to be specifically about the given document structure (`test/unit/utils/test-dom-transform-stream.js`)**

Original PR description:
> Suggested changes and additions based on the TetraLogical accessibility review commissioned by @nainar / @caroqliu
>
> x-ref ampproject/amp.dev#4972

Others in the series: #34757 #34758 #34759 #34766

/cc @TetraLogicalHelpdesk 