### PR TITLE
♻️ Import Preact namespace via alias to prepare for eslint sorting/grouping (see desc)

### DIFF
--- a/build-system/eslint-rules/preact.js
+++ b/build-system/eslint-rules/preact.js
@@ -20,7 +20,7 @@ const path = require('path');
 // Enforces importing a Preact namespace specifier if using JSX
 //
 // Good
-// import * as Preact from 'path/to/preact';
+// import * as Preact from '#preact-ns';
 // <div />
 //
 // Bad
@@ -39,10 +39,7 @@ module.exports = {
      * @param {*} node
      */
     function requirePreact(node) {
-      if (imported) {
-        return;
-      }
-      if (warned) {
+      if (imported || warned) {
         return;
       }
       warned = true;
@@ -51,27 +48,19 @@ module.exports = {
         node,
         message: [
           'Using JSX requires importing the Preact namespace',
-          "Eg, `import * as Preact from 'src/preact'`",
+          "Eg, `import * as Preact from '#preact-ns'`",
         ].join('\n\t'),
 
         fix(fixer) {
-          const fileName = context.getFilename();
-          const absolutePath = path
-            .relative(path.dirname(fileName), './src/preact')
-            .replace(/\.js$/, '');
-
           const ancestors = context.getAncestors();
           const program = ancestors[0];
-          let firstImport = program.body.find(
-            (node) => node.type === 'ImportDeclaration'
-          );
-          if (!firstImport) {
-            firstImport = ancestors[1];
-          }
+          const firstImport =
+            program.body.find((node) => node.type === 'ImportDeclaration') ||
+            ancestors[1];
 
           return fixer.insertTextBefore(
             firstImport,
-            `import * as Preact from '${absolutePath}';\n`
+            `import * as Preact from '#preact-ns';\n`
           );
         },
       });

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {ContainWrapper} from '#preact/component';
 import {
   useCallback,

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {__component_name_pascalcase__} from '../component'
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
+++ b/builtins/storybook/amp-layout-with-aspect-ratio-css.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {number, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/builtins/storybook/amp-layout.amp.js
+++ b/builtins/storybook/amp-layout.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {number, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-accordion/1.0/base-element.js
+++ b/extensions/amp-accordion/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-accordion/1.0/component.js
+++ b/extensions/amp-accordion/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {WithAmpContext} from '#preact/context';
 import {animateCollapse, animateExpand} from './animations';
 import {forwardRef} from '#preact/compat';

--- a/extensions/amp-accordion/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-accordion/1.0/storybook/Basic.js
+++ b/extensions/amp-accordion/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-accordion/1.0/storybook/Bind.amp.js
+++ b/extensions/amp-accordion/1.0/storybook/Bind.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-accordion/1.0/test/test-component.js
+++ b/extensions/amp-accordion/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-animation/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-animation/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {AnimationTemplate} from './template';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-animation/0.1/storybook/Random.amp.js
+++ b/extensions/amp-animation/0.1/storybook/Random.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {AnimationTemplate} from './template';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';

--- a/extensions/amp-animation/0.1/storybook/template.js
+++ b/extensions/amp-animation/0.1/storybook/template.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {button, number, select, text} from '@storybook/addon-knobs';
 
 const FILL_OPTIONS = {

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
 

--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Alignment,
   Axis,

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Alignment,
   Axis,

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, number, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-base-carousel/1.0/storybook/Basic.js
+++ b/extensions/amp-base-carousel/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {BaseCarousel} from '../component';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-base-carousel/1.0/test/test-component.js
+++ b/extensions/amp-base-carousel/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {BaseCarousel} from '../component';
 import {mount} from 'enzyme';
 import {useStyles} from '../component.jss';

--- a/extensions/amp-date-countdown/1.0/component.js
+++ b/extensions/amp-date-countdown/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Wrapper, useRenderer} from '#preact/component';
 import {dict} from '#core/types/object';
 import {getDate} from '#core/types/date';

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, date, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-date-countdown/1.0/storybook/Basic.js
+++ b/extensions/amp-date-countdown/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {DateCountdown} from '../component';
 import {boolean, date, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-date-countdown/1.0/test/test-component.js
+++ b/extensions/amp-date-countdown/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {DateCountdown} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-date-display/1.0/component.js
+++ b/extensions/amp-date-display/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Wrapper, useRenderer} from '#preact/component';
 import {getDate} from '#core/types/date';
 import {useMemo} from '#preact';

--- a/extensions/amp-date-display/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-date-display/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {date, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-date-display/1.0/storybook/Basic.js
+++ b/extensions/amp-date-display/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {DateDisplay} from '../component';
 import {date, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-date-display/1.0/test/test-component.js
+++ b/extensions/amp-date-display/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {DateDisplay} from '../component';
 import {mount} from 'enzyme';
 import {user} from '../../../../src/log';

--- a/extensions/amp-facebook-comments/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook-comments/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, text, withKnobs} from '@storybook/addon-knobs';
 import {withA11y} from '@storybook/addon-a11y';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-facebook-like/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook-like/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-facebook-page/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook-page/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, optionsKnob, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-facebook/1.0/component.js
+++ b/extensions/amp-facebook/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {MessageType, ProxyIframeEmbed} from '#preact/component/3p-frame';
 import {dashToUnderline} from '#core/types/string';
 import {deserializeMessage} from '../../../src/3p-frame-messaging';

--- a/extensions/amp-facebook/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-facebook/1.0/storybook/Basic.js
+++ b/extensions/amp-facebook/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Facebook} from '../component';
 import {
   boolean,

--- a/extensions/amp-facebook/1.0/test/test-component.js
+++ b/extensions/amp-facebook/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Facebook} from '../component';
 import {WithAmpContext} from '#preact/context';
 import {createRef} from '#preact';

--- a/extensions/amp-fit-text/1.0/component.js
+++ b/extensions/amp-fit-text/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {ContainWrapper} from '#preact/component';
 import {LINE_HEIGHT_EM_, useStyles} from './component.jss';
 import {px, resetStyles, setStyle, setStyles} from '#core/dom/style';

--- a/extensions/amp-fit-text/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-fit-text/1.0/storybook/Basic.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {FitText} from '../component';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-fit-text/1.0/test/test-component.js
+++ b/extensions/amp-fit-text/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {FitText, calculateFontSize, setOverflowStyle} from '../component';
 import {computedStyle} from '#core/dom/style';
 import {mount} from 'enzyme';

--- a/extensions/amp-iframe/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-iframe/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-image-slider/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-image-slider/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-inline-gallery/1.0/base-element.js
+++ b/extensions/amp-inline-gallery/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
 import {InlineGallery} from './component';
 import {PreactBaseElement} from '#preact/base-element';

--- a/extensions/amp-inline-gallery/1.0/component.js
+++ b/extensions/amp-inline-gallery/1.0/component.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {CarouselContext} from '../../amp-base-carousel/1.0/carousel-context';
 import {ContainWrapper} from '#preact/component';
 import {useMemo, useState} from '#preact';

--- a/extensions/amp-inline-gallery/1.0/pagination.js
+++ b/extensions/amp-inline-gallery/1.0/pagination.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {CarouselContext} from '../../amp-base-carousel/1.0/carousel-context';
 import {Wrapper} from '#preact/component';
 import {useContext} from '#preact';

--- a/extensions/amp-inline-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-inline-gallery/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-inline-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-inline-gallery/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {BaseCarousel} from '../../../amp-base-carousel/1.0/component';
 import {InlineGallery} from '../component';
 import {Pagination} from '../pagination';

--- a/extensions/amp-inline-gallery/1.0/test/test-component.js
+++ b/extensions/amp-inline-gallery/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {BaseCarousel} from '../../../amp-base-carousel/1.0/component';
 import {InlineGallery} from '../component';
 import {Pagination} from '../pagination';

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {BaseCarousel} from '../../amp-base-carousel/1.0/component';
 import {CarouselContext} from '../../amp-base-carousel/1.0/carousel-context';
 import {px} from '#core/dom/style';

--- a/extensions/amp-instagram/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-instagram/1.0/component.js
+++ b/extensions/amp-instagram/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {IframeEmbed} from '#preact/component/iframe';
 import {dict} from '#core/types/object';
 import {forwardRef} from '#preact/compat';

--- a/extensions/amp-instagram/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-instagram/1.0/storybook/Basic.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-instagram/1.0/test/test-component.js
+++ b/extensions/amp-instagram/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Instagram} from '../component';
 import {WithAmpContext} from '#preact/context';
 import {createRef} from '#preact';

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {LightboxGalleryContext} from './context';
 import {sequentialIdGenerator} from '#core/math/id-generator';
 import {useContext, useLayoutEffect, useMemo, useState} from '#preact';

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Lightbox} from './../../amp-lightbox/1.0/component';
 import {LightboxGalleryContext} from './context';
 import {useCallback, useRef} from '#preact';

--- a/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {BaseCarousel} from '../../../amp-base-carousel/1.0/component';
 import {LightboxGalleryProvider, WithLightbox} from '../component';
 import {withKnobs} from '@storybook/addon-knobs';

--- a/extensions/amp-lightbox-gallery/1.0/test/test-component.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {LightboxGalleryProvider, WithLightbox} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {ContainWrapper, useValueRef} from '#preact/component';
 import {Keys} from '#core/constants/key-codes';
 import {forwardRef} from '#preact/compat';

--- a/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-lightbox/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Lightbox} from '../component';
 import {boolean, select, text, withKnobs} from '@storybook/addon-knobs';
 import {useRef} from '#preact';

--- a/extensions/amp-lightbox/1.0/test/test-component.js
+++ b/extensions/amp-lightbox/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Lightbox} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-render/1.0/component.js
+++ b/extensions/amp-render/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Wrapper, useRenderer} from '#preact/component';
 import {forwardRef} from '#preact/compat';
 import {useCallback, useEffect, useImperativeHandle, useState} from '#preact';

--- a/extensions/amp-render/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-render/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-render/1.0/storybook/Basic.js
+++ b/extensions/amp-render/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Render} from '../component';
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-render/1.0/test/test-component.js
+++ b/extensions/amp-render/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Render} from '../component';
 import {macroTask} from '../../../../testing/yield';
 import {mount} from 'enzyme';

--- a/extensions/amp-selector/1.0/base-element.js
+++ b/extensions/amp-selector/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Option, Selector} from './component';
 import {PreactBaseElement} from '#preact/base-element';
 import {closestAncestorElementBySelector} from '#core/dom/query';

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Keys} from '#core/constants/key-codes';
 import {forwardRef} from '#preact/compat';
 import {mod} from '#core/math';

--- a/extensions/amp-selector/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-selector/1.0/storybook/Basic.js
+++ b/extensions/amp-selector/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Option, Selector} from '../component';
 import {select, withKnobs} from '@storybook/addon-knobs';
 import {useState} from '#preact';

--- a/extensions/amp-selector/1.0/test/test-component.js
+++ b/extensions/amp-selector/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Keys} from '#core/constants/key-codes';
 import {Option, Selector} from '../component';
 import {mount} from 'enzyme';

--- a/extensions/amp-sidebar/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/0.1/storybook/Basic.amp.js
@@ -16,7 +16,7 @@
 
 // To do: how to add CSS
 //import '!style-loader!css-loader!./Basic-styles.css';
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {CSS as COMPONENT_CSS} from './component.jss';
 import {PreactBaseElement} from '#preact/base-element';
 import {Sidebar} from './component';

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {ContainWrapper, useValueRef} from '#preact/component';
 import {Keys} from '#core/constants/key-codes';
 import {Side} from './sidebar-config';

--- a/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   boolean,
   color,

--- a/extensions/amp-sidebar/1.0/storybook/Basic.js
+++ b/extensions/amp-sidebar/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Sidebar, SidebarToolbar} from '../component';
 import {boolean, color, select, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-sidebar/1.0/test/test-component.js
+++ b/extensions/amp-sidebar/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Sidebar, SidebarToolbar} from '../component';
 import {htmlFor} from '#core/dom/static-template';
 import {mount} from 'enzyme';

--- a/extensions/amp-social-share/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-social-share/1.0/component.js
+++ b/extensions/amp-social-share/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Keys} from '#core/constants/key-codes';
 import {SocialShareIcon} from './social-share-svgs';
 import {Wrapper} from '#preact/component';

--- a/extensions/amp-social-share/1.0/social-share-svgs.js
+++ b/extensions/amp-social-share/1.0/social-share-svgs.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 
 /**
  * @param {!JsonObject} props

--- a/extensions/amp-social-share/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {select, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-social-share/1.0/storybook/Basic.js
+++ b/extensions/amp-social-share/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {SocialShare} from '../component';
 import {color, object, select, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-social-share/1.0/test/test-component.js
+++ b/extensions/amp-social-share/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {SocialShare} from '../component';
 import {dict} from '#core/types/object';
 import {mount} from 'enzyme';

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {BaseCarousel} from '../../amp-base-carousel/1.0/component';
 import {forwardRef} from '#preact/compat';
 import {setStyle} from '#core/dom/style';

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-stream-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-stream-gallery/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {StreamGallery} from '../component';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-stream-gallery/1.0/test/test-component.js
+++ b/extensions/amp-stream-gallery/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {StreamGallery} from '../component';
 import {mount} from 'enzyme';
 

--- a/extensions/amp-timeago/1.0/component.js
+++ b/extensions/amp-timeago/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Wrapper} from '#preact/component';
 import {format, getLocale} from './locales';
 import {getDate} from '#core/types/date';

--- a/extensions/amp-timeago/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-timeago/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {date, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-timeago/1.0/storybook/Basic.js
+++ b/extensions/amp-timeago/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Timeago} from '../component';
 import {date, number, select, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-timeago/1.0/test/test-component.js
+++ b/extensions/amp-timeago/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Timeago} from '../component';
 import {mount} from 'enzyme';
 import {waitFor} from '../../../../testing/test-helper';

--- a/extensions/amp-twitter/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-twitter/1.0/component.js
+++ b/extensions/amp-twitter/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {MessageType, ProxyIframeEmbed} from '#preact/component/3p-frame';
 import {deserializeMessage} from '../../../src/3p-frame-messaging';
 import {forwardRef} from '#preact/compat';

--- a/extensions/amp-twitter/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-twitter/1.0/storybook/Basic.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Twitter} from '../component';
 import {boolean, number, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-twitter/1.0/test/test-component.js
+++ b/extensions/amp-twitter/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Twitter} from '../component';
 import {WithAmpContext} from '#preact/context';
 import {createRef} from '#preact';

--- a/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-video/1.0/component.js
+++ b/extensions/amp-video/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {ContainWrapper, useValueRef} from '#preact/component';
 import {Deferred} from '#core/data-structures/promise';
 import {Loading} from '#core/loading-instructions';

--- a/extensions/amp-video/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {VideoElementWithActions} from './_helpers';
 import {boolean, number, object, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-video/1.0/storybook/Basic.js
+++ b/extensions/amp-video/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-video/1.0/storybook/VideoIframe.js
+++ b/extensions/amp-video/1.0/storybook/VideoIframe.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-video/1.0/storybook/_helpers.js
+++ b/extensions/amp-video/1.0/storybook/_helpers.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 
 export const VideoElementWithActions = ({
   id,

--- a/extensions/amp-video/1.0/test/test-video-iframe.js
+++ b/extensions/amp-video/1.0/test/test-video-iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {VideoIframeInternal} from '../video-iframe';
 import {createRef} from '#preact';
 import {mount} from 'enzyme';

--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {VideoWrapper} from '../component';
 import {WithAmpContext} from '#preact/context';
 import {createRef} from '#preact';

--- a/extensions/amp-video/1.0/video-iframe.js
+++ b/extensions/amp-video/1.0/video-iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Deferred} from '#core/data-structures/promise';
 import {VideoWrapper} from './component';
 import {forwardRef} from '#preact/compat';

--- a/extensions/amp-vimeo/1.0/component.js
+++ b/extensions/amp-vimeo/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   VIMEO_EVENTS,
   getVimeoIframeSrc,

--- a/extensions/amp-vimeo/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-vimeo/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {VideoElementWithActions} from '../../../amp-video/1.0/storybook/_helpers';
 import {boolean, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-vimeo/1.0/storybook/Basic.js
+++ b/extensions/amp-vimeo/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Vimeo} from '../component';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/extensions/amp-youtube/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/0.1/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';
 

--- a/extensions/amp-youtube/1.0/component.js
+++ b/extensions/amp-youtube/1.0/component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {VideoEvents} from '../../../src/video-interface';
 import {VideoIframe} from '../../amp-video/1.0/video-iframe';
 import {addParamsToUrl} from '../../../src/url';

--- a/extensions/amp-youtube/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.amp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {VideoElementWithActions} from '../../../amp-video/1.0/storybook/_helpers';
 import {boolean, number, text, withKnobs} from '@storybook/addon-knobs';
 import {withAmp} from '@ampproject/storybook-addon';

--- a/extensions/amp-youtube/1.0/storybook/Basic.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {
   Accordion,
   AccordionContent,

--- a/extensions/amp-youtube/1.0/test/test-component.js
+++ b/extensions/amp-youtube/1.0/test/test-component.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {Youtube} from '../component';
 import {createRef} from '#preact';
 import {dispatchCustomEvent} from '#core/dom';

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -12,6 +12,7 @@
       "#inabox/*": ["./src/inabox/*"],
       "#polyfills/*": ["./src/polyfills/*"],
       "#preact/*": ["./src/preact/*"],
+      "#preact-ns": ["./src/preact/index.js"],
       "#purifier/*": ["./src/purifier/*"],
       "#service/*": ["./src/service/*"]
     }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from './index';
+import * as Preact from '#preact-ns';
 import {ActionTrust} from '#core/constants/action-constants';
 import {AmpEvents} from '#core/constants/amp-events';
 import {CanPlay, CanRender, LoadingProp} from '../context/contextprops';

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {IframeEmbed} from './iframe';
 import {dict} from '#core/types/object';
 import {forwardRef} from '#preact/compat';

--- a/src/preact/component/contain.js
+++ b/src/preact/component/contain.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {forwardRef} from '#preact/compat';
 
 const CONTAIN = [

--- a/src/preact/component/iframe.js
+++ b/src/preact/component/iframe.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {ContainWrapper, useValueRef} from '#preact/component';
 import {Loading} from '#core/loading-instructions';
 import {ReadyState} from '#core/constants/ready-state';

--- a/src/preact/component/wrapper.js
+++ b/src/preact/component/wrapper.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {forwardRef} from '#preact/compat';
 
 /**

--- a/src/preact/context.js
+++ b/src/preact/context.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from './index';
+import * as Preact from '#preact-ns';
 import {Loading, reducer as loadingReducer} from '#core/loading-instructions';
 import {createContext, useContext, useMemo} from './index';
 

--- a/src/preact/slot.js
+++ b/src/preact/slot.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from './index';
+import * as Preact from '#preact-ns';
 import {CanPlay, CanRender, LoadingProp} from '../context/contextprops';
 import {Loading} from '#core/loading-instructions';
 import {devAssert} from '#core/assert';

--- a/src/preact/storybook/Context.js
+++ b/src/preact/storybook/Context.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {WithAmpContext, useAmpContext, useLoading} from '#preact/context';
 import {boolean, select, withKnobs} from '@storybook/addon-knobs';
 

--- a/src/preact/storybook/Wrappers.js
+++ b/src/preact/storybook/Wrappers.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact';
+import * as Preact from '#preact-ns';
 import {ContainWrapper, Wrapper} from '#preact/component';
 import {boolean, object, text, withKnobs} from '@storybook/addon-knobs';
 

--- a/test/unit/preact/component/test-renderer.js
+++ b/test/unit/preact/component/test-renderer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact/index';
+import * as Preact from '#preact-ns';
 import {mount} from 'enzyme';
 import {useRenderer} from '#preact/component';
 

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact/index';
+import * as Preact from '#preact-ns';
 import {PreactBaseElement} from '#preact/base-element';
 import {Slot} from '#preact/slot';
 import {createElementWithAttributes} from '#core/dom';

--- a/test/unit/preact/test-base-element-runtime.js
+++ b/test/unit/preact/test-base-element-runtime.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact/index';
+import * as Preact from '#preact-ns';
 import {CanRender} from '../../../src/context/contextprops';
 import {PreactBaseElement, whenUpgraded} from '#preact/base-element';
 import {Slot} from '#preact/slot';

--- a/test/unit/preact/test-context.js
+++ b/test/unit/preact/test-context.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact/index';
+import * as Preact from '#preact-ns';
 import {WithAmpContext, useAmpContext, useLoading} from '#preact/context';
 import {mount} from 'enzyme';
 

--- a/test/unit/preact/test-slot.js
+++ b/test/unit/preact/test-slot.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as Preact from '#preact/index';
+import * as Preact from '#preact-ns';
 import * as fakeTimers from '@sinonjs/fake-timers';
 import {
   CanPlay,


### PR DESCRIPTION
Only 1st commit diff is important: bc7e119
Rest are import updates

Creates alias `'#preact-ns'` to be used only by 1st-line `import * as Preact from '#preact-ns';`. Using a "special" alias for importing the namespace allows built-in eslint rules to treat it differently (including auto-sort/group at the top of the file).

Part of #34529 
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
