### PR TITLE
🏗 Move `exclude` out of `compilerOptions` in `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
       "#third_party/*": ["./third_party/*"]
     }
   },
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "allowJs": true,
     "baseUrl": ".",
-    "exclude": ["node_modules"],
     "paths": {
       "#3p/*": ["./3p/*"],
       "#ads/*": ["./ads/*"],
@@ -22,5 +21,6 @@
 
       "#third_party/*": ["./third_party/*"]
     }
-  }
+  },
+  "exclude": ["node_modules"],
 }


### PR DESCRIPTION
According to https://www.typescriptlang.org/tsconfig, `exclude` is a top-level option and should not go under `compilerOptions`. Noticed this because VSCode shows red squiggly lines in the editor when you open `tsconfig.json`.

![image](https://user-images.githubusercontent.com/26553114/122983619-31c63700-d36a-11eb-9ce1-56f3ac8ade80.png)

Follow up to #34901