### PR TITLE
Revert "✨🧪 Use injected AMP_EXP to toggle experiments (#34736)"

### DIFF
--- a/build-system/externs/amp.extern.js
+++ b/build-system/externs/amp.extern.js
@@ -320,8 +320,6 @@ AmpConfigType.prototype.betaErrorReportingUrl;
 AmpConfigType.prototype.localDev;
 /* @public {string} */
 AmpConfigType.prototype.v;
-/* @public {string} */
-AmpConfigType.prototype.type;
 /* @public {boolean} */
 AmpConfigType.prototype.canary;
 /* @public {string} */
@@ -337,10 +335,8 @@ AmpConfigType.prototype.geoApi;
 /* @public {string} */
 AmpConfigType.prototype.geoApiUrl;
 
-/** @type {!AmpConfigType} */
+/** @type {!AmpConfigType}  */
 window.AMP_CONFIG;
-/** @type {undefined|!Object<string, number>} */
-window.AMP_EXP;
 
 window.AMP_CONTEXT_DATA;
 

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -108,10 +108,7 @@ const TYPE_CHECK_TARGETS = {
   'src-context': ['src/context/**/*.js', ...CORE_SRCS_GLOBS],
   'src-core': CORE_SRCS_GLOBS,
   'src-examiner': ['src/examiner/**/*.js'],
-  'src-experiments': {
-    srcGlobs: ['src/experiments/**/*.js', ...CORE_SRCS_GLOBS],
-    externGlobs: ['build-system/externs/amp.extern.js'],
-  },
+  'src-experiments': ['src/experiments/**/*.js', ...CORE_SRCS_GLOBS],
   'src-inabox': {
     srcGlobs: ['src/inabox/**/*.js'],
     warningLevel: 'QUIET',

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -605,23 +605,6 @@ const forbiddenTermsGlobal = {
       'src/service/resources-impl.js',
     ],
   },
-  '__AMP_EXP': {
-    message:
-      'Do not access __AMP_EXP directly. Use isExperimentOn() to access config',
-    allowlist: [
-      'src/experiments/index.js',
-      'src/experiments/experiments.extern.js',
-    ],
-  },
-  'AMP_EXP': {
-    message:
-      'Do not access AMP_EXP directly. Use isExperimentOn() to access config',
-    allowlist: [
-      'build-system/externs/amp.extern.js',
-      'src/experiments/index.js',
-      'src/experiments/experiments.extern.js',
-    ],
-  },
   'AMP_CONFIG': {
     message:
       'Do not access AMP_CONFIG directly. Use isExperimentOn() ' +
@@ -643,6 +626,7 @@ const forbiddenTermsGlobal = {
       'build-system/tasks/helpers.js',
       'src/config.js',
       'src/experiments/index.js',
+      'src/experiments/shame.extern.js',
       'src/mode.js',
       'src/web-worker/web-worker.js', // Web worker custom error reporter.
       'testing/init-tests.js',

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -916,7 +916,6 @@ const forbiddenTermsSrcInclusive = {
       'ads/_a4a-config.js',
       'build-system/server/amp4test.js',
       'build-system/server/app-index/amphtml-helpers.js',
-      'build-system/server/app-utils.js',
       'build-system/server/app-video-testbench.js',
       'build-system/server/app.js',
       'build-system/server/shadow-viewer.js',

--- a/src/experiments/experiments.extern.js
+++ b/src/experiments/experiments.extern.js
@@ -21,6 +21,3 @@
 
 /** @type {undefined|Object<string, ?string>} */
 window.__AMP_EXPERIMENT_BRANCHES;
-
-/** @type {undefined|HTMLScriptElement} */
-window.__AMP_EXP;

--- a/src/experiments/index.js
+++ b/src/experiments/index.js
@@ -26,7 +26,6 @@ import {getMode} from '../mode';
 import {getTopWindow} from '../service';
 import {hasOwn, map} from '../core/types/object';
 import {isArray} from '../core/types';
-import {parseJson} from '../core/types/object/json';
 import {parseQueryString} from '../core/types/string/url';
 
 // typedef imports
@@ -126,15 +125,13 @@ export function experimentToggles(win) {
   win[TOGGLES_WINDOW_PROPERTY] = map();
   const toggles = win[TOGGLES_WINDOW_PROPERTY];
 
-  // Read default and injected configs of this build.
-  const buildExperimentConfigs = {
-    ...(win.AMP_CONFIG ?? {}),
-    ...(win.AMP_EXP ?? parseJson(win.__AMP_EXP?.textContent || '{}')),
-  };
-  for (const experimentId in buildExperimentConfigs) {
-    const frequency = buildExperimentConfigs[experimentId];
-    if (typeof frequency === 'number' && frequency >= 0 && frequency <= 1) {
-      toggles[experimentId] = Math.random() < frequency;
+  // Read the default config of this build.
+  if (win.AMP_CONFIG) {
+    for (const experimentId in win.AMP_CONFIG) {
+      const frequency = win.AMP_CONFIG[experimentId];
+      if (typeof frequency === 'number' && frequency >= 0 && frequency <= 1) {
+        toggles[experimentId] = Math.random() < frequency;
+      }
     }
   }
   // Read document level override from meta tag.

--- a/src/experiments/shame.extern.js
+++ b/src/experiments/shame.extern.js
@@ -46,3 +46,10 @@ let getTopWindow$$module$src$service;
 
 /** @type {function(string):!JsonObject} */
 let parseQueryString$$module$src$url;
+
+/** @type {?} */
+window.AMP_CONFIG;
+/** @type {boolean|undefined} */
+window.AMP_CONFIG.canary;
+/** @type {string|undefined} */
+window.AMP_CONFIG.type;

--- a/test/unit/test-experiments.js
+++ b/test/unit/test-experiments.js
@@ -41,50 +41,24 @@ function fakeLocalStorage(initial = {}) {
 describes.sandboxed('experimentToggles', {}, () => {
   it('should return experiment status map', () => {
     const win = {
+      localStorage: fakeLocalStorage({
+        'amp-experiment-toggles': '-exp3,exp4,exp5',
+      }),
       AMP_CONFIG: {
-        exp1: 1, // Initialized here
-        exp2: 0, // Initialized here
-        exp3: 1, // Initialized here
-        exp4: 0, // Initialized here
-        exp5: 1, // Initialized here
-        exp6: 0, // Initialized here
+        exp1: 1,
+        exp2: 0,
+        exp3: 1,
+        exp4: 0,
         v: '12345667',
       },
-      AMP_EXP: {
-        exp3: 0, // Overrides AMP_CONFIG
-        exp4: 1, // Overrides AMP_CONFIG
-        exp5: 0, // Overrides AMP_CONFIG
-        exp6: 1, // Overrides AMP_CONFIG
-        exp7: 1, // Initialized here
-        exp8: 0, // Initialized here
-        exp9: 1, // Initialized here
-        exp10: 0, // Initialized here
-      },
-      localStorage: fakeLocalStorage({
-        'amp-experiment-toggles': [
-          'exp5', // Overrides AMP_CONFIG and AMP_EXP
-          '-exp6', // Overrides AMP_CONFIG and AMP_EXP
-          '-exp9', // Overrides AMP_EXP
-          'exp10', // Overrides AMP_EXP
-          'exp11', // Initialized here
-          '-exp12', // Initialized here
-        ].join(','),
-      }),
     };
     resetExperimentTogglesForTesting(window);
     expect(experimentToggles(win)).to.deep.equal({
       exp1: true,
       exp2: false,
-      exp3: false,
-      exp4: true,
+      exp3: false, // overridden in cookie
+      exp4: true, // overridden in cookie
       exp5: true,
-      exp6: false,
-      exp7: true,
-      exp8: false,
-      exp9: false,
-      exp10: true,
-      exp11: true,
-      exp12: false,
       // "v" should not appear here
     });
   });


### PR DESCRIPTION
This reverts commit 3d8ba1654e71d2e7d7938133ac45ccebd3d3c0ff, as it broke `main`: https://app.circleci.com/pipelines/github/ampproject/amphtml/11002/workflows/e68a853c-d2bf-4f79-ab19-ea6fc83ff4a3/jobs/173299