### PR TITLE
🏗 Refinements to renovate config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -21,6 +21,7 @@
     {
       "groupName": "subpackage devDependencies",
       "matchPaths": ["**/*"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -28,6 +29,7 @@
       "groupName": "build-system devDependencies",
       "matchPaths": ["build-system/**"],
       "labels": ["WG: infra"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -35,6 +37,7 @@
       "groupName": "validator devDependencies",
       "matchPaths": ["validator/**"],
       "labels": ["WG: caching"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -47,6 +50,7 @@
       "groupName": "core devDependencies",
       "matchFiles": ["package.json"],
       "labels": ["WG: infra"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -55,6 +59,7 @@
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\b(prettier|eslint)\\b"],
       "labels": ["WG: infra"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -64,6 +69,7 @@
       "matchPackagePatterns": ["\\bbabel"],
       "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra", "WG: performance"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -72,6 +78,7 @@
       "matchFiles": ["package.json"],
       "matchPackagePatterns": ["\\besbuild\\b"],
       "labels": ["WG: infra", "WG: performance"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -81,6 +88,7 @@
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["devDependencies"],
       "labels": ["WG: bento", "WG: components", "WG: performance"],
+      "rebaseWhen": "never",
       "automerge": true,
       "assignAutomerge": true
     },
@@ -90,6 +98,7 @@
       "matchPackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["dependencies"],
       "labels": ["WG: bento", "WG: components", "WG: performance"],
+      "rebaseWhen": "never",
       "automerge": false,
       "assignAutomerge": false
     },
@@ -99,6 +108,7 @@
       "excludePackagePatterns": ["^@ampproject/"],
       "matchDepTypes": ["dependencies"],
       "labels": ["WG: bento", "WG: components", "WG: performance"],
+      "rebaseWhen": "never",
       "automerge": false,
       "assignAutomerge": false
     }

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -22,24 +22,21 @@
       "groupName": "subpackage devDependencies",
       "matchPaths": ["**/*"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "build-system devDependencies",
       "matchPaths": ["build-system/**"],
       "labels": ["WG: infra"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "validator devDependencies",
       "matchPaths": ["validator/**"],
       "labels": ["WG: caching"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "validator webui",
@@ -51,8 +48,7 @@
       "matchFiles": ["package.json"],
       "labels": ["WG: infra"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "linting devDependencies",
@@ -60,8 +56,7 @@
       "matchPackagePatterns": ["\\b(prettier|eslint)\\b"],
       "labels": ["WG: infra"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "babel devDependencies",
@@ -70,8 +65,7 @@
       "major": {"automerge": false, "assignAutomerge": false},
       "labels": ["WG: infra", "WG: performance"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "esbuild devDependencies",
@@ -79,8 +73,7 @@
       "matchPackagePatterns": ["\\besbuild\\b"],
       "labels": ["WG: infra", "WG: performance"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "ampproject devDependencies",
@@ -89,8 +82,7 @@
       "matchDepTypes": ["devDependencies"],
       "labels": ["WG: bento", "WG: components", "WG: performance"],
       "rebaseWhen": "never",
-      "automerge": true,
-      "assignAutomerge": true
+      "automerge": true
     },
     {
       "groupName": "ampproject dependencies",
@@ -99,8 +91,7 @@
       "matchDepTypes": ["dependencies"],
       "labels": ["WG: bento", "WG: components", "WG: performance"],
       "rebaseWhen": "never",
-      "automerge": false,
-      "assignAutomerge": false
+      "automerge": false
     },
     {
       "groupName": "core dependencies",
@@ -109,8 +100,7 @@
       "matchDepTypes": ["dependencies"],
       "labels": ["WG: bento", "WG: components", "WG: performance"],
       "rebaseWhen": "never",
-      "automerge": false,
-      "assignAutomerge": false
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
**Two changes:**
- Set `rebaseWhen` to `never` (prevents ~hourly auto-rebasing and avoids unnecessary wastage of CI resources)
- Remove the unnecessary `assignAutomerge` setting (it's used only when `reviewers` or `assignees` is set)

**References:**
- https://docs.renovatebot.com/configuration-options/#rebasewhen
- https://docs.renovatebot.com/configuration-options/#assignautomerge
