### PR TITLE
🐛 amp-ima-video: Fix duration label on livestreams

### DIFF
--- a/ads/google/ima/ima-video.js
+++ b/ads/google/ima/ima-video.js
@@ -960,7 +960,7 @@ export function updateTime(currentTime, duration) {
   // need this clause if we switch. https://go.amp.dev/issue/8841
   if (progress.hasAttribute('hidden') !== isLivestream) {
     toggle(progress, !isLivestream);
-    progress.setAttribute('aria-hidden', isLivestream ? 'true' : 'false');
+    progress.setAttribute('aria-hidden', String(isLivestream));
   }
 
   // TODO(alanorozco): Consider adding a label for livestreams to display next

--- a/ads/google/ima/ima-video.js
+++ b/ads/google/ima/ima-video.js
@@ -254,10 +254,7 @@ function renderElements(elementOrDoc) {
           </div>
         </div>
 
-        <div ref="time">
-          <!-- Text content must match format in updateTime(). -->
-          -:- / 0:00
-        </div>
+        <div ref="time">-:-</div>
 
         <div ref="progress" hidden>
           <div ref="progressLine"></div>

--- a/css/amp-ima-video-iframe.css
+++ b/css/amp-ima-video-iframe.css
@@ -104,7 +104,6 @@ button > svg {
 }
 
 .time {
-  margin-right: 20px;
   text-align: center;
   font-size: 14px;
   text-shadow: 0 0 10px black;
@@ -114,7 +113,12 @@ button > svg {
   height: 30px;
   flex-grow: 1;
   position: relative;
-  margin-right: 20px;
+  margin: 0 20px;
+}
+
+/* Push the next item as if `.progress` was present */
+.progress[hidden] + * {
+  margin-left: auto;
 }
 
 .progress::after {

--- a/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
+++ b/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
@@ -827,50 +827,37 @@ describes.realWin('UI loaded in frame by amp-ima-video', {}, (env) => {
       tag: adTagUrl,
     });
 
+    const {elements} = imaVideoObj.getPropertiesForTesting();
+
     imaVideoObj.updateTime(0, 60);
-    expect(imaVideoObj.getPropertiesForTesting().timeDiv.textContent).to.eql(
-      '0:00 / 1:00'
-    );
-    expect(
-      imaVideoObj.getPropertiesForTesting().progressLine.style.width
-    ).to.eql('0%');
-    expect(
-      imaVideoObj.getPropertiesForTesting().progressMarkerDiv.style.left
-    ).to.eql('-1%');
+    expect(elements.progress).to.not.have.attribute('hidden');
+    expect(elements.progress.getAttribute('aria-hidden')).to.equal('false');
+    expect(elements.time.textContent).to.eql('0:00 / 1:00');
+    expect(elements.progressLine.style.width).to.eql('0%');
+    expect(elements.progressMarker.style.left).to.eql('-1%');
+
     imaVideoObj.updateTime(30, 60);
-    expect(imaVideoObj.getPropertiesForTesting().timeDiv.textContent).to.eql(
-      '0:30 / 1:00'
-    );
-    expect(
-      imaVideoObj.getPropertiesForTesting().progressLine.style.width
-    ).to.eql('50%');
-    expect(
-      imaVideoObj.getPropertiesForTesting().progressMarkerDiv.style.left
-    ).to.eql('49%');
+    expect(elements.progress).to.not.have.attribute('hidden');
+    expect(elements.progress.getAttribute('aria-hidden')).to.equal('false');
+    expect(elements.time.textContent).to.eql('0:30 / 1:00');
+    expect(elements.progressLine.style.width).to.eql('50%');
+    expect(elements.progressMarker.style.left).to.eql('49%');
+
     imaVideoObj.updateTime(60, 60);
-    expect(imaVideoObj.getPropertiesForTesting().timeDiv.textContent).to.eql(
-      '1:00 / 1:00'
-    );
-    expect(
-      imaVideoObj.getPropertiesForTesting().progressLine.style.width
-    ).to.eql('100%');
-    expect(
-      imaVideoObj.getPropertiesForTesting().progressMarkerDiv.style.left
-    ).to.eql('99%');
+    expect(elements.progress).to.not.have.attribute('hidden');
+    expect(elements.progress.getAttribute('aria-hidden')).to.equal('false');
+    expect(elements.time.textContent).to.eql('1:00 / 1:00');
+    expect(elements.progressLine.style.width).to.eql('100%');
+    expect(elements.progressMarker.style.left).to.eql('99%');
+
+    // Livestreams
+    imaVideoObj.updateTime(61, Infinity);
+    expect(elements.progress).to.have.attribute('hidden');
+    expect(elements.progress.getAttribute('aria-hidden')).to.equal('true');
+    expect(elements.time.textContent).to.eql('1:01');
   });
 
   it('formats time', () => {
-    const div = doc.createElement('div');
-    div.setAttribute('id', 'c');
-    doc.body.appendChild(div);
-
-    imaVideoObj.imaVideo(win, {
-      width: 640,
-      height: 360,
-      src: srcUrl,
-      tag: adTagUrl,
-    });
-
     let formattedTime = imaVideoObj.formatTime(0);
     expect(formattedTime).to.eql('0:00');
     formattedTime = imaVideoObj.formatTime(55);

--- a/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
+++ b/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
@@ -830,31 +830,31 @@ describes.realWin('UI loaded in frame by amp-ima-video', {}, (env) => {
     const {elements} = imaVideoObj.getPropertiesForTesting();
 
     imaVideoObj.updateTime(0, 60);
+    expect(elements.time.textContent).to.eql('0:00 / 1:00');
     expect(elements.progress).to.not.have.attribute('hidden');
     expect(elements.progress.getAttribute('aria-hidden')).to.equal('false');
-    expect(elements.time.textContent).to.eql('0:00 / 1:00');
     expect(elements.progressLine.style.width).to.eql('0%');
     expect(elements.progressMarker.style.left).to.eql('-1%');
 
     imaVideoObj.updateTime(30, 60);
+    expect(elements.time.textContent).to.eql('0:30 / 1:00');
     expect(elements.progress).to.not.have.attribute('hidden');
     expect(elements.progress.getAttribute('aria-hidden')).to.equal('false');
-    expect(elements.time.textContent).to.eql('0:30 / 1:00');
     expect(elements.progressLine.style.width).to.eql('50%');
     expect(elements.progressMarker.style.left).to.eql('49%');
 
     imaVideoObj.updateTime(60, 60);
+    expect(elements.time.textContent).to.eql('1:00 / 1:00');
     expect(elements.progress).to.not.have.attribute('hidden');
     expect(elements.progress.getAttribute('aria-hidden')).to.equal('false');
-    expect(elements.time.textContent).to.eql('1:00 / 1:00');
     expect(elements.progressLine.style.width).to.eql('100%');
     expect(elements.progressMarker.style.left).to.eql('99%');
 
     // Livestreams
     imaVideoObj.updateTime(61, Infinity);
+    expect(elements.time.textContent).to.eql('1:01');
     expect(elements.progress).to.have.attribute('hidden');
     expect(elements.progress.getAttribute('aria-hidden')).to.equal('true');
-    expect(elements.time.textContent).to.eql('1:01');
   });
 
   it('formats time', () => {

--- a/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
+++ b/extensions/amp-ima-video/0.1/test/test-ima-video-internal.js
@@ -850,11 +850,25 @@ describes.realWin('UI loaded in frame by amp-ima-video', {}, (env) => {
     expect(elements.progressLine.style.width).to.eql('100%');
     expect(elements.progressMarker.style.left).to.eql('99%');
 
-    // Livestreams
-    imaVideoObj.updateTime(61, Infinity);
+    const livestreamDuration = Infinity;
+
+    // Compare against current progress state since livestreams should not change it.
+    const progressLineWidth = elements.progressLine.style.width;
+    const progressMarkerLeft = elements.progressMarker.style.left;
+
+    imaVideoObj.updateTime(61, livestreamDuration);
     expect(elements.time.textContent).to.eql('1:01');
     expect(elements.progress).to.have.attribute('hidden');
     expect(elements.progress.getAttribute('aria-hidden')).to.equal('true');
+    expect(elements.progressLine.style.width).to.eql(progressLineWidth);
+    expect(elements.progressMarker.style.left).to.eql(progressMarkerLeft);
+
+    imaVideoObj.updateTime(122, livestreamDuration);
+    expect(elements.time.textContent).to.eql('2:02');
+    expect(elements.progress).to.have.attribute('hidden');
+    expect(elements.progress.getAttribute('aria-hidden')).to.equal('true');
+    expect(elements.progressLine.style.width).to.eql(progressLineWidth);
+    expect(elements.progressMarker.style.left).to.eql(progressMarkerLeft);
   });
 
   it('formats time', () => {


### PR DESCRIPTION
Fixes #34831

In addition, hides progress slider on livestreams since it's not usable.