### PR TITLE
🏗  🐛  ❄️  always check forbidden terms

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -146,9 +146,8 @@ function getFilesToCheck(globs, options = {}, ignoreFile = undefined) {
       return [];
     }
     // forbidden-terms always needs to be checked.
-    if (!filesChanged.includes('build-system/test-configs/forbidden-terms.js')) {
-      filesChanged.push('build-system/test-configs/forbidden-terms.js');
-    }
+    const forbiddenTerms = 'build-system/test-configs/forbidden-terms.js';
+    filesChanged.includes(forbiddenTerms) && filesChanged.push(forbiddenTerms);
     return logFiles(filesChanged);
   }
   return ignored.filter(globby.sync(globs, options));

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -147,11 +147,9 @@ function getFilesToCheck(globs, options = {}, ignoreFile = undefined) {
       log(green('INFO: ') + 'No files to check in this PR');
       return [];
     }
-    /** forbidden-terms always needs to be checked. */
-    if (
-      !filesChanged.includes('build-system/test-configs/forbidden-terms.js')
-    ) {
-      filesChanged.push('build-system/test-configs/forbidden-terms.js');
+    const forbiddenTerms = 'build-system/test-configs/forbidden-terms.js';
+    if (!filesChanged.includes(forbiddenTerms)) {
+      filesChanged.push(forbiddenTerms);
     }
     return logFiles(filesChanged);
   }

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -145,6 +145,10 @@ function getFilesToCheck(globs, options = {}, ignoreFile = undefined) {
       log(green('INFO: ') + 'No files to check in this PR');
       return [];
     }
+    // forbidden-terms always needs to be checked.
+    if (!filesChanged.includes('build-system/test-configs/forbidden-terms.js')) {
+      filesChanged.push('build-system/test-configs/forbidden-terms.js');
+    }
     return logFiles(filesChanged);
   }
   return ignored.filter(globby.sync(globs, options));

--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -124,6 +124,8 @@ function getFilesFromArgv() {
  * Gets a list of files to be checked based on command line args and the given
  * file matching globs. Used by tasks like prettify, lint, check-links, etc.
  * Optionally takes in options for globbing and a file containing ignore rules.
+ * When local changes are linted (e.g. during CI), we also check if the list of
+ * forbidden terms needs to be updated.
  *
  * @param {!Array<string>} globs
  * @param {Object=} options
@@ -145,9 +147,12 @@ function getFilesToCheck(globs, options = {}, ignoreFile = undefined) {
       log(green('INFO: ') + 'No files to check in this PR');
       return [];
     }
-    // forbidden-terms always needs to be checked.
-    const forbiddenTerms = 'build-system/test-configs/forbidden-terms.js';
-    filesChanged.includes(forbiddenTerms) && filesChanged.push(forbiddenTerms);
+    /** forbidden-terms always needs to be checked. */
+    if (
+      !filesChanged.includes('build-system/test-configs/forbidden-terms.js')
+    ) {
+      filesChanged.push('build-system/test-configs/forbidden-terms.js');
+    }
     return logFiles(filesChanged);
   }
   return ignored.filter(globby.sync(globs, options));

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -238,6 +238,7 @@ const targetMatchers = {
     return (
       file.startsWith('build-system/eslint-rules') ||
       file.endsWith('.eslintrc.js') ||
+      file.endsWith('.prettierrc') ||
       file == 'build-system/test-configs/forbidden-terms.js' ||
       file == 'package.json'
     );

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -232,7 +232,15 @@ const targetMatchers = {
     );
   },
   [Targets.LINT_RULES]: (file) => {
-    return file.endsWith('.eslintrc.js') || file == 'package.json';
+    if (isOwnersFile(file)) {
+      return false;
+    }
+    return (
+      file.startsWith('build-system/eslint-rules') ||
+      file.endsWith('.eslintrc.js') ||
+      file == 'build-system/test-configs/forbidden-terms.js' ||
+      file == 'package.json'
+    );
   },
   [Targets.OWNERS]: (file) => {
     return isOwnersFile(file) || file == 'build-system/tasks/check-owners.js';

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -238,7 +238,9 @@ const targetMatchers = {
     return (
       file.startsWith('build-system/eslint-rules') ||
       file.endsWith('.eslintrc.js') ||
-      file.endsWith('.prettierrc') ||
+      file == '.eslintignore' ||
+      file == '.prettierrc' ||
+      file == '.prettierignore' ||
       file == 'build-system/test-configs/forbidden-terms.js' ||
       file == 'package.json'
     );


### PR DESCRIPTION
#34887 demonstrated that the `forbidden-terms` file always needs to be checked by removing forbidden terms from files on the allowlist. Because the we run `amp lint --local_changes` in CI now the checks passed but then started failing on main.

Checks run from bad PR
https://app.circleci.com/pipelines/github/ampproject/amphtml/11572/workflows/fa5345cd-0ebe-4663-b8a1-f5905a1b63da/jobs/183106
![image](https://user-images.githubusercontent.com/78179109/122291645-e4e5ea80-cea9-11eb-8058-383add0d9d39.png)

Future checks run on main
https://app.circleci.com/pipelines/github/ampproject/amphtml/11572/workflows/fa5345cd-0ebe-4663-b8a1-f5905a1b63da/jobs/183106
![image](https://user-images.githubusercontent.com/78179109/122291917-3f7f4680-ceaa-11eb-97f4-afa81ebffdd7.png)

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
