### PR TITLE
Enable amp-ad sticky type top/bottom

### DIFF
--- a/extensions/amp-ad/0.1/test/validator-amp-ad.html
+++ b/extensions/amp-ad/0.1/test/validator-amp-ad.html
@@ -43,6 +43,12 @@
   <amp-ad sticky width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302">
   </amp-ad>
   <!-- Valid -->
+  <amp-ad sticky="top" width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302">
+  </amp-ad>
+  <!-- Valid -->
+  <amp-ad sticky="bottom" width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302">
+  </amp-ad>
+  <!-- Valid -->
   <amp-ad width=300 height=250
       type="custom"
       data-url="https://foobar.com"
@@ -80,6 +86,10 @@
       type="custom"
       data-url="http://foobar.com"
       template="template-1">
+  </amp-ad>
+  <!-- Invalid: amp-ad sticky attribute invalid -->
+  <amp-ad sticky="center" width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123"
+    data-aax_src="302">
   </amp-ad>
 </body>
 </html>

--- a/extensions/amp-ad/0.1/test/validator-amp-ad.out
+++ b/extensions/amp-ad/0.1/test/validator-amp-ad.out
@@ -44,6 +44,12 @@ FAIL
 |    <amp-ad sticky width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302">
 |    </amp-ad>
 |    <!-- Valid -->
+|    <amp-ad sticky="top" width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302">
+|    </amp-ad>
+|    <!-- Valid -->
+|    <amp-ad sticky="bottom" width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302">
+|    </amp-ad>
+|    <!-- Valid -->
 |    <amp-ad width=300 height=250
 |        type="custom"
 |        data-url="https://foobar.com"
@@ -65,32 +71,38 @@ FAIL
 |    <amp-fx-flying-carpet height="300">
 |      <amp-ad data-multi-size="" height="300" type="foo"></amp-ad>
 >>     ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:65:4 The tag 'amp-ad' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad/)
+amp-ad/0.1/test/validator-amp-ad.html:71:4 The tag 'amp-ad' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad/)
 |    </amp-fx-flying-carpet>
 |    <!-- Invalid: amp-ad in an amp ad container with data-multi-size attr -->
 |    <amp-fx-flying-carpet height="300">
 |      <amp-embed data-multi-size="" height="300" type="foo"></amp-ad>
 >>     ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:69:4 The tag 'amp-embed' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad/)
+amp-ad/0.1/test/validator-amp-ad.html:75:4 The tag 'amp-embed' may not appear as a descendant of tag 'amp-fx-flying-carpet'. (see https://amp.dev/documentation/components/amp-ad/)
 |    </amp-fx-flying-carpet>
 |    <!-- Invalid: amp-ad missing layout=fluid for fluid ad -->
 |    <amp-ad type=doubleclick width="100" height="fluid"></amp-ad>
 >>   ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:72:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'fluid'. (see https://amp.dev/documentation/components/amp-ad/)
+amp-ad/0.1/test/validator-amp-ad.html:78:2 The attribute 'height' in tag 'amp-ad' is set to the invalid value 'fluid'. (see https://amp.dev/documentation/components/amp-ad/)
 |    <!-- Invalid: amp-ad type=custom missing data-url-->
 |    <amp-ad width=300 height=250
 >>   ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:74:2 The mandatory attribute 'data-url' is missing in tag 'amp-ad'. (see https://github.com/ampproject/amphtml/blob/main/ads/custom.md)
+amp-ad/0.1/test/validator-amp-ad.html:80:2 The mandatory attribute 'data-url' is missing in tag 'amp-ad'. (see https://github.com/ampproject/amphtml/blob/main/ads/custom.md)
 |        type="custom"
 |        template="template-1">
 |    </amp-ad>
 |    <!-- Invalid: amp-ad type=custom non-https data-url-->
 |    <amp-ad width=300 height=250
 >>   ^~~~~~~~~
-amp-ad/0.1/test/validator-amp-ad.html:79:2 Invalid URL protocol 'http:' for attribute 'data-url' in tag 'amp-ad'. (see https://github.com/ampproject/amphtml/blob/main/ads/custom.md)
+amp-ad/0.1/test/validator-amp-ad.html:85:2 Invalid URL protocol 'http:' for attribute 'data-url' in tag 'amp-ad'. (see https://github.com/ampproject/amphtml/blob/main/ads/custom.md)
 |        type="custom"
 |        data-url="http://foobar.com"
 |        template="template-1">
+|    </amp-ad>
+|    <!-- Invalid: amp-ad sticky attribute invalid -->
+|    <amp-ad sticky="center" width=300 height=250 type="a9" data-aax_size="300x250" data-aax_pubname="test123"
+>>   ^~~~~~~~~
+amp-ad/0.1/test/validator-amp-ad.html:91:2 The attribute 'sticky' in tag 'amp-ad' is set to the invalid value 'center'. (see https://amp.dev/documentation/components/amp-ad/)
+|      data-aax_src="302">
 |    </amp-ad>
 |  </body>
 |  </html>

--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -64,7 +64,12 @@ tags: {  # <amp-ad>
   }
   attrs: { name: "template" }
   attrs: { name: "type" mandatory: true }
-  attrs: { name: "sticky" value: "" }
+  attrs: {
+    name: "sticky"
+    value: ""
+    value: "top"
+    value: "bottom"
+  }
   attrs: { name: "always-serve-npa" }
   attrs: { name: "block-rtc" }
   attr_lists: "extended-amp-global"


### PR DESCRIPTION
Closes https://github.com/ampproject/amphtml/issues/31513

This change allows the top/bottom sticky ads to pass AMP validator.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
