### PR TITLE
Support `amp-yotpo` `data-widget-type="ReviewsTab"`

### DIFF
--- a/3p/yotpo.js
+++ b/3p/yotpo.js
@@ -20,12 +20,15 @@ import {loadScript} from './3p';
  * Get the correct script for the container.
  * @param {!Window} global
  * @param {string} scriptSource The source of the script, different for post and comment embeds.
+ * @param {string} widgetType The type of the widget being instantiated.
  * @param {function(!Object, string)} cb
  */
-function getContainerScript(global, scriptSource, cb) {
+function getContainerScript(global, scriptSource, widgetType, cb) {
   loadScript(global, scriptSource, () => {
     global.Yotpo = global.Yotpo || {};
-    delete global.Yotpo.widgets['testimonials'];
+    if (widgetType !== 'ReviewsTab') {
+      delete global.Yotpo.widgets['testimonials'];
+    }
     const yotpoWidget =
       typeof global.yotpo === 'undefined' ? undefined : global.yotpo;
     yotpoWidget.on('CssReady', function () {
@@ -301,23 +304,28 @@ export function yotpo(global, data) {
   let batchLoaded = false;
   const scriptSource =
     'https://staticw2.yotpo.com/' + data.appKey + '/widget.js';
-  getContainerScript(global, scriptSource, (yotpoWidget, eventType) => {
-    if (eventType === 'cssLoaded') {
-      cssLoaded = true;
-    }
-    if (eventType === 'batchLoaded') {
-      batchLoaded = true;
-    }
+  getContainerScript(
+    global,
+    scriptSource,
+    widgetType,
+    (yotpoWidget, eventType) => {
+      if (eventType === 'cssLoaded') {
+        cssLoaded = true;
+      }
+      if (eventType === 'batchLoaded') {
+        batchLoaded = true;
+      }
 
-    if (batchLoaded && cssLoaded) {
-      setTimeout(() => {
-        if (yotpoWidget.widgets[0]) {
-          context.updateDimensions(
-            yotpoWidget.widgets[0].element./*OK*/ offsetWidth,
-            yotpoWidget.widgets[0].element./*OK*/ offsetHeight
-          );
-        }
-      }, 100);
+      if (batchLoaded && cssLoaded) {
+        setTimeout(() => {
+          if (yotpoWidget.widgets[0]) {
+            context.updateDimensions(
+              yotpoWidget.widgets[0].element./*OK*/ offsetWidth,
+              yotpoWidget.widgets[0].element./*OK*/ offsetHeight
+            );
+          }
+        }, 100);
+      }
     }
-  });
+  );
 }

--- a/examples/amp-yotpo.amp.html
+++ b/examples/amp-yotpo.amp.html
@@ -16,6 +16,13 @@
 </head>
 <body>
   <amp-yotpo
+    width="200"
+    height="200"
+    layout="responsive"
+    data-app-key="BQKC6AiRH3x7argyT9LckQoqbyRmvSta6kSLTpHZ"
+    data-widget-type="ReviewsTab">
+  </amp-yotpo>
+  <amp-yotpo
           width="550"
           height="500"
           layout="responsive"

--- a/extensions/amp-yotpo/0.1/test/test-amp-yotpo.js
+++ b/extensions/amp-yotpo/0.1/test/test-amp-yotpo.js
@@ -32,6 +32,7 @@ describes.realWin(
       {name: 'BottomLine', selector: '.yotpo.bottomLine'},
       {name: 'PicturesGallery', selector: '.yotpo.yotpo-pictures-gallery'},
       {name: 'ReviewsCarousel', selector: '.yotpo.yotpo-reviews-carousel'},
+      {name: 'ReviewsTab', selector: '.yotpo.yotpo-modal'},
       {name: 'badge', selector: '.yotpo.badge,.yotpo.yotpo-badge'},
       {name: 'questions-bottomline', selector: '.yotpo.QABottomLine'},
       {name: 'slider', selector: '.yotpo.yotpo-slider'},


### PR DESCRIPTION
It looks like we intend to support it: 
https://github.com/ampproject/amphtml/blob/1f2308befa3015c84f0c8839357884dff36880d2/3p/yotpo.js#L282

But ultimately do not due to removing the part of the 3p script which inserts the Reviews Tab element:
https://github.com/ampproject/amphtml/blob/1f2308befa3015c84f0c8839357884dff36880d2/3p/yotpo.js#L28

Fixes #34859