### PR TITLE
🐛 Fix local/no-duplicate-import autofix bug

### DIFF
--- a/build-system/eslint-rules/no-duplicate-import.js
+++ b/build-system/eslint-rules/no-duplicate-import.js
@@ -59,7 +59,20 @@ module.exports = {
                   }
                 }
 
-                return [fixer.remove(node), fixer.insertTextAfter(last, text)];
+                const fixes = [
+                  fixer.remove(node),
+                  fixer.insertTextAfter(last, text),
+                ];
+
+                // If removing the import creates a blank line, remove that line
+                const nextToken = context.getTokenAfter(node);
+                if (nextToken) {
+                  fixes.unshift(
+                    fixer.removeRange([node.range[1], nextToken.range[0]])
+                  );
+                }
+
+                return fixes;
               },
             });
           }

--- a/build-system/eslint-rules/no-duplicate-import.js
+++ b/build-system/eslint-rules/no-duplicate-import.js
@@ -59,20 +59,11 @@ module.exports = {
                   }
                 }
 
-                const fixes = [
+                return [
+                  fixer.removeRange([node.range[1], node.range[1] + 1]),
                   fixer.remove(node),
                   fixer.insertTextAfter(last, text),
                 ];
-
-                // If removing the import creates a blank line, remove that line
-                const nextToken = context.getTokenAfter(node);
-                if (nextToken) {
-                  fixes.unshift(
-                    fixer.removeRange([node.range[1], nextToken.range[0]])
-                  );
-                }
-
-                return fixes;
               },
             });
           }


### PR DESCRIPTION
We have a custom rule that merges import declarations from the same location. It deletes the duplicate import statement, but leaves a blank line in its place, segmenting the imports into unrelated groups which are sorted separately. 
Example:
![image](https://user-images.githubusercontent.com/6694512/122826917-b7d27700-d2b1-11eb-9358-a3fe5be1f66a.png)

This fix removes the newline after the removed import.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
