### PR TITLE
Build AMP Cache URLs for inline attachment CTA when served from AMP Cache.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -19,6 +19,7 @@
  */
 import {AttachmentTheme} from './amp-story-page-attachment';
 import {LocalizedStringId} from '../../../src/localized-strings';
+import {Services} from '#service';
 import {computedStyle, setImportantStyles} from '#core/dom/style';
 import {getLocalizationService} from './amp-story-localization-service';
 import {getRGBFromCssColorValue, getTextColorForRGB} from './utils';
@@ -273,15 +274,36 @@ const renderInlinePageAttachmentUi = (pageEl, attachmentEl) => {
 
   const openImgAttr2 = attachmentEl.getAttribute('cta-image-2');
   if (openImgAttr2) {
-    chipEl.prepend(makeImgElWithBG(openImgAttr2));
+    const src = maybeMakeProxyUrl(openImgAttr2, pageEl);
+    chipEl.prepend(makeImgElWithBG(src));
   }
 
   const openImgAttr = attachmentEl.getAttribute('cta-image');
   if (openImgAttr) {
-    chipEl.prepend(makeImgElWithBG(openImgAttr));
+    const src = maybeMakeProxyUrl(openImgAttr, pageEl);
+    chipEl.prepend(makeImgElWithBG(src));
   }
 
   return openAttachmentEl;
+};
+
+/**
+ * Makes a proxy URL if document is served from a proxy origin. No-op otherwise.
+ * @param {string} url
+ * @param {!Element} pageEl
+ * @return {string}
+ */
+const maybeMakeProxyUrl = (url, pageEl) => {
+  const urlService = Services.urlForDoc(pageEl);
+  const loc = pageEl.getAmpDoc().win.location;
+  if (!urlService.isProxyOrigin(loc.origin) || urlService.isProxyOrigin(url)) {
+    return url;
+  }
+  url = urlService.resolveRelativeUrl(
+    url,
+    urlService.getSourceOrigin(loc.href)
+  );
+  return loc.origin + '/i/s/' + url.replace(/https?:\/\//, '');
 };
 
 /**

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -299,11 +299,11 @@ const maybeMakeProxyUrl = (url, pageEl) => {
   if (!urlService.isProxyOrigin(loc.origin) || urlService.isProxyOrigin(url)) {
     return url;
   }
-  url = urlService.resolveRelativeUrl(
+  const resolvedRelativeUrl = urlService.resolveRelativeUrl(
     url,
     urlService.getSourceOrigin(loc.href)
   );
-  return loc.origin + '/i/s/' + url.replace(/https?:\/\//, '');
+  return loc.origin + '/i/s/' + resolvedRelativeUrl.replace(/https?:\/\//, '');
 };
 
 /**

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -781,6 +781,32 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     ).to.equal(2);
   });
 
+  it('should NOT rewrite the attachment UI images to a proxy URL', async () => {
+    toggleExperiment(win, 'amp-story-page-attachment-ui-v2', true);
+
+    const attachmentEl = win.document.createElement(
+      'amp-story-page-attachment'
+    );
+
+    const src = 'https://examples.com/foo.bar.png';
+    attachmentEl.setAttribute('layout', 'nodisplay');
+    attachmentEl.setAttribute('cta-image', src);
+    element.appendChild(attachmentEl);
+
+    page.buildCallback();
+    await page.layoutCallback();
+    page.setState(PageState.PLAYING);
+
+    const openAttachmentEl = element.querySelector(
+      '.i-amphtml-story-page-open-attachment'
+    );
+
+    const imgEl = openAttachmentEl.querySelector(
+      '.i-amphtml-story-inline-page-attachment-img'
+    );
+    expect(imgEl.getAttribute('style')).to.contain(src);
+  });
+
   it('should build the new default outlink page attachment UI', async () => {
     toggleExperiment(win, 'amp-story-page-attachment-ui-v2', true);
 


### PR DESCRIPTION
Build AMP Cache URLs for inline attachment CTA when served from AMP Cache.

Early return on publisher's origin, or if an AMP Cache URL is already provided.