### PR TITLE
✨ `amp-story-desktop-one-panel` Position distance="2" page below viewport

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -272,10 +272,6 @@ amp-story-page[distance="1"] {
 }
 
 amp-story-page[distance="2"] {
-  transform: translateY(100%) !important;
-}
-
-.i-amphtml-story-desktop-one-panel amp-story-page[distance="2"] {
   transform: translateY(100vh) !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -275,6 +275,10 @@ amp-story-page[distance="2"] {
   transform: translateY(100%) !important;
 }
 
+.i-amphtml-story-desktop-one-panel amp-story-page[distance="2"] {
+  transform: translateY(100vh) !important;
+}
+
 amp-story-page [data-text-background-color] {
   border-radius: 3px !important;
   line-height: 1.5em !important;


### PR DESCRIPTION
Context / Fixes #34830

Positions `distance="2"` page below viewport when `amp-story-desktop-one-panel` is active.

`100vh` will ensure the panel will always be off of the viewport.