### PR TITLE
🐛✨ [amp-analytics] add missing Support for Session cookies

### DIFF
--- a/extensions/amp-analytics/0.1/cookie-writer.js
+++ b/extensions/amp-analytics/0.1/cookie-writer.js
@@ -153,14 +153,20 @@ export class CookieWriter {
    * Retrieves cookieMaxAge from given config, provides default value if no
    * value is found or value is invalid
    * @param {JsonObject} inputConfig
-   * @return {number}
+   * @return {number|undefined} cookieMaxAge in ms or undefined for Session cookies
    */
   getCookieMaxAgeMs_(inputConfig) {
     if (!hasOwn(inputConfig, 'cookieMaxAge')) {
       return BASE_CID_MAX_AGE_MILLIS;
     }
 
-    const cookieMaxAgeNumber = Number(inputConfig['cookieMaxAge']);
+    const cookieMaxAge = inputConfig['cookieMaxAge'];
+
+    if (cookieMaxAge === 'Session') {
+      return undefined;
+    }
+
+    const cookieMaxAgeNumber = Number(cookieMaxAge);
 
     // 0 is a special case which we allow
     if (!cookieMaxAgeNumber && cookieMaxAgeNumber !== 0) {
@@ -218,7 +224,7 @@ export class CookieWriter {
    * Expand the value and write to cookie if necessary
    * @param {string} cookieName
    * @param {string} cookieValue
-   * @param {number} cookieExpireDateMs
+   * @param {number|undefined} cookieExpireDateMs
    * @param {!SameSite=} sameSite
    * @return {!Promise}
    */
@@ -231,7 +237,7 @@ export class CookieWriter {
         // Note: We ignore empty cookieValue, that means currently we don't
         // provide a way to overwrite or erase existing cookie
         if (value) {
-          const expireDate = Date.now() + cookieExpireDateMs;
+          const expireDate = cookieExpireDateMs ? Date.now() + cookieExpireDateMs : undefined;
           // SameSite=None must be secure as per
           // https://web.dev/samesite-cookies-explained/#samesitenone-must-be-secure
           const secure = sameSite === SameSite.NONE;

--- a/extensions/amp-analytics/0.1/test/test-cookie-writer.js
+++ b/extensions/amp-analytics/0.1/test/test-cookie-writer.js
@@ -430,6 +430,28 @@ describes.fakeWin('amp-analytics.cookie-writer value', {amp: true}, (env) => {
     });
   });
 
+  it('should write cookie with custom expiration ("Session")', () => {
+    win.location = 'https://www.example.test/';
+    const cookieWriter = new CookieWriter(
+      win,
+      win.document.body,
+      dict({
+        'cookies': {
+          'cookieMaxAge': 'Session', // Session Cookie
+          'aCookie': {
+            'value': 'testValue',
+          },
+        },
+      })
+    );
+    return cookieWriter.write().then(() => {
+      expect(win.document.lastSetCookieRaw).to.equal(
+        'aCookie=testValue; path=/; domain=example.test; ' +
+          'expires=Session'
+      );
+    });
+  });
+
   it('should write cookie with custom expiration (decimal value)', () => {
     win.location = 'https://www.example.test/';
     const cookieWriter = new CookieWriter(

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -84,7 +84,7 @@ function tryGetDocumentCookie_(win) {
  * @param {!Window} win
  * @param {string} name
  * @param {string} value
- * @param {time} expirationTime
+ * @param {time|undefined} expirationTime
  * @param {{
  *   highestAvailableDomain:(boolean|undefined),
  *   domain:(string|undefined),
@@ -183,7 +183,7 @@ export function getHighestAvailableDomain(win) {
  * @param {!Window} win
  * @param {string} name
  * @param {string} value
- * @param {time} expirationTime
+ * @param {time|undefined} expirationTime
  * @param {string|undefined} domain
  * @param {!SameSite=} sameSite
  * @param {boolean|undefined=} secure
@@ -211,8 +211,8 @@ function trySetCookie(
     encodeURIComponent(value) +
     '; path=/' +
     (domain ? '; domain=' + domain : '') +
-    '; expires=' +
-    new Date(expirationTime).toUTCString() +
+    (expirationTime ? '; expires=' +
+      new Date(expirationTime).toUTCString() : "") +
     getSameSiteString(win, sameSite) +
     (secure ? '; Secure' : '');
   try {


### PR DESCRIPTION
This PR makes it possible to create Session cookies
via inputConfig['cookieMaxAge'] === 'Session'

Example:
```html
<amp-analytics><script type="application/json">
{
        'cookies': {
          'cookieMaxAge': 'Session', // Session Cookie
          'aCookie': {
            'value': 'testValue',
          },
        },
}
</script></amp-analytics>
```



Closes #34937
