### PR TITLE
🏗🐛 Allow Design Review rotation item to specify own day-of-week

### DIFF
--- a/.github/workflows/update-design-review-issues.yml
+++ b/.github/workflows/update-design-review-issues.yml
@@ -7,13 +7,10 @@ on:
   # for Daylight Savings.
   schedule:
     # Africa/Europe/western Asia
-    # At 16:30 and 17:30 on Wednesday.
     - cron: '30 16,17 * * 3'
     # Americas
-    # At 21:00 and 22:00 on Wednesday.
     - cron: '00 21,22 * * 3'
     # Asia/Oceania
-    # At 01:00 and 02:00 on Thursday.
     - cron: '00 01,02 * * 4'
 
 jobs:

--- a/.github/workflows/update-design-review-issues.yml
+++ b/.github/workflows/update-design-review-issues.yml
@@ -6,12 +6,9 @@ on:
   # Times correspond to session end, and additionally 1 hour earlier to account
   # for Daylight Savings.
   schedule:
-    # Africa/Europe/western Asia
-    - cron: '30 16,17 * * 3'
-    # Americas
-    - cron: '00 21,22 * * 3'
-    # Asia/Oceania
-    - cron: '00 01,02 * * 4'
+    - cron: '30 16,17 * * 3' # Africa/Europe/western Asia
+    - cron: '00 21,22 * * 3' # Americas
+    - cron: '00 01,02 * * 4' # Asia/Oceania
 
 jobs:
   update-design-review-issues:

--- a/.github/workflows/update-design-review-issues.yml
+++ b/.github/workflows/update-design-review-issues.yml
@@ -6,15 +6,15 @@ on:
   # Times correspond to session end, and additionally 1 hour earlier to account
   # for Daylight Savings.
   schedule:
+    # Africa/Europe/western Asia
+    # At 16:30 and 17:30 on Wednesday.
+    - cron: '30 16,17 * * 3'
     # Americas
     # At 21:00 and 22:00 on Wednesday.
     - cron: '00 21,22 * * 3'
     # Asia/Oceania
     # At 01:00 and 02:00 on Thursday.
     - cron: '00 01,02 * * 4'
-    # Africa/Europe/western Asia
-    # At 16:30 and 17:30 on Wednesday.
-    - cron: '30 16,17 * * 3'
 
 jobs:
   update-design-review-issues:

--- a/.github/workflows/update-design-review-issues.yml
+++ b/.github/workflows/update-design-review-issues.yml
@@ -1,9 +1,20 @@
 name: Update Design Review Issues
 
 on:
+  # This schedule should match the time rotation configured on
+  # update-design-review-issues.js.
+  # Times correspond to session end, and additionally 1 hour earlier to account
+  # for Daylight Savings.
   schedule:
-    # At minute 1 on Wednesday (every hour).
-    - cron: '1 * * * 3'
+    # Americas
+    # At 21:00 and 22:00 on Wednesday.
+    - cron: '00 21,22 * * 3'
+    # Asia/Oceania
+    # At 01:00 and 02:00 on Thursday.
+    - cron: '00 01,02 * * 4'
+    # Africa/Europe/western Asia
+    # At 16:30 and 17:30 on Wednesday.
+    - cron: '30 16,17 * * 3'
 
 jobs:
   update-design-review-issues:

--- a/.github/workflows/update-design-review-issues.yml
+++ b/.github/workflows/update-design-review-issues.yml
@@ -7,8 +7,8 @@ on:
   # for Daylight Savings.
   schedule:
     - cron: '30 16,17 * * 3' # Africa/Europe/western Asia
-    - cron: '00 21,22 * * 3' # Americas
-    - cron: '00 01,02 * * 4' # Asia/Oceania
+    - cron: '0 21,22 * * 3' # Americas
+    - cron: '0 1,2 * * 4' # Asia/Oceania
 
 jobs:
   update-design-review-issues:

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -44,12 +44,12 @@ let RotationItemDef;
  * @type {Array<RotationItemDef>}
  */
 const timeRotationUtc = [
+  [/* wed */ 3, 'Africa/Europe/western Asia', '16:30'],
   [/* wed */ 3, 'Americas', '21:00'],
   [/* thu */ 4, 'Asia/Oceania', '01:00'],
-  [/* wed */ 3, 'Africa/Europe/western Asia', '16:30'],
 ];
 
-const timeRotationStart = new Date('2021-03-31');
+const timeRotationStart = new Date('2021-04-14');
 
 // All previous weeks have already been handled.
 const generateWeeksFromNow = 3;

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -44,9 +44,9 @@ let RotationItemDef;
  * @type {Array<RotationItemDef>}
  */
 const timeRotationUtc = [
-  [/* wed */ 3, 'Africa/Europe/western Asia', '16:30'],
-  [/* wed */ 3, 'Americas', '21:00'],
-  [/* thu */ 4, 'Asia/Oceania', '01:00'],
+  [/* wed */ 3, '16:30', 'Africa/Europe/western Asia'],
+  [/* wed */ 3, '21:00', 'Americas'],
+  [/* thu */ 4, '01:00', 'Asia/Oceania'],
 ];
 
 const timeRotationStart = new Date('2021-04-14');
@@ -351,7 +351,7 @@ const timeZ = (yyyy, mm, dd, hours, minutes) =>
 function getNextIssueData() {
   const upcomingWeekday = addDays(new Date(), generateWeeksFromNow * 7);
 
-  const [dayOfWeek, region, timeUtcNoDst] = getRotation(
+  const [dayOfWeek, timeUtcNoDst, region] = getRotation(
     upcomingWeekday,
     timeRotationStart
   );

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -474,6 +474,12 @@ async function closeStaleIssues(token, repo, issuesWithSessionDate) {
   // We may run matching a session's end by the minute, add to prevent off-by-one.
   now.setMinutes(now.getMinutes() + 1);
 
+  console./*OK*/ log(
+    'Closing issues for sessions before',
+    now.toISOString(),
+    '...'
+  );
+
   const issues = issuesWithSessionDate.filter(
     ({sessionDate}) => sessionDate < now.getTime()
   );

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -471,14 +471,10 @@ async function closeStaleIssues(token, repo, issuesWithSessionDate) {
   // Compensate duration so that we swap only once the session has ended.
   now.setHours(now.getHours() - sessionDurationHours);
 
-  // We may run matching a session's end by the minute, add to prevent off-by-one.
-  now.setMinutes(now.getMinutes() + 1);
+  // We may run matching a session's end by the minute, this prevents off-by-one.
+  now.setSeconds(Math.max(1, now.getSeconds()));
 
-  console./*OK*/ log(
-    'Closing issues for sessions before',
-    now.toISOString(),
-    '...'
-  );
+  console./*OK*/ log('Session close cutoff:', now);
 
   const issues = issuesWithSessionDate.filter(
     ({sessionDate}) => sessionDate < now.getTime()

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -332,14 +332,9 @@ function addDays(date, days = 1) {
  * @return {RotationItemDef}
  */
 function getRotation(nextDay, start) {
-  const dateBeginningOfDay = new Date(
-    nextDay.getFullYear(),
-    nextDay.getMonth(),
-    nextDay.getDate()
-  );
   const weeks = Math.round(
     // @ts-ignore date calc
-    (dateBeginningOfDay - start) / (7 * 24 * 60 * 60 * 1000)
+    (nextDay - start) / (7 * 24 * 60 * 60 * 1000)
   );
   return timeRotationUtc[weeks % timeRotationUtc.length];
 }

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -339,7 +339,7 @@ function getRotation(nextDay, start) {
 }
 
 const timeZ = (yyyy, mm, dd, hours, minutes) =>
-  `${yyyy + mm + dd}T${leadingZero(hours) + leadingZero(minutes)}Z`;
+  `${yyyy + mm + dd}T${leadingZero(hours) + leadingZero(minutes)}00Z`;
 
 /**
  * @return {Object}

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -20,7 +20,7 @@
  *
  * https://go.amp.dev/design-reviews
  *
- * A Github Action runs this once a week. See create-design-review-issues.yml
+ * A Github Action runs this once a week. See update-design-review-issues.yml
  */
 
 /*
@@ -40,7 +40,9 @@ const sessionDurationHours = 1;
 let RotationItemDef;
 
 /**
- * Times in this rotation are adjusted according to Daylight Savings
+ * Times in this rotation are adjusted according to Daylight Savings.
+ * If these are updated, the schedule on update-design-review-issues.yml should
+ * also be updated correspondingly.
  * @type {Array<RotationItemDef>}
  */
 const timeRotationUtc = [

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -349,12 +349,7 @@ const timeZ = (yyyy, mm, dd, hours, minutes) =>
  * @return {Object}
  */
 function getNextIssueData() {
-  const today = new Date();
-
-  // Since we may run matching a session's end, add 1 to prevent off-by-one.
-  today.setMinutes(today.getMinutes() + 1);
-
-  const upcomingWeekday = addDays(today, generateWeeksFromNow * 7);
+  const upcomingWeekday = addDays(new Date(), generateWeeksFromNow * 7);
 
   const [dayOfWeek, region, timeUtcNoDst] = getRotation(
     upcomingWeekday,
@@ -475,6 +470,9 @@ async function closeStaleIssues(token, repo, issuesWithSessionDate) {
 
   // Compensate duration so that we swap only once the session has ended.
   now.setHours(now.getHours() - sessionDurationHours);
+
+  // We may run matching a session's end by the minute, add to prevent off-by-one.
+  now.setMinutes(now.getMinutes() + 1);
 
   const issues = issuesWithSessionDate.filter(
     ({sessionDate}) => sessionDate < now.getTime()

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -332,10 +332,9 @@ function addDays(date, days = 1) {
  * @return {RotationItemDef}
  */
 function getRotation(nextDay, start) {
-  const weeks = Math.round(
-    // @ts-ignore date calc
-    (nextDay - start) / (7 * 24 * 60 * 60 * 1000)
-  );
+  // @ts-ignore date calc
+  const delta = nextDay - start;
+  const weeks = Math.round(delta / (7 * 24 * 60 * 60 * 1000));
   return timeRotationUtc[weeks % timeRotationUtc.length];
 }
 


### PR DESCRIPTION
Sessions for region `Asia/Oceania` should actually occur on Thursdays 01:00 UTC, as opposed to Wednesdays like the other regions.

After this change, issues should also close at the correct time. See https://github.com/ampproject/amphtml/issues/34439#issuecomment-857303300
