### PR TITLE
✨ Bento: LightboxGallery grid view 

### DIFF
--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -96,6 +96,7 @@ function BaseCarouselWithRef(
     lightbox = false,
     loop,
     mixedLength = false,
+    onClick,
     onFocus,
     onMouseEnter,
     onSlideChange,
@@ -344,6 +345,7 @@ function BaseCarouselWithRef(
         lightbox={lightbox}
         loop={loop}
         mixedLength={mixedLength}
+        onClick={onClick}
         restingIndex={currentSlide}
         setRestingIndex={setRestingIndex}
         snap={snap}

--- a/extensions/amp-lightbox-gallery/1.0/component.jss.js
+++ b/extensions/amp-lightbox-gallery/1.0/component.jss.js
@@ -52,6 +52,37 @@ const lightbox = {
   },
 };
 
+const grid = {
+  ...gallery,
+  display: 'grid !important',
+  justifyContent: 'center !important',
+  gridGap: '5px !important',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  gridAutoRows: 'min-content !important',
+  padding: '0px 5px !important',
+  top: '56px !important',
+  height: 'calc(100% - 56px) !important',
+  width: 'calc(100% - 10px) !important',
+  '@media (min-width: 1024px)': {
+    gridTemplateColumns: 'repeat(4, calc(1024px/4 - 5px * 5 / 4))',
+    top: '80px !important' /* Matches height of top-bar */,
+    height: 'calc(100% - 80px) !important',
+  },
+};
+
+const thumbnail = {
+  position: 'relative !important',
+  paddingTop: '100% !important',
+  '& > img': {
+    width: '100% !important',
+    height: '100% !important',
+    position: 'absolute !important',
+    top: '0 !important',
+    objectFit: 'cover !important',
+    cursor: 'pointer !important',
+  },
+};
+
 const showControls = {};
 const hideControls = {};
 
@@ -126,9 +157,11 @@ const JSS = {
   hideControls,
   lightbox,
   gallery,
+  grid,
   nextArrow,
   prevArrow,
   showControls,
+  thumbnail,
   topControl,
 };
 

--- a/extensions/amp-lightbox-gallery/1.0/component.jss.js
+++ b/extensions/amp-lightbox-gallery/1.0/component.jss.js
@@ -53,7 +53,6 @@ const lightbox = {
 };
 
 const grid = {
-  ...gallery,
   display: 'grid !important',
   justifyContent: 'center !important',
   gridGap: '5px !important',

--- a/extensions/amp-lightbox-gallery/1.0/component.jss.js
+++ b/extensions/amp-lightbox-gallery/1.0/component.jss.js
@@ -16,14 +16,22 @@
 
 import {createUseStyles} from 'react-jss';
 
-const DEFAULT_LARGE_DIMENSION = 40;
-const DEFAULT_LARGE_PADDING = 20;
+const TOP_BAR_HEIGHT = 56;
+const DEFAULT_DIMENSION = 24;
+const DEFAULT_PADDING = 16;
+
+const TOP_BAR_HEIGHT_LARGE = 80;
+const DEFAULT_DIMENSION_LARGE = 40;
+const DEFAULT_PADDING_LARGE = 20;
+
+const DEFAULT_GRID_NUM = 4;
+const DEFAULT_GRID_PADDING = 5;
 
 const gallery = {
   position: 'absolute !important',
   left: '0 !important',
   right: '0 !important',
-  top: '0 !important' /* Matches height of top-bar */,
+  top: '0 !important',
   height: '100%',
   width: '100%',
   bottom: '0 !important',
@@ -32,12 +40,12 @@ const gallery = {
 
 const controlsPanel = {
   position: 'absolute !important',
-  height: '56px !important' /* Matches top of gallery */,
+  height: `${TOP_BAR_HEIGHT}px !important`,
   width: '100% !important',
   zIndex: '1',
   background: 'linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0))',
   '@media (min-width:1024px)': {
-    height: '80px !important' /* Matches top of gallery */,
+    height: `${TOP_BAR_HEIGHT_LARGE}px !important`,
   },
 };
 
@@ -55,17 +63,17 @@ const lightbox = {
 const grid = {
   display: 'grid !important',
   justifyContent: 'center !important',
-  gridGap: '5px !important',
+  gridGap: `${DEFAULT_GRID_PADDING}px !important`,
   gridTemplateColumns: 'repeat(3, 1fr)',
   gridAutoRows: 'min-content !important',
-  padding: '0px 5px !important',
-  top: '56px !important',
-  height: 'calc(100% - 56px) !important',
+  padding: `0px ${DEFAULT_GRID_PADDING}px !important`,
+  top: `${TOP_BAR_HEIGHT}px !important`,
+  height: `calc(100% - ${TOP_BAR_HEIGHT}px) !important`,
   width: 'calc(100% - 10px) !important',
   '@media (min-width: 1024px)': {
-    gridTemplateColumns: 'repeat(4, calc(1024px/4 - 5px * 5 / 4))',
-    top: '80px !important' /* Matches height of top-bar */,
-    height: 'calc(100% - 80px) !important',
+    gridTemplateColumns: `repeat(${DEFAULT_GRID_NUM}, calc(1024px/${DEFAULT_GRID_NUM} - ${DEFAULT_GRID_PADDING}px * ${DEFAULT_GRID_PADDING} / ${DEFAULT_GRID_NUM}))`,
+    top: `${TOP_BAR_HEIGHT_LARGE}px !important`,
+    height: `calc(100% - ${TOP_BAR_HEIGHT_LARGE}px) !important`,
   },
 };
 
@@ -95,13 +103,13 @@ const control = {
 };
 
 const topControl = {
-  width: 24,
-  height: 24,
-  padding: 16,
+  width: DEFAULT_DIMENSION,
+  height: DEFAULT_DIMENSION,
+  padding: DEFAULT_PADDING,
   '@media (min-width:1024px)': {
-    width: DEFAULT_LARGE_DIMENSION,
-    height: DEFAULT_LARGE_DIMENSION,
-    padding: DEFAULT_LARGE_PADDING,
+    width: DEFAULT_DIMENSION_LARGE,
+    height: DEFAULT_DIMENSION_LARGE,
+    padding: DEFAULT_PADDING_LARGE,
   },
 };
 
@@ -119,9 +127,9 @@ const arrow = {
   bottom: '0 !important',
   margin: 'auto !important',
   filter: 'drop-shadow(0 0 1px black) !important',
-  width: DEFAULT_LARGE_DIMENSION,
-  height: DEFAULT_LARGE_DIMENSION,
-  padding: DEFAULT_LARGE_PADDING,
+  width: DEFAULT_DIMENSION_LARGE,
+  height: DEFAULT_DIMENSION_LARGE,
+  padding: DEFAULT_PADDING_LARGE,
   '&$nextArrow': {
     right: '0 !important',
     /* Needed for screen reader mode to size correctly. */

--- a/extensions/amp-lightbox-gallery/1.0/component.jss.js
+++ b/extensions/amp-lightbox-gallery/1.0/component.jss.js
@@ -24,7 +24,6 @@ const TOP_BAR_HEIGHT_LARGE = 80;
 const DEFAULT_DIMENSION_LARGE = 40;
 const DEFAULT_PADDING_LARGE = 20;
 
-const DEFAULT_GRID_NUM = 4;
 const DEFAULT_GRID_PADDING = 5;
 
 const gallery = {
@@ -71,7 +70,7 @@ const grid = {
   height: `calc(100% - ${TOP_BAR_HEIGHT}px) !important`,
   width: 'calc(100% - 10px) !important',
   '@media (min-width: 1024px)': {
-    gridTemplateColumns: `repeat(${DEFAULT_GRID_NUM}, calc(1024px/${DEFAULT_GRID_NUM} - ${DEFAULT_GRID_PADDING}px * ${DEFAULT_GRID_PADDING} / ${DEFAULT_GRID_NUM}))`,
+    gridTemplateColumns: `repeat(4, calc(1024px/4 - ${DEFAULT_GRID_PADDING}px * 5 / 4))`,
     top: `${TOP_BAR_HEIGHT_LARGE}px !important`,
     height: `calc(100% - ${TOP_BAR_HEIGHT_LARGE}px) !important`,
   },

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -54,13 +54,13 @@ export function WithLightbox({
       renderProp
         ? renderProp()
         : toChildArray(children).map((child) => cloneElement(child)),
-    [renderProp, children]
+    [children, renderProp]
   );
 
   useLayoutEffect(() => {
     register(genKey, render);
     return () => deregister(genKey);
-  }, [register, deregister, genKey, render]);
+  }, [genKey, deregister, register, render]);
 
   const activationProps = useMemo(
     () =>

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -16,8 +16,16 @@
 
 import * as Preact from '#preact';
 import {LightboxGalleryContext} from './context';
+import {
+  cloneElement,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from '#preact';
 import {sequentialIdGenerator} from '#core/math/id-generator';
-import {useContext, useLayoutEffect, useMemo, useState} from '#preact';
+import {toChildArray} from '#preact/compat';
 
 const generateLightboxItemKey = sequentialIdGenerator();
 
@@ -36,15 +44,23 @@ export function WithLightbox({
   as: Comp = 'div',
   children,
   enableActivation = true,
-  render = () => children,
+  render: renderProp,
   ...rest
 }) {
   const [genKey] = useState(generateLightboxItemKey);
   const {deregister, open, register} = useContext(LightboxGalleryContext);
+  const render = useCallback(
+    () =>
+      renderProp
+        ? renderProp()
+        : toChildArray(children).map((child) => cloneElement(child)),
+    [renderProp, children]
+  );
+
   useLayoutEffect(() => {
     register(genKey, render);
     return () => deregister(genKey);
-  }, [genKey, deregister, register, render]);
+  }, [register, deregister, genKey, render]);
 
   const activationProps = useMemo(
     () =>

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -109,7 +109,7 @@ export function LightboxGalleryProvider({children, render}) {
           onClick={() => setShowControls(!showControls)}
           ref={carouselRef}
         >
-          {showCarousel && carouselElements.current}
+          {carouselElements.current}
         </BaseCarousel>
         {!showCarousel && (
           <div

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -32,6 +32,10 @@ export function LightboxGalleryProvider({children, render}) {
   const carouselRef = useRef(null);
   const [index, setIndex] = useState(0);
   const renderers = useRef([]);
+
+  // Prefer counting elements over retrieving array length because
+  // array can contain empty values that have been deregistered.
+  const count = useRef(0);
   const carouselElements = useRef([]);
   const gridElements = useRef([]);
   const register = (key, render) => {
@@ -53,15 +57,12 @@ export function LightboxGalleryProvider({children, render}) {
   };
 
   useLayoutEffect(() => {
-    carouselRef.current?.goToSlide(index);
+    carouselRef.current?.goToSlide(mod(index, count.current));
   }, [index]);
 
   const [showCarousel, setShowCarousel] = useState(true);
   const [showControls, setShowControls] = useState(true);
   const renderElements = useCallback(() => {
-    // Prefer counting elements over retrieving array length because
-    // array can contain empty values that have been deregistered.
-    let count = 0;
     renderers.current.forEach((render, index) => {
       if (!carouselElements.current[index]) {
         carouselElements.current[index] = render();
@@ -69,12 +70,12 @@ export function LightboxGalleryProvider({children, render}) {
           <Thumbnail
             onClick={() => {
               setShowCarousel(true);
-              setIndex(mod(index, count));
+              setIndex(index);
             }}
             render={render}
           />
         );
-        count++;
+        count.current += 1;
       }
     });
   }, []);

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -111,7 +111,11 @@ export function LightboxGalleryProvider({children, render}) {
           {showCarousel && carouselElements.current}
         </BaseCarousel>
         {!showCarousel && (
-          <div className={classes.grid}>{gridElements.current}</div>
+          <div
+            className={objstr({[classes.gallery]: true, [classes.grid]: true})}
+          >
+            {gridElements.current}
+          </div>
         )}
       </Lightbox>
       <LightboxGalleryContext.Provider value={context}>

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -66,16 +66,13 @@ export function LightboxGalleryProvider({children, render}) {
       if (!carouselElements.current[index]) {
         carouselElements.current[index] = render();
         gridElements.current[index] = (
-          <div
-            role="button"
-            aria-label="View in carousel"
+          <Thumbnail
             onClick={() => {
               setViewCarousel(true);
               setIndex(mod(index, count));
             }}
-          >
-            {render()}
-          </div>
+            render={render}
+          />
         );
         count++;
       }
@@ -112,7 +109,7 @@ export function LightboxGalleryProvider({children, render}) {
         >
           {viewCarousel && carouselElements.current}
         </BaseCarousel>
-        <div className={classes.gallery} hidden={viewCarousel}>
+        <div className={classes.grid} hidden={viewCarousel}>
           {!viewCarousel && gridElements.current}
         </div>
       </Lightbox>
@@ -180,5 +177,23 @@ function NavButtonIcon({by, ...rest}) {
         stroke-linecap="round"
       />
     </svg>
+  );
+}
+
+/**
+ * @param {!LightboxGalleryDef.ThumbnailProps} props
+ * @return {PreactDef.Renderable}
+ */
+function Thumbnail({onClick, render}) {
+  const classes = useStyles();
+  return (
+    <div
+      aria-label="View in carousel"
+      className={classes.thumbnail}
+      onClick={onClick}
+      role="button"
+    >
+      {render()}
+    </div>
   );
 }

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -46,7 +46,7 @@ export function LightboxGalleryProvider({children, render}) {
     deregister,
     register,
     open: (index) => {
-      setViewCarousel(true);
+      setShowCarousel(true);
       setIndex(index);
       lightboxRef.current.open();
     },
@@ -56,7 +56,7 @@ export function LightboxGalleryProvider({children, render}) {
     carouselRef.current?.goToSlide(index);
   }, [index]);
 
-  const [viewCarousel, setViewCarousel] = useState(true);
+  const [showCarousel, setShowCarousel] = useState(true);
   const [showControls, setShowControls] = useState(true);
   const renderElements = useCallback(() => {
     // Prefer counting elements over retrieving array length because
@@ -68,7 +68,7 @@ export function LightboxGalleryProvider({children, render}) {
         gridElements.current[index] = (
           <Thumbnail
             onClick={() => {
-              setViewCarousel(true);
+              setShowCarousel(true);
               setIndex(mod(index, count));
             }}
             render={render}
@@ -93,25 +93,26 @@ export function LightboxGalleryProvider({children, render}) {
         ref={lightboxRef}
       >
         <div className={classes.controlsPanel}>
-          <button onClick={() => setViewCarousel(!viewCarousel)}>
-            toggle view
-          </button>
+          <ToggleViewIcon
+            onClick={() => setShowCarousel(!showCarousel)}
+            showCarousel={showCarousel}
+          />
         </div>
         <BaseCarousel
           arrowPrevAs={NavButtonIcon}
           arrowNextAs={NavButtonIcon}
           className={classes.gallery}
           defaultSlide={index}
-          hidden={!viewCarousel}
+          hidden={!showCarousel}
           loop
           onClick={() => setShowControls(!showControls)}
           ref={carouselRef}
         >
-          {viewCarousel && carouselElements.current}
+          {showCarousel && carouselElements.current}
         </BaseCarousel>
-        <div className={classes.grid} hidden={viewCarousel}>
-          {!viewCarousel && gridElements.current}
-        </div>
+        {!showCarousel && (
+          <div className={classes.grid}>{gridElements.current}</div>
+        )}
       </Lightbox>
       <LightboxGalleryContext.Provider value={context}>
         {render ? render() : children}
@@ -176,6 +177,55 @@ function NavButtonIcon({by, ...rest}) {
         stroke-linejoin="round"
         stroke-linecap="round"
       />
+    </svg>
+  );
+}
+
+/**
+ * @param {!BaseCarouselDef.ArrowProps} props
+ * @return {PreactDef.Renderable}
+ */
+function ToggleViewIcon({showCarousel, ...rest}) {
+  const classes = useStyles();
+  return (
+    <svg
+      aria-label={`Switch to ${showCarousel ? 'grid view' : 'carousel view'}`}
+      className={objstr({
+        [classes.control]: true,
+        [classes.topControl]: true,
+      })}
+      role="button"
+      tabIndex="0"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+    >
+      {showCarousel ? (
+        <g fill="#fff">
+          <rect x="3" y="3" width="6" height="8" rx="1" ry="1" />
+          <rect x="15" y="13" width="6" height="8" rx="1" ry="1" />
+          <rect x="11" y="3" width="10" height="8" rx="1" ry="1" />
+          <rect x="3" y="13" width="10" height="8" rx="1" ry="1" />
+        </g>
+      ) : (
+        <>
+          <rect
+            x="4"
+            y="4"
+            width="16"
+            height="16"
+            rx="1"
+            stroke-width="2"
+            stroke="#fff"
+            fill="none"
+          />
+          <circle fill="#fff" cx="15.5" cy="8.5" r="1.5" />
+          <polygon
+            fill="#fff"
+            points="5,19 5,13 8,10 13,15 16,12 19,15 19,19"
+          />
+        </>
+      )}
     </svg>
   );
 }

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -194,7 +194,9 @@ function ToggleViewIcon({showCarousel, ...rest}) {
   const classes = useStyles();
   return (
     <svg
-      aria-label={`Switch to ${showCarousel ? 'grid view' : 'carousel view'}`}
+      aria-label={
+        showCarousel ? 'Switch to grid view' : 'Switch to carousel view'
+      }
       className={objstr({
         [classes.control]: true,
         [classes.topControl]: true,

--- a/extensions/amp-lightbox-gallery/1.0/test/test-component.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-component.js
@@ -17,6 +17,7 @@
 import * as Preact from '#preact';
 import {LightboxGalleryProvider, WithLightbox} from '../component';
 import {mount} from 'enzyme';
+import {useStyles} from '../component.jss';
 
 describes.sandboxed('LightboxGallery preact component', {}, () => {
   describe('LightboxGalleryProvider with children', () => {
@@ -80,6 +81,7 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
     });
 
     it('opens with clones when clicking on a lightboxed element', () => {
+      const classes = useStyles();
       const wrapper = mount(
         <LightboxGalleryProvider>
           <WithLightbox key="1" id="standard">
@@ -119,6 +121,14 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
       expect(lightbox.prop('closeButtonAs').name).to.equal('CloseButtonIcon');
       expect(lightbox.children()).to.have.lengthOf(1);
 
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+
       // Carousel UI
       const carousel = lightbox.find('BaseCarousel');
       expect(carousel).to.have.lengthOf(1);
@@ -128,6 +138,7 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
     });
 
     it('opens with rendered when given', () => {
+      const classes = useStyles();
       const renderImg = () => <img className="rendered-img"></img>;
       const wrapper = mount(
         <LightboxGalleryProvider>
@@ -175,6 +186,14 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
       expect(lightbox.prop('closeButtonAs').name).to.equal('CloseButtonIcon');
       expect(lightbox.children()).to.have.lengthOf(1);
 
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+
       // Carousel UI
       const carousel = lightbox.find('BaseCarousel');
       expect(carousel).to.have.lengthOf(1);
@@ -188,6 +207,172 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
       expect(imgs.at(1).hasClass('rendered-img')).to.be.true;
       expect(imgs.at(2).hasClass('rendered-img')).to.be.false;
       expect(imgs.at(3).hasClass('rendered-img')).to.be.true;
+    });
+
+    it('toggles to grid view', () => {
+      const classes = useStyles();
+      const renderImg = () => <img className="rendered-img"></img>;
+      const wrapper = mount(
+        <LightboxGalleryProvider>
+          <WithLightbox key="1" id="standard">
+            <img />
+          </WithLightbox>
+          <img key="2" id="no-lightbox" />
+          <WithLightbox key="3" as="img" id="with-as" render={renderImg} />
+          <div key="4">
+            <div>
+              <WithLightbox id="deeply-nested">
+                <img />
+              </WithLightbox>
+              <WithLightbox
+                as="img"
+                id="deeply-nested-with-as"
+                render={renderImg}
+              />
+            </div>
+          </div>
+        </LightboxGalleryProvider>
+      );
+
+      // Open lightbox
+      wrapper.find('div').first().simulate('click');
+      wrapper.update();
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI is not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel')).to.have.lengthOf(1);
+
+      // Toggle to grid UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      const grid = wrapper.find(`.${classes.grid}`);
+      expect(grid).to.have.lengthOf(1);
+
+      // Children are cloned to grid
+      const gridImgs = grid.find('img');
+      expect(gridImgs).to.have.lengthOf(4);
+      expect(gridImgs.at(0).hasClass('rendered-img')).to.be.false;
+      expect(gridImgs.at(1).hasClass('rendered-img')).to.be.true;
+      expect(gridImgs.at(2).hasClass('rendered-img')).to.be.false;
+      expect(gridImgs.at(3).hasClass('rendered-img')).to.be.true;
+
+      // Carousel is hidden, and its children still exist
+      const carousel = wrapper.find('BaseCarousel');
+      expect(carousel).to.have.lengthOf(1);
+      expect(carousel.prop('hidden')).to.be.true;
+      const imgs = carousel.find('img');
+      expect(imgs).to.have.lengthOf(4);
+      expect(imgs.at(0).hasClass('rendered-img')).to.be.false;
+      expect(imgs.at(1).hasClass('rendered-img')).to.be.true;
+      expect(imgs.at(2).hasClass('rendered-img')).to.be.false;
+      expect(imgs.at(3).hasClass('rendered-img')).to.be.true;
+    });
+
+    it('toggles to grid view and back to carousel', () => {
+      const classes = useStyles();
+      const renderImg = () => <img className="rendered-img"></img>;
+      const wrapper = mount(
+        <LightboxGalleryProvider>
+          <WithLightbox key="1" id="standard">
+            <img />
+          </WithLightbox>
+          <img key="2" id="no-lightbox" />
+          <WithLightbox key="3" as="img" id="with-as" render={renderImg} />
+          <div key="4">
+            <div>
+              <WithLightbox id="deeply-nested">
+                <img />
+              </WithLightbox>
+              <WithLightbox
+                as="img"
+                id="deeply-nested-with-as"
+                render={renderImg}
+              />
+            </div>
+          </div>
+        </LightboxGalleryProvider>
+      );
+
+      // Open lightbox
+      wrapper.find('div').first().simulate('click');
+      wrapper.update();
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
+
+      // Toggle to grid UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(1);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.true;
+
+      // Toggle back to carousel UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
+    });
+
+    it('toggles to specific carousel slide from grid view ', () => {
+      const classes = useStyles();
+      const renderImg = () => <img className="rendered-img"></img>;
+      const wrapper = mount(
+        <LightboxGalleryProvider>
+          <WithLightbox key="1" id="standard">
+            <img />
+          </WithLightbox>
+          <img key="2" id="no-lightbox" />
+          <WithLightbox key="3" as="img" id="with-as" render={renderImg} />
+          <div key="4">
+            <div>
+              <WithLightbox id="deeply-nested">
+                <img />
+              </WithLightbox>
+              <WithLightbox
+                as="img"
+                id="deeply-nested-with-as"
+                render={renderImg}
+              />
+            </div>
+          </div>
+        </LightboxGalleryProvider>
+      );
+
+      // Open lightbox
+      wrapper.find('div').first().simulate('click');
+      wrapper.update();
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
+
+      // Toggle to grid UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(1);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.true;
+
+      // Click thumbnail item to go back to carousel UI
+      wrapper.find(`.${classes.grid} div`).at(2).simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
     });
   });
 
@@ -250,6 +435,7 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
     });
 
     it('opens with clones when clicking on a lightboxed element', () => {
+      const classes = useStyles();
       const render = () => [
         <WithLightbox key="1" id="standard">
           <img />
@@ -288,6 +474,14 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
       expect(lightbox.prop('closeButtonAs').name).to.equal('CloseButtonIcon');
       expect(lightbox.children()).to.have.lengthOf(1);
 
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+
       // Carousel UI
       const carousel = lightbox.find('BaseCarousel');
       expect(carousel).to.have.lengthOf(1);
@@ -297,6 +491,7 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
     });
 
     it('opens with rendered when given', () => {
+      const classes = useStyles();
       const renderImg = () => <img className="rendered-img"></img>;
       const render = () => [
         <WithLightbox key="1" id="standard">
@@ -343,6 +538,14 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
       expect(lightbox.prop('closeButtonAs').name).to.equal('CloseButtonIcon');
       expect(lightbox.children()).to.have.lengthOf(1);
 
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+
       // Carousel UI
       const carousel = lightbox.find('BaseCarousel');
       expect(carousel).to.have.lengthOf(1);
@@ -356,6 +559,169 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
       expect(imgs.at(1).hasClass('rendered-img')).to.be.true;
       expect(imgs.at(2).hasClass('rendered-img')).to.be.false;
       expect(imgs.at(3).hasClass('rendered-img')).to.be.true;
+    });
+
+    it('toggles to grid view', () => {
+      const classes = useStyles();
+      const renderImg = () => <img className="rendered-img"></img>;
+      const render = () => [
+        <WithLightbox key="1" id="standard">
+          <img />
+        </WithLightbox>,
+        <img key="2" id="no-lightbox" />,
+        <WithLightbox key="3" as="img" id="with-as" render={renderImg} />,
+        <div key="4">
+          <div>
+            <WithLightbox id="deeply-nested">
+              <img />
+            </WithLightbox>
+            <WithLightbox
+              as="img"
+              id="deeply-nested-with-as"
+              render={renderImg}
+            />
+          </div>
+        </div>,
+      ];
+      const wrapper = mount(<LightboxGalleryProvider render={render} />);
+
+      // Open lightbox
+      wrapper.find('div').first().simulate('click');
+      wrapper.update();
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI is not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel')).to.have.lengthOf(1);
+
+      // Toggle to grid UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      const grid = wrapper.find(`.${classes.grid}`);
+      expect(grid).to.have.lengthOf(1);
+
+      // Children are cloned to grid
+      const gridImgs = grid.find('img');
+      expect(gridImgs).to.have.lengthOf(4);
+      expect(gridImgs.at(0).hasClass('rendered-img')).to.be.false;
+      expect(gridImgs.at(1).hasClass('rendered-img')).to.be.true;
+      expect(gridImgs.at(2).hasClass('rendered-img')).to.be.false;
+      expect(gridImgs.at(3).hasClass('rendered-img')).to.be.true;
+
+      // Carousel is hidden, and its children still exist
+      const carousel = wrapper.find('BaseCarousel');
+      expect(carousel).to.have.lengthOf(1);
+      expect(carousel.prop('hidden')).to.be.true;
+      const imgs = carousel.find('img');
+      expect(imgs).to.have.lengthOf(4);
+      expect(imgs.at(0).hasClass('rendered-img')).to.be.false;
+      expect(imgs.at(1).hasClass('rendered-img')).to.be.true;
+      expect(imgs.at(2).hasClass('rendered-img')).to.be.false;
+      expect(imgs.at(3).hasClass('rendered-img')).to.be.true;
+    });
+
+    it('toggles to grid view and back to carousel', () => {
+      const classes = useStyles();
+      const renderImg = () => <img className="rendered-img"></img>;
+      const render = () => [
+        <WithLightbox key="1" id="standard">
+          <img />
+        </WithLightbox>,
+        <img key="2" id="no-lightbox" />,
+        <WithLightbox key="3" as="img" id="with-as" render={renderImg} />,
+        <div key="4">
+          <div>
+            <WithLightbox id="deeply-nested">
+              <img />
+            </WithLightbox>
+            <WithLightbox
+              as="img"
+              id="deeply-nested-with-as"
+              render={renderImg}
+            />
+          </div>
+        </div>,
+      ];
+      const wrapper = mount(<LightboxGalleryProvider render={render} />);
+
+      // Open lightbox
+      wrapper.find('div').first().simulate('click');
+      wrapper.update();
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
+
+      // Toggle to grid UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(1);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.true;
+
+      // Toggle back to carousel UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
+    });
+
+    it('toggles to specific carousel slide from grid view ', () => {
+      const classes = useStyles();
+      const renderImg = () => <img className="rendered-img"></img>;
+      const render = () => [
+        <WithLightbox key="1" id="standard">
+          <img />
+        </WithLightbox>,
+        <img key="2" id="no-lightbox" />,
+        <WithLightbox key="3" as="img" id="with-as" render={renderImg} />,
+        <div key="4">
+          <div>
+            <WithLightbox id="deeply-nested">
+              <img />
+            </WithLightbox>
+            <WithLightbox
+              as="img"
+              id="deeply-nested-with-as"
+              render={renderImg}
+            />
+          </div>
+        </div>,
+      ];
+      const wrapper = mount(<LightboxGalleryProvider render={render} />);
+
+      // Open lightbox
+      wrapper.find('div').first().simulate('click');
+      wrapper.update();
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
+
+      // Toggle to grid UI
+      toggleViewIcon.find('svg').simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(1);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.true;
+
+      // Click thumbnail item to go back to carousel UI
+      wrapper.find(`.${classes.grid} div`).at(2).simulate('click');
+      wrapper.update();
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+      expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
     });
   });
 });

--- a/extensions/amp-lightbox-gallery/1.0/test/test-component.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-component.js
@@ -183,10 +183,11 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
 
       // Children are given to carousel
       const imgs = carousel.find('img');
-      expect(imgs).to.have.lengthOf(3); // Carousel only renders 3 items.
+      expect(imgs).to.have.lengthOf(4);
       expect(imgs.at(0).hasClass('rendered-img')).to.be.false;
       expect(imgs.at(1).hasClass('rendered-img')).to.be.true;
       expect(imgs.at(2).hasClass('rendered-img')).to.be.false;
+      expect(imgs.at(3).hasClass('rendered-img')).to.be.true;
     });
   });
 
@@ -350,10 +351,11 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
 
       // Children are given to carousel
       const imgs = carousel.find('img');
-      expect(imgs).to.have.lengthOf(3); // Carousel only renders 3 items.
+      expect(imgs).to.have.lengthOf(4);
       expect(imgs.at(0).hasClass('rendered-img')).to.be.false;
       expect(imgs.at(1).hasClass('rendered-img')).to.be.true;
       expect(imgs.at(2).hasClass('rendered-img')).to.be.false;
+      expect(imgs.at(3).hasClass('rendered-img')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
This PR adds the following user interface features:
- Display lightboxed elements in a grid in the open gallery
- Allow toggling between grid and carousel views in the open gallery
- Display SVGs for the toggle-to-grid and toggle-to-carousel button, swapping them in place depending on the current state
- Unit tests

It also adds a change to `BaseCarousel` to propagate its `onClick` prop to the `Scroller` as opposed to the `ContainWrapper`, so as to exclude arrows (which already have a click-behavior) from triggering it.

Partial for #32759