### PR TITLE
✨ `amp-story-desktop-one-panel` Check UI type to get page dimension on tap

### DIFF
--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -752,8 +752,10 @@ export class ManualAdvancement extends AdvancementConfig {
    * @private
    */
   getStoryPageRect_() {
+    const uiState = this.storeService_.get(StateProperty.UI_STATE);
     if (
-      this.storeService_.get(StateProperty.UI_STATE) !== UIType.DESKTOP_PANELS
+      uiState !== UIType.DESKTOP_PANELS &&
+      uiState !== UIType.DESKTOP_ONE_PANEL
     ) {
       return this.element_.getLayoutBox();
     } else {
@@ -1166,9 +1168,9 @@ export class MediaBasedAdvancement extends AdvancementConfig {
       // are eligible for media based auto advance.
       let element = pageEl.querySelector(
         `amp-video[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
-          amp-video#${escapeCssSelectorIdent(autoAdvanceStr)},
-          amp-audio[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
-          amp-audio#${escapeCssSelectorIdent(autoAdvanceStr)}`
+           amp-video#${escapeCssSelectorIdent(autoAdvanceStr)},
+           amp-audio[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
+           amp-audio#${escapeCssSelectorIdent(autoAdvanceStr)}`
       );
       if (
         matches(

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -1168,9 +1168,9 @@ export class MediaBasedAdvancement extends AdvancementConfig {
       // are eligible for media based auto advance.
       let element = pageEl.querySelector(
         `amp-video[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
-           amp-video#${escapeCssSelectorIdent(autoAdvanceStr)},
-           amp-audio[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
-           amp-audio#${escapeCssSelectorIdent(autoAdvanceStr)}`
+          amp-video#${escapeCssSelectorIdent(autoAdvanceStr)},
+          amp-audio[data-id=${escapeCssSelectorIdent(autoAdvanceStr)}],
+          amp-audio#${escapeCssSelectorIdent(autoAdvanceStr)}`
       );
       if (
         matches(


### PR DESCRIPTION
Context / Fixes #34815

Get page dimension when in `DESKTOP_ONE_PANEL` instead of story dimensions to decide left or right navigation intention.

[Demo](https://philipbell-stamp-ui.web.app/examples/amp-story/amp-story-desktop-one-panel.html)