### PR TITLE
✨ `amp-story-desktop-one-panel` Position of ad badge and progress bar in new one-panel UI

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css
@@ -64,3 +64,9 @@
   visibility: visible !important;
   opacity: 1 !important;
 }
+
+.i-amphtml-ad-overlay-container[desktop-one-panel] { 
+  top: var(--i-amphtml-story-desktop-one-panel-responsive-margin) !important;
+  /* Calculates position by factoring in page width. */
+  left: calc(50vw - var(--i-amphtml-story-desktop-one-panel-width) / 2) !important;
+}

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-ad-badge.css
@@ -65,7 +65,7 @@
   opacity: 1 !important;
 }
 
-.i-amphtml-ad-overlay-container[desktop-one-panel] { 
+.i-amphtml-ad-overlay-container[desktop-one-panel] {
   top: var(--i-amphtml-story-desktop-one-panel-responsive-margin) !important;
   /* Calculates position by factoring in page width. */
   left: calc(50vw - var(--i-amphtml-story-desktop-one-panel-width) / 2) !important;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-progress-bar.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-progress-bar.css
@@ -42,7 +42,7 @@
   transition: opacity 0.1s linear 0.3s;
 }
 
-.i-amphtml-story-ad-progress-background[desktop-one-panel] { 
+.i-amphtml-story-ad-progress-background[desktop-one-panel] {
   top: var(--i-amphtml-story-desktop-one-panel-responsive-margin) !important;
   /* Calculates position by factoring in page width. */
   left: calc(50vw - var(--i-amphtml-story-desktop-one-panel-width) / 2 + 4px) !important;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-progress-bar.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads-progress-bar.css
@@ -42,6 +42,13 @@
   transition: opacity 0.1s linear 0.3s;
 }
 
+.i-amphtml-story-ad-progress-background[desktop-one-panel] { 
+  top: var(--i-amphtml-story-desktop-one-panel-responsive-margin) !important;
+  /* Calculates position by factoring in page width. */
+  left: calc(50vw - var(--i-amphtml-story-desktop-one-panel-width) / 2 + 4px) !important;
+  width: calc(var(--i-amphtml-story-desktop-one-panel-width) - 8px) !important;
+}
+
 .i-amphtml-story-ad-progress-bar {
   background: #fff !important;
   height: 2px !important;

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -64,8 +64,8 @@ const MUSTACHE_TAG = 'amp-mustache';
 /** @enum {string} */
 export const Attributes = {
   AD_SHOWING: 'ad-showing',
-  DESKTOP_PANELS: 'desktop-panels',
   DESKTOP_ONE_PANEL: 'desktop-one-panel',
+  DESKTOP_PANELS: 'desktop-panels',
   DIR: 'dir',
   PAUSED: 'paused',
 };
@@ -316,7 +316,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    */
   onUIStateUpdate_(uiState) {
     this.mutateElement(() => {
-      const {DESKTOP_PANELS, DESKTOP_ONE_PANEL} = Attributes;
+      const {DESKTOP_ONE_PANEL, DESKTOP_PANELS} = Attributes;
       this.adBadgeContainer_.removeAttribute(DESKTOP_PANELS);
       this.adBadgeContainer_.removeAttribute(DESKTOP_ONE_PANEL);
       // TODO(#33969) can no longer be null when launched.

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -65,6 +65,7 @@ const MUSTACHE_TAG = 'amp-mustache';
 export const Attributes = {
   AD_SHOWING: 'ad-showing',
   DESKTOP_PANELS: 'desktop-panels',
+  DESKTOP_ONE_PANEL: 'desktop-one-panel',
   DIR: 'dir',
   PAUSED: 'paused',
 };
@@ -315,14 +316,20 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
    */
   onUIStateUpdate_(uiState) {
     this.mutateElement(() => {
-      const {DESKTOP_PANELS} = Attributes;
+      const {DESKTOP_PANELS, DESKTOP_ONE_PANEL} = Attributes;
       this.adBadgeContainer_.removeAttribute(DESKTOP_PANELS);
+      this.adBadgeContainer_.removeAttribute(DESKTOP_ONE_PANEL);
       // TODO(#33969) can no longer be null when launched.
       this.progressBarBackground_?.removeAttribute(DESKTOP_PANELS);
+      this.progressBarBackground_?.removeAttribute(DESKTOP_ONE_PANEL);
 
       if (uiState === UIType.DESKTOP_PANELS) {
         this.adBadgeContainer_.setAttribute(DESKTOP_PANELS, '');
         this.progressBarBackground_?.setAttribute(DESKTOP_PANELS, '');
+      }
+      if (uiState === UIType.DESKTOP_ONE_PANEL) {
+        this.adBadgeContainer_.setAttribute(DESKTOP_ONE_PANEL, '');
+        this.progressBarBackground_?.setAttribute(DESKTOP_ONE_PANEL, '');
       }
     });
   }

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -343,6 +343,30 @@ describes.realWin(
         expect(progressBackground).to.have.attribute(Attributes.DESKTOP_PANELS);
       });
 
+      it('should propagate the desktop-one-panel attribute to badge & progress bar', () => {
+        toggleExperiment(win, 'amp-story-desktop-one-panel', true);
+
+        const adBadgeContainer = doc.querySelector(
+          '.i-amphtml-ad-overlay-container'
+        );
+        const progressBackground = doc.querySelector(
+          '.i-amphtml-story-ad-progress-background'
+        );
+        expect(adBadgeContainer).not.to.have.attribute(
+          Attributes.DESKTOP_ONE_PANEL
+        );
+        expect(progressBackground).not.to.have.attribute(
+          Attributes.DESKTOP_ONE_PANEL
+        );
+        storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_ONE_PANEL);
+        expect(adBadgeContainer).to.have.attribute(
+          Attributes.DESKTOP_ONE_PANEL
+        );
+        expect(progressBackground).to.have.attribute(
+          Attributes.DESKTOP_ONE_PANEL
+        );
+      });
+
       it('should propagate the dir=rtl attribute', () => {
         const adBadgeContainer = doc.querySelector(
           '.i-amphtml-ad-overlay-container'


### PR DESCRIPTION
Context / fixes #34785

Positions badge and progress bar based on story panel in new `amp-story-desktop-one-panel` UI.

<img width="1374" alt="Screen Shot 2021-06-18 at 1 09 31 PM" src="https://user-images.githubusercontent.com/3860311/122595525-9ca80300-d036-11eb-8cff-47c0cdcf6584.png">
 
<img width="919" alt="Screen Shot 2021-06-18 at 1 09 52 PM" src="https://user-images.githubusercontent.com/3860311/122595523-9b76d600-d036-11eb-893a-a4adabadb0c0.png">

Progress bar and badge:
<img width="1573" alt="Screen Shot 2021-06-18 at 3 32 59 PM" src="https://user-images.githubusercontent.com/3860311/122608593-7be9a880-d04a-11eb-8af5-d4fc43197544.png">
