### PR TITLE
🏗 Allow extension bundles to specify their own wrapper

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -849,7 +849,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "noWrapper": true
+      "wrapper": "none"
     }
   },
   {

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -44,6 +44,11 @@ exports.extension = function (name, version, latest, isModule, loadPriority) {
   }
   // Use a numeric value instead of boolean. "m" stands for "module"
   const m = isModule ? 1 : 0;
+  // The `function` is wrapped in `()` to avoid lazy parsing it, since it will
+  // be immediately executed anyway.
+  // See https://github.com/ampproject/amphtml/issues/3977
+  // TODO(wg-performance): At some point in history, the build pipeline started
+  // to strip out these parentheses. Is this optimization still relevant?
   return (
     `(self.AMP=self.AMP||[]).push({n:"${name}",ev:"${version}",l:${latest},` +
     `${priority}` +
@@ -51,5 +56,8 @@ exports.extension = function (name, version, latest, isModule, loadPriority) {
     '<%= contents %>\n})});'
   );
 };
+
+// TODO(alanorozco): Implement with Bento Auto-Envelope.
+exports.bento = exports.extension;
 
 exports.none = '<%= contents %>';

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -63,9 +63,8 @@ exports.extension = function (name, version, latest, isModule, loadPriority) {
     // The `function` is wrapped in `()` to avoid lazy parsing it, since it will
     // be immediately executed anyway.
     // See https://github.com/ampproject/amphtml/issues/3977
-    // TODO(wg-performance): At some point in history, the build pipeline
-    // began stripping out these parentheses.
-    // Is this optimization still relevant?
+    // TODO(wg-performance): At some point, the build pipeline began stripping
+    // out these parentheses. Is this optimization still relevant?
     `v:"${VERSION}",m:${m},f:(function(AMP,_){\n` +
     '<%= contents %>\n})});'
   );

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -34,6 +34,9 @@ exports.mainBinary =
   's.animation="none";' +
   's.WebkitAnimation="none;"},1000);throw e};';
 
+/** @type {'high'} */
+let ExtensionLoadPriorityDef;
+
 /**
  * Wrapper that either registers the extension or schedules it for execution
  * by the main binary
@@ -41,7 +44,7 @@ exports.mainBinary =
  * @param {string} version
  * @param {boolean} latest
  * @param {boolean=} isModule
- * @param {'high'=} loadPriority
+ * @param {ExtensionLoadPriorityDef=} loadPriority
  * @return {string}
  */
 exports.extension = function (name, version, latest, isModule, loadPriority) {

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -34,6 +34,16 @@ exports.mainBinary =
   's.animation="none";' +
   's.WebkitAnimation="none;"},1000);throw e};';
 
+/**
+ * Wrapper that either registers the extension or schedules it for execution
+ * by the main binary
+ * @param {string} name
+ * @param {string} version
+ * @param {boolean} latest
+ * @param {boolean=} isModule
+ * @param {'high'=} loadPriority
+ * @return {string}
+ */
 exports.extension = function (name, version, latest, isModule, loadPriority) {
   let priority = '';
   if (loadPriority) {

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -57,14 +57,15 @@ exports.extension = function (name, version, latest, isModule, loadPriority) {
   }
   // Use a numeric value instead of boolean. "m" stands for "module"
   const m = isModule ? 1 : 0;
-  // The `function` is wrapped in `()` to avoid lazy parsing it, since it will
-  // be immediately executed anyway.
-  // See https://github.com/ampproject/amphtml/issues/3977
-  // TODO(wg-performance): At some point in history, the build pipeline started
-  // to strip out these parentheses. Is this optimization still relevant?
   return (
     `(self.AMP=self.AMP||[]).push({n:"${name}",ev:"${version}",l:${latest},` +
     `${priority}` +
+    // The `function` is wrapped in `()` to avoid lazy parsing it, since it will
+    // be immediately executed anyway.
+    // See https://github.com/ampproject/amphtml/issues/3977
+    // TODO(wg-performance): At some point in history, the build pipeline
+    // began stripping out these parentheses.
+    // Is this optimization still relevant?
     `v:"${VERSION}",m:${m},f:(function(AMP,_){\n` +
     '<%= contents %>\n})});'
   );

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -661,6 +661,7 @@ async function buildExtensionJs(extDir, name, version, latestVersion, options) {
     typeof wrapperOrFn === 'function'
       ? wrapperOrFn(name, version, latest, argv.esm, options.loadPriority)
       : wrapperOrFn;
+
   await compileJs(
     extDir + '/',
     filename,

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -93,6 +93,7 @@ const DEFAULT_EXTENSION_SET = ['amp-loader', 'amp-auto-lightbox'];
  *   extraGlobs?: Array<string>,
  *   binaries?: Array<ExtensionBinaryDef>,
  *   npm?: boolean,
+ *   wrapper?: string,
  * }}
  */
 const ExtensionOptionDef = {};
@@ -624,7 +625,6 @@ function buildBinaries(extDir, binaries, options) {
         minifiedName: maybeToNpmEsmName(`${name}.js`),
         latestName: '',
         outputFormat: esm ? 'esm' : 'cjs',
-        wrapper: '',
         externalDependencies: external,
         remapDependencies: remap,
       })
@@ -648,6 +648,20 @@ function buildBinaries(extDir, binaries, options) {
 async function buildExtensionJs(extDir, name, version, latestVersion, options) {
   const filename = options.filename || name + '.js';
   const latest = version === latestVersion;
+
+  const {wrapper = 'extension'} = options;
+  if (!wrappers[wrapper]) {
+    throw new Error(
+      `Unknown options.wrapper "${wrapper}" (${name}:${version})\n` +
+        `Expected one of: ${Object.keys(wrappers).join(', ')}`
+    );
+  }
+  const wrapperOrFn = wrappers[wrapper];
+  const wrapperString =
+    typeof wrapperOrFn === 'function'
+      ? wrapperOrFn(name, version, latest, argv.esm, options.loadPriority)
+      : wrapperOrFn;
+
   await compileJs(
     extDir + '/',
     filename,
@@ -656,20 +670,7 @@ async function buildExtensionJs(extDir, name, version, latestVersion, options) {
       toName: `${name}-${version}.max.js`,
       minifiedName: `${name}-${version}.js`,
       latestName: latest ? `${name}-latest.js` : '',
-      // Wrapper that either registers the extension or schedules it for
-      // execution after the main binary comes back.
-      // The `function` is wrapped in `()` to avoid lazy parsing it,
-      // since it will be immediately executed anyway.
-      // See https://github.com/ampproject/amphtml/issues/3977
-      wrapper: options.noWrapper
-        ? ''
-        : wrappers.extension(
-            name,
-            version,
-            latest,
-            argv.esm,
-            options.loadPriority
-          ),
+      wrapper: wrapperString,
     })
   );
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -649,19 +649,18 @@ async function buildExtensionJs(extDir, name, version, latestVersion, options) {
   const filename = options.filename || name + '.js';
   const latest = version === latestVersion;
 
-  const {wrapper = 'extension'} = options;
-  if (!wrappers[wrapper]) {
+  const wrapperName = options.wrapper || 'extension';
+  const wrapperOrFn = wrappers[wrapperName];
+  if (!wrapperOrFn) {
     throw new Error(
-      `Unknown options.wrapper "${wrapper}" (${name}:${version})\n` +
+      `Unknown options.wrapper "${wrapperName}" (${name}:${version})\n` +
         `Expected one of: ${Object.keys(wrappers).join(', ')}`
     );
   }
-  const wrapperOrFn = wrappers[wrapper];
-  const wrapperString =
+  const wrapper =
     typeof wrapperOrFn === 'function'
       ? wrapperOrFn(name, version, latest, argv.esm, options.loadPriority)
       : wrapperOrFn;
-
   await compileJs(
     extDir + '/',
     filename,
@@ -670,7 +669,7 @@ async function buildExtensionJs(extDir, name, version, latestVersion, options) {
       toName: `${name}-${version}.max.js`,
       minifiedName: `${name}-${version}.js`,
       latestName: latest ? `${name}-latest.js` : '',
-      wrapper: wrapperString,
+      wrapper,
     })
   );
 

--- a/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
+++ b/extensions/amp-shadow-dom-polyfill/0.1/amp-shadow-dom-polyfill.js
@@ -19,3 +19,5 @@
  * injected here from the `node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js`
  * script.
  */
+
+(function () {})();


### PR DESCRIPTION
In preparation for a larger Bento change, allow extension bundles to specify their own compile wrapper.

Bento bundles already set `"wrapper": "bento"`. By specifying this wrapper to be the same as `wrappers.extension`, this has no effect on actual output.
