### PR TITLE
♻️  Extract `applyFillContent` into a standalone function

### DIFF
--- a/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
+++ b/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import {applyFillContent} from "#core/dom/layout";
 __css_import__;
-import {Layout} from '../../../src/core/dom/layout';
+import {Layout, applyFillContent} from '#core/dom/layout';
 
 const TAG = 'amp-__component_name_hyphenated__';
 

--- a/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
+++ b/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import {applyFillContent} from "#core/dom/layout";
 __css_import__;
 import {Layout} from '../../../src/core/dom/layout';
 
 const TAG = 'amp-__component_name_hyphenated__';
- 
+
 export class Amp__component_name_pascalcase__ extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
@@ -37,7 +38,7 @@ export class Amp__component_name_pascalcase__ extends AMP.BaseElement {
     this.container_ = this.element.ownerDocument.createElement('div');
     this.container_.textContent = this.myText_;
     this.element.appendChild(this.container_);
-    this.applyFillContent(this.container_, /* replacedContent */ true);
+    applyFillContent(this.container_, /* replacedContent */ true);
   }
 
   /** @override */

--- a/builtins/amp-img/amp-img.js
+++ b/builtins/amp-img/amp-img.js
@@ -15,7 +15,7 @@
  */
 
 import {BaseElement} from '../../src/base-element';
-import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
+import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {ReadyState} from '#core/constants/ready-state';
 import {Services} from '#service';
 import {dev} from '../../src/log';
@@ -222,7 +222,7 @@ export class AmpImg extends BaseElement {
     if (!IS_ESM) {
       guaranteeSrcForSrcsetUnsupportedBrowsers(this.img_);
     }
-    this.applyFillContent(this.img_, true);
+    applyFillContent(this.img_, true);
     propagateObjectFitStyles(this.element, this.img_);
 
     if (!serverRendered) {

--- a/builtins/amp-layout/amp-layout.js
+++ b/builtins/amp-layout/amp-layout.js
@@ -15,7 +15,7 @@
  */
 
 import {BaseElement} from '../../src/base-element';
-import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
+import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {registerElement} from '#service/custom-element-registry';
 
 class AmpLayout extends BaseElement {
@@ -35,7 +35,7 @@ class AmpLayout extends BaseElement {
       return;
     }
     const container = this.win.document.createElement('div');
-    this.applyFillContent(container);
+    applyFillContent(container);
     this.getRealChildNodes().forEach((child) => {
       container.appendChild(child);
     });

--- a/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
+++ b/extensions/amp-3d-gltf/0.1/amp-3d-gltf.js
@@ -16,11 +16,11 @@
 import {ActionTrust} from '#core/constants/action-constants';
 import {Deferred} from '#core/data-structures/promise';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {assertHttpsUrl, resolveRelativeUrl} from '../../../src/url';
 import {dev, devAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenFor, postMessage} from '../../../src/iframe-helper';
 import {
   observeContentSize,
@@ -166,7 +166,7 @@ export class Amp3dGltf extends AMP.BaseElement {
 
     const iframe = getIframe(this.win, this.element, TYPE, this.context_);
     iframe.title = this.element.title || 'GLTF 3D model';
-    this.applyFillContent(iframe, true);
+    applyFillContent(iframe, true);
     this.iframe_ = iframe;
     this.unlistenMessage_ = devAssert(this.listenGltfViewerMessages_());
 

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -21,7 +21,12 @@ import {Deferred, tryResolve} from '#core/data-structures/promise';
 import {DetachedDomStream, streamResponseToWriter} from '#core/dom/stream';
 import {DomTransformStream} from '../../../src/utils/dom-tranform-stream';
 import {GEO_IN_GROUP} from '../../amp-geo/0.1/amp-geo-in-group';
-import {Layout, LayoutPriority, isLayoutSizeDefined} from '#core/dom/layout';
+import {
+  Layout,
+  LayoutPriority,
+  applyFillContent,
+  isLayoutSizeDefined,
+} from '#core/dom/layout';
 import {Services} from '#service';
 import {SignatureVerifier, VerificationStatus} from './signature-verifier';
 import {
@@ -1817,7 +1822,7 @@ export class AmpA4A extends AMP.BaseElement {
       width
     );
     if (!this.uiHandler.isStickyAd()) {
-      this.applyFillContent(this.iframe);
+      applyFillContent(this.iframe);
     }
 
     let body = '';
@@ -1908,7 +1913,7 @@ export class AmpA4A extends AMP.BaseElement {
       )
     );
     if (!this.uiHandler.isStickyAd()) {
-      this.applyFillContent(this.iframe);
+      applyFillContent(this.iframe);
     }
     const fontsArray = [];
     if (creativeMetaData.customStylesheets) {

--- a/extensions/amp-a4a/0.1/test/test-name-frame-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-name-frame-renderer.js
@@ -36,7 +36,6 @@ describes.realWin('NameFrameRenderer', realWinConfig, (env) => {
       size: {width: '320', height: '50'},
       requestUrl: 'http://www.google.com',
       win: env.win,
-      applyFillContent: () => {},
       sentinel: 's-1234',
     };
 

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -25,6 +25,7 @@ import {
   listenForOncePromise,
   postMessageToWindows,
 } from '../../../src/iframe-helper';
+import {applyFillContent} from '#core/dom/layout';
 import {dev, devAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {getData} from '../../../src/event-helper';
@@ -101,7 +102,7 @@ export class AmpAdXOriginIframeHandler {
     this.iframe = iframe;
     this.iframe.setAttribute('scrolling', 'no');
     if (!this.uiHandler_.isStickyAd()) {
-      this.baseInstance_.applyFillContent(this.iframe);
+      applyFillContent(this.iframe);
     }
     const timer = Services.timerFor(this.baseInstance_.win);
 

--- a/extensions/amp-addthis/0.1/amp-addthis.js
+++ b/extensions/amp-addthis/0.1/amp-addthis.js
@@ -52,6 +52,7 @@ import {DwellMonitor} from './addthis-utils/monitors/dwell-monitor';
 import {PostMessageDispatcher} from './post-message-dispatcher';
 import {ScrollMonitor} from './addthis-utils/monitors/scroll-monitor';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {callEng} from './addthis-utils/eng';
 import {callLojson} from './addthis-utils/lojson';
 import {callPjson} from './addthis-utils/pjson';
@@ -66,7 +67,6 @@ import {
 import {getOgImage} from './addthis-utils/meta';
 import {getWidgetOverload} from './addthis-utils/get-widget-id-overloaded-with-json-for-anonymous-mode';
 import {internalRuntimeVersion} from '../../../src/internal-version';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listen} from '../../../src/event-helper';
 import {parseUrlDeprecated} from '../../../src/url';
 import {setStyle} from '#core/dom/style';
@@ -310,7 +310,7 @@ class AmpAddThis extends AMP.BaseElement {
     );
     const iframeLoadPromise = this.loadPromise(iframe);
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = /** @type {HTMLIFrameElement} */ (iframe);
 

--- a/extensions/amp-anim/0.1/amp-anim.js
+++ b/extensions/amp-anim/0.1/amp-anim.js
@@ -15,9 +15,9 @@
  */
 
 import * as st from '#core/dom/style';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dev} from '../../../src/log';
 import {guaranteeSrcForSrcsetUnsupportedBrowsers} from '#core/dom/img';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {
   observeWithSharedInOb,
   unobserveWithSharedInOb,
@@ -56,7 +56,7 @@ export class AmpAnim extends AMP.BaseElement {
     this.img_ = new Image();
     this.img_.setAttribute('decoding', 'async');
     this.propagateAttributes(BUILD_ATTRIBUTES, this.img_);
-    this.applyFillContent(this.img_, true);
+    applyFillContent(this.img_, true);
     propagateObjectFitStyles(this.element, this.img_);
 
     // Remove role=img otherwise this breaks screen-readers focus and

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -17,6 +17,11 @@ import {CSS} from '../../../build/amp-apester-media-0.1.css';
 import {IntersectionObserver3pHost} from '../../../src/utils/intersection-observer-3p-host';
 import {Services} from '#service';
 import {addParamsToUrl} from '../../../src/url';
+import {
+  applyFillContent,
+  getLengthNumeral,
+  isLayoutSizeDefined,
+} from '#core/dom/layout';
 import {dev, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {
@@ -26,7 +31,6 @@ import {
   setFullscreenOff,
   setFullscreenOn,
 } from './utils';
-import {getLengthNumeral, isLayoutSizeDefined} from '#core/dom/layout';
 import {handleCompanionAds} from './monetization';
 import {
   observeWithSharedInOb,
@@ -245,7 +249,7 @@ class AmpApesterMedia extends AMP.BaseElement {
     iframe.height = this.height_;
     iframe.width = this.width_;
     iframe.classList.add('amp-apester-iframe');
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     return iframe;
   }
 

--- a/extensions/amp-audio/0.1/amp-audio.js
+++ b/extensions/amp-audio/0.1/amp-audio.js
@@ -22,7 +22,7 @@ import {
   setMediaSession,
   validateMediaMetadata,
 } from '../../../src/mediasession-helper';
-import {Layout, isLayoutSizeFixed} from '#core/dom/layout';
+import {Layout, applyFillContent, isLayoutSizeFixed} from '#core/dom/layout';
 import {assertHttpsUrl} from '../../../src/url';
 import {closestAncestorElementBySelector} from '#core/dom/query';
 import {dev, user} from '../../../src/log';
@@ -134,7 +134,7 @@ export class AmpAudio extends AMP.BaseElement {
       audio
     );
 
-    this.applyFillContent(audio);
+    applyFillContent(audio);
     this.getRealChildNodes().forEach((child) => {
       if (child.getAttribute && child.getAttribute('src')) {
         assertHttpsUrl(child.getAttribute('src'), dev().assertElement(child));

--- a/extensions/amp-beopinion/0.1/amp-beopinion.js
+++ b/extensions/amp-beopinion/0.1/amp-beopinion.js
@@ -15,8 +15,8 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '#core/dom';
 
@@ -72,7 +72,7 @@ class AmpBeOpinion extends AMP.BaseElement {
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, TYPE);
     iframe.title = this.element.title || 'BeOpinion content';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     listenFor(
       iframe,
       'embed-size',

--- a/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
+++ b/extensions/amp-bodymovin-animation/0.1/amp-bodymovin-animation.js
@@ -17,6 +17,7 @@
 import {ActionTrust} from '#core/constants/action-constants';
 import {Deferred} from '#core/data-structures/promise';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {assertHttpsUrl} from '../../../src/url';
 import {batchFetchJsonFor} from '../../../src/batched-json';
 import {clamp} from '#core/math';
@@ -24,7 +25,6 @@ import {dict} from '#core/types/object';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {isFiniteNumber, isObject} from '#core/types';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 
 import {parseJson} from '#core/types/object/json';
 import {removeElement} from '#core/dom';
@@ -146,7 +146,7 @@ export class AmpBodymovinAnimation extends AMP.BaseElement {
       iframe.title = this.element.title || 'Airbnb BodyMovin animation';
       return Services.vsyncFor(this.win)
         .mutatePromise(() => {
-          this.applyFillContent(iframe);
+          applyFillContent(iframe);
           this.unlistenMessage_ = listen(
             this.win,
             'message',

--- a/extensions/amp-brid-player/0.1/amp-brid-player.js
+++ b/extensions/amp-brid-player/0.1/amp-brid-player.js
@@ -34,6 +34,7 @@ import {
   isFullscreenElement,
 } from '#core/dom/fullscreen';
 
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {
   getConsentPolicyInfo,
   getConsentPolicyState,
@@ -41,7 +42,6 @@ import {
 import {getData, listen} from '../../../src/event-helper';
 import {htmlFor} from '#core/dom/static-template';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 
 const TAG = 'amp-brid-player';
 
@@ -248,7 +248,7 @@ class AmpBridPlayer extends AMP.BaseElement {
     `;
 
     this.propagateAttributes(['aria-label'], placeholder);
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
 
     const altText = placeholder.hasAttribute('aria-label')
       ? 'Loading video - ' + placeholder.getAttribute('aria-label')

--- a/extensions/amp-byside-content/0.1/amp-byside-content.js
+++ b/extensions/amp-byside-content/0.1/amp-byside-content.js
@@ -35,10 +35,10 @@
 import {CSS} from '../../../build/amp-byside-content-0.1.css';
 import {Services} from '#service';
 import {addParamsToUrl, assertHttpsUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {debounce} from '#core/types/function';
 import {dict} from '#core/types/object';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {setStyles} from '#core/dom/style';
 import {user, userAssert} from '../../../src/log';
@@ -170,7 +170,7 @@ export class AmpBysideContent extends AMP.BaseElement {
     placeholder.setAttribute('placeholder', '');
     placeholder.appendChild(this.createBySideLoader_());
 
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
 
     return placeholder;
   }
@@ -197,7 +197,7 @@ export class AmpBysideContent extends AMP.BaseElement {
     });
 
     this.element.appendChild(this.getOverflowElement_());
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
 
     return this.composeSrcUrl_()
       .then((src) => {

--- a/extensions/amp-connatix-player/0.1/amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/amp-connatix-player.js
@@ -22,6 +22,7 @@ import {Deferred} from '#core/data-structures/promise';
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dict} from '#core/types/object';
 import {
   getConsentMetadata,
@@ -30,7 +31,6 @@ import {
   getConsentPolicyState,
 } from '../../../src/consent';
 import {getData} from '../../../src/event-helper';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {
   observeContentSize,
   unobserveContentSize,
@@ -292,7 +292,7 @@ export class AmpConnatixPlayer extends AMP.BaseElement {
     iframe.src = src;
 
     // applyFillContent so that frame covers the entire component.
-    this.applyFillContent(iframe, /* replacedContent */ true);
+    applyFillContent(iframe, /* replacedContent */ true);
 
     // append child iframe for element
     element.appendChild(iframe);

--- a/extensions/amp-delight-player/0.1/amp-delight-player.js
+++ b/extensions/amp-delight-player/0.1/amp-delight-player.js
@@ -18,6 +18,7 @@ import {Deferred} from '#core/data-structures/promise';
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
 import {VideoAttributes, VideoEvents} from '../../../src/video-interface';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {
   createFrameFor,
   objOrParseJson,
@@ -35,7 +36,6 @@ import {
 import {getData, listen, listenOncePromise} from '../../../src/event-helper';
 import {htmlFor} from '#core/dom/static-template';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {
   observeWithSharedInOb,
   unobserveWithSharedInOb,
@@ -238,7 +238,7 @@ class AmpDelightPlayer extends AMP.BaseElement {
       <img placeholder referrerpolicy="origin" loading="lazy" />
     `;
 
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
 
     const src = `${this.baseURL_}/poster/${this.contentID_}`;
     placeholder.setAttribute('src', src);

--- a/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
+++ b/extensions/amp-embedly-card/0.1/amp-embedly-card-impl.js
@@ -15,7 +15,7 @@
  */
 
 import {TAG as KEY_TAG} from './amp-embedly-key';
-import {Layout} from '#core/dom/layout';
+import {Layout, applyFillContent} from '#core/dom/layout';
 import {Services} from '#service';
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
@@ -87,7 +87,7 @@ export class AmpEmbedlyCard extends AMP.BaseElement {
       opt_is3P
     );
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.getVsync().mutate(() => {
       this.element.appendChild(iframe);
     });

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -15,11 +15,11 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 import {dashToUnderline} from '#core/types/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {isObject} from '#core/types';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '#core/dom';
@@ -83,7 +83,7 @@ class AmpFacebookComments extends AMP.BaseElement {
     this.element.setAttribute('data-embed-as', 'comments');
     const iframe = getIframe(this.win, this.element, TYPE);
     iframe.title = this.element.title || 'Facebook comments';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(
       iframe,

--- a/extensions/amp-facebook-like/0.1/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/0.1/amp-facebook-like.js
@@ -15,10 +15,10 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dashToUnderline} from '#core/types/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {isObject} from '#core/types';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '#core/dom';
@@ -77,7 +77,7 @@ class AmpFacebookLike extends AMP.BaseElement {
     this.element.setAttribute('data-embed-as', 'like');
     const iframe = getIframe(this.win, this.element, TYPE);
     iframe.title = this.element.title || 'Facebook like button';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(
       iframe,

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -15,11 +15,11 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 import {dashToUnderline} from '#core/types/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {isObject} from '#core/types';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '#core/dom';
@@ -83,7 +83,7 @@ class AmpFacebookPage extends AMP.BaseElement {
     this.element.setAttribute('data-embed-as', 'page');
     const iframe = getIframe(this.win, this.element, TYPE);
     iframe.title = this.element.title || 'Facebook page';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(
       iframe,

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -15,12 +15,12 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {createLoaderLogo} from './facebook-loader';
 import {dashToUnderline} from '#core/types/string';
 import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {getMode} from '../../../src/mode';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {isObject} from '#core/types';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '#core/dom';
@@ -94,7 +94,7 @@ class AmpFacebook extends AMP.BaseElement {
     );
     const iframe = getIframe(this.win, this.element, TYPE);
     iframe.title = this.element.title || 'Facebook';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     if (this.element.hasAttribute('data-allowfullscreen')) {
       iframe.setAttribute('allowfullscreen', 'true');
     }

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -15,7 +15,11 @@
  */
 
 import {CSS} from '../../../build/amp-fit-text-0.1.css';
-import {getLengthNumeral, isLayoutSizeDefined} from '#core/dom/layout';
+import {
+  applyFillContent,
+  getLengthNumeral,
+  isLayoutSizeDefined,
+} from '#core/dom/layout';
 import {px, setStyle, setStyles} from '#core/dom/style';
 import {throttle} from '#core/types/function';
 
@@ -67,7 +71,7 @@ class AmpFitText extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     this.content_ = this.element.ownerDocument.createElement('div');
-    this.applyFillContent(this.content_);
+    applyFillContent(this.content_);
     this.content_.classList.add('i-amphtml-fit-text-content');
     setStyles(this.content_, {zIndex: 2});
 

--- a/extensions/amp-gfycat/0.1/amp-gfycat.js
+++ b/extensions/amp-gfycat/0.1/amp-gfycat.js
@@ -17,6 +17,7 @@
 import {Services} from '#service';
 import {VideoEvents} from '../../../src/video-interface';
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dev, userAssert} from '../../../src/log';
 import {
   dispatchCustomEvent,
@@ -25,7 +26,6 @@ import {
 } from '#core/dom';
 import {getData, listen} from '../../../src/event-helper';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 
 const TAG = 'amp-gfycat';
 
@@ -89,7 +89,7 @@ class AmpGfycat extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('img');
     const videoid = dev().assertString(this.videoid_);
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
     this.propagateAttributes(['alt', 'aria-label'], placeholder);
     placeholder.setAttribute('loading', 'lazy');
     placeholder.setAttribute('placeholder', '');
@@ -153,7 +153,7 @@ class AmpGfycat extends AMP.BaseElement {
 
     iframe.setAttribute('frameborder', '0');
     iframe.src = src;
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.iframe_ = iframe;
 
     this.unlistenMessage_ = listen(

--- a/extensions/amp-gist/0.1/amp-gist.js
+++ b/extensions/amp-gist/0.1/amp-gist.js
@@ -27,7 +27,7 @@
  * </code>
  */
 
-import {Layout} from '#core/dom/layout';
+import {Layout, applyFillContent} from '#core/dom/layout';
 import {Services} from '#service';
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
@@ -64,7 +64,7 @@ export class AmpGist extends AMP.BaseElement {
     /* the third parameter 'github' ties it to the 3p/github.js */
     const iframe = getIframe(this.win, this.element, 'github');
     iframe.title = this.element.title || 'Github gist';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     // Triggered by window.context.requestResize() inside the iframe.
     listenFor(
       iframe,

--- a/extensions/amp-google-assistant-assistjs/0.1/amp-google-assistant-inline-suggestion-bar.js
+++ b/extensions/amp-google-assistant-assistjs/0.1/amp-google-assistant-inline-suggestion-bar.js
@@ -21,7 +21,7 @@
 
 import {Services} from '#service';
 import {addAttributesToElement} from '#core/dom';
-import {isLayoutSizeDefined} from '#core/dom/layout';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 
 export class AmpGoogleAssistantInlineSuggestionBar extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -59,7 +59,7 @@ export class AmpGoogleAssistantInlineSuggestionBar extends AMP.BaseElement {
         });
 
         // applyFillContent so that frame covers the entire component.
-        this.applyFillContent(iframe, /* replacedContent */ true);
+        applyFillContent(iframe, /* replacedContent */ true);
 
         this.element.appendChild(iframe);
       });

--- a/extensions/amp-google-assistant-assistjs/0.1/amp-google-assistant-voice-bar.js
+++ b/extensions/amp-google-assistant-assistjs/0.1/amp-google-assistant-voice-bar.js
@@ -22,7 +22,7 @@
 import * as closure from '../../../third_party/closure-responding-channel/closure-bundle';
 import {Services} from '#service';
 import {addAttributesToElement} from '#core/dom';
-import {isLayoutSizeDefined} from '#core/dom/layout';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 
 export class AmpGoogleAssistantVoiceBar extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -58,7 +58,7 @@ export class AmpGoogleAssistantVoiceBar extends AMP.BaseElement {
       });
 
       // applyFillContent so that frame covers the entire component.
-      this.applyFillContent(iframe, /* replacedContent */ true);
+      applyFillContent(iframe, /* replacedContent */ true);
 
       this.element.appendChild(iframe);
     });

--- a/extensions/amp-google-assistant-assistjs/0.1/amp-google-assistant-voice-button.js
+++ b/extensions/amp-google-assistant-assistjs/0.1/amp-google-assistant-voice-button.js
@@ -21,7 +21,7 @@
 
 import {Services} from '#service';
 import {addAttributesToElement} from '#core/dom';
-import {isLayoutSizeDefined} from '#core/dom/layout';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 
 export class AmpGoogleAssistantVoiceButton extends AMP.BaseElement {
   /** @param {!AmpElement} element */
@@ -57,7 +57,7 @@ export class AmpGoogleAssistantVoiceButton extends AMP.BaseElement {
       });
 
       // applyFillContent so that frame covers the entire component.
-      this.applyFillContent(iframe, /* replacedContent */ true);
+      applyFillContent(iframe, /* replacedContent */ true);
 
       this.element.appendChild(iframe);
     });

--- a/extensions/amp-google-document-embed/0.1/amp-google-document-embed.js
+++ b/extensions/amp-google-document-embed/0.1/amp-google-document-embed.js
@@ -29,8 +29,8 @@
 
 import {Services} from '#service';
 import {addParamToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dev, userAssert} from '../../../src/log';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {removeElement} from '#core/dom';
 
 export const TAG = 'amp-google-document-embed';
@@ -94,7 +94,7 @@ export class AmpDriveViewer extends AMP.BaseElement {
 
     iframe.src = this.getSrc_(this.element.getAttribute('src'));
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
     return this.loadPromise(iframe);
   }

--- a/extensions/amp-hulu/0.1/amp-hulu.js
+++ b/extensions/amp-hulu/0.1/amp-hulu.js
@@ -15,8 +15,8 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {devAssert, userAssert} from '../../../src/log';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {removeElement} from '#core/dom';
 import {setIsMediaComponent} from '../../../src/video-interface';
 
@@ -52,7 +52,7 @@ class AmpHulu extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
 

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -17,7 +17,11 @@
 import {AMPDOC_SINGLETON_NAME} from '#core/constants/enums';
 import {ActionTrust} from '#core/constants/action-constants';
 import {IntersectionObserver3pHost} from '../../../src/utils/intersection-observer-3p-host';
-import {LayoutPriority, isLayoutSizeDefined} from '#core/dom/layout';
+import {
+  LayoutPriority,
+  applyFillContent,
+  isLayoutSizeDefined,
+} from '#core/dom/layout';
 import {MessageType} from '../../../src/3p-frame-messaging';
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
@@ -407,7 +411,7 @@ export class AmpIframe extends AMP.BaseElement {
 
     this.iframe_ = /** @type {HTMLIFrameElement} */ (iframe);
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     iframe.name = 'amp_iframe' + count++;
 
     if (this.isClickToPlay_) {

--- a/extensions/amp-iframely/0.1/amp-iframely.js
+++ b/extensions/amp-iframely/0.1/amp-iframely.js
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {getData, listen} from '../../../src/event-helper';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {measureIntersection} from '../../../src/utils/intersection';
 import {omit} from '#core/types/object';
 import {setStyle} from '#core/dom/style';
@@ -131,7 +131,7 @@ export class AmpIframely extends AMP.BaseElement {
           'placeholder': '',
         }
       );
-      this.applyFillContent(element);
+      applyFillContent(element);
       return element;
     }
     return null;
@@ -148,7 +148,7 @@ export class AmpIframely extends AMP.BaseElement {
     );
     this.src_ = addParamsToUrl(this.src_, this.options_);
     this.iframe_.src = this.src_;
-    this.applyFillContent(this.iframe_);
+    applyFillContent(this.iframe_);
     this.element.appendChild(this.iframe_);
 
     this.unlistener_ = listen(this.win, 'message', (event) => {

--- a/extensions/amp-ima-video/0.1/amp-ima-video.js
+++ b/extensions/amp-ima-video/0.1/amp-ima-video.js
@@ -20,6 +20,7 @@ import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
 import {VideoEvents} from '../../../src/video-interface';
 import {addUnsafeAllowAutoplay} from '../../../src/iframe-video';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {assertHttpsUrl} from '../../../src/url';
 import {childElementsByTag} from '#core/dom/query';
 import {dict} from '#core/types/object';
@@ -29,7 +30,6 @@ import {getData, listen} from '../../../src/event-helper';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
 import {isEnumValue, isObject} from '#core/types';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {
   observeContentSize,
   unobserveContentSize,
@@ -216,7 +216,7 @@ class AmpImaVideo extends AMP.BaseElement {
       );
       iframe.title = this.element.title || 'IMA video';
 
-      this.applyFillContent(iframe);
+      applyFillContent(iframe);
 
       // This is temporary until M74 launches.
       // TODO(aghassemi, #21247)
@@ -358,7 +358,7 @@ class AmpImaVideo extends AMP.BaseElement {
     img.src = poster;
     img.setAttribute('placeholder', '');
     img.setAttribute('loading', 'lazy');
-    this.applyFillContent(img);
+    applyFillContent(img);
     return img;
   }
 

--- a/extensions/amp-imgur/0.1/amp-imgur.js
+++ b/extensions/amp-imgur/0.1/amp-imgur.js
@@ -29,9 +29,9 @@
 
 import {Deferred} from '#core/data-structures/promise';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {getData, listen} from '../../../src/event-helper';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {isObject} from '#core/types';
 import {tryParseJson} from '#core/types/object/json';
 import {user, userAssert} from '../../../src/log';
@@ -131,7 +131,7 @@ export class AmpImgur extends AMP.BaseElement {
     this.iframe_ = iframe;
     element.appendChild(iframe);
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
 
     // We're sure we've loaded when we receive the first message.
     const {promise, resolve} = new Deferred();

--- a/extensions/amp-instagram/0.1/amp-instagram.js
+++ b/extensions/amp-instagram/0.1/amp-instagram.js
@@ -37,8 +37,8 @@
 
 import {CSS} from '../../../build/amp-instagram-0.1.css';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {getData, listen} from '../../../src/event-helper';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {isObject} from '#core/types';
 import {removeElement} from '#core/dom';
 import {setStyle} from '#core/dom/style';
@@ -137,7 +137,7 @@ export class AmpInstagram extends AMP.BaseElement {
       '/embed/' +
       this.captioned_ +
       '?cr=1&v=12';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
     setStyle(iframe, 'opacity', 0);
     return (this.iframePromise_ = this.loadPromise(iframe).then(() => {

--- a/extensions/amp-izlesene/0.1/amp-izlesene.js
+++ b/extensions/amp-izlesene/0.1/amp-izlesene.js
@@ -17,10 +17,10 @@
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {getDataParamsFromAttributes} from '#core/dom';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {setIsMediaComponent} from '../../../src/video-interface';
 
 class AmpIzlesene extends AMP.BaseElement {
@@ -104,7 +104,7 @@ class AmpIzlesene extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
 

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -27,6 +27,7 @@ import {
   objOrParseJson,
   redispatch,
 } from '../../../src/iframe-video';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dev, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {disableScrollingOnIframe} from '../../../src/iframe-helper';
@@ -39,7 +40,6 @@ import {
 import {getData, listen} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {once} from '#core/types/function';
 
 const JWPLAYER_EVENTS = {
@@ -349,7 +349,7 @@ class AmpJWPlayer extends AMP.BaseElement {
     }
     const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
     if (placeholder.hasAttribute('aria-label')) {

--- a/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
+++ b/extensions/amp-kaltura-player/0.1/amp-kaltura-player.js
@@ -17,9 +17,9 @@
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dict} from '#core/types/object';
 import {getDataParamsFromAttributes} from '#core/dom';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {setIsMediaComponent} from '../../../src/video-interface';
 import {userAssert} from '../../../src/log';
 
@@ -102,7 +102,7 @@ class AmpKaltura extends AMP.BaseElement {
     iframe.setAttribute('frameborder', '0');
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = src;
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = /** @type {HTMLIFrameElement} */ (iframe);
 
@@ -126,7 +126,7 @@ class AmpKaltura extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
     placeholder.setAttribute('loading', 'lazy');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -22,6 +22,7 @@ import {Gestures} from '../../../src/gesture';
 import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
+import {applyFillContent} from '#core/dom/layout';
 import {assertDoesNotContainDisplay} from '../../../src/assert-display';
 import {
   computedStyle,
@@ -236,7 +237,7 @@ class AmpLightbox extends AMP.BaseElement {
 
     this.container_ = element.ownerDocument.createElement('div');
     if (!this.isScrollable_) {
-      this.applyFillContent(this.container_);
+      applyFillContent(this.container_);
     }
     element.appendChild(this.container_);
 

--- a/extensions/amp-list/0.1/amp-list.js
+++ b/extensions/amp-list/0.1/amp-list.js
@@ -26,6 +26,7 @@ import {
 import {Deferred} from '#core/data-structures/promise';
 import {
   Layout,
+  applyFillContent,
   getLayoutClass,
   isLayoutSizeDefined,
   parseLayout,
@@ -559,7 +560,7 @@ export class AmpList extends AMP.BaseElement {
     // to take the height of its children instead,
     // whereas fill-content forces height:0
     if (!this.loadMoreEnabled_ && !this.enableManagedResizing_) {
-      this.applyFillContent(container, true);
+      applyFillContent(container, true);
     }
     return container;
   }

--- a/extensions/amp-mathml/0.1/amp-mathml.js
+++ b/extensions/amp-mathml/0.1/amp-mathml.js
@@ -15,7 +15,7 @@
  */
 
 import {CSS} from '../../../build/amp-mathml-0.1.css';
-import {Layout} from '#core/dom/layout';
+import {Layout, applyFillContent} from '#core/dom/layout';
 import {Services} from '#service';
 import {getIframe} from '../../../src/3p-frame';
 import {listenFor} from '../../../src/iframe-helper';
@@ -68,7 +68,7 @@ export class AmpMathml extends AMP.BaseElement {
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'mathml');
     iframe.title = this.element.title || 'MathML formula';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     // Triggered by context.updateDimensions() inside the iframe.
     listenFor(
       iframe,

--- a/extensions/amp-megaphone/0.1/amp-megaphone.js
+++ b/extensions/amp-megaphone/0.1/amp-megaphone.js
@@ -30,9 +30,9 @@
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeFixed} from '#core/dom/layout';
 import {dict} from '#core/types/object';
 import {getData, listen} from '../../../src/event-helper';
-import {isLayoutSizeFixed} from '#core/dom/layout';
 import {isObject} from '#core/types';
 import {removeElement} from '#core/dom';
 import {setIsMediaComponent} from '../../../src/video-interface';
@@ -109,7 +109,7 @@ class AmpMegaphone extends AMP.BaseElement {
       this.handleMegaphoneMessages_.bind(this)
     );
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
 
     this.iframe_ = iframe;

--- a/extensions/amp-o2-player/0.1/amp-o2-player.js
+++ b/extensions/amp-o2-player/0.1/amp-o2-player.js
@@ -18,12 +18,12 @@ import {CONSENT_POLICY_STATE} from '#core/constants/consent-state';
 import {MessageType} from '../../../src/3p-frame-messaging';
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dict} from '#core/types/object';
 import {
   getConsentPolicyInfo,
   getConsentPolicyState,
 } from '../../../src/consent';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {setIsMediaComponent} from '../../../src/video-interface';
 import {userAssert} from '../../../src/log';
@@ -133,7 +133,7 @@ class AmpO2Player extends AMP.BaseElement {
     iframe.setAttribute('allowfullscreen', 'true');
     iframe.src = this.src_;
     this.iframe_ = /** @type {HTMLIFrameElement} */ (iframe);
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
 
     listenFor(iframe, MessageType.SEND_CONSENT_DATA, (data, source, origin) => {
       this.sendConsentData_(source, origin);

--- a/extensions/amp-playbuzz/0.1/amp-playbuzz.js
+++ b/extensions/amp-playbuzz/0.1/amp-playbuzz.js
@@ -40,7 +40,7 @@
 import * as events from '../../../src/event-helper';
 import * as utils from './utils';
 import {CSS} from '#build/amp-playbuzz-0.1.css.js';
-import {Layout} from '#core/dom/layout';
+import {Layout, applyFillContent} from '#core/dom/layout';
 import {Services} from '#service';
 import {
   assertAbsoluteHttpOrHttpsUrl,
@@ -199,7 +199,7 @@ class AmpPlaybuzz extends AMP.BaseElement {
 
     this.element.appendChild(this.getOverflowElement_());
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
 
     return (this.iframePromise_ = this.loadPromise(iframe).then(() => {

--- a/extensions/amp-reach-player/0.1/amp-reach-player.js
+++ b/extensions/amp-reach-player/0.1/amp-reach-player.js
@@ -16,7 +16,7 @@
 
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
-import {isLayoutSizeDefined} from '#core/dom/layout';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {setIsMediaComponent} from '../../../src/video-interface';
 
 class AmpReachPlayer extends AMP.BaseElement {
@@ -64,7 +64,7 @@ class AmpReachPlayer extends AMP.BaseElement {
     iframe.src =
       'https://player-cdn.beachfrontmedia.com/playerapi/v1/frame/player/?embed_id=' +
       encodeURIComponent(embedId);
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
     this.iframe_ = iframe;
 

--- a/extensions/amp-reddit/0.1/amp-reddit.js
+++ b/extensions/amp-reddit/0.1/amp-reddit.js
@@ -15,8 +15,8 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {userAssert} from '../../../src/log';
 
@@ -78,7 +78,7 @@ class AmpReddit extends AMP.BaseElement {
       allowFullscreen: true,
     });
     iframe.title = this.element.title || 'Reddit';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     listenFor(
       iframe,
       'embed-size',

--- a/extensions/amp-riddle-quiz/0.1/amp-riddle-quiz.js
+++ b/extensions/amp-riddle-quiz/0.1/amp-riddle-quiz.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {getData, listen} from './../../../src/event-helper';
 import {isFiniteNumber, isObject} from '#core/types';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 
 import {removeElement} from '#core/dom';
 import {userAssert} from '../../../src/log';
@@ -91,7 +91,7 @@ export class AmpRiddleQuiz extends AMP.BaseElement {
     iframe.src =
       'https://www.riddle.com/a/iframe/' + encodeURIComponent(this.riddleId_);
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
 
     return this.loadPromise(iframe);

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -17,7 +17,7 @@
 import * as WorkerDOM from '@ampproject/worker-dom/dist/amp-production/main.mjs';
 import {CSS} from '../../../build/amp-script-0.1.css';
 import {Deferred} from '#core/data-structures/promise';
-import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
+import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {Purifier} from '#purifier/purifier';
 import {Services} from '#service';
 import {UserActivationTracker} from './user-activation-tracker';
@@ -234,7 +234,7 @@ export class AmpScript extends AMP.BaseElement {
     let container;
     if (this.element.sizerElement) {
       container = this.win.document.createElement('div');
-      this.applyFillContent(container, true);
+      applyFillContent(container, true);
       // Reparent all real children to the container.
       const realChildren = this.getRealChildren();
       for (let i = 0; i < realChildren.length; i++) {

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -234,7 +234,7 @@ export class AmpScript extends AMP.BaseElement {
     let container;
     if (this.element.sizerElement) {
       container = this.win.document.createElement('div');
-      applyFillContent(container, true);
+      applyFillContent(container, /* replacedContent */ true);
       // Reparent all real children to the container.
       const realChildren = this.getRealChildren();
       for (let i = 0; i < realChildren.length; i++) {

--- a/extensions/amp-soundcloud/0.1/amp-soundcloud.js
+++ b/extensions/amp-soundcloud/0.1/amp-soundcloud.js
@@ -29,8 +29,8 @@
 
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dict} from '#core/types/object';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {setIsMediaComponent} from '../../../src/video-interface';
 import {userAssert} from '../../../src/log';
 
@@ -107,7 +107,7 @@ class AmpSoundcloud extends AMP.BaseElement {
 
     iframe.src = src;
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     iframe.height = height;
     this.element.appendChild(iframe);
 

--- a/extensions/amp-springboard-player/0.1/amp-springboard-player.js
+++ b/extensions/amp-springboard-player/0.1/amp-springboard-player.js
@@ -16,7 +16,7 @@
 
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
-import {isLayoutSizeDefined} from '#core/dom/layout';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {setIsMediaComponent} from '../../../src/video-interface';
 import {userAssert} from '../../../src/log';
 
@@ -124,7 +124,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
       encodeURIComponent(this.domain_) +
       '/' +
       encodeURIComponent(items);
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.iframe_ = /** @type {HTMLIFrameElement} */ (iframe);
     this.element.appendChild(iframe);
 
@@ -155,7 +155,7 @@ class AmpSpringboardPlayer extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.win.document.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');
     if (placeholder.hasAttribute('aria-label')) {

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -28,10 +28,10 @@ import {CommonSignals} from '#core/constants/common-signals';
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {Matrix, Renderer} from '../../../third_party/zuho/zuho';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {closest} from '#core/dom/query';
 import {dev, user, userAssert} from '../../../src/log';
 import {htmlFor} from '#core/dom/static-template';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenOncePromise} from '../../../src/event-helper';
 import {timeStrToMillis} from '../../../extensions/amp-story/1.0/utils';
 import {whenUpgradedToCustomElement} from '../../../src/amp-element-helpers';
@@ -354,7 +354,7 @@ export class AmpStory360 extends AMP.BaseElement {
     this.canvas_ = this.element.ownerDocument.createElement('canvas');
     this.element.appendChild(container);
     container.appendChild(this.canvas_);
-    this.applyFillContent(container, /* replacedContent */ true);
+    applyFillContent(container, /* replacedContent */ true);
 
     // Mutation observer for distance attribute
     const config = {attributes: true, attributeFilter: ['distance']};

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -16,9 +16,9 @@
 
 import {MessageType} from '../../../src/3p-frame-messaging';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {htmlFor} from '#core/dom/static-template';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '#core/dom';
 
@@ -101,7 +101,7 @@ class AmpTwitter extends AMP.BaseElement {
       allowFullscreen: true,
     });
     iframe.title = this.element.title || 'Twitter';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.updateForLoadingState_();
     listenFor(
       iframe,

--- a/extensions/amp-video-docking/0.1/amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.js
@@ -29,6 +29,7 @@ import {
 import {Services} from '#service';
 import {VideoDockingEvents, pointerCoords} from './events';
 import {applyBreakpointClassname} from './breakpoints';
+import {applyFillContent} from '#core/dom/layout';
 import {
   calculateLeftJustifiedX,
   calculateRightJustifiedX,
@@ -1009,8 +1010,8 @@ export class VideoDocking {
       toggle(shadowLayer, true);
       toggle(overlay, true);
 
-      video.applyFillContent(this.getPlaceholderRefs_()['poster']);
-      video.applyFillContent(placeholderBackground);
+      applyFillContent(this.getPlaceholderRefs_()['poster']);
+      applyFillContent(placeholderBackground);
       this.setPosterImage_(video);
 
       element.appendChild(placeholderBackground);

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as layout from '#core/dom/layout';
 import {
   Actions,
   BASE_CLASS_NAME,
@@ -37,7 +38,6 @@ import {Services} from '#service';
 import {createElementWithAttributes} from '#core/dom';
 import {htmlFor} from '#core/dom/static-template';
 import {layoutRectLtwh} from '#core/math/layout-rect';
-import layout from '#core/dom/layout';
 
 const slotId = 'my-slot-element';
 

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as layout from '#core/dom/layout';
 import {
   Actions,
   BASE_CLASS_NAME,
@@ -49,7 +48,6 @@ describes.realWin('video docking', {amp: true}, (env) => {
   let querySelectorStub;
   let any;
   let slotAttr = '';
-  let applyFillContent;
 
   const viewportSize = {width: 0, height: 0};
 
@@ -191,8 +189,6 @@ describes.realWin('video docking', {amp: true}, (env) => {
 
     docking = new VideoDocking(ampdoc);
 
-    applyFillContent = env.sandbox.stub(layout, 'applyFillContent');
-
     env.sandbox.stub(docking, 'getTimer_').returns({
       promise: () => Promise.resolve(),
     });
@@ -274,16 +270,12 @@ describes.realWin('video docking', {amp: true}, (env) => {
       await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       expect(
-        applyFillContent.withArgs(
-          videoLayerElement('.amp-video-docked-placeholder-background')
-        )
-      ).to.have.been.calledOnce;
+        videoLayerElement('.amp-video-docked-placeholder-background')
+      ).to.have.class('i-amphtml-fill-content');
 
       expect(
-        applyFillContent.withArgs(
-          videoLayerElement('.amp-video-docked-placeholder-background-poster')
-        )
-      ).to.have.been.calledOnce;
+        videoLayerElement('.amp-video-docked-placeholder-background-poster')
+      ).to.have.class('i-amphtml-fill-content');
     });
 
     it('styles and transforms elements into docked area', async () => {

--- a/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
+++ b/extensions/amp-video-docking/0.1/test/test-amp-video-docking.js
@@ -37,6 +37,7 @@ import {Services} from '#service';
 import {createElementWithAttributes} from '#core/dom';
 import {htmlFor} from '#core/dom/static-template';
 import {layoutRectLtwh} from '#core/math/layout-rect';
+import layout from '#core/dom/layout';
 
 const slotId = 'my-slot-element';
 
@@ -48,6 +49,7 @@ describes.realWin('video docking', {amp: true}, (env) => {
   let querySelectorStub;
   let any;
   let slotAttr = '';
+  let applyFillContent;
 
   const viewportSize = {width: 0, height: 0};
 
@@ -57,7 +59,6 @@ describes.realWin('video docking', {amp: true}, (env) => {
     const impl = {
       element,
       mutateElement: (cb) => tryResolve(cb),
-      applyFillContent: env.sandbox.spy(),
     };
     stubLayoutBox(impl, defaultLayoutRect);
     return impl;
@@ -190,6 +191,8 @@ describes.realWin('video docking', {amp: true}, (env) => {
 
     docking = new VideoDocking(ampdoc);
 
+    applyFillContent = env.sandbox.stub(layout, 'applyFillContent');
+
     env.sandbox.stub(docking, 'getTimer_').returns({
       promise: () => Promise.resolve(),
     });
@@ -271,13 +274,13 @@ describes.realWin('video docking', {amp: true}, (env) => {
       await docking.placeAt_(video, x, y, scale, step, transitionDurationMs);
 
       expect(
-        video.applyFillContent.withArgs(
+        applyFillContent.withArgs(
           videoLayerElement('.amp-video-docked-placeholder-background')
         )
       ).to.have.been.calledOnce;
 
       expect(
-        video.applyFillContent.withArgs(
+        applyFillContent.withArgs(
           videoLayerElement('.amp-video-docked-placeholder-background-poster')
         )
       ).to.have.been.calledOnce;

--- a/extensions/amp-video-iframe/0.1/amp-video-iframe.js
+++ b/extensions/amp-video-iframe/0.1/amp-video-iframe.js
@@ -29,6 +29,7 @@ import {
 } from '../../../src/iframe-video';
 import {Services} from '#service';
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dev, devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {
@@ -44,7 +45,6 @@ import {getConsentDataToForward} from '../../../src/consent';
 import {getData, listen} from '../../../src/event-helper';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
 import {isFullscreenElement} from '#core/dom/fullscreen';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {measureIntersection} from '../../../src/utils/intersection';
 import {once} from '#core/types/function';
 
@@ -200,7 +200,7 @@ class AmpVideoIframe extends AMP.BaseElement {
     img.src = addDataParamsToUrl(poster, element);
     img.setAttribute('loading', 'lazy');
     img.setAttribute('placeholder', '');
-    this.applyFillContent(img);
+    applyFillContent(img);
     return img;
   }
 

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -20,6 +20,7 @@ import {Services} from '#service';
 import {VideoEvents} from '../../../src/video-interface';
 import {VisibilityState} from '#core/constants/visibility-state';
 import {addParamsToUrl} from '../../../src/url';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {
   childElement,
   childElementByTag,
@@ -42,7 +43,6 @@ import {getBitrateManager} from './flexible-bitrate';
 import {getMode} from '../../../src/mode';
 import {htmlFor} from '#core/dom/static-template';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listen, listenOncePromise} from '../../../src/event-helper';
 import {mutedOrUnmutedEvent} from '../../../src/iframe-video';
 import {
@@ -244,7 +244,7 @@ export class AmpVideo extends AMP.BaseElement {
       /* opt_removeMissingAttrs */ true
     );
     this.installEventHandlers_();
-    this.applyFillContent(this.video_, true);
+    applyFillContent(this.video_, true);
     propagateObjectFitStyles(this.element, this.video_);
 
     element.appendChild(this.video_);
@@ -770,7 +770,7 @@ export class AmpVideo extends AMP.BaseElement {
       'background-position': 'center',
     });
     poster.classList.add('i-amphtml-android-poster-bug');
-    this.applyFillContent(poster);
+    applyFillContent(poster);
     element.appendChild(poster);
   }
 

--- a/extensions/amp-vine/0.1/amp-vine.js
+++ b/extensions/amp-vine/0.1/amp-vine.js
@@ -16,7 +16,7 @@
 
 import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
-import {isLayoutSizeDefined} from '#core/dom/layout';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {userAssert} from '../../../src/log';
 
 class AmpVine extends AMP.BaseElement {
@@ -67,7 +67,7 @@ class AmpVine extends AMP.BaseElement {
     iframe.src =
       'https://vine.co/v/' + encodeURIComponent(vineid) + '/embed/simple';
 
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
     this.element.appendChild(iframe);
 
     this.iframe_ = iframe;

--- a/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
+++ b/extensions/amp-viqeo-player/0.1/amp-viqeo-player.js
@@ -16,7 +16,7 @@
  */
 
 import {Deferred} from '#core/data-structures/promise';
-import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
+import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {Services} from '#service';
 import {VideoAttributes, VideoEvents} from '../../../src/video-interface';
 import {dev, userAssert} from '../../../src/log';
@@ -152,7 +152,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
     return this.mutateElement(() => {
       this.element.appendChild(iframe);
       this.iframe_ = iframe;
-      this.applyFillContent(iframe);
+      applyFillContent(iframe);
     }).then(() => {
       return this.playerReadyPromise_;
     });
@@ -205,7 +205,7 @@ class AmpViqeoPlayer extends AMP.BaseElement {
   createPlaceholderCallback() {
     const placeholder = this.element.ownerDocument.createElement('img');
     this.propagateAttributes(['aria-label'], placeholder);
-    this.applyFillContent(placeholder);
+    applyFillContent(placeholder);
     placeholder.setAttribute('loading', 'lazy');
     placeholder.setAttribute('placeholder', '');
     placeholder.setAttribute('referrerpolicy', 'origin');

--- a/extensions/amp-viz-vega/0.1/amp-viz-vega.js
+++ b/extensions/amp-viz-vega/0.1/amp-viz-vega.js
@@ -17,13 +17,13 @@
 import * as dom from '#core/dom';
 import {CSS} from '../../../build/amp-viz-vega-0.1.css';
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {assertHttpsUrl} from '../../../src/url';
 import {childElementsByTag} from '#core/dom/query';
 import {dev, devAssert, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {isExperimentOn} from '#experiments';
 import {isFiniteNumber, isObject} from '#core/types';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 
 import {
   observeContentSize,
@@ -155,7 +155,7 @@ export class AmpVizVega extends AMP.BaseElement {
   initialize_() {
     this.container_ = this.element.ownerDocument.createElement('div');
 
-    this.applyFillContent(this.container_, true);
+    applyFillContent(this.container_, true);
     this.element.appendChild(this.container_);
   }
 

--- a/extensions/amp-vk/0.1/amp-vk.js
+++ b/extensions/amp-vk/0.1/amp-vk.js
@@ -22,7 +22,7 @@ const EmbedType = {
   POLL: 'poll',
 };
 
-import {Layout} from '#core/dom/layout';
+import {Layout, applyFillContent} from '#core/dom/layout';
 import {Services} from '#service';
 import {addParamsToUrl, appendEncodedParamStringToUrl} from '../../../src/url';
 import {dict} from '#core/types/object';
@@ -225,7 +225,7 @@ export class AmpVk extends AMP.BaseElement {
       iframe.setAttribute('frameborder', '0');
       iframe.setAttribute('allowfullscreen', 'true');
 
-      this.applyFillContent(iframe);
+      applyFillContent(iframe);
       this.element.appendChild(iframe);
 
       return this.loadPromise(iframe);

--- a/extensions/amp-yotpo/0.1/amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/amp-yotpo.js
@@ -15,8 +15,8 @@
  */
 
 import {Services} from '#service';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {getIframe} from '../../../src/3p-frame';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {listenFor} from '../../../src/iframe-helper';
 import {removeElement} from '#core/dom';
 import {userAssert} from '../../../src/log';
@@ -85,7 +85,7 @@ export class AmpYotpo extends AMP.BaseElement {
   layoutCallback() {
     const iframe = getIframe(this.win, this.element, 'yotpo');
     iframe.title = this.element.title || 'Yotpo widget';
-    this.applyFillContent(iframe);
+    applyFillContent(iframe);
 
     const unlisten = listenFor(
       iframe,

--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -28,6 +28,7 @@ import {
   originMatches,
   redispatch,
 } from '../../../src/iframe-video';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {dev, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {
@@ -43,7 +44,6 @@ import {
 import {getData, listen} from '../../../src/event-helper';
 import {htmlFor} from '#core/dom/static-template';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
-import {isLayoutSizeDefined} from '#core/dom/layout';
 import {setStyles} from '#core/dom/style';
 
 const TAG = 'amp-youtube';
@@ -515,7 +515,7 @@ class AmpYoutube extends AMP.BaseElement {
     } else {
       imgPlaceholder.setAttribute('alt', 'Loading video');
     }
-    this.applyFillContent(imgPlaceholder);
+    applyFillContent(imgPlaceholder);
 
     // Because sddefault.jpg isn't available for all videos, we try to load
     // it and fallback to hqdefault.jpg.

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -869,25 +869,6 @@ export class BaseElement {
   }
 
   /**
-   * Configures the supplied element to have a "fill content" layout. The
-   * exact interpretation of "fill content" depends on the element's layout.
-   *
-   * If `opt_replacedContent` is specified, it indicates whether the "replaced
-   * content" styling should be applied. Replaced content is not allowed to
-   * have its own paddings or border.
-   *
-   * @param {!Element} element
-   * @param {boolean=} opt_replacedContent
-   * @public @final
-   */
-  applyFillContent(element, opt_replacedContent) {
-    element.classList.add('i-amphtml-fill-content');
-    if (opt_replacedContent) {
-      element.classList.add('i-amphtml-replaced-content');
-    }
-  }
-
-  /**
    * Returns the viewport within which the element operates.
    * @return {!./service/viewport/viewport-interface.ViewportInterface}
    */

--- a/src/core/dom/layout.js
+++ b/src/core/dom/layout.js
@@ -264,3 +264,21 @@ export function isIframeVideoPlayerComponent(tagName) {
   }
   return videoPlayerTagNameRe.test(tagName);
 }
+
+/**
+ * Configures the supplied element to have a "fill content" layout. The
+ * exact interpretation of "fill content" depends on the element's layout.
+ *
+ * If `opt_replacedContent` is specified, it indicates whether the "replaced
+ * content" styling should be applied. Replaced content is not allowed to
+ * have its own paddings or border.
+ *
+ * @param {!Element} element
+ * @param {boolean=} opt_replacedContent
+ */
+export function applyFillContent(element, opt_replacedContent) {
+  element.classList.add('i-amphtml-fill-content');
+  if (opt_replacedContent) {
+    element.classList.add('i-amphtml-replaced-content');
+  }
+}

--- a/src/iframe-video.js
+++ b/src/iframe-video.js
@@ -15,6 +15,7 @@
  */
 import {Services} from './service';
 import {VideoEvents} from './video-interface';
+import {applyFillContent} from '#core/dom/layout';
 import {dev} from './log';
 import {dispatchCustomEvent} from './core/dom';
 import {htmlFor} from './core/dom/static-template';
@@ -94,7 +95,7 @@ export function createFrameFor(video, src, opt_name, opt_sandbox) {
 
   frame.src = Services.urlForDoc(element).assertHttpsUrl(src, element);
 
-  video.applyFillContent(frame);
+  applyFillContent(frame);
   element.appendChild(frame);
 
   return frame;

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -19,7 +19,7 @@ import {ActionTrust} from '#core/constants/action-constants';
 import {AmpEvents} from '#core/constants/amp-events';
 import {CanPlay, CanRender, LoadingProp} from '../context/contextprops';
 import {Deferred} from '#core/data-structures/promise';
-import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
+import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {Loading} from '#core/loading-instructions';
 import {MediaQueryProps} from '#core/dom/media-query-props';
 import {PauseHelper} from '#core/dom/video/pause-helper';
@@ -658,7 +658,7 @@ export class PreactBaseElement extends AMP.BaseElement {
       } else {
         const container = doc.createElement('i-amphtml-c');
         this.container_ = container;
-        this.applyFillContent(container);
+        applyFillContent(container);
         if (!isDetached) {
           this.element.appendChild(container);
         }


### PR DESCRIPTION
Bento components cannot rely on a full `BaseElement` implementation, so we intend to extract standalone helpers piece-meal.

We extract `applyFillContent` first since that's the only standalone method used by `PreactBaseElement` for now.
