### PR TITLE
🏗 Ensure correctness of Workflow schedule for Design Review issues

### DIFF
--- a/.github/workflows/update-design-review-issues.yml
+++ b/.github/workflows/update-design-review-issues.yml
@@ -1,10 +1,11 @@
 name: Update Design Review Issues
 
 on:
-  # This schedule should match the time rotation configured on
-  # update-design-review-issues.js.
   # Times correspond to session end, and additionally 1 hour earlier to account
   # for Daylight Savings.
+  #
+  # Update this list by running:
+  #     amp check-update-design-review-issues --fix
   schedule:
     - cron: '30 16,17 * * 3' # Africa/Europe/western Asia
     - cron: '0 21,22 * * 3' # Americas

--- a/amp.js
+++ b/amp.js
@@ -49,6 +49,7 @@ createTask('check-owners', 'checkOwners');
 createTask('check-renovate-config', 'checkRenovateConfig');
 createTask('check-sourcemaps', 'checkSourcemaps');
 createTask('check-types', 'checkTypes');
+createTask('check-update-design-review-issues', 'check');
 createTask('check-video-interface-list', 'checkVideoInterfaceList');
 createTask('cherry-pick', 'cherryPick');
 createTask('clean');

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -560,9 +560,18 @@ async function updateDesignReviewIssues(token, repo) {
   await closeStalePinUpcoming(token, repo, existing);
 }
 
-updateDesignReviewIssues(env('GITHUB_TOKEN'), env('GITHUB_REPOSITORY')).catch(
-  (e) => {
-    console./*OK*/ error(e);
-    process.exit(1);
-  }
-);
+if (require.main === module) {
+  updateDesignReviewIssues(env('GITHUB_TOKEN'), env('GITHUB_REPOSITORY')).catch(
+    (e) => {
+      console./*OK*/ error(e);
+      process.exit(1);
+    }
+  );
+}
+
+module.exports = {
+  DayOfWeekDef,
+  RotationItemDef,
+  timeRotationUtc,
+  sessionDurationHours,
+};

--- a/build-system/common/update-design-review-issues.js
+++ b/build-system/common/update-design-review-issues.js
@@ -41,8 +41,11 @@ let RotationItemDef;
 
 /**
  * Times in this rotation are adjusted according to Daylight Savings.
- * If these are updated, the schedule on update-design-review-issues.yml should
- * also be updated correspondingly.
+ *
+ * If these are updated, the correspoding Workflow schedule should be updated as
+ * well. Update it by running:
+ *     amp check-update-design-review-issues --fix
+ *
  * @type {Array<RotationItemDef>}
  */
 const timeRotationUtc = [

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -161,7 +161,8 @@ const targetMatchers = {
       (file.startsWith('build-system') &&
         (file.endsWith('.js') ||
           file.endsWith('.ts') ||
-          file.endsWith('.json')))
+          file.endsWith('.json'))) ||
+      file.startsWith('.github/workflows/')
     );
   },
   [Targets.CACHES_JSON]: (file) => {

--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -50,6 +50,7 @@ function pushBuildWorkflow() {
   timedExecOrDie('amp check-sourcemaps');
   timedExecOrDie('amp performance-urls');
   timedExecOrDie('amp check-analytics-vendors-list');
+  timedExecOrDie('amp check-update-design-review-issues');
   timedExecOrDie('amp check-video-interface-list');
   timedExecOrDie('amp get-zindex');
   timedExecOrDie('amp markdown-toc');
@@ -90,6 +91,7 @@ async function prBuildWorkflow() {
 
   if (buildTargetsInclude(Targets.BUILD_SYSTEM)) {
     timedExecOrDie('amp check-build-system');
+    timedExecOrDie('amp check-update-design-review-issues');
   }
 
   if (buildTargetsInclude(Targets.BABEL_PLUGIN)) {

--- a/build-system/tasks/check-update-design-review-issues.js
+++ b/build-system/tasks/check-update-design-review-issues.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const {
+  DayOfWeekDef,
+  RotationItemDef,
+  sessionDurationHours,
+  timeRotationUtc,
+} = require('../common/update-design-review-issues');
+const {cyan, red, yellow} = require('../common/colors');
+const {readFile} = require('fs-extra');
+const {writeDiffOrFail} = require('../common/diff');
+
+const filepath = '.github/workflows/update-design-review-issues.yml';
+
+const indent = (level = 1) => new Array(level).fill('  ').join('');
+
+const cronItemLevel = 2;
+const cronItemIndent = indent(cronItemLevel);
+
+/**
+ * Times correspond to session end, and additionally 1 hour earlier to account
+ * for Daylight Savings.
+ * @param {DayOfWeekDef} dayOfWeek
+ * @param {string} timeUtc
+ * @return {string}
+ */
+function getRotationCron(dayOfWeek, timeUtc) {
+  const [hours, minutes] = timeUtc.split(':').map((n) => parseInt(n, 10));
+  const endHours = hours + sessionDurationHours;
+  const endHoursDst = endHours - 1;
+  return `${minutes} ${endHoursDst},${endHours} * * ${dayOfWeek}`;
+}
+
+/**
+ * @param {RotationItemDef} rotationItem
+ * @return {string}
+ */
+function getRotationCronItem([dayOfWeek, timeUtc, region]) {
+  const pattern = getRotationCron(dayOfWeek, timeUtc);
+  return `${cronItemIndent}- cron: '${pattern}' # ${region}\n`;
+}
+
+/**
+ * Ensures that the Github Workflow update-design-review-issues is scheduled
+ * to run matching the configured session times for its corresponding script.
+ *
+ * It does this by replacing `- cron` entries on the Workflow's YAML file.
+ * See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#schedule
+ */
+async function check() {
+  const content = await readFile(filepath, 'utf8');
+
+  const separator = `${indent(cronItemLevel - 1)}schedule:\n`;
+  const [prefix] = content.split(separator + cronItemIndent, 1);
+
+  if (prefix.length === content.length) {
+    throw new Error(
+      `${cyan('on.schedule')} items were not found in ${red(filepath)}.\n` +
+        `  ⤷, ${yellow('To fix:')}\n\n` +
+        '    1. Add the default `cron` example from https://git.io/JZns3\n' +
+        '    2. Run this command again.\n'
+    );
+  }
+
+  const expectedCronItems = timeRotationUtc.map(getRotationCronItem).join('');
+  const sufix = content.substr(prefix.length + separator.length);
+  const itemsAtDepthRegExp = new RegExp(`^(${cronItemIndent}[^\n]*\n)*`, 'm');
+  const expectedSufix = sufix.replace(itemsAtDepthRegExp, expectedCronItems);
+  const expected = prefix + separator + expectedSufix;
+
+  await writeDiffOrFail(
+    'check-update-design-review-issues',
+    filepath,
+    expected
+  );
+}
+
+check.flags = {
+  fix: 'Update the schedule and write results to file',
+};
+
+module.exports = {
+  check,
+};


### PR DESCRIPTION
Ensures that the Github Workflow update-design-review-issues is scheduled to run matching the configured session times for its corresponding script. For example:

```diff
--- a/.github/workflows/update-design-review-issues.yml
+++ b/.github/workflows/update-design-review-issues.yml
@@ -9,4 +9,5 @@ on:
   schedule:
-    - cron: '30 16,17 * * 2' # Africa/Europe/western Asia
+    - cron: '30 16,17 * * 3' # Africa/Europe/western Asia
     - cron: '0 21,22 * * 3' # Americas
+    - cron: '0 1,2 * * 4' # Asia/Oceania
```