### PR TITLE
Move building outlink attachment to layoutcallback.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -121,10 +121,12 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       this.element.hasAttribute('href');
     this.type_ = isOutlink ? AttachmentType.OUTLINK : AttachmentType.INLINE;
 
-    // Inline attachments are pre-built so their content can be re-parented
-    // in draggable-drawer's layoutCallback.
     if (this.type_ === AttachmentType.INLINE) {
       this.buildInline_();
+    }
+
+    if (this.type_ === AttachmentType.OUTLINK) {
+      this.buildRemote_();
     }
 
     this.win.addEventListener('pageshow', (event) => {
@@ -142,13 +144,12 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
   layoutCallback() {
     super.layoutCallback();
-
-    if (this.type_ === AttachmentType.OUTLINK) {
-      if (isPageAttachmentUiV2ExperimentOn(this.win)) {
-        this.buildRemoteV2_();
-      } else {
-        this.buildRemote_();
-      }
+    // Outlink attachment v2 renders an image and must be built in layoutCallback.
+    if (
+      this.type_ === AttachmentType.OUTLINK &&
+      isPageAttachmentUiV2ExperimentOn(this.win)
+    ) {
+      this.buildRemoteV2_();
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -121,16 +121,10 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       this.element.hasAttribute('href');
     this.type_ = isOutlink ? AttachmentType.OUTLINK : AttachmentType.INLINE;
 
+    // Inline attachments are pre-built so their content can be re-parented
+    // in draggable-drawer's layoutCallback.
     if (this.type_ === AttachmentType.INLINE) {
       this.buildInline_();
-    }
-
-    if (this.type_ === AttachmentType.OUTLINK) {
-      if (isPageAttachmentUiV2ExperimentOn(this.win)) {
-        this.buildRemoteV2_();
-      } else {
-        this.buildRemote_();
-      }
     }
 
     this.win.addEventListener('pageshow', (event) => {
@@ -144,6 +138,18 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     toggle(this.element, true);
     this.element.setAttribute('aria-live', 'assertive');
+  }
+
+  layoutCallback() {
+    super.layoutCallback();
+
+    if (this.type_ === AttachmentType.OUTLINK) {
+      if (isPageAttachmentUiV2ExperimentOn(this.win)) {
+        this.buildRemoteV2_();
+      } else {
+        this.buildRemote_();
+      }
+    }
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -145,6 +145,9 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     this.element.setAttribute('aria-live', 'assertive');
   }
 
+  /**
+   * @override
+   */
   layoutCallback() {
     super.layoutCallback();
     // Outlink attachment v2 renders an image and must be built in layoutCallback.

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -125,7 +125,10 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       this.buildInline_();
     }
 
-    if (this.type_ === AttachmentType.OUTLINK) {
+    if (
+      this.type_ === AttachmentType.OUTLINK &&
+      !isPageAttachmentUiV2ExperimentOn(this.win)
+    ) {
       this.buildRemote_();
     }
 


### PR DESCRIPTION
Moves the building of the outlink preview to layoutCallback.

This element for reference:
<img width="435" alt="Screen Shot 2021-06-18 at 2 20 07 PM" src="https://user-images.githubusercontent.com/3860311/122602393-be0dec80-d040-11eb-83d3-19fb5b7a8aa7.png">
