### PR TITLE
Deprecate notice for amp-ad sticky with empty attribute value

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -17,7 +17,7 @@
 import {Services} from '#service';
 import {ancestorElementsByTag} from '#core/dom/query';
 import {createElementWithAttributes, removeElement} from '#core/dom';
-import {devAssert} from '../../../src/log';
+import {devAssert, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 
 import {getAdContainer} from '../../../src/ad-helper';
@@ -66,6 +66,11 @@ export class AmpAdUIHandler {
     if (this.element_.hasAttribute(STICKY_AD_PROP)) {
       // TODO(powerivq@) Kargo is currently running an experiment using empty sticky attribute, so
       // we default the position to bottom right. Remove this default afterwards.
+      userAssert(
+        this.element_.getAttribute(STICKY_AD_PROP),
+        'amp-ad sticky is deprecating empty attribute value, please use <amp-ad sticky="bottom" instead'
+      );
+
       this.stickyAdPosition_ =
         this.element_.getAttribute(STICKY_AD_PROP) ||
         StickyAdPositions.BOTTOM_RIGHT;


### PR DESCRIPTION
We need to add this messaging to ensure that sites using <amp-ad sticky> will need to change to <amp-ad sticky=bottom>. Currently, only sites coordinated with Kargo know this since the api is not documented yet, so this should not become a big surprise. 