### PR TITLE
Refactor: move getRealChildNodes and getRealChildren to core

### DIFF
--- a/builtins/amp-layout/amp-layout.js
+++ b/builtins/amp-layout/amp-layout.js
@@ -16,7 +16,7 @@
 
 import {BaseElement} from '../../src/base-element';
 import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
-import {getRealChildNodes} from '#core/dom/query';
+import {realChildNodes} from '#core/dom/query';
 import {registerElement} from '#service/custom-element-registry';
 
 class AmpLayout extends BaseElement {
@@ -37,7 +37,7 @@ class AmpLayout extends BaseElement {
     }
     const container = this.win.document.createElement('div');
     this.applyFillContent(container);
-    getRealChildNodes(this.element).forEach((child) => {
+    realChildNodes(this.element).forEach((child) => {
       container.appendChild(child);
     });
     this.element.appendChild(container);

--- a/builtins/amp-layout/amp-layout.js
+++ b/builtins/amp-layout/amp-layout.js
@@ -16,6 +16,7 @@
 
 import {BaseElement} from '../../src/base-element';
 import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
+import {getRealChildNodes} from '#core/dom/query';
 import {registerElement} from '#service/custom-element-registry';
 
 class AmpLayout extends BaseElement {
@@ -36,7 +37,7 @@ class AmpLayout extends BaseElement {
     }
     const container = this.win.document.createElement('div');
     this.applyFillContent(container);
-    this.getRealChildNodes().forEach((child) => {
+    getRealChildNodes(this.element).forEach((child) => {
       container.appendChild(child);
     });
     this.element.appendChild(container);

--- a/docs/building-an-amp-extension.md
+++ b/docs/building-an-amp-extension.md
@@ -367,7 +367,7 @@ The AMP runtime will not manage scheduling layouting for elements that have
 owners.
 
 ```javascript
-this.cells_ = getRealChildren(this.element);
+this.cells_ = realChildElements(this.element);
 
 this.cells_.forEach((cell) => {
   Services.ownersForDoc(this.element).setOwner(cell, this.element);

--- a/docs/building-an-amp-extension.md
+++ b/docs/building-an-amp-extension.md
@@ -367,7 +367,7 @@ The AMP runtime will not manage scheduling layouting for elements that have
 owners.
 
 ```javascript
-this.cells_ = this.getRealChildren();
+this.cells_ = getRealChildren(this.element);
 
 this.cells_.forEach((cell) => {
   Services.ownersForDoc(this.element).setOwner(cell, this.element);

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -22,7 +22,7 @@ import {Layout} from '#core/dom/layout';
 import {Services} from '#service';
 import {bezierCurve} from '#core/data-structures/curve';
 import {clamp} from '#core/math';
-import {closest, getRealChildren} from '#core/dom/query';
+import {closest, realChildElements} from '#core/dom/query';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
@@ -89,7 +89,7 @@ class AmpAccordion extends AMP.BaseElement {
     this.sessionId_ = this.getSessionStorageKey_();
     this.currentState_ = this.getSessionState_();
 
-    this.sections_ = getRealChildren(this.element);
+    this.sections_ = realChildElements(this.element);
     this.sections_.forEach((section, index) => {
       userAssert(
         section.tagName.toLowerCase() == 'section',

--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -22,7 +22,7 @@ import {Layout} from '#core/dom/layout';
 import {Services} from '#service';
 import {bezierCurve} from '#core/data-structures/curve';
 import {clamp} from '#core/math';
-import {closest} from '#core/dom/query';
+import {closest, getRealChildren} from '#core/dom/query';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
@@ -89,7 +89,7 @@ class AmpAccordion extends AMP.BaseElement {
     this.sessionId_ = this.getSessionStorageKey_();
     this.currentState_ = this.getSessionState_();
 
-    this.sections_ = this.getRealChildren();
+    this.sections_ = getRealChildren(this.element);
     this.sections_.forEach((section, index) => {
       userAssert(
         section.tagName.toLowerCase() == 'section',

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -24,7 +24,10 @@ import {
 } from '../../../src/mediasession-helper';
 import {Layout, isLayoutSizeFixed} from '#core/dom/layout';
 import {assertHttpsUrl} from '../../../src/url';
-import {closestAncestorElementBySelector} from '#core/dom/query';
+import {
+  closestAncestorElementBySelector,
+  getRealChildNodes,
+} from '#core/dom/query';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
 import {listen} from '../../../src/event-helper';
@@ -135,7 +138,7 @@ export class AmpAudio extends AMP.BaseElement {
     );
 
     this.applyFillContent(audio);
-    this.getRealChildNodes().forEach((child) => {
+    getRealChildNodes(this.element).forEach((child) => {
       if (child.getAttribute && child.getAttribute('src')) {
         assertHttpsUrl(child.getAttribute('src'), dev().assertElement(child));
       }

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -26,7 +26,7 @@ import {Layout, isLayoutSizeFixed} from '#core/dom/layout';
 import {assertHttpsUrl} from '../../../src/url';
 import {
   closestAncestorElementBySelector,
-  getRealChildNodes,
+  realChildNodes,
 } from '#core/dom/query';
 import {dev, user} from '../../../src/log';
 import {getMode} from '../../../src/mode';
@@ -138,7 +138,7 @@ export class AmpAudio extends AMP.BaseElement {
     );
 
     this.applyFillContent(audio);
-    getRealChildNodes(this.element).forEach((child) => {
+    realChildNodes(this.element).forEach((child) => {
       if (child.getAttribute && child.getAttribute('src')) {
         assertHttpsUrl(child.getAttribute('src'), dev().assertElement(child));
       }

--- a/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
@@ -17,6 +17,7 @@
 import '../amp-call-tracking';
 import {Services} from '#service';
 import {clearResponseCacheForTesting} from '../amp-call-tracking';
+import {getRealChildren} from '#core/dom/query';
 
 describes.realWin(
   'amp-call-tracking',
@@ -77,7 +78,7 @@ describes.realWin(
     }
 
     function expectHyperlinkToBe(callTrackingEl, href, textContent) {
-      const hyperlink = callTrackingEl.getRealChildren()[0];
+      const hyperlink = getRealChildren(callTrackingEl)[0];
 
       expect(hyperlink.getAttribute('href')).to.equal(href);
       expect(hyperlink.textContent).to.equal(textContent);

--- a/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
+++ b/extensions/amp-call-tracking/0.1/test/test-amp-call-tracking.js
@@ -17,7 +17,7 @@
 import '../amp-call-tracking';
 import {Services} from '#service';
 import {clearResponseCacheForTesting} from '../amp-call-tracking';
-import {getRealChildren} from '#core/dom/query';
+import {realChildElements} from '#core/dom/query';
 
 describes.realWin(
   'amp-call-tracking',
@@ -78,7 +78,7 @@ describes.realWin(
     }
 
     function expectHyperlinkToBe(callTrackingEl, href, textContent) {
-      const hyperlink = getRealChildren(callTrackingEl)[0];
+      const hyperlink = realChildElements(callTrackingEl)[0];
 
       expect(hyperlink.getAttribute('href')).to.equal(href);
       expect(hyperlink.textContent).to.equal(textContent);

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -20,7 +20,6 @@ import {BaseCarousel} from './base-carousel';
 import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {dev} from '../../../src/log';
-import {getRealChildren} from '#core/dom/query';
 import {isLayoutSizeFixed} from '#core/dom/layout';
 import {listen} from '../../../src/event-helper';
 import {numeric} from '../../../src/transition';
@@ -28,6 +27,7 @@ import {
   observeWithSharedInOb,
   unobserveWithSharedInOb,
 } from '../../../src/viewport-observer';
+import {realChildElements} from '#core/dom/query';
 
 /** @const {string} */
 const TAG = 'amp-scrollable-carousel';
@@ -60,7 +60,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /** @override */
   buildCarousel() {
-    this.cells_ = getRealChildren(this.element);
+    this.cells_ = realChildElements(this.element);
 
     this.container_ = this.element.ownerDocument.createElement('div');
     this.container_.classList.add('i-amphtml-scrollable-carousel-container');

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -20,6 +20,7 @@ import {BaseCarousel} from './base-carousel';
 import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {dev} from '../../../src/log';
+import {getRealChildren} from '#core/dom/query';
 import {isLayoutSizeFixed} from '#core/dom/layout';
 import {listen} from '../../../src/event-helper';
 import {numeric} from '../../../src/transition';
@@ -59,7 +60,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
 
   /** @override */
   buildCarousel() {
-    this.cells_ = this.getRealChildren();
+    this.cells_ = getRealChildren(this.element);
 
     this.container_ = this.element.ownerDocument.createElement('div');
     this.container_.classList.add('i-amphtml-scrollable-carousel-container');

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -20,11 +20,15 @@ import {BaseSlides} from './base-slides';
 import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {bezierCurve} from '#core/data-structures/curve';
-import {closestAncestorElementBySelector} from '#core/dom/query';
+import {
+  closestAncestorElementBySelector,
+  getRealChildren,
+} from '#core/dom/query';
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {dispatchCustomEvent} from '#core/dom';
+
 import {getStyle, setStyle} from '#core/dom/style';
 import {isExperimentOn} from '#experiments';
 import {isFiniteNumber} from '#core/types';
@@ -174,7 +178,7 @@ export class AmpSlideScroll extends BaseSlides {
 
     this.element.classList.add('i-amphtml-slidescroll');
 
-    this.slides_ = this.getRealChildren();
+    this.slides_ = getRealChildren(this.element);
 
     this.noOfSlides_ = this.slides_.length;
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -22,13 +22,12 @@ import {Services} from '#service';
 import {bezierCurve} from '#core/data-structures/curve';
 import {
   closestAncestorElementBySelector,
-  getRealChildren,
+  realChildElements,
 } from '#core/dom/query';
 import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, user} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {dispatchCustomEvent} from '#core/dom';
-
 import {getStyle, setStyle} from '#core/dom/style';
 import {isExperimentOn} from '#experiments';
 import {isFiniteNumber} from '#core/types';
@@ -178,7 +177,7 @@ export class AmpSlideScroll extends BaseSlides {
 
     this.element.classList.add('i-amphtml-slidescroll');
 
-    this.slides_ = getRealChildren(this.element);
+    this.slides_ = realChildElements(this.element);
 
     this.noOfSlides_ = this.slides_.length;
 

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -21,7 +21,10 @@ import {Carousel} from '../../amp-base-carousel/0.1/carousel.js';
 import {CarouselEvents} from '../../amp-base-carousel/0.1/carousel-events';
 import {ChildLayoutManager} from '../../amp-base-carousel/0.1/child-layout-manager';
 import {Services} from '#service';
-import {closestAncestorElementBySelector} from '#core/dom/query';
+import {
+  closestAncestorElementBySelector,
+  getRealChildren,
+} from '#core/dom/query';
 import {computedStyle} from '#core/dom/style';
 import {createCustomEvent, getDetail, listen} from '../../../src/event-helper';
 import {dev, devAssert, userAssert} from '../../../src/log';
@@ -142,7 +145,7 @@ class AmpCarousel extends AMP.BaseElement {
     this.action_ = Services.actionServiceForDoc(this.element);
 
     const {element, win} = this;
-    const slides = this.getRealChildren();
+    const slides = getRealChildren(this.element);
 
     element.appendChild(this.renderContainerDom_());
     this.scrollContainer_ = this.element.querySelector(

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -23,7 +23,7 @@ import {ChildLayoutManager} from '../../amp-base-carousel/0.1/child-layout-manag
 import {Services} from '#service';
 import {
   closestAncestorElementBySelector,
-  getRealChildren,
+  realChildElements,
 } from '#core/dom/query';
 import {computedStyle} from '#core/dom/style';
 import {createCustomEvent, getDetail, listen} from '../../../src/event-helper';
@@ -145,7 +145,7 @@ class AmpCarousel extends AMP.BaseElement {
     this.action_ = Services.actionServiceForDoc(this.element);
 
     const {element, win} = this;
-    const slides = getRealChildren(this.element);
+    const slides = realChildElements(this.element);
 
     element.appendChild(this.renderContainerDom_());
     this.scrollContainer_ = this.element.querySelector(

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -48,9 +48,9 @@ import {
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict, hasOwn} from '#core/types/object';
 import {getData} from '../../../src/event-helper';
-import {getRealChildren} from '#core/dom/query';
 import {getServicePromiseForDoc} from '../../../src/service-helpers';
 import {isArray, isEnumValue, isObject} from '#core/types';
+import {realChildElements} from '#core/dom/query';
 
 import {isExperimentOn} from '#experiments';
 
@@ -224,7 +224,7 @@ export class AmpConsent extends AMP.BaseElement {
       /** @type {string} */ (this.consentId_)
     );
 
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
       toggle(child, false);

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -48,6 +48,7 @@ import {
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict, hasOwn} from '#core/types/object';
 import {getData} from '../../../src/event-helper';
+import {getRealChildren} from '#core/dom/query';
 import {getServicePromiseForDoc} from '../../../src/service-helpers';
 import {isArray, isEnumValue, isObject} from '#core/types';
 
@@ -223,7 +224,7 @@ export class AmpConsent extends AMP.BaseElement {
       /** @type {string} */ (this.consentId_)
     );
 
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
       toggle(child, false);

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -16,6 +16,7 @@
 
 import {CSS} from '../../../build/amp-fit-text-0.1.css';
 import {getLengthNumeral, isLayoutSizeDefined} from '#core/dom/layout';
+import {getRealChildNodes} from '#core/dom/query';
 import {px, setStyle, setStyles} from '#core/dom/style';
 import {throttle} from '#core/types/function';
 
@@ -86,7 +87,7 @@ class AmpFitText extends AMP.BaseElement {
       lineHeight: `${LINE_HEIGHT_EM_}em`,
     });
 
-    this.getRealChildNodes().forEach((node) => {
+    getRealChildNodes(this.element).forEach((node) => {
       this.contentWrapper_.appendChild(node);
     });
     this.updateMeasurerContent_();

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -16,8 +16,8 @@
 
 import {CSS} from '../../../build/amp-fit-text-0.1.css';
 import {getLengthNumeral, isLayoutSizeDefined} from '#core/dom/layout';
-import {getRealChildNodes} from '#core/dom/query';
 import {px, setStyle, setStyles} from '#core/dom/style';
+import {realChildNodes} from '#core/dom/query';
 import {throttle} from '#core/types/function';
 
 const TAG = 'amp-fit-text';
@@ -87,7 +87,7 @@ class AmpFitText extends AMP.BaseElement {
       lineHeight: `${LINE_HEIGHT_EM_}em`,
     });
 
-    getRealChildNodes(this.element).forEach((node) => {
+    realChildNodes(this.element).forEach((node) => {
       this.contentWrapper_.appendChild(node);
     });
     this.updateMeasurerContent_();

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -19,6 +19,7 @@ import {CommonSignals} from '#core/constants/common-signals';
 import {Layout} from '#core/dom/layout';
 import {Services} from '#service';
 import {dev, userAssert} from '../../../src/log';
+import {getRealChildNodes, getRealChildren} from '#core/dom/query';
 import {setStyle} from '#core/dom/style';
 
 const TAG = 'amp-fx-flying-carpet';
@@ -75,10 +76,10 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
     const doc = this.element.ownerDocument;
     const container = doc.createElement('div');
 
-    this.children_ = this.getRealChildren();
+    this.children_ = getRealChildren(this.element);
     this.container_ = container;
 
-    const childNodes = this.getRealChildNodes();
+    const childNodes = getRealChildNodes(this.element);
     this.totalChildren_ = this.visibileChildren_(childNodes).length;
 
     const owners = Services.ownersForDoc(this.element);

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -19,7 +19,7 @@ import {CommonSignals} from '#core/constants/common-signals';
 import {Layout} from '#core/dom/layout';
 import {Services} from '#service';
 import {dev, userAssert} from '../../../src/log';
-import {getRealChildNodes, getRealChildren} from '#core/dom/query';
+import {realChildElements, realChildNodes} from '#core/dom/query';
 import {setStyle} from '#core/dom/style';
 
 const TAG = 'amp-fx-flying-carpet';
@@ -76,10 +76,10 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
     const doc = this.element.ownerDocument;
     const container = doc.createElement('div');
 
-    this.children_ = getRealChildren(this.element);
+    this.children_ = realChildElements(this.element);
     this.container_ = container;
 
-    const childNodes = getRealChildNodes(this.element);
+    const childNodes = realChildNodes(this.element);
     this.totalChildren_ = this.visibileChildren_(childNodes).length;
 
     const owners = Services.ownersForDoc(this.element);

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -22,13 +22,13 @@ import {Services} from '#service';
 import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {clamp} from '#core/math';
 import {dev, user, userAssert} from '../../../src/log';
-import {getRealChildren} from '#core/dom/query';
 import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listen} from '../../../src/event-helper';
 import {
   observeWithSharedInOb,
   unobserveWithSharedInOb,
 } from '../../../src/viewport-observer';
+import {realChildElements} from '#core/dom/query';
 import {setStyles} from '#core/dom/style';
 
 export class AmpImageSlider extends AMP.BaseElement {
@@ -111,7 +111,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
 
     for (let i = 0; i < children.length; i++) {
       const child = children[i];

--- a/extensions/amp-image-slider/0.1/amp-image-slider.js
+++ b/extensions/amp-image-slider/0.1/amp-image-slider.js
@@ -22,6 +22,7 @@ import {Services} from '#service';
 import {SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {clamp} from '#core/math';
 import {dev, user, userAssert} from '../../../src/log';
+import {getRealChildren} from '#core/dom/query';
 import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listen} from '../../../src/event-helper';
 import {
@@ -110,7 +111,7 @@ export class AmpImageSlider extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
 
     for (let i = 0; i < children.length; i++) {
       const child = children[i];

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -32,7 +32,11 @@ import {Services} from '#service';
 import {WindowInterface} from '#core/window/interface';
 import {bezierCurve} from '#core/data-structures/curve';
 import {boundValue, distance, magnitude} from '#core/math';
-import {closestAncestorElementBySelector, elementByTag} from '#core/dom/query';
+import {
+  closestAncestorElementBySelector,
+  elementByTag,
+  getRealChildren,
+} from '#core/dom/query';
 import {continueMotion} from '../../../src/motion';
 import {createCustomEvent} from '../../../src/event-helper';
 import {dev, userAssert} from '../../../src/log';
@@ -133,7 +137,7 @@ export class AmpImageViewer extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.element.classList.add('i-amphtml-image-viewer');
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
 
     userAssert(
       children.length == 1,

--- a/extensions/amp-image-viewer/0.1/amp-image-viewer.js
+++ b/extensions/amp-image-viewer/0.1/amp-image-viewer.js
@@ -35,7 +35,7 @@ import {boundValue, distance, magnitude} from '#core/math';
 import {
   closestAncestorElementBySelector,
   elementByTag,
-  getRealChildren,
+  realChildElements,
 } from '#core/dom/query';
 import {continueMotion} from '../../../src/motion';
 import {createCustomEvent} from '../../../src/event-helper';
@@ -137,7 +137,7 @@ export class AmpImageViewer extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.element.classList.add('i-amphtml-image-viewer');
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
 
     userAssert(
       children.length == 1,

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -37,9 +37,9 @@ import {debounce} from '#core/types/function';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, hasOwn} from '#core/types/object';
 import {getMode} from '../../../src/mode';
-import {getRealChildren} from '#core/dom/query';
 import {htmlFor} from '#core/dom/static-template';
 import {isInFie} from '../../../src/iframe-helper';
+import {realChildElements} from '#core/dom/query';
 import {toArray} from '#core/types/array';
 import {tryFocus} from '#core/dom';
 import {unmountAll} from '../../../src/utils/resource-container-helper';
@@ -233,7 +233,7 @@ class AmpLightbox extends AMP.BaseElement {
 
     this.isScrollable_ = element.hasAttribute('scrollable');
 
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
 
     this.container_ = element.ownerDocument.createElement('div');
     if (!this.isScrollable_) {

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -37,6 +37,7 @@ import {debounce} from '#core/types/function';
 import {dev, devAssert, user} from '../../../src/log';
 import {dict, hasOwn} from '#core/types/object';
 import {getMode} from '../../../src/mode';
+import {getRealChildren} from '#core/dom/query';
 import {htmlFor} from '#core/dom/static-template';
 import {isInFie} from '../../../src/iframe-helper';
 import {toArray} from '#core/types/array';
@@ -232,7 +233,7 @@ class AmpLightbox extends AMP.BaseElement {
 
     this.isScrollable_ = element.hasAttribute('scrollable');
 
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
 
     this.container_ = element.ownerDocument.createElement('div');
     if (!this.isScrollable_) {

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -33,6 +33,7 @@ import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {dispatchCustomEvent} from '#core/dom';
+import {getRealChildren} from '#core/dom/query';
 import {layoutRectFromDomRect, layoutRectLtwh} from '#core/math/layout-rect';
 import {numeric} from '../../../src/transition';
 import {
@@ -166,7 +167,7 @@ export class AmpPanZoom extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
 
     userAssert(
       children.length == 1,

--- a/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
+++ b/extensions/amp-pan-zoom/0.1/amp-pan-zoom.js
@@ -33,7 +33,6 @@ import {createCustomEvent, listen} from '../../../src/event-helper';
 import {dev, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {dispatchCustomEvent} from '#core/dom';
-import {getRealChildren} from '#core/dom/query';
 import {layoutRectFromDomRect, layoutRectLtwh} from '#core/math/layout-rect';
 import {numeric} from '../../../src/transition';
 import {
@@ -41,6 +40,7 @@ import {
   unobserveContentSize,
 } from '#core/dom/size-observer';
 import {px, scale, setStyles, translate} from '#core/dom/style';
+import {realChildElements} from '#core/dom/query';
 
 const PAN_ZOOM_CURVE_ = bezierCurve(0.4, 0, 0.2, 1.4);
 const TAG = 'amp-pan-zoom';
@@ -167,7 +167,7 @@ export class AmpPanZoom extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.action_ = Services.actionServiceForDoc(this.element);
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
 
     userAssert(
       children.length == 1,

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -27,8 +27,8 @@ import {dev, user, userAssert} from '../../../src/log';
 import {dict, map} from '#core/types/object';
 import {getElementServiceForDoc} from '../../../src/element-service';
 import {getMode} from '../../../src/mode';
-import {getRealChildren} from '#core/dom/query';
 import {getService, registerServiceBuilder} from '../../../src/service-helpers';
+import {realChildElements} from '#core/dom/query';
 import {rewriteAttributeValue} from '../../../src/url-rewrite';
 import {tryParseJson} from '#core/types/object/json';
 import {urls} from '../../../src/config';
@@ -237,7 +237,7 @@ export class AmpScript extends AMP.BaseElement {
       container = this.win.document.createElement('div');
       this.applyFillContent(container, true);
       // Reparent all real children to the container.
-      const realChildren = getRealChildren(this.element);
+      const realChildren = realChildElements(this.element);
       for (let i = 0; i < realChildren.length; i++) {
         container.appendChild(realChildren[i]);
       }

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -27,6 +27,7 @@ import {dev, user, userAssert} from '../../../src/log';
 import {dict, map} from '#core/types/object';
 import {getElementServiceForDoc} from '../../../src/element-service';
 import {getMode} from '../../../src/mode';
+import {getRealChildren} from '#core/dom/query';
 import {getService, registerServiceBuilder} from '../../../src/service-helpers';
 import {rewriteAttributeValue} from '../../../src/url-rewrite';
 import {tryParseJson} from '#core/types/object/json';
@@ -236,7 +237,7 @@ export class AmpScript extends AMP.BaseElement {
       container = this.win.document.createElement('div');
       this.applyFillContent(container, true);
       // Reparent all real children to the container.
-      const realChildren = this.getRealChildren();
+      const realChildren = getRealChildren(this.element);
       for (let i = 0; i < realChildren.length; i++) {
         container.appendChild(realChildren[i]);
       }

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -25,7 +25,7 @@ import {SwipeDef, SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {Toolbar} from './toolbar';
 import {
   closestAncestorElementBySelector,
-  getRealChildren,
+  realChildElements,
 } from '#core/dom/query';
 import {createCustomEvent} from '../../../src/event-helper';
 import {debounce} from '#core/types/function';
@@ -455,7 +455,7 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   updateForOpened_(trust) {
     // On open sidebar
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
     const owners = Services.ownersForDoc(this.element);
     owners.scheduleLayout(this.element, children);
     owners.scheduleResume(this.element, children);
@@ -505,7 +505,7 @@ export class AmpSidebar extends AMP.BaseElement {
     toggle(this.getMaskElement_(), /* display */ false);
     Services.ownersForDoc(this.element).schedulePause(
       this.element,
-      getRealChildren(this.element)
+      realChildElements(this.element)
     );
     this.triggerEvent_(SidebarEvents.CLOSE, trust);
 

--- a/extensions/amp-sidebar/0.1/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/amp-sidebar.js
@@ -23,7 +23,10 @@ import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {SwipeDef, SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {Toolbar} from './toolbar';
-import {closestAncestorElementBySelector} from '#core/dom/query';
+import {
+  closestAncestorElementBySelector,
+  getRealChildren,
+} from '#core/dom/query';
 import {createCustomEvent} from '../../../src/event-helper';
 import {debounce} from '#core/types/function';
 import {descendsFromStory} from '../../../src/utils/story';
@@ -452,7 +455,7 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   updateForOpened_(trust) {
     // On open sidebar
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
     const owners = Services.ownersForDoc(this.element);
     owners.scheduleLayout(this.element, children);
     owners.scheduleResume(this.element, children);
@@ -502,7 +505,7 @@ export class AmpSidebar extends AMP.BaseElement {
     toggle(this.getMaskElement_(), /* display */ false);
     Services.ownersForDoc(this.element).schedulePause(
       this.element,
-      this.getRealChildren()
+      getRealChildren(this.element)
     );
     this.triggerEvent_(SidebarEvents.CLOSE, trust);
 

--- a/extensions/amp-sidebar/0.2/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.js
@@ -23,7 +23,10 @@ import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {SwipeDef, SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {Toolbar} from './toolbar';
-import {closestAncestorElementBySelector} from '#core/dom/query';
+import {
+  closestAncestorElementBySelector,
+  getRealChildren,
+} from '#core/dom/query';
 import {createCustomEvent} from '../../../src/event-helper';
 import {debounce} from '#core/types/function';
 import {descendsFromStory} from '../../../src/utils/story';
@@ -450,7 +453,7 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   updateForOpened_(trust) {
     // On open sidebar
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
     const owners = Services.ownersForDoc(this.element);
     owners.scheduleLayout(this.element, children);
     owners.scheduleResume(this.element, children);
@@ -501,7 +504,7 @@ export class AmpSidebar extends AMP.BaseElement {
     toggle(this.getMaskElement_(), /* display */ false);
     Services.ownersForDoc(this.element).schedulePause(
       this.element,
-      this.getRealChildren()
+      getRealChildren(this.element)
     );
     // TODO(#25080): update history manipulation based on resolution of this issue.
     if (this.historyId_ != -1) {

--- a/extensions/amp-sidebar/0.2/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.js
@@ -25,7 +25,7 @@ import {SwipeDef, SwipeXRecognizer} from '../../../src/gesture-recognizers';
 import {Toolbar} from './toolbar';
 import {
   closestAncestorElementBySelector,
-  getRealChildren,
+  realChildElements,
 } from '#core/dom/query';
 import {createCustomEvent} from '../../../src/event-helper';
 import {debounce} from '#core/types/function';
@@ -453,7 +453,7 @@ export class AmpSidebar extends AMP.BaseElement {
    */
   updateForOpened_(trust) {
     // On open sidebar
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
     const owners = Services.ownersForDoc(this.element);
     owners.scheduleLayout(this.element, children);
     owners.scheduleResume(this.element, children);
@@ -504,7 +504,7 @@ export class AmpSidebar extends AMP.BaseElement {
     toggle(this.getMaskElement_(), /* display */ false);
     Services.ownersForDoc(this.element).schedulePause(
       this.element,
-      getRealChildren(this.element)
+      realChildElements(this.element)
     );
     // TODO(#25080): update history manipulation based on resolution of this issue.
     if (this.historyId_ != -1) {

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -19,8 +19,8 @@ import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '#preact/base-element';
 import {Sidebar} from './component';
 import {dict} from '#core/types/object';
-import {getRealChildNodes} from '#core/dom/query';
 import {pauseAll} from '../../../src/utils/resource-container-helper';
+import {realChildNodes} from '#core/dom/query';
 import {toggle} from '#core/dom/style';
 import {toggleAttribute} from '#core/dom';
 import {useToolbarHook} from './sidebar-toolbar-hook';
@@ -51,7 +51,7 @@ export class BaseElement extends PreactBaseElement {
 
   /** @override */
   updatePropsForRendering(props) {
-    getRealChildNodes(this.element).map((child) => {
+    realChildNodes(this.element).map((child) => {
       if (
         child.nodeName === 'NAV' &&
         child.hasAttribute('toolbar') &&

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -19,6 +19,7 @@ import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '#preact/base-element';
 import {Sidebar} from './component';
 import {dict} from '#core/types/object';
+import {getRealChildNodes} from '#core/dom/query';
 import {pauseAll} from '../../../src/utils/resource-container-helper';
 import {toggle} from '#core/dom/style';
 import {toggleAttribute} from '#core/dom';
@@ -50,7 +51,7 @@ export class BaseElement extends PreactBaseElement {
 
   /** @override */
   updatePropsForRendering(props) {
-    this.getRealChildNodes().map((child) => {
+    getRealChildNodes(this.element).map((child) => {
       if (
         child.nodeName === 'NAV' &&
         child.hasAttribute('toolbar') &&

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -24,7 +24,7 @@ import {
   toggle,
 } from '#core/dom/style';
 import {dev, user, userAssert} from '../../../src/log';
-import {getRealChildren} from '#core/dom/query';
+import {realChildElements} from '#core/dom/query';
 import {removeElement} from '#core/dom';
 import {whenUpgradedToCustomElement} from '../../../src/amp-element-helpers';
 
@@ -60,7 +60,7 @@ class AmpStickyAd extends AMP.BaseElement {
     this.viewport_ = this.getViewport();
     this.element.classList.add('i-amphtml-sticky-ad-layout');
 
-    const children = getRealChildren(this.element);
+    const children = realChildElements(this.element);
     userAssert(
       children.length == 1 && children[0].tagName == 'AMP-AD',
       'amp-sticky-ad must have a single amp-ad child'

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -24,6 +24,7 @@ import {
   toggle,
 } from '#core/dom/style';
 import {dev, user, userAssert} from '../../../src/log';
+import {getRealChildren} from '#core/dom/query';
 import {removeElement} from '#core/dom';
 import {whenUpgradedToCustomElement} from '../../../src/amp-element-helpers';
 
@@ -59,7 +60,7 @@ class AmpStickyAd extends AMP.BaseElement {
     this.viewport_ = this.getViewport();
     this.element.classList.add('i-amphtml-sticky-ad-layout');
 
-    const children = this.getRealChildren();
+    const children = getRealChildren(this.element);
     userAssert(
       children.length == 1 && children[0].tagName == 'AMP-AD',
       'amp-sticky-ad must have a single amp-ad child'

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.js
@@ -19,7 +19,7 @@ import {Services} from '#service';
 import {CSS as ShadowCSS} from '../../../build/amp-truncate-text-shadow-0.1.css';
 import {
   closestAncestorElementBySelector,
-  getRealChildNodes,
+  realChildNodes,
 } from '#core/dom/query';
 import {createShadowRoot} from './shadow-utils';
 import {dev} from '../../../src/log';
@@ -149,7 +149,7 @@ export class AmpTruncateText extends AMP.BaseElement {
         this.persistentSlot_.appendChild(el);
       }
     );
-    getRealChildNodes(this.element).forEach((node) => {
+    realChildNodes(this.element).forEach((node) => {
       defaultSlot.appendChild(node);
     });
 

--- a/extensions/amp-truncate-text/0.1/amp-truncate-text.js
+++ b/extensions/amp-truncate-text/0.1/amp-truncate-text.js
@@ -17,7 +17,10 @@
 import {CSS} from '../../../build/amp-truncate-text-0.1.css';
 import {Services} from '#service';
 import {CSS as ShadowCSS} from '../../../build/amp-truncate-text-shadow-0.1.css';
-import {closestAncestorElementBySelector} from '#core/dom/query';
+import {
+  closestAncestorElementBySelector,
+  getRealChildNodes,
+} from '#core/dom/query';
 import {createShadowRoot} from './shadow-utils';
 import {dev} from '../../../src/log';
 import {htmlFor} from '#core/dom/static-template';
@@ -146,7 +149,7 @@ export class AmpTruncateText extends AMP.BaseElement {
         this.persistentSlot_.appendChild(el);
       }
     );
-    this.getRealChildNodes().forEach((node) => {
+    getRealChildNodes(this.element).forEach((node) => {
       defaultSlot.appendChild(node);
     });
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -848,27 +848,6 @@ export class BaseElement {
   }
 
   /**
-   * Returns the original nodes of the custom element without any service nodes
-   * that could have been added for markup. These nodes can include Text,
-   * Comment and other child nodes.
-   * @return {!Array<!Node>}
-   * @public @final
-   */
-  getRealChildNodes() {
-    return this.element.getRealChildNodes();
-  }
-
-  /**
-   * Returns the original children of the custom element without any service
-   * nodes that could have been added for markup.
-   * @return {!Array<!Element>}
-   * @public @final
-   */
-  getRealChildren() {
-    return this.element.getRealChildren();
-  }
-
-  /**
    * Configures the supplied element to have a "fill content" layout. The
    * exact interpretation of "fill content" depends on the element's layout.
    *

--- a/src/core/dom/layout.js
+++ b/src/core/dom/layout.js
@@ -19,8 +19,8 @@
  * details.
  */
 
-import {devAssertElement, userAssert} from '#core/assert';
 import {isFiniteNumber} from '#core/types';
+import {userAssert} from '#core/assert';
 
 /**
  * @enum {string}
@@ -142,23 +142,6 @@ export function isLayoutSizeDefined(layout) {
  */
 export function isLayoutSizeFixed(layout) {
   return layout == Layout.FIXED || layout == Layout.FIXED_HEIGHT;
-}
-
-/**
- * Whether the tag is an internal (service) AMP tag.
- * @param {!Node|string} nodeOrTagName
- * @return {boolean}
- */
-export function isInternalElement(nodeOrTagName) {
-  /** @type string */
-  let tagName;
-  if (typeof nodeOrTagName == 'string') {
-    tagName = nodeOrTagName;
-  } else if (nodeOrTagName.nodeType === Node.ELEMENT_NODE) {
-    tagName = devAssertElement(nodeOrTagName).tagName;
-  }
-
-  return !!tagName && tagName.toLowerCase().startsWith('i-');
 }
 
 /**

--- a/src/core/dom/query.js
+++ b/src/core/dom/query.js
@@ -364,15 +364,16 @@ export function isInternalOrServiceNode(node) {
   if (isInternalElement(node)) {
     return true;
   }
-  if (
-    node.tagName &&
-    (node.hasAttribute('placeholder') ||
-      node.hasAttribute('fallback') ||
-      node.hasAttribute('overflow'))
-  ) {
-    return true;
+  if (node.nodeType !== Node.ELEMENT_NODE) {
+    return false;
   }
-  return false;
+  devAssertElement(node);
+
+  return (
+    node.hasAttribute('placeholder') ||
+    node.hasAttribute('fallback') ||
+    node.hasAttribute('overflow')
+  );
 }
 
 /**

--- a/src/core/dom/query.js
+++ b/src/core/dom/query.js
@@ -340,7 +340,7 @@ export function elementByTag(element, tagName) {
  * @param {!Node} element
  * @return {!Array<!Node>}
  */
-export function getRealChildNodes(element) {
+export function realChildNodes(element) {
   return childNodes(element, (node) => !isInternalOrServiceNode(node));
 }
 
@@ -350,9 +350,8 @@ export function getRealChildNodes(element) {
  *
  * @param {!Element} element
  * @return {!Array<!Element>}
- * @package @final
  */
-export function getRealChildren(element) {
+export function realChildElements(element) {
   return childElements(element, (element) => !isInternalOrServiceNode(element));
 }
 

--- a/src/core/dom/query.js
+++ b/src/core/dom/query.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {devAssert} from '#core/assert';
+import {devAssert, devAssertElement} from '#core/assert';
 import {isScopeSelectorSupported, prependSelectorsWith} from './css-selectors';
 
 /** @fileoverview Helper functions for DOM queries. */
@@ -330,4 +330,65 @@ export function childElementsByTag(parent, tagName) {
 export function elementByTag(element, tagName) {
   assertIsName(tagName);
   return element./*OK*/ querySelector(tagName);
+}
+
+/**
+ * Returns the original nodes of the custom element without any service
+ * nodes that could have been added for markup. These nodes can include
+ * Text, Comment and other child nodes.
+ *
+ * @param {!Node} element
+ * @return {!Array<!Node>}
+ */
+export function getRealChildNodes(element) {
+  return childNodes(element, (node) => !isInternalOrServiceNode(node));
+}
+
+/**
+ * Returns the original children of the custom element without any service
+ * nodes that could have been added for markup.
+ *
+ * @param {!Element} element
+ * @return {!Array<!Element>}
+ * @package @final
+ */
+export function getRealChildren(element) {
+  return childElements(element, (element) => !isInternalOrServiceNode(element));
+}
+
+/**
+ * Returns "true" for internal AMP nodes or for placeholder elements.
+ * @param {!Node} node
+ * @return {boolean}
+ */
+export function isInternalOrServiceNode(node) {
+  if (isInternalElement(node)) {
+    return true;
+  }
+  if (
+    node.tagName &&
+    (node.hasAttribute('placeholder') ||
+      node.hasAttribute('fallback') ||
+      node.hasAttribute('overflow'))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Whether the tag is an internal (service) AMP tag.
+ * @param {!Node|string} nodeOrTagName
+ * @return {boolean}
+ */
+function isInternalElement(nodeOrTagName) {
+  /** @type string */
+  let tagName;
+  if (typeof nodeOrTagName == 'string') {
+    tagName = nodeOrTagName;
+  } else if (nodeOrTagName.nodeType === Node.ELEMENT_NODE) {
+    tagName = devAssertElement(nodeOrTagName).tagName;
+  }
+
+  return !!tagName && tagName.toLowerCase().startsWith('i-');
 }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -19,12 +19,7 @@ import * as query from './core/dom/query';
 import {AmpEvents} from './core/constants/amp-events';
 import {CommonSignals} from './core/constants/common-signals';
 import {ElementStub} from './element-stub';
-import {
-  Layout,
-  LayoutPriority,
-  isInternalElement,
-  isLoadingAllowed,
-} from './core/dom/layout';
+import {Layout, LayoutPriority, isLoadingAllowed} from './core/dom/layout';
 import {MediaQueryProps} from './core/dom/media-query-props';
 import {ReadyState} from './core/constants/ready-state';
 import {ResourceState} from './service/resource';
@@ -1897,30 +1892,6 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     }
 
     /**
-     * Returns the original nodes of the custom element without any service
-     * nodes that could have been added for markup. These nodes can include
-     * Text, Comment and other child nodes.
-     * @return {!Array<!Node>}
-     * @package @final
-     */
-    getRealChildNodes() {
-      return query.childNodes(this, (node) => !isInternalOrServiceNode(node));
-    }
-
-    /**
-     * Returns the original children of the custom element without any service
-     * nodes that could have been added for markup.
-     * @return {!Array<!Element>}
-     * @package @final
-     */
-    getRealChildren() {
-      return query.childElements(
-        this,
-        (element) => !isInternalOrServiceNode(element)
-      );
-    }
-
-    /**
      * Returns an optional placeholder element for this custom element.
      * @return {?Element}
      * @package @final
@@ -2042,7 +2013,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         this.hasAttribute('noloading') ||
         (laidOut && !force) ||
         !isLoadingAllowed(this) ||
-        isInternalOrServiceNode(this)
+        query.isInternalOrServiceNode(this)
       ) {
         return false;
       }
@@ -2169,26 +2140,6 @@ function isInputPlaceholder(element) {
 /** @param {!Element} element */
 function assertNotTemplate(element) {
   devAssert(!element.isInTemplate_, 'Must never be called in template');
-}
-
-/**
- * Returns "true" for internal AMP nodes or for placeholder elements.
- * @param {!Node} node
- * @return {boolean}
- */
-function isInternalOrServiceNode(node) {
-  if (isInternalElement(node)) {
-    return true;
-  }
-  if (
-    node.tagName &&
-    (node.hasAttribute('placeholder') ||
-      node.hasAttribute('fallback') ||
-      node.hasAttribute('overflow'))
-  ) {
-    return true;
-  }
-  return false;
 }
 
 /**

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -33,7 +33,12 @@ import {
   setParent,
   subscribe,
 } from '../context';
-import {childElementByAttr, childElementByTag, matches} from '#core/dom/query';
+import {
+  childElementByAttr,
+  childElementByTag,
+  getRealChildNodes,
+  matches,
+} from '#core/dom/query';
 import {
   createElementWithAttributes,
   dispatchCustomEvent,
@@ -44,11 +49,11 @@ import {devAssert} from '#core/assert';
 import {dict, hasOwn, map} from '#core/types/object';
 import {getDate} from '#core/types/date';
 import {getMode} from '../mode';
+
 import {hydrate, render} from './index';
 import {installShadowStyle} from '../shadow-embed';
 import {isElement} from '#core/types';
 import {sequentialIdGenerator} from '#core/math/id-generator';
-import {toArray} from '#core/types/array';
 
 /**
  * The following combinations are allowed.
@@ -1083,9 +1088,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
     // as separate properties. Thus in a carousel the plain "children" are
     // slides, and the "arrowNext" children are passed via a "arrowNext"
     // property.
-    const nodes = element.getRealChildNodes
-      ? element.getRealChildNodes()
-      : toArray(element.childNodes);
+    const nodes = getRealChildNodes(element);
     for (let i = 0; i < nodes.length; i++) {
       const childElement = nodes[i];
       const match = matchChild(childElement, propDefs);
@@ -1157,7 +1160,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
       devAssert(Ctor['usesShadowDom']);
       // Use lazy loading inside the passthrough by default due to too many
       // elements.
-      value = element.getRealChildNodes().every(IS_EMPTY_TEXT_NODE)
+      value = getRealChildNodes(element).every(IS_EMPTY_TEXT_NODE)
         ? null
         : [<Slot loading={Loading.LAZY} />];
     } else if (def.attr) {

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -36,8 +36,8 @@ import {
 import {
   childElementByAttr,
   childElementByTag,
-  getRealChildNodes,
   matches,
+  realChildNodes,
 } from '#core/dom/query';
 import {
   createElementWithAttributes,
@@ -49,7 +49,6 @@ import {devAssert} from '#core/assert';
 import {dict, hasOwn, map} from '#core/types/object';
 import {getDate} from '#core/types/date';
 import {getMode} from '../mode';
-
 import {hydrate, render} from './index';
 import {installShadowStyle} from '../shadow-embed';
 import {isElement} from '#core/types';
@@ -1088,7 +1087,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
     // as separate properties. Thus in a carousel the plain "children" are
     // slides, and the "arrowNext" children are passed via a "arrowNext"
     // property.
-    const nodes = getRealChildNodes(element);
+    const nodes = realChildNodes(element);
     for (let i = 0; i < nodes.length; i++) {
       const childElement = nodes[i];
       const match = matchChild(childElement, propDefs);
@@ -1160,7 +1159,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
       devAssert(Ctor['usesShadowDom']);
       // Use lazy loading inside the passthrough by default due to too many
       // elements.
-      value = getRealChildNodes(element).every(IS_EMPTY_TEXT_NODE)
+      value = realChildNodes(element).every(IS_EMPTY_TEXT_NODE)
         ? null
         : [<Slot loading={Loading.LAZY} />];
     } else if (def.attr) {

--- a/test/unit/core/dom/test-dom.js
+++ b/test/unit/core/dom/test-dom.js
@@ -16,9 +16,8 @@
 
 import * as dom from '#core/dom';
 import {createElementWithAttributes} from '#core/dom';
-import {getRealChildNodes, getRealChildren, matches} from '#core/dom/query';
 import {loadPromise} from '../../../../src/event-helper';
-
+import {matches, realChildElements, realChildNodes} from '#core/dom/query';
 import {setScopeSelectorSupportedForTesting} from '#core/dom/css-selectors';
 import {setShadowDomSupportedVersionForTesting} from '#core/dom/web-components';
 
@@ -507,18 +506,18 @@ describes.sandboxed('DOM', {}, (env) => {
     });
   });
 
-  describe('getRealChildren and getRealChildNodes', () => {
+  describe('realChildElements and realChildNodes', () => {
     let element;
     beforeEach(() => {
       element = document.createElement('div');
     });
 
-    it('getRealChildren should return nothing', () => {
-      expect(getRealChildNodes(element).length).to.equal(0);
-      expect(getRealChildren(element).length).to.equal(0);
+    it('realChildElements should return nothing', () => {
+      expect(realChildNodes(element).length).to.equal(0);
+      expect(realChildElements(element).length).to.equal(0);
     });
 
-    it('getRealChildren should return content-only nodes', () => {
+    it('realChildElements should return content-only nodes', () => {
       const createWithAttr = (attr) =>
         createElementWithAttributes(document, 'div', {[attr]: ''});
 
@@ -529,12 +528,12 @@ describes.sandboxed('DOM', {}, (env) => {
       element.appendChild(document.createTextNode('abc'));
       element.appendChild(document.createElement('content'));
 
-      const nodes = getRealChildNodes(element);
+      const nodes = realChildNodes(element);
       expect(nodes.length).to.equal(2);
       expect(nodes[0].textContent).to.equal('abc');
       expect(nodes[1].tagName.toLowerCase()).to.equal('content');
 
-      const elements = getRealChildren(element);
+      const elements = realChildElements(element);
       expect(elements.length).to.equal(1);
       expect(elements[0].tagName.toLowerCase()).to.equal('content');
     });

--- a/test/unit/core/dom/test-dom.js
+++ b/test/unit/core/dom/test-dom.js
@@ -15,8 +15,10 @@
  */
 
 import * as dom from '#core/dom';
+import {createElementWithAttributes} from '#core/dom';
+import {getRealChildNodes, getRealChildren, matches} from '#core/dom/query';
 import {loadPromise} from '../../../../src/event-helper';
-import {matches} from '#core/dom/query';
+
 import {setScopeSelectorSupportedForTesting} from '#core/dom/css-selectors';
 import {setShadowDomSupportedVersionForTesting} from '#core/dom/web-components';
 
@@ -502,6 +504,39 @@ describes.sandboxed('DOM', {}, (env) => {
       const focusSpy = env.sandbox.spy(element, 'focus');
       expect(() => dom.tryFocus(element)).to.not.throw();
       expect(focusSpy).to.have.been.called;
+    });
+  });
+
+  describe('getRealChildren and getRealChildNodes', () => {
+    let element;
+    beforeEach(() => {
+      element = document.createElement('div');
+    });
+
+    it('getRealChildren should return nothing', () => {
+      expect(getRealChildNodes(element).length).to.equal(0);
+      expect(getRealChildren(element).length).to.equal(0);
+    });
+
+    it('getRealChildren should return content-only nodes', () => {
+      const createWithAttr = (attr) =>
+        createElementWithAttributes(document, 'div', {[attr]: ''});
+
+      element.appendChild(document.createElement('i-amp-service'));
+      element.appendChild(createWithAttr('placeholder'));
+      element.appendChild(createWithAttr('fallback'));
+      element.appendChild(createWithAttr('overflow'));
+      element.appendChild(document.createTextNode('abc'));
+      element.appendChild(document.createElement('content'));
+
+      const nodes = getRealChildNodes(element);
+      expect(nodes.length).to.equal(2);
+      expect(nodes[0].textContent).to.equal('abc');
+      expect(nodes[1].tagName.toLowerCase()).to.equal('content');
+
+      const elements = getRealChildren(element);
+      expect(elements.length).to.equal(1);
+      expect(elements[0].tagName.toLowerCase()).to.equal('content');
     });
   });
 

--- a/test/unit/core/dom/test-dom.js
+++ b/test/unit/core/dom/test-dom.js
@@ -15,9 +15,8 @@
  */
 
 import * as dom from '#core/dom';
-import {createElementWithAttributes} from '#core/dom';
 import {loadPromise} from '../../../../src/event-helper';
-import {matches, realChildElements, realChildNodes} from '#core/dom/query';
+import {matches} from '#core/dom/query';
 import {setScopeSelectorSupportedForTesting} from '#core/dom/css-selectors';
 import {setShadowDomSupportedVersionForTesting} from '#core/dom/web-components';
 
@@ -503,39 +502,6 @@ describes.sandboxed('DOM', {}, (env) => {
       const focusSpy = env.sandbox.spy(element, 'focus');
       expect(() => dom.tryFocus(element)).to.not.throw();
       expect(focusSpy).to.have.been.called;
-    });
-  });
-
-  describe('realChildElements and realChildNodes', () => {
-    let element;
-    beforeEach(() => {
-      element = document.createElement('div');
-    });
-
-    it('realChildElements should return nothing', () => {
-      expect(realChildNodes(element).length).to.equal(0);
-      expect(realChildElements(element).length).to.equal(0);
-    });
-
-    it('realChildElements should return content-only nodes', () => {
-      const createWithAttr = (attr) =>
-        createElementWithAttributes(document, 'div', {[attr]: ''});
-
-      element.appendChild(document.createElement('i-amp-service'));
-      element.appendChild(createWithAttr('placeholder'));
-      element.appendChild(createWithAttr('fallback'));
-      element.appendChild(createWithAttr('overflow'));
-      element.appendChild(document.createTextNode('abc'));
-      element.appendChild(document.createElement('content'));
-
-      const nodes = realChildNodes(element);
-      expect(nodes.length).to.equal(2);
-      expect(nodes[0].textContent).to.equal('abc');
-      expect(nodes[1].tagName.toLowerCase()).to.equal('content');
-
-      const elements = realChildElements(element);
-      expect(elements.length).to.equal(1);
-      expect(elements[0].tagName.toLowerCase()).to.equal('content');
     });
   });
 

--- a/test/unit/core/dom/test-query.js
+++ b/test/unit/core/dom/test-query.js
@@ -15,6 +15,7 @@
  */
 
 import * as query from '#core/dom/query';
+import {createElementWithAttributes} from '#core/dom';
 import {isElement} from '#core/types';
 import {loadPromise} from '../../../../src/event-helper';
 import {setScopeSelectorSupportedForTesting} from '#core/dom/css-selectors';
@@ -68,6 +69,39 @@ describes.sandboxed('DOM - query helpers', {}, (env) => {
     expect(
       toArray(query.scopedQuerySelectorAll(grandparent, 'div div'))
     ).to.deep.equal([element1, element2]);
+  });
+
+  describe('realChildElements and realChildNodes', () => {
+    let element;
+    beforeEach(() => {
+      element = document.createElement('div');
+    });
+
+    it('realChildElements should return nothing', () => {
+      expect(query.realChildNodes(element).length).to.equal(0);
+      expect(query.realChildElements(element).length).to.equal(0);
+    });
+
+    it('realChildElements should return content-only nodes', () => {
+      const createWithAttr = (attr) =>
+        createElementWithAttributes(document, 'div', {[attr]: ''});
+
+      element.appendChild(document.createElement('i-amp-service'));
+      element.appendChild(createWithAttr('placeholder'));
+      element.appendChild(createWithAttr('fallback'));
+      element.appendChild(createWithAttr('overflow'));
+      element.appendChild(document.createTextNode('abc'));
+      element.appendChild(document.createElement('content'));
+
+      const nodes = query.realChildNodes(element);
+      expect(nodes.length).to.equal(2);
+      expect(nodes[0].textContent).to.equal('abc');
+      expect(nodes[1].tagName.toLowerCase()).to.equal('content');
+
+      const elements = query.realChildElements(element);
+      expect(elements.length).to.equal(1);
+      expect(elements[0].tagName.toLowerCase()).to.equal('content');
+    });
   });
 
   describe('matches', () => {

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -28,7 +28,6 @@ import {
   getImplSyncForTesting,
 } from '../../src/custom-element';
 import {elementConnectedCallback} from '#service/custom-element-registry';
-import {getRealChildNodes, getRealChildren} from '#core/dom/query';
 import {toggleExperiment} from '#experiments';
 
 describes.realWin('CustomElement', {amp: true}, (env) => {
@@ -1978,29 +1977,6 @@ describes.realWin('CustomElement Service Elements', {amp: true}, (env) => {
     child.setAttribute(attr, '');
     return child;
   }
-
-  it('getRealChildren should return nothing', () => {
-    expect(getRealChildNodes(element).length).to.equal(0);
-    expect(getRealChildren(element).length).to.equal(0);
-  });
-
-  it('getRealChildren should return content-only nodes', () => {
-    element.appendChild(doc.createElement('i-amp-service'));
-    element.appendChild(createWithAttr('placeholder'));
-    element.appendChild(createWithAttr('fallback'));
-    element.appendChild(createWithAttr('overflow'));
-    element.appendChild(doc.createTextNode('abc'));
-    element.appendChild(doc.createElement('content'));
-
-    const nodes = getRealChildNodes(element);
-    expect(nodes.length).to.equal(2);
-    expect(nodes[0].textContent).to.equal('abc');
-    expect(nodes[1].tagName.toLowerCase()).to.equal('content');
-
-    const elements = getRealChildren(element);
-    expect(elements.length).to.equal(1);
-    expect(elements[0].tagName.toLowerCase()).to.equal('content');
-  });
 
   it('getPlaceholder should return nothing', () => {
     expect(element.getPlaceholder()).to.be.null;

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -28,6 +28,7 @@ import {
   getImplSyncForTesting,
 } from '../../src/custom-element';
 import {elementConnectedCallback} from '#service/custom-element-registry';
+import {getRealChildNodes, getRealChildren} from '#core/dom/query';
 import {toggleExperiment} from '#experiments';
 
 describes.realWin('CustomElement', {amp: true}, (env) => {
@@ -1979,8 +1980,8 @@ describes.realWin('CustomElement Service Elements', {amp: true}, (env) => {
   }
 
   it('getRealChildren should return nothing', () => {
-    expect(element.getRealChildNodes().length).to.equal(0);
-    expect(element.getRealChildren().length).to.equal(0);
+    expect(getRealChildNodes(element).length).to.equal(0);
+    expect(getRealChildren(element).length).to.equal(0);
   });
 
   it('getRealChildren should return content-only nodes', () => {
@@ -1991,12 +1992,12 @@ describes.realWin('CustomElement Service Elements', {amp: true}, (env) => {
     element.appendChild(doc.createTextNode('abc'));
     element.appendChild(doc.createElement('content'));
 
-    const nodes = element.getRealChildNodes();
+    const nodes = getRealChildNodes(element);
     expect(nodes.length).to.equal(2);
     expect(nodes[0].textContent).to.equal('abc');
     expect(nodes[1].tagName.toLowerCase()).to.equal('content');
 
-    const elements = element.getRealChildren();
+    const elements = getRealChildren(element);
     expect(elements.length).to.equal(1);
     expect(elements[0].tagName.toLowerCase()).to.equal('content');
   });


### PR DESCRIPTION
**summary**
In order to remove Runtime dependencies from `amp-layout`'s `buildCallback`, I've extracted getRealChildNodes and getRealChildren to core from CE and BE.

The primary diff in most files looks like this:
```diff
-const children = this.getRealChildren();
+const children = getRealChildren(this.element);
```

---

Note: I've noticed that in the transition from classic to bento, we are making lots of small tradeoffs that reduce our reliance on runtime code (v0.js) and will end up duplicated in all of the extensions. It is definitely a worthwhile tradeoff, but at some point far in the future may be worth mitigating.