### PR TITLE
Tag stable version as latest on npm

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           npm install
           node ./build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
-          node ./build-system/npm-publish/write-package-files.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
+          node ./build-system/npm-publish/write-package-files.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }} ${{ matrix.version }}
       - name: Publish package for Nightly releases
         if: github.event.inputs.tag != 'latest'
         run: npm publish ./extensions/${{ matrix.extension }}/${{ matrix.version }} --access public --tag ${{ github.event.inputs.tag }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -47,14 +47,16 @@ jobs:
           npm install
           node ./build-system/npm-publish/build-npm-binaries.js ${{ matrix.extension }}
           node ./build-system/npm-publish/write-package-files.js ${{ matrix.extension }} ${{ github.event.inputs.ampversion }}
-      - name: Publish v1
-        run: npm publish ./extensions/${{ matrix.extension }}/1.0 --access public --tag ${{ github.event.inputs.tag }}
+      - name: Publish package for Nightly releases
+        if: github.event.inputs.tag != 'latest'
+        run: npm publish ./extensions/${{ matrix.extension }}/${{ matrix.version }} --access public --tag ${{ github.event.inputs.tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Publish v2 if it exists
+      - name: Tag package as latest for Stable releases
+        if: github.event.inputs.tag == 'latest'
         run: |
-          if $(test -d ${{ github.workspace }}/extensions/${{ matrix.extension }}/2.0); then      
-            npm publish ./extensions/${{ matrix.extension }}/2.0 --access public --tag ${{ github.event.inputs.tag }}
-          fi
+          NPM_PACKAGE=$(jq -r .name ./extensions/${{ matrix.extension }}/${{ matrix.version }}/package.json)
+          NPM_VERSION=$(jq -r .version ./extensions/${{ matrix.extension }}/${{ matrix.version }}/package.json)
+          npm dist-tag add ${NPM_PACKAGE}@${NPM_VERSION} latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.events.inputs.ampversion }}
+      - name: Get latest scripts
+        run: wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/get-extensions.js" -O ./build-system/npm-publish/get-extensions.js
       - name: Get extensions to publish
         id: get-extensions
         run: |

--- a/build-system/npm-publish/get-extensions.js
+++ b/build-system/npm-publish/get-extensions.js
@@ -22,6 +22,9 @@
 const bundles = require('../compile/bundles.config.extensions.json');
 const extensions = bundles
   .filter((bundle) => bundle.options?.npm)
-  .map((bundle) => ({'extension': bundle.name}));
+  .map((bundle) => ({
+    'extension': bundle.name,
+    'version': bundle.version,
+  }));
 console /*OK*/
   .log(JSON.stringify(extensions));

--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -19,17 +19,16 @@
  * Creates npm package files for a given component and AMP version.
  */
 
-const [extension, ampVersion] = process.argv.slice(2);
+const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
 const {log} = require('../common/logging');
 const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
 
 /**
  * Determines whether to skip
- * @param {string} extensionVersion
  * @return {Promise<boolean>}
  */
-async function shouldSkip(extensionVersion) {
+async function shouldSkip() {
   try {
     await stat(`extensions/${extension}/${extensionVersion}`);
     return false;
@@ -41,9 +40,8 @@ async function shouldSkip(extensionVersion) {
 
 /**
  * Write package.json
- * @param {string} extensionVersion
  */
-async function writePackageJson(extensionVersion) {
+async function writePackageJson() {
   const extensionVersionArr = extensionVersion.split('.', 2);
   const major = extensionVersionArr[0];
   const minor = ampVersion.slice(0, 10);
@@ -118,9 +116,8 @@ async function writePackageJson(extensionVersion) {
 
 /**
  * Write react.js
- * @param {string} extensionVersion
  */
-async function writeReactJs(extensionVersion) {
+async function writeReactJs() {
   const content = "module.exports = require('./dist/component-react');";
   try {
     await writeFile(
@@ -139,13 +136,11 @@ async function writeReactJs(extensionVersion) {
  * Main
  */
 async function main() {
-  for (const version of ['1.0', '2.0']) {
-    if (await shouldSkip(version)) {
-      continue;
-    }
-    writePackageJson(version);
-    writeReactJs(version);
+  if (await shouldSkip()) {
+    return;
   }
+  writePackageJson();
+  writeReactJs();
 }
 
 main();


### PR DESCRIPTION
There's a bug where GHA attempts to publish latest package for stable releases, but npm says it can't since it was already published as nightly. Fixes bug by tagging instead of publishing for stable.

Tag-along: removes hard-coded extension versions i.e `1.0` and `2.0`. Use matrix instead by getting `version` values from bundle config