### PR TITLE
♻️ First line import `import * as Preact from '#preact/index';`

### DIFF
--- a/build-system/eslint-rules/preact.js
+++ b/build-system/eslint-rules/preact.js
@@ -20,7 +20,7 @@ const path = require('path');
 // Enforces importing a Preact namespace specifier if using JSX
 //
 // Good
-// import * as Preact from 'path/to/preact';
+// import * as Preact from '#preact/index';
 // <div />
 //
 // Bad
@@ -55,23 +55,15 @@ module.exports = {
         ].join('\n\t'),
 
         fix(fixer) {
-          const fileName = context.getFilename();
-          const absolutePath = path
-            .relative(path.dirname(fileName), './src/preact')
-            .replace(/\.js$/, '');
-
           const ancestors = context.getAncestors();
           const program = ancestors[0];
-          let firstImport = program.body.find(
-            (node) => node.type === 'ImportDeclaration'
-          );
-          if (!firstImport) {
-            firstImport = ancestors[1];
-          }
+          const firstImport =
+            program.body.find((node) => node.type === 'ImportDeclaration') ||
+            ancestors[1];
 
           return fixer.insertTextBefore(
             firstImport,
-            `import * as Preact from '${absolutePath}';\n`
+            `import * as Preact from '#preact/index';\n`
           );
         },
       });

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {ContainWrapper} from '../../../src/preact/component';
 import {
   useCallback,

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {__component_name_pascalcase__} from '../component'
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
+++ b/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../src/preact';
+import * as Preact from '#preact/index';
 import {number, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/builtins/storybook/amp-layout.amp.js
+++ b/builtins/storybook/amp-layout.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../src/preact';
+import * as Preact from '#preact/index';
 import {number, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/docs/building-a-bento-amp-extension.md
+++ b/docs/building-a-bento-amp-extension.md
@@ -168,7 +168,7 @@ BaseElement['props'] = {  // Map DOM attributes and children to Preact Component
 The following shows the corresponding overall structure of your Preact functional component implementation file (extensions/amp-my-element/0.1/component.js).
 
 ```js
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {func1, func2} from '../../../src/module';
 // more ES2015-style import statements.
 

--- a/extensions/amp-accordion/1.0/base-element.js
+++ b/extensions/amp-accordion/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-accordion/1.0/component.js
+++ b/extensions/amp-accordion/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {WithAmpContext} from '../../../src/preact/context';
 import {animateCollapse, animateExpand} from './animations';
 import {forwardRef} from '../../../src/preact/compat';

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-accordion/1.0/storybook/Bind.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Bind.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-accordion/1.0/test/test-component.js
+++ b/extensions/amp-accordion/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-animation/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-animation/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {AnimationTemplate} from './template';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-animation/0.1/storybook/Random.amp.js
+++ b/extensions/amp-animation/0.1/storybook/Random.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {AnimationTemplate} from './template';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';

--- a/extensions/amp-animation/0.1/storybook/template.js
+++ b/extensions/amp-animation/0.1/storybook/template.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {button, number, select, text} from '@storybook/addon-knobs';
 
 const FILL_OPTIONS = {

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
 

--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Alignment,
   Axis,

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Alignment,
   Axis,

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, number, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {BaseCarousel} from '../component';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-base-carousel/1.0/test/test-component.js
+++ b/extensions/amp-base-carousel/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {BaseCarousel} from '../component';
 import {mount} from 'enzyme';
 import {useStyles} from '../component.jss';

--- a/extensions/amp-date-countdown/1.0/component.js
+++ b/extensions/amp-date-countdown/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Wrapper, useRenderer} from '../../../src/preact/component';
 import {dict} from '../../../src/core/types/object';
 import {getDate} from '../../../src/core/types/date';

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, date, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {DateCountdown} from '../component';
 import {boolean, date, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-date-countdown/1.0/test/test-component.js
+++ b/extensions/amp-date-countdown/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {DateCountdown} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-date-display/1.0/component.js
+++ b/extensions/amp-date-display/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Wrapper, useRenderer} from '../../../src/preact/component';
 import {getDate} from '../../../src/core/types/date';
 import {useMemo} from '../../../src/preact';

--- a/extensions/amp-date-display/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-display/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {date, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-date-display/1.0/storybook/Basic.js
+++ b/extensions/amp-date-display/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {DateDisplay} from '../component';
 import {date, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-date-display/1.0/test/test-component.js
+++ b/extensions/amp-date-display/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {DateDisplay} from '../component';
 import {mount} from 'enzyme';
 import {user} from '../../../../src/log';

--- a/extensions/amp-facebook-comments/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook-comments/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-facebook-like/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook-like/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-facebook-page/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook-page/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, optionsKnob, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-facebook/1.0/component.js
+++ b/extensions/amp-facebook/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   MessageType,
   ProxyIframeEmbed,

--- a/extensions/amp-facebook/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-facebook/1.0/storybook/Basic.js
+++ b/extensions/amp-facebook/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Facebook} from '../component';
 import {
   boolean,

--- a/extensions/amp-facebook/1.0/test/test-component.js
+++ b/extensions/amp-facebook/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Facebook} from '../component';
 import {WithAmpContext} from '../../../../src/preact/context';
 import {createRef} from '../../../../src/preact';

--- a/extensions/amp-fit-text/1.0/component.js
+++ b/extensions/amp-fit-text/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {ContainWrapper} from '../../../src/preact/component';
 import {LINE_HEIGHT_EM_, useStyles} from './component.jss';
 import {

--- a/extensions/amp-fit-text/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-fit-text/1.0/storybook/Basic.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {FitText} from '../component';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-fit-text/1.0/test/test-component.js
+++ b/extensions/amp-fit-text/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {FitText, calculateFontSize, setOverflowStyle} from '../component';
 import {computedStyle} from '../../../../src/core/dom/style';
 import {mount} from 'enzyme';

--- a/extensions/amp-iframe/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-iframe/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-image-slider/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-image-slider/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-inline-gallery/1.0/base-element.js
+++ b/extensions/amp-inline-gallery/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
 import {InlineGallery} from './component';
 import {PreactBaseElement} from '../../../src/preact/base-element';

--- a/extensions/amp-inline-gallery/1.0/component.js
+++ b/extensions/amp-inline-gallery/1.0/component.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {CarouselContext} from '../../amp-base-carousel/1.0/carousel-context';
 import {ContainWrapper} from '../../../src/preact/component';
 import {useMemo, useState} from '../../../src/preact';

--- a/extensions/amp-inline-gallery/1.0/pagination.js
+++ b/extensions/amp-inline-gallery/1.0/pagination.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {CarouselContext} from '../../amp-base-carousel/1.0/carousel-context';
 import {Wrapper} from '../../../src/preact/component';
 import {useContext} from '../../../src/preact';

--- a/extensions/amp-inline-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-inline-gallery/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-inline-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-inline-gallery/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {BaseCarousel} from '../../../amp-base-carousel/1.0/component';
 import {InlineGallery} from '../component';
 import {Pagination} from '../pagination';

--- a/extensions/amp-inline-gallery/1.0/test/test-component.js
+++ b/extensions/amp-inline-gallery/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {BaseCarousel} from '../../../amp-base-carousel/1.0/component';
 import {InlineGallery} from '../component';
 import {Pagination} from '../pagination';

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {BaseCarousel} from '../../amp-base-carousel/1.0/component';
 import {CarouselContext} from '../../amp-base-carousel/1.0/carousel-context';
 import {px} from '../../../src/core/dom/style';

--- a/extensions/amp-instagram/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-instagram/1.0/component.js
+++ b/extensions/amp-instagram/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {IframeEmbed} from '../../../src/preact/component/iframe';
 import {dict} from '../../../src/core/types/object';
 import {forwardRef} from '../../../src/preact/compat';

--- a/extensions/amp-instagram/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-instagram/1.0/storybook/Basic.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-instagram/1.0/test/test-component.js
+++ b/extensions/amp-instagram/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Instagram} from '../component';
 import {WithAmpContext} from '../../../../src/preact/context';
 import {createRef} from '../../../../src/preact';

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {LightboxGalleryContext} from './context';
 import {sequentialIdGenerator} from '../../../src/core/math/id-generator';
 import {

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Lightbox} from './../../amp-lightbox/1.0/component';
 import {LightboxGalleryContext} from './context';
 import {useCallback, useRef} from '../../../src/preact';

--- a/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {BaseCarousel} from '../../../amp-base-carousel/1.0/component';
 import {LightboxGalleryProvider, WithLightbox} from '../component';
 import {withKnobs} from '@storybook/addon-knobs';

--- a/extensions/amp-lightbox-gallery/1.0/test/test-component.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {LightboxGalleryProvider, WithLightbox} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {forwardRef} from '../../../src/preact/compat';

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Lightbox} from '../component';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {useRef} from '../../../../src/preact';

--- a/extensions/amp-lightbox/1.0/test/test-component.js
+++ b/extensions/amp-lightbox/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Lightbox} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-render/1.0/component.js
+++ b/extensions/amp-render/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Wrapper, useRenderer} from '../../../src/preact/component';
 import {forwardRef} from '../../../src/preact/compat';
 import {

--- a/extensions/amp-render/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-render/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-render/1.0/storybook/Basic.js
+++ b/extensions/amp-render/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Render} from '../component';
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-render/1.0/test/test-component.js
+++ b/extensions/amp-render/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Render} from '../component';
 import {macroTask} from '../../../../testing/yield';
 import {mount} from 'enzyme';

--- a/extensions/amp-selector/1.0/base-element.js
+++ b/extensions/amp-selector/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Option, Selector} from './component';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {closestAncestorElementBySelector} from '../../../src/core/dom/query';

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {forwardRef} from '../../../src/preact/compat';
 import {mod} from '../../../src/core/math';

--- a/extensions/amp-selector/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-selector/1.0/storybook/Basic.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Option, Selector} from '../component';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {useState} from '../../../../src/preact';

--- a/extensions/amp-selector/1.0/test/test-component.js
+++ b/extensions/amp-selector/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Keys} from '../../../../src/core/constants/key-codes';
 import {Option, Selector} from '../component';
 import {mount} from 'enzyme';

--- a/extensions/amp-sidebar/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/0.1/storybook/Basic.amp.js
@@ -16,7 +16,7 @@
 
 // To do: how to add CSS
 //import '!style-loader!css-loader!./Basic-styles.css';
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Sidebar} from './component';

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {Side} from './sidebar-config';

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   boolean,
   color,

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Sidebar, SidebarToolbar} from '../component';
 import {boolean, color, select, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-sidebar/1.0/test/test-component.js
+++ b/extensions/amp-sidebar/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Sidebar, SidebarToolbar} from '../component';
 import {htmlFor} from '../../../../src/core/dom/static-template';
 import {mount} from 'enzyme';

--- a/extensions/amp-social-share/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-social-share/1.0/social-share-svgs.js
+++ b/extensions/amp-social-share/1.0/social-share-svgs.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 
 /**
  * @param {!JsonObject} props

--- a/extensions/amp-social-share/1.0/social-share.js
+++ b/extensions/amp-social-share/1.0/social-share.js
@@ -15,7 +15,7 @@
  */
 
 import * as CSS from './social-share.css';
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Keys} from '../../../src/core/constants/key-codes';
 import {SocialShareIcon} from './social-share-svgs';
 import {Wrapper} from '../../../src/preact/component';

--- a/extensions/amp-social-share/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-social-share/1.0/storybook/Basic.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {SocialShare} from '../social-share';
 import {color, object, select, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-social-share/1.0/test/test-social-share.js
+++ b/extensions/amp-social-share/1.0/test/test-social-share.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {SocialShare} from '../social-share';
 import {dict} from '../../../../src/core/types/object';
 import {mount} from 'enzyme';

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {BaseCarousel} from '../../amp-base-carousel/1.0/component';
 import {forwardRef} from '../../../src/preact/compat';
 import {setStyle} from '../../../src/core/dom/style';

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {StreamGallery} from '../component';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-stream-gallery/1.0/test/test-component.js
+++ b/extensions/amp-stream-gallery/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {StreamGallery} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-timeago/1.0/component.js
+++ b/extensions/amp-timeago/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Wrapper} from '../../../src/preact/component';
 import {format, getLocale} from './locales';
 import {getDate} from '../../../src/core/types/date';

--- a/extensions/amp-timeago/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-timeago/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {date, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-timeago/1.0/storybook/Basic.js
+++ b/extensions/amp-timeago/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Timeago} from '../component';
 import {date, number, select, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-timeago/1.0/test/test-component.js
+++ b/extensions/amp-timeago/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Timeago} from '../component';
 import {mount} from 'enzyme';
 import {waitFor} from '../../../../testing/test-helper';

--- a/extensions/amp-twitter/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-twitter/1.0/component.js
+++ b/extensions/amp-twitter/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   MessageType,
   ProxyIframeEmbed,

--- a/extensions/amp-twitter/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-twitter/1.0/storybook/Basic.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Twitter} from '../component';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-twitter/1.0/test/test-component.js
+++ b/extensions/amp-twitter/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Twitter} from '../component';
 import {WithAmpContext} from '../../../../src/preact/context';
 import {createRef} from '../../../../src/preact';

--- a/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-video/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {VideoElementWithActions} from './_helpers';
 import {boolean, number, object, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-video/1.0/storybook/Basic.js
+++ b/extensions/amp-video/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-video/1.0/storybook/VideoIframe.js
+++ b/extensions/amp-video/1.0/storybook/VideoIframe.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-video/1.0/storybook/_helpers.js
+++ b/extensions/amp-video/1.0/storybook/_helpers.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 
 export const VideoElementWithActions = ({
   id,

--- a/extensions/amp-video/1.0/test/test-video-iframe.js
+++ b/extensions/amp-video/1.0/test/test-video-iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {VideoIframeInternal} from '../video-iframe';
 import {createRef} from '../../../../src/preact';
 import {mount} from 'enzyme';

--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {VideoWrapper} from '../video-wrapper';
 import {WithAmpContext} from '../../../../src/preact/context';
 import {createRef} from '../../../../src/preact';

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {Deferred} from '../../../src/core/data-structures/promise';
 import {VideoWrapper} from './video-wrapper';
 import {forwardRef} from '../../../src/preact/compat';

--- a/extensions/amp-video/1.0/video-wrapper.js
+++ b/extensions/amp-video/1.0/video-wrapper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Deferred} from '../../../src/core/data-structures/promise';
 import {Loading} from '../../../src/core/loading-instructions';

--- a/extensions/amp-vimeo/1.0/component.js
+++ b/extensions/amp-vimeo/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   VIMEO_EVENTS,
   getVimeoIframeSrc,

--- a/extensions/amp-vimeo/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-vimeo/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {VideoElementWithActions} from '../../../amp-video/1.0/storybook/_helpers';
 import {boolean, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-vimeo/1.0/storybook/Basic.js
+++ b/extensions/amp-vimeo/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Vimeo} from '../component';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-youtube/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-youtube/1.0/component.js
+++ b/extensions/amp-youtube/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {VideoEvents} from '../../../src/video-interface';
 import {VideoIframe} from '../../amp-video/1.0/video-iframe';
 import {addParamsToUrl} from '../../../src/url';

--- a/extensions/amp-youtube/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {VideoElementWithActions} from '../../../amp-video/1.0/storybook/_helpers';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-youtube/1.0/storybook/Basic.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-youtube/1.0/test/test-component.js
+++ b/extensions/amp-youtube/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact';
+import * as Preact from '#preact/index';
 import {Youtube} from '../component';
 import {createRef} from '../../../../src/preact';
 

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from './index';
+import * as Preact from '#preact/index';
 import {ActionTrust} from '../core/constants/action-constants';
 import {AmpEvents} from '../core/constants/amp-events';
 import {CanPlay, CanRender, LoadingProp} from '../context/contextprops';

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {IframeEmbed} from './iframe';
 import {dict} from '../../core/types/object';
 import {forwardRef} from '../compat';

--- a/src/preact/component/contain.js
+++ b/src/preact/component/contain.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../';
+import * as Preact from '#preact/index';
 import {forwardRef} from '../compat';
 
 const CONTAIN = [

--- a/src/preact/component/iframe.js
+++ b/src/preact/component/iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact';
+import * as Preact from '#preact/index';
 import {ContainWrapper, useValueRef} from '../../../src/preact/component';
 import {Loading} from '../../../src/core/loading-instructions';
 import {ReadyState} from '../../../src/core/constants/ready-state';

--- a/src/preact/component/wrapper.js
+++ b/src/preact/component/wrapper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../';
+import * as Preact from '#preact/index';
 import {forwardRef} from '../compat';
 
 /**

--- a/src/preact/context.js
+++ b/src/preact/context.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from './index';
+import * as Preact from '#preact/index';
 import {Loading, reducer as loadingReducer} from '../core/loading-instructions';
 import {createContext, useContext, useMemo} from './index';
 

--- a/src/preact/slot.js
+++ b/src/preact/slot.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from './index';
+import * as Preact from '#preact/index';
 import {CanPlay, CanRender, LoadingProp} from '../context/contextprops';
 import {Loading} from '../core/loading-instructions';
 import {devAssert} from '../core/assert';

--- a/src/preact/storybook/Context.js
+++ b/src/preact/storybook/Context.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../';
+import * as Preact from '#preact/index';
 import {WithAmpContext, useAmpContext, useLoading} from '../context';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/src/preact/storybook/Wrappers.js
+++ b/src/preact/storybook/Wrappers.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../';
+import * as Preact from '#preact/index';
 import {ContainWrapper, Wrapper} from '../component';
 import {boolean, object, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/test/unit/preact/component/test-renderer.js
+++ b/test/unit/preact/component/test-renderer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../../src/preact/index';
+import * as Preact from '#preact/index';
 import {mount} from 'enzyme';
 import {useRenderer} from '../../../../src/preact/component';
 

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact/index';
+import * as Preact from '#preact/index';
 import {PreactBaseElement} from '../../../src/preact/base-element';
 import {Slot} from '../../../src/preact/slot';
 import {createElementWithAttributes} from '../../../src/core/dom';

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact/index';
+import * as Preact from '#preact/index';
 import {CanRender} from '../../../src/context/contextprops';
 import {
   PreactBaseElement,

--- a/test/unit/preact/test-context.js
+++ b/test/unit/preact/test-context.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact/index';
+import * as Preact from '#preact/index';
 import {
   WithAmpContext,
   useAmpContext,

--- a/test/unit/preact/test-slot.js
+++ b/test/unit/preact/test-slot.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '../../../src/preact/index';
+import * as Preact from '#preact/index';
 import * as fakeTimers from '@sinonjs/fake-timers';
 import {
   CanPlay,


### PR DESCRIPTION
Companion/prelude PR to a lint update adding support for auto-sorting and grouping of imports by path (externa/builtins, #alias internal imports, `./*` module imports, `../*` parent imports). It's important that `import * as Preact` is the first import for many files to ensure a Preact namespace exists. We have a lint rule to ensure this, which currently imports from the relative path to Preact.

Instead, this makes that first import use `#preact/index`. This allows other code to import specific helpers from `#preact` and still be sorted separately, while `#preact/index` can be special-cased to always appear at the top of the file.

Will link related lint change PR once it's created.