### PR TITLE
Add validation rules and tests for all `amp-facebook` components

### DIFF
--- a/extensions/amp-facebook-comments/1.0/test/validator-amp-facebook-comments.html
+++ b/extensions/amp-facebook-comments/1.0/test/validator-amp-facebook-comments.html
@@ -1,0 +1,39 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests support for the amp-facebook-comments tag.
+-->
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-facebook-comments" src="https://cdn.ampproject.org/v0/amp-facebook-comments-1.0.js"></script>
+</head>
+<body>
+  <!-- Example of a valid amp-facebook-comments -->
+  <amp-facebook-comments
+      width=486
+      height=657
+      layout="responsive"
+      data-href="http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html">
+  </amp-facebook>
+</body>
+</html>

--- a/extensions/amp-facebook-comments/1.0/test/validator-amp-facebook-comments.out
+++ b/extensions/amp-facebook-comments/1.0/test/validator-amp-facebook-comments.out
@@ -1,0 +1,40 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-facebook-comments tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡ lang="en">
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-facebook-comments" src="https://cdn.ampproject.org/v0/amp-facebook-comments-1.0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-facebook-comments -->
+|    <amp-facebook-comments
+|        width=486
+|        height=657
+|        layout="responsive"
+|        data-href="http://www.directlyrics.com/adele-25-complete-album-lyrics-news.html">
+|    </amp-facebook>
+|  </body>
+|  </html>

--- a/extensions/amp-facebook-comments/validator-amp-facebook-comments.protoascii
+++ b/extensions/amp-facebook-comments/validator-amp-facebook-comments.protoascii
@@ -20,6 +20,7 @@ tags: {  # amp-facebook-comments
   extension_spec: {
     name: "amp-facebook-comments"
     version: "0.1"
+    version: "1.0"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"

--- a/extensions/amp-facebook-page/1.0/test/validator-amp-facebook-page.html
+++ b/extensions/amp-facebook-page/1.0/test/validator-amp-facebook-page.html
@@ -1,0 +1,43 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests support for the amp-facebook-page tag.
+-->
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-facebook-page" src="https://cdn.ampproject.org/v0/amp-facebook-page-1.0.js"></script>
+</head>
+<body>
+  <amp-facebook-page width=552 height=310
+      layout="responsive"
+      data-tabs="timeline"
+      data-href="https://www.facebook.com/barackobama/">
+  </amp-facebook-page>
+  <amp-facebook-page width="300" height="300"
+      layout="fixed"
+      data-adapt-container-width="true"
+      data-show-facepile="true"
+      data-href="https://www.facebook.com/itsdougthepug">
+  </amp-facebook-page>
+</body>
+</html>

--- a/extensions/amp-facebook-page/1.0/test/validator-amp-facebook-page.out
+++ b/extensions/amp-facebook-page/1.0/test/validator-amp-facebook-page.out
@@ -1,0 +1,44 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-facebook-page tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡ lang="en">
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-facebook-page" src="https://cdn.ampproject.org/v0/amp-facebook-page-1.0.js"></script>
+|  </head>
+|  <body>
+|    <amp-facebook-page width=552 height=310
+|        layout="responsive"
+|        data-tabs="timeline"
+|        data-href="https://www.facebook.com/barackobama/">
+|    </amp-facebook-page>
+|    <amp-facebook-page width="300" height="300"
+|        layout="fixed"
+|        data-adapt-container-width="true"
+|        data-show-facepile="true"
+|        data-href="https://www.facebook.com/itsdougthepug">
+|    </amp-facebook-page>
+|  </body>
+|  </html>

--- a/extensions/amp-facebook-page/validator-amp-facebook-page.protoascii
+++ b/extensions/amp-facebook-page/validator-amp-facebook-page.protoascii
@@ -20,6 +20,7 @@ tags: {  # amp-facebook-page
   extension_spec: {
     name: "amp-facebook-page"
     version: "0.1"
+    version: "1.0"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"

--- a/extensions/amp-facebook/1.0/test/validator-amp-facebook.html
+++ b/extensions/amp-facebook/1.0/test/validator-amp-facebook.html
@@ -1,0 +1,72 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests support for the amp-facebook tag.
+-->
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-1.0.js"></script>
+</head>
+<body>
+  <!-- Example of a valid amp-facebook (embedded post) -->
+  <amp-facebook
+      width=486
+      height=657
+      layout="responsive"
+      data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+  </amp-facebook>
+  <!-- Example of a valid amp-facebook (embedded post) with data-locale specified -->
+  <amp-facebook
+      width=486
+      height=657
+      layout="responsive"
+      data-href="https://www.facebook.com/zuck/posts/10102593740125791"
+      data-locale="fr_FR">
+  </amp-facebook>
+  <!-- Example of a valid amp-facebook (embedded video) -->
+  <amp-facebook
+      width=552
+      height=574
+      layout="responsive"
+      data-embed-as="video"
+      data-allowfullscreen="true"
+      data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+  </amp-facebook>
+  <!-- Example of a valid amp-facebook (embedded video) -->
+  <amp-facebook
+      width=552
+      height=574
+      layout="responsive"
+      data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+  </amp-facebook>
+  <!-- Example of a valid amp-facebook (embedded comment) -->
+  <amp-facebook
+      width=552
+      height=200
+      layout="responsive"
+      data-embed-as="comment"
+      data-include-parent="true"
+      data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=717538375088203">
+  </amp-facebook>
+</body>
+</html>

--- a/extensions/amp-facebook/1.0/test/validator-amp-facebook.out
+++ b/extensions/amp-facebook/1.0/test/validator-amp-facebook.out
@@ -1,0 +1,73 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests support for the amp-facebook tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡ lang="en">
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-facebook" src="https://cdn.ampproject.org/v0/amp-facebook-1.0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-facebook (embedded post) -->
+|    <amp-facebook
+|        width=486
+|        height=657
+|        layout="responsive"
+|        data-href="https://www.facebook.com/zuck/posts/10102593740125791">
+|    </amp-facebook>
+|    <!-- Example of a valid amp-facebook (embedded post) with data-locale specified -->
+|    <amp-facebook
+|        width=486
+|        height=657
+|        layout="responsive"
+|        data-href="https://www.facebook.com/zuck/posts/10102593740125791"
+|        data-locale="fr_FR">
+|    </amp-facebook>
+|    <!-- Example of a valid amp-facebook (embedded video) -->
+|    <amp-facebook
+|        width=552
+|        height=574
+|        layout="responsive"
+|        data-embed-as="video"
+|        data-allowfullscreen="true"
+|        data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+|    </amp-facebook>
+|    <!-- Example of a valid amp-facebook (embedded video) -->
+|    <amp-facebook
+|        width=552
+|        height=574
+|        layout="responsive"
+|        data-href="https://www.facebook.com/zuck/videos/10102509264909801/">
+|    </amp-facebook>
+|    <!-- Example of a valid amp-facebook (embedded comment) -->
+|    <amp-facebook
+|        width=552
+|        height=200
+|        layout="responsive"
+|        data-embed-as="comment"
+|        data-include-parent="true"
+|        data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=717538375088203">
+|    </amp-facebook>
+|  </body>
+|  </html>

--- a/extensions/amp-facebook/validator-amp-facebook.protoascii
+++ b/extensions/amp-facebook/validator-amp-facebook.protoascii
@@ -14,9 +14,23 @@
 # limitations under the license.
 #
 
-tags: {  # amp-facebook
+tags: {  # amp-facebook 1.0
   html_format: AMP
   tag_name: "SCRIPT"
+  satisfies: "amp-facebook 1.0"
+  excludes: "amp-facebook 0.1"
+  extension_spec: {
+    name: "amp-facebook"
+    version_name: "v1.0"
+    version: "1.0"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-facebook 0.1 and latest
+  html_format: AMP
+  tag_name: "SCRIPT"
+  satisfies: "amp-social-share 0.1"
+  excludes: "amp-social-share 1.0"
   extension_spec: {
     name: "amp-facebook"
     version: "0.1"


### PR DESCRIPTION
- Includes `amp-facebook`, `amp-facebook-comments`, and `amp-facebook-page`
- Excludes `amp-facebook-like`, which already has these files