### PR TITLE
🏗 Add `"wrapper": "bento"` option to Bento components

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -55,7 +55,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -192,7 +193,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -282,7 +284,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -295,7 +298,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -342,16 +346,23 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
     "name": "amp-facebook-comments",
-    "version": [
-      "0.1",
-      "1.0"
-    ],
+    "version": "0.1",
     "latestVersion": "0.1"
+  },
+  {
+    "name": "amp-facebook-comments",
+    "version": "1.0",
+    "latestVersion": "0.1",
+    "options": {
+      "wrapper": "bento"
+    }
   },
   {
     "name": "amp-facebook-like",
@@ -363,7 +374,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -376,7 +388,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -393,7 +406,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -531,7 +545,8 @@
       "cssBinaries": [
         "amp-inline-gallery-pagination"
       ],
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -553,7 +568,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -595,7 +611,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -786,7 +803,10 @@
   {
     "name": "amp-render",
     "version": "1.0",
-    "latestVersion": "1.0"
+    "latestVersion": "1.0",
+    "options": {
+      "wrapper": "bento"
+    }
   },
   {
     "name": "amp-resize-observer-polyfill",
@@ -820,7 +840,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -835,12 +856,20 @@
     "name": "amp-sidebar",
     "version": [
       "0.1",
-      "0.2",
-      "1.0"
+      "0.2"
     ],
     "latestVersion": "0.1",
     "options": {
       "hasCss": true
+    }
+  },
+  {
+    "name": "amp-sidebar",
+    "version": "1.0",
+    "latestVersion": "0.1",
+    "options": {
+      "hasCss": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -873,7 +902,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -1009,7 +1039,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -1046,7 +1077,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -1071,7 +1103,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -1092,7 +1125,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -1114,7 +1148,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -1140,7 +1175,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   },
   {
@@ -1195,7 +1231,8 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "npm": true
+      "npm": true,
+      "wrapper": "bento"
     }
   }
 ]


### PR DESCRIPTION
This PR establishes `build-system/compile/bundles.config.extensions.json` as the file to be utilized as the ground truth for all components which have a Bento version and what that version is, while configuring all current Bento components with `options: { "wrapper": "bento" }`. This change does not impact the bundling/build process.

Notes:
- `options: {wrapper: "bento"}` is a temporary state that is being introduced immediately for ease of reference by publishers wanting to use Bento components and easily identify which these are. It is preferred to `bento: true` or `bentoVersion: "1.0"` because the `wrapper` piece will be utilized by the auto-envelope effort (see below).
- The final state is expected to be `options: {wrapper: wrappers.bento}` once ~#30275~ #34820 is finalized.
- The `option` is made distinct from the `npm: true` option because the set of Bento components is not equal to the set of components that publish to npm (though it is true that these heavily overlap.) 