### PR TITLE
🏗🚀 Speed up validated example grouping ~45x

### DIFF
--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -27,7 +27,7 @@ const {cyan, green, red} = require('../common/colors');
 const {getFilesToCheck} = require('../common/utils');
 const {getOutput} = require('../common/process');
 const {htmlFixtureGlobs} = require('../test-configs/config');
-const {readFile} = require('fs/promises');
+const {readFile} = require('fs-extra');
 
 const defaultFormat = 'AMP';
 

--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -41,20 +41,19 @@ const formatSuffixes = ['4ads', '4email'];
  * @return {string}
  */
 function posthtmlGetAmpFormat(tree) {
-  const rootChildren = Array.isArray(tree) ? tree : [tree];
-  for (const node of rootChildren) {
-    if (node?.tag === 'html') {
-      for (const prefix of formatPrefixes) {
-        for (const suffix of formatSuffixes) {
-          const attrValue = node.attrs[prefix + suffix];
-          if (attrValue === '' || attrValue === true) {
-            return 'AMP' + suffix.toUpperCase();
-          }
+  let format = defaultFormat;
+  tree.match({tag: 'html'}, (node) => {
+    for (const prefix of formatPrefixes) {
+      for (const suffix of formatSuffixes) {
+        const attrValue = node.attrs[prefix + suffix];
+        if (attrValue === '' || attrValue === true) {
+          format = 'AMP' + suffix.toUpperCase();
         }
       }
     }
-  }
-  return defaultFormat;
+    return node;
+  });
+  return format;
 }
 
 /**

--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -16,6 +16,7 @@
 'using strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const posthtml = require('posthtml');
 const {
   log,
   logLocalDev,
@@ -26,7 +27,35 @@ const {cyan, green, red} = require('../common/colors');
 const {getFilesToCheck} = require('../common/utils');
 const {getOutput} = require('../common/process');
 const {htmlFixtureGlobs} = require('../test-configs/config');
-const {JSDOM} = require('jsdom');
+const {readFile} = require('fs/promises');
+
+const defaultFormat = 'AMP';
+
+// Note that the two lightning bolt emojis are encoded differently.
+// https://github.com/ampproject/amphtml/issues/25990
+const formatPrefixes = ['amp', '⚡️', '⚡'];
+const formatSuffixes = ['4ads', '4email'];
+
+/**
+ * @param {posthtml.Node} tree
+ * @return {string}
+ */
+function posthtmlGetAmpFormat(tree) {
+  const rootChildren = Array.isArray(tree) ? tree : [tree];
+  for (const node of rootChildren) {
+    if (node?.tag === 'html') {
+      for (const prefix of formatPrefixes) {
+        for (const suffix of formatSuffixes) {
+          const attrValue = node.attrs[prefix + suffix];
+          if (attrValue === '' || attrValue === true) {
+            return 'AMP' + suffix.toUpperCase();
+          }
+        }
+      }
+    }
+  }
+  return defaultFormat;
+}
 
 /**
  * Gets the AMP format type for the given HTML file by parsing its contents and
@@ -35,11 +64,12 @@ const {JSDOM} = require('jsdom');
  * @return {Promise<string>}
  */
 async function getAmpFormat(file) {
-  const jsdom = await JSDOM.fromFile(file);
-  const {documentElement} = jsdom.window.document;
-  const isAds = documentElement.hasAttribute('amp4ads');
-  const isEmail = documentElement.hasAttribute('amp4email');
-  return isAds ? 'AMP4ADS' : isEmail ? 'AMP4EMAIL' : 'AMP';
+  const source = await readFile(file, 'utf8');
+  if (!formatSuffixes.some((suffix) => source.includes(suffix))) {
+    return defaultFormat;
+  }
+  const result = await posthtml([posthtmlGetAmpFormat]).process(source);
+  return result.html.trim();
 }
 
 /**


### PR DESCRIPTION
Makes the grouping process of `amp validate-html-fixtures` about **`45x` faster**. This represents a `~24%` speedup of the overall task.

- Uses `posthtml` instead of `JSDOM` to parse the tree when necessary. 
- Filters out files that lack a suffix like `4email`.

### Performance comparison

| method   | filters | time (ms) |          |
| -------- | ------- | --------: | -------- |
| JSDOM    |         |      2095 | (before) |
| JSDOM    | yes     |       241 |          |
| posthtml |         |       116 |          |
| posthtml | yes     |        47 | (after)  |
