### PR TITLE
Apply `lang="en"` in bulk to `examples/`

### DIFF
--- a/examples/ad-lightbox.amp.html
+++ b/examples/ad-lightbox.amp.html
@@ -14,7 +14,7 @@
   limitations under the license.
 -->
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
 <head>
     <meta charset="utf-8">
     <title>AMP Ad Lightbox Prototype Example</title>

--- a/examples/amp-ad-exit-conversion.html
+++ b/examples/amp-ad-exit-conversion.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html amp4ads>
+<html amp4ads lang="en">
 <head>
   <title>amp-ad-exit example with conversion tracking</title>
   <meta charset="utf-8">

--- a/examples/amp-ad-exit.amp.html
+++ b/examples/amp-ad-exit.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html amp4ads>
+<html amp4ads lang="en">
 <head>
   <title>amp-ad-exit example</title>
   <meta charset="utf-8">

--- a/examples/amp-ad/sticky-creative.html
+++ b/examples/amp-ad/sticky-creative.html
@@ -1,4 +1,4 @@
-<!doctype html><html>
+<!doctype html><html lang="en">
 <head><meta charset=utf-8>
 <meta content=width=device-width,minimum-scale=1,initial-scale=1 name=viewport>
 <body>

--- a/examples/amp-autocomplete.ssr.html
+++ b/examples/amp-autocomplete.ssr.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ⚡ allow-viewer-render-template>
+<html ⚡ allow-viewer-render-template lang="en">
   <head>
     <meta charset="utf-8">
     <title>Forms Examples in AMP</title>

--- a/examples/amp-consent/amp-consent-iframe.embed.html
+++ b/examples/amp-consent/amp-consent-iframe.embed.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <body style="background-color:#EEEEEE">
   <script>
     function isAmpMessage(event, type) {

--- a/examples/amp-consent/diy-3p-iframe-tcf-postmessage.html
+++ b/examples/amp-consent/diy-3p-iframe-tcf-postmessage.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/examples/amp-consent/diy-consent.html
+++ b/examples/amp-consent/diy-consent.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <link rel="stylesheet" type="text/css" href="https://raw.githack.com/ganapativs/bttn.css/master/dist/bttn.min.css" />
     <link rel="stylesheet" href="https://unpkg.com/sakura.css/css/sakura.css" type="text/css" />

--- a/examples/amp-form.ssr.html
+++ b/examples/amp-form.ssr.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡ allow-viewer-render-template>
+<html ⚡ allow-viewer-render-template lang="en">
 <head>
     <meta charset="utf-8">
     <title>Forms Examples in AMP</title>

--- a/examples/amp-list.ssr.html
+++ b/examples/amp-list.ssr.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡ allow-viewer-render-template>
+<html ⚡ allow-viewer-render-template lang="en">
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/amp-script/hello-world.html
+++ b/examples/amp-script/hello-world.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <script async src="hello-world.js"></script>
 </head>

--- a/examples/amp-story/ads/app-install.html
+++ b/examples/amp-story/ads/app-install.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡4ads>
+<html ⚡4ads lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1">

--- a/examples/amp-story/amp-story-desktop-one-panel.html
+++ b/examples/amp-story/amp-story-desktop-one-panel.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡>
+<html ⚡ lang="en">
   <head>
     <meta charset="utf-8">
     <title>amp-story-desktop-one-panel example</title>

--- a/examples/amp-story/player-local-stories.html
+++ b/examples/amp-story/player-local-stories.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Story Player (Non-AMP)</title>
     <script async src="../../dist/amp-story-player.js"></script>

--- a/examples/amp-story/player-story-attribution.html
+++ b/examples/amp-story/player-story-attribution.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Story Attribution</title>
     <script async src="../../dist/amp-story-player.js"></script>

--- a/examples/amp-story/player-with-button.html
+++ b/examples/amp-story/player-with-button.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <title>Story Player (Non-AMP)</title>
     <script async src="../../dist/amp-story-player.js"></script>

--- a/examples/amp-story/player.html
+++ b/examples/amp-story/player.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Story Player (Non-AMP)</title>
     <script async src="../../dist/amp-story-player.js"></script>

--- a/examples/amp-subscriptions-google/amp-subscriptions-iframe.provider.html
+++ b/examples/amp-subscriptions-google/amp-subscriptions-iframe.provider.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <script src="/extensions/amp-access/0.1/iframe-api/build/index.js"></script>
 

--- a/examples/amp-video-iframe/frame-consent-es2015.html
+++ b/examples/amp-video-iframe/frame-consent-es2015.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/examples/amp-video-iframe/frame-consent.html
+++ b/examples/amp-video-iframe/frame-consent.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/examples/amp-video-iframe/frame-es2015.html
+++ b/examples/amp-video-iframe/frame-es2015.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/examples/amp-video-iframe/frame-videojs.html
+++ b/examples/amp-video-iframe/frame-videojs.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <link href="https://vjs.zencdn.net/7.3.0/video-js.css" rel="stylesheet">

--- a/examples/amp-video-iframe/frame.html
+++ b/examples/amp-video-iframe/frame.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/examples/ampcontext-creative-json.html
+++ b/examples/ampcontext-creative-json.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <style>
       body {

--- a/examples/ampcontext-creative.html
+++ b/examples/ampcontext-creative.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <style>
       body {

--- a/examples/amphtml-ads/adchoices-1.a4a.html
+++ b/examples/amphtml-ads/adchoices-1.a4a.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html amp4ads>
+<html amp4ads lang="en">
 <head>
     <meta charset="utf-8">
     <meta content="width=device-width,minimum-scale=1,initial-scale=1" name="viewport">

--- a/examples/amphtml-ads/adchoices-2.a4a.html
+++ b/examples/amphtml-ads/adchoices-2.a4a.html
@@ -1,4 +1,4 @@
-<html amp4ads>
+<html amp4ads lang="en">
 <head>
     <meta http-equiv="Content-Security-Policy" content="script-src https://cdn.ampproject.org/;object-src 'none';child-src blob:;frame-src 'none'">
     <meta charset="utf-8">

--- a/examples/amphtml-ads/animation-ad.a4a.html
+++ b/examples/amphtml-ads/animation-ad.a4a.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡4ads>
+<html ⚡4ads lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/examples/amphtml-ads/gif-ad.a4a.html
+++ b/examples/amphtml-ads/gif-ad.a4a.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡4ads>
+<html ⚡4ads lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/examples/amphtml-ads/gpt.host.html
+++ b/examples/amphtml-ads/gpt.host.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script async="async" src="https://www.googletagservices.com/tag/js/gpt.js"></script>

--- a/examples/amphtml-ads/text-ad.a4a.html
+++ b/examples/amphtml-ads/text-ad.a4a.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡4ads>
+<html ⚡4ads lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/examples/amphtml-ads/visibility-ad.a4a.html
+++ b/examples/amphtml-ads/visibility-ad.a4a.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡4ads>
+<html ⚡4ads lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/examples/everything.iframed.html
+++ b/examples/everything.iframed.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">

--- a/examples/mraid/inabox-mraid.html
+++ b/examples/mraid/inabox-mraid.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡4ads>
+<html ⚡4ads lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">

--- a/examples/multiple-docs.html
+++ b/examples/multiple-docs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">

--- a/examples/pwa/pwa-sd-polyfill.html
+++ b/examples/pwa/pwa-sd-polyfill.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>PWA</title>

--- a/examples/pwa/pwa.html
+++ b/examples/pwa/pwa.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>PWA</title>

--- a/examples/timeago.amp.html
+++ b/examples/timeago.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html amp4email data-css-strict>
+<html amp4email data-css-strict lang="en">
 <head>
   <meta charset="utf-8">
   <script async src="https://cdn.ampproject.org/v0.js"></script>

--- a/examples/viewer-iframe-poll.html
+++ b/examples/viewer-iframe-poll.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Viewer</title>

--- a/examples/viewer-webview.html
+++ b/examples/viewer-webview.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Viewer</title>

--- a/examples/viewer.html
+++ b/examples/viewer.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>Viewer</title>

--- a/examples/visual-tests/amp-story-player/back-button.html
+++ b/examples/visual-tests/amp-story-player/back-button.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <title>Story Player (Non-AMP)</title>
     <script>

--- a/examples/visual-tests/amp-story-player/close-button.html
+++ b/examples/visual-tests/amp-story-player/close-button.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <head>
     <title>Story Player (Non-AMP)</title>
     <script>

--- a/examples/visual-tests/amp-story-player/player-local-story.html
+++ b/examples/visual-tests/amp-story-player/player-local-story.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Story Player (Non-AMP)</title>
     <script>

--- a/examples/visual-tests/amp-story-player/story-attribution.html
+++ b/examples/visual-tests/amp-story-player/story-attribution.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Story Attribution</title>
     <script>

--- a/examples/visual-tests/amp-video-docking/video-iframe-inner.html
+++ b/examples/visual-tests/amp-video-docking/video-iframe-inner.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/examples/visual-tests/amphtml-ads/amp-inabox-adchoices.html
+++ b/examples/visual-tests/amphtml-ads/amp-inabox-adchoices.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>AMP Inabox Test</title>

--- a/examples/visual-tests/font.amp/font.amp.html
+++ b/examples/visual-tests/font.amp/font.amp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡ class="comic-amp-font-loading comic-amp-bold-font-loading">
+<html ⚡ class="comic-amp-font-loading comic-amp-bold-font-loading" lang="en">
 <head>
   <meta charset="utf-8">
   <title>Font example</title>

--- a/examples/xhr-intercept.html
+++ b/examples/xhr-intercept.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ⚡ allow-xhr-interception>
+<html ⚡ allow-xhr-interception lang="en">
 <head>
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>


### PR DESCRIPTION
This PR completes #34759 by applying `lang="en"` to all `html` tags, regardless of existing attributes. (The original approach used a naive find and replace on `<html ⚡ `