### PR TITLE
🏗 Require rcebulko for check-types.js

### DIFF
--- a/build-system/tasks/OWNERS
+++ b/build-system/tasks/OWNERS
@@ -8,7 +8,10 @@
     },
     {
       pattern: 'check-types.js',
-      owners: [{name: 'ampproject/wg-performance'}],
+      owners: [
+        {name: 'ampproject/wg-performance'},
+        {name: 'rcebulko', required: true},
+      ],
     },
   ],
 }


### PR DESCRIPTION
Context: https://github.com/ampproject/amphtml/pull/34736 added a global list of externs to one of the typecheck targets. One goal of the type-check effort is to split those externs closer to where they are required. Since this was a broader PR, it was reviewed by another member of the performance WG with less visibility into the type-checking effort. New code added to typechecked directories should pass typechecking, and accidentally pulling in new files/externs can be difficult to revert if the checked-in code doesn't pass. There are almost no circumstances where type-check targets should be altered at this stage, with the exception of PRs that are enabling new ones.