### PR TITLE
Coreify specific layout.js, CE, and BE functions

### DIFF
--- a/builtins/amp-layout/amp-layout.js
+++ b/builtins/amp-layout/amp-layout.js
@@ -16,6 +16,7 @@
 
 import {BaseElement} from '../../src/base-element';
 import {Layout, isLayoutSizeDefined} from '../../src/layout';
+import {getRealChildNodes} from '../../src/core/dom';
 import {registerElement} from '../../src/service/custom-element-registry';
 
 class AmpLayout extends BaseElement {
@@ -36,7 +37,7 @@ class AmpLayout extends BaseElement {
     }
     const container = this.win.document.createElement('div');
     this.applyFillContent(container);
-    this.getRealChildNodes().forEach((child) => {
+    getRealChildNodes(this.element).forEach((child) => {
       container.appendChild(child);
     });
     this.element.appendChild(container);

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -27,6 +27,7 @@ import {assertHttpsUrl} from '../../../src/url';
 import {closestAncestorElementBySelector} from '../../../src/core/dom/query';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
+import {getRealChildNodes} from '../../../src/core/dom';
 import {listen} from '../../../src/event-helper';
 import {setIsMediaComponent} from '../../../src/video-interface';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
@@ -135,7 +136,7 @@ export class AmpAudio extends AMP.BaseElement {
     );
 
     this.applyFillContent(audio);
-    this.getRealChildNodes().forEach((child) => {
+    getRealChildNodes(this.element).forEach((child) => {
       if (child.getAttribute && child.getAttribute('src')) {
         assertHttpsUrl(child.getAttribute('src'), dev().assertElement(child));
       }

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -16,6 +16,7 @@
 
 import {CSS} from '../../../build/amp-fit-text-0.1.css';
 import {getLengthNumeral, isLayoutSizeDefined} from '../../../src/layout';
+import {getRealChildNodes} from '../../../src/core/dom';
 import {px, setStyle, setStyles} from '../../../src/core/dom/style';
 import {throttle} from '../../../src/core/types/function';
 
@@ -86,7 +87,7 @@ class AmpFitText extends AMP.BaseElement {
       lineHeight: `${LINE_HEIGHT_EM_}em`,
     });
 
-    this.getRealChildNodes().forEach((node) => {
+    getRealChildNodes(this.element).forEach((node) => {
       this.contentWrapper_.appendChild(node);
     });
     this.updateMeasurerContent_();

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -19,6 +19,7 @@ import {CommonSignals} from '../../../src/core/constants/common-signals';
 import {Layout} from '../../../src/layout';
 import {Services} from '../../../src/services';
 import {dev, userAssert} from '../../../src/log';
+import {getRealChildNodes} from '../../../src/core/dom';
 import {setStyle} from '../../../src/core/dom/style';
 
 const TAG = 'amp-fx-flying-carpet';
@@ -78,7 +79,7 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
     this.children_ = this.getRealChildren();
     this.container_ = container;
 
-    const childNodes = this.getRealChildNodes();
+    const childNodes = getRealChildNodes(this.element);
     this.totalChildren_ = this.visibileChildren_(childNodes).length;
 
     const owners = Services.ownersForDoc(this.element);

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -19,9 +19,9 @@ import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Sidebar} from './component';
 import {dict} from '../../../src/core/types/object';
+import {getRealChildNodes, toggleAttribute} from '../../../src/core/dom';
 import {pauseAll} from '../../../src/utils/resource-container-helper';
 import {toggle} from '../../../src/core/dom/style';
-import {toggleAttribute} from '../../../src/core/dom';
 import {useToolbarHook} from './sidebar-toolbar-hook';
 import {useValueRef} from '../../../src/preact/component';
 
@@ -50,7 +50,7 @@ export class BaseElement extends PreactBaseElement {
 
   /** @override */
   updatePropsForRendering(props) {
-    this.getRealChildNodes().map((child) => {
+    getRealChildNodes(this.element).map((child) => {
       if (
         child.nodeName === 'NAV' &&
         child.hasAttribute('toolbar') &&

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.js
@@ -20,9 +20,9 @@ import {CSS as ShadowCSS} from '../../../build/amp-truncate-text-shadow-0.1.css'
 import {closestAncestorElementBySelector} from '../../../src/core/dom/query';
 import {createShadowRoot} from './shadow-utils';
 import {dev} from '../../../src/log';
+import {getRealChildNodes, iterateCursor} from '../../../src/core/dom';
 import {htmlFor} from '../../../src/core/dom/static-template';
 import {isExperimentOn} from '../../../src/experiments';
-import {iterateCursor} from '../../../src/core/dom';
 import {toArray} from '../../../src/core/types/array';
 import {truncateText} from './truncate-text';
 
@@ -146,7 +146,7 @@ export class AmpTruncateText extends AMP.BaseElement {
         this.persistentSlot_.appendChild(el);
       }
     );
-    this.getRealChildNodes().forEach((node) => {
+    getRealChildNodes(this.element).forEach((node) => {
       defaultSlot.appendChild(node);
     });
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -17,8 +17,8 @@
 import {ActionTrust, DEFAULT_ACTION} from './core/constants/action-constants';
 import {Layout, LayoutPriority} from './layout';
 import {Services} from './services';
+import {applyFillContent, dispatchCustomEvent} from './core/dom';
 import {devAssert, user, userAssert} from './log';
-import {dispatchCustomEvent} from './core/dom';
 import {getData, listen, loadPromise} from './event-helper';
 import {getMode} from './mode';
 import {isArray} from './core/types';
@@ -869,22 +869,14 @@ export class BaseElement {
   }
 
   /**
-   * Configures the supplied element to have a "fill content" layout. The
-   * exact interpretation of "fill content" depends on the element's layout.
-   *
-   * If `opt_replacedContent` is specified, it indicates whether the "replaced
-   * content" styling should be applied. Replaced content is not allowed to
-   * have its own paddings or border.
+   * See src/core/dom.js for full description.
    *
    * @param {!Element} element
    * @param {boolean=} opt_replacedContent
    * @public @final
    */
   applyFillContent(element, opt_replacedContent) {
-    element.classList.add('i-amphtml-fill-content');
-    if (opt_replacedContent) {
-      element.classList.add('i-amphtml-replaced-content');
-    }
+    applyFillContent(element, opt_replacedContent);
   }
 
   /**

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -848,17 +848,6 @@ export class BaseElement {
   }
 
   /**
-   * Returns the original nodes of the custom element without any service nodes
-   * that could have been added for markup. These nodes can include Text,
-   * Comment and other child nodes.
-   * @return {!Array<!Node>}
-   * @public @final
-   */
-  getRealChildNodes() {
-    return this.element.getRealChildNodes();
-  }
-
-  /**
    * Returns the original children of the custom element without any service
    * nodes that could have been added for markup.
    * @return {!Array<!Element>}

--- a/src/core/dom/index.js
+++ b/src/core/dom/index.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {assertElement} from '../assert/base';
 import {childNodes, matches} from './query';
 import {dict} from '../types/object';
 import {isInternalOrServiceNode} from '../layout';
@@ -563,12 +562,9 @@ export function applyFillContent(element, opt_replacedContent) {
  * nodes that could have been added for markup. These nodes can include
  * Text, Comment and other child nodes.
  *
- * @param {!Element} element
+ * @param {!Node} element
  * @return {!Array<!Node>}
  */
 export function getRealChildNodes(element) {
-  return childNodes(
-    element,
-    (node) => !isInternalOrServiceNode(assertElement(node))
-  );
+  return childNodes(element, (node) => !isInternalOrServiceNode(node));
 }

--- a/src/core/dom/index.js
+++ b/src/core/dom/index.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+import {assertElement} from '../assert/base';
+import {childNodes, matches} from './query';
 import {dict} from '../types/object';
-import {matches} from './query';
+import {isInternalOrServiceNode} from '../layout';
 import {toWin} from '../window';
 
 const HTML_ESCAPE_CHARS = {
@@ -535,4 +537,38 @@ export function dispatchCustomEvent(node, name, opt_data, opt_options) {
  */
 export function containsNotSelf(parent, child) {
   return child !== parent && parent.contains(child);
+}
+
+/**
+ * Configures the supplied element to have a "fill content" layout. The
+ * exact interpretation of "fill content" depends on the element's layout.
+ *
+ * If `opt_replacedContent` is specified, it indicates whether the "replaced
+ * content" styling should be applied. Replaced content is not allowed to
+ * have its own paddings or border.
+ *
+ * @param {!Element} element
+ * @param {boolean=} opt_replacedContent
+ * @public @final
+ */
+export function applyFillContent(element, opt_replacedContent) {
+  element.classList.add('i-amphtml-fill-content');
+  if (opt_replacedContent) {
+    element.classList.add('i-amphtml-replaced-content');
+  }
+}
+
+/**
+ * Returns the original nodes of the custom element without any service
+ * nodes that could have been added for markup. These nodes can include
+ * Text, Comment and other child nodes.
+ *
+ * @param {!Element} element
+ * @return {!Array<!Node>}
+ */
+export function getRealChildNodes(element) {
+  return childNodes(
+    element,
+    (node) => !isInternalOrServiceNode(assertElement(node))
+  );
 }

--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Whether the tag is an internal (service) AMP tag.
+ * @param {!Element|string} tag
+ * @return {boolean}
+ */
+function isInternalElement(tag) {
+  const tagName = typeof tag == 'string' ? tag : tag.tagName;
+  return !!(tagName && tagName.toLowerCase().startsWith('i-'));
+}
+
+/**
+ * Returns "true" for internal AMP nodes or for placeholder elements.
+ * @param {!Element} node
+ * @return {boolean}
+ */
+export function isInternalOrServiceNode(node) {
+  if (isInternalElement(node)) {
+    return true;
+  }
+  if (
+    node.tagName &&
+    (node.hasAttribute('placeholder') ||
+      node.hasAttribute('fallback') ||
+      node.hasAttribute('overflow'))
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {devAssertElement} from './assert';
+
 /**
  * Whether the tag is an internal (service) AMP tag.
  * @param {!Element|string} tag
@@ -26,10 +28,15 @@ function isInternalElement(tag) {
 
 /**
  * Returns "true" for internal AMP nodes or for placeholder elements.
- * @param {!Element} node
+ * @param {!Node} node
  * @return {boolean}
  */
 export function isInternalOrServiceNode(node) {
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return false;
+  }
+  node = devAssertElement(node);
+
   if (isInternalElement(node)) {
     return true;
   }

--- a/src/core/layout.js
+++ b/src/core/layout.js
@@ -17,16 +17,6 @@
 import {devAssertElement} from './assert';
 
 /**
- * Whether the tag is an internal (service) AMP tag.
- * @param {!Element|string} tag
- * @return {boolean}
- */
-function isInternalElement(tag) {
-  const tagName = typeof tag == 'string' ? tag : tag.tagName;
-  return !!(tagName && tagName.toLowerCase().startsWith('i-'));
-}
-
-/**
  * Returns "true" for internal AMP nodes or for placeholder elements.
  * @param {!Node} node
  * @return {boolean}
@@ -37,14 +27,13 @@ export function isInternalOrServiceNode(node) {
   }
   node = devAssertElement(node);
 
-  if (isInternalElement(node)) {
+  if (node.tagName.toLowerCase().startsWith('i-')) {
     return true;
   }
   if (
-    node.tagName &&
-    (node.hasAttribute('placeholder') ||
-      node.hasAttribute('fallback') ||
-      node.hasAttribute('overflow'))
+    node.hasAttribute('placeholder') ||
+    node.hasAttribute('fallback') ||
+    node.hasAttribute('overflow')
   ) {
     return true;
   }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1897,18 +1897,6 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     }
 
     /**
-     * See dom.getRealChildNodes for the full description.
-     * TODO: migrate to the fn in dom.js.
-     * @deprecated
-     * @package @final
-     *
-     * @return {!Array<!Node>}
-     */
-    getRealChildNodes() {
-      return dom.getRealChildNodes(this);
-    }
-
-    /**
      * Returns the original children of the custom element without any service
      * nodes that could have been added for markup.
      * @return {!Array<!Element>}

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -23,7 +23,6 @@ import {
   Layout,
   LayoutPriority,
   applyStaticLayout,
-  isInternalElement,
   isLoadingAllowed,
 } from './layout';
 import {MediaQueryProps} from './core/dom/media-query-props';
@@ -47,6 +46,7 @@ import {getIntersectionChangeEntry} from './utils/intersection-observer-3p-host'
 import {getMode} from './mode';
 import {getSchedulerForDoc} from './service/scheduler';
 import {isExperimentOn} from './experiments';
+import {isInternalOrServiceNode} from './core/layout';
 import {rethrowAsync} from './core/error';
 import {setStyle} from './core/dom/style';
 import {shouldBlockOnConsentByMeta} from './consent';
@@ -1897,14 +1897,15 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     }
 
     /**
-     * Returns the original nodes of the custom element without any service
-     * nodes that could have been added for markup. These nodes can include
-     * Text, Comment and other child nodes.
-     * @return {!Array<!Node>}
+     * See dom.getRealChildNodes for the full description.
+     * TODO: migrate to the fn in dom.js.
+     * @deprecated
      * @package @final
+     *
+     * @return {!Array<!Node>}
      */
     getRealChildNodes() {
-      return query.childNodes(this, (node) => !isInternalOrServiceNode(node));
+      return dom.getRealChildNodes(this);
     }
 
     /**
@@ -2169,26 +2170,6 @@ function isInputPlaceholder(element) {
 /** @param {!Element} element */
 function assertNotTemplate(element) {
   devAssert(!element.isInTemplate_, 'Must never be called in template');
-}
-
-/**
- * Returns "true" for internal AMP nodes or for placeholder elements.
- * @param {!Node} node
- * @return {boolean}
- */
-function isInternalOrServiceNode(node) {
-  if (isInternalElement(node)) {
-    return true;
-  }
-  if (
-    node.tagName &&
-    (node.hasAttribute('placeholder') ||
-      node.hasAttribute('fallback') ||
-      node.hasAttribute('overflow'))
-  ) {
-    return true;
-  }
-  return false;
 }
 
 /**

--- a/src/layout.js
+++ b/src/layout.js
@@ -174,16 +174,6 @@ export function isLayoutSizeFixed(layout) {
 }
 
 /**
- * Whether the tag is an internal (service) AMP tag.
- * @param {!Node|string} tag
- * @return {boolean}
- */
-export function isInternalElement(tag) {
-  const tagName = typeof tag == 'string' ? tag : tag.tagName;
-  return tagName && tagName.toLowerCase().startsWith('i-');
-}
-
-/**
  * Parses the CSS length value. If no units specified, the assumed value is
  * "px". Returns undefined in case of parsing error.
  * @param {string|undefined|null} s

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -41,6 +41,7 @@ import {
 import {
   createElementWithAttributes,
   dispatchCustomEvent,
+  getRealChildNodes,
   parseBooleanAttribute,
 } from '../core/dom';
 import {dashToCamelCase} from '../core/types/string';
@@ -48,11 +49,11 @@ import {devAssert} from '../core/assert';
 import {dict, hasOwn, map} from '../core/types/object';
 import {getDate} from '../core/types/date';
 import {getMode} from '../mode';
+
 import {hydrate, render} from './index';
 import {installShadowStyle} from '../shadow-embed';
 import {isElement} from '../core/types';
 import {sequentialIdGenerator} from '../core/math/id-generator';
-import {toArray} from '../core/types/array';
 
 /**
  * The following combinations are allowed.
@@ -1087,9 +1088,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
     // as separate properties. Thus in a carousel the plain "children" are
     // slides, and the "arrowNext" children are passed via a "arrowNext"
     // property.
-    const nodes = element.getRealChildNodes
-      ? element.getRealChildNodes()
-      : toArray(element.childNodes);
+    const nodes = getRealChildNodes(element);
     for (let i = 0; i < nodes.length; i++) {
       const childElement = nodes[i];
       const match = matchChild(childElement, propDefs);
@@ -1161,7 +1160,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
       devAssert(Ctor['usesShadowDom']);
       // Use lazy loading inside the passthrough by default due to too many
       // elements.
-      value = element.getRealChildNodes().every(IS_EMPTY_TEXT_NODE)
+      value = getRealChildNodes(element).every(IS_EMPTY_TEXT_NODE)
         ? null
         : [<Slot loading={Loading.LAZY} />];
     } else if (def.attr) {

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -28,6 +28,7 @@ import {
   getImplSyncForTesting,
 } from '../../src/custom-element';
 import {elementConnectedCallback} from '../../src/service/custom-element-registry';
+import {getRealChildNodes} from '../../src/core/dom';
 import {toggleExperiment} from '../../src/experiments';
 
 describes.realWin('CustomElement', {amp: true}, (env) => {
@@ -1979,7 +1980,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, (env) => {
   }
 
   it('getRealChildren should return nothing', () => {
-    expect(element.getRealChildNodes().length).to.equal(0);
+    expect(getRealChildNodes(element).length).to.equal(0);
     expect(element.getRealChildren().length).to.equal(0);
   });
 
@@ -1991,7 +1992,7 @@ describes.realWin('CustomElement Service Elements', {amp: true}, (env) => {
     element.appendChild(doc.createTextNode('abc'));
     element.appendChild(doc.createElement('content'));
 
-    const nodes = element.getRealChildNodes();
+    const nodes = getRealChildNodes(element);
     expect(nodes.length).to.equal(2);
     expect(nodes[0].textContent).to.equal('abc');
     expect(nodes[1].tagName.toLowerCase()).to.equal('content');


### PR DESCRIPTION
**summary**
Core-ifies specific functions needed for https://github.com/ampproject/amphtml/pull/34770.
The functions are: `getRealChildNodes`, `isInternalOrServiceNode`, and `applyFillContent`

Turns out that the typing for the very old function `isInternalOrServiceNode` has been wrong this whole time.
I wonder if our new type checking is more strict than it had originally been. Calling `node.tagName` and `node.hasAttribute` is incorrect because a `Node` could be a comment node or a text node. I fix that by adding a check for ELEMENT_NODE at the top.