### PR TITLE
update forbidden-terms check to only run during lint

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -124,8 +124,6 @@ function getFilesFromArgv() {
  * Gets a list of files to be checked based on command line args and the given
  * file matching globs. Used by tasks like prettify, lint, check-links, etc.
  * Optionally takes in options for globbing and a file containing ignore rules.
- * When local changes are linted (e.g. during CI), we also check if the list of
- * forbidden terms needs to be updated.
  *
  * @param {!Array<string>} globs
  * @param {Object=} options
@@ -146,10 +144,6 @@ function getFilesToCheck(globs, options = {}, ignoreFile = undefined) {
     if (filesChanged.length == 0) {
       log(green('INFO: ') + 'No files to check in this PR');
       return [];
-    }
-    const forbiddenTerms = 'build-system/test-configs/forbidden-terms.js';
-    if (!filesChanged.includes(forbiddenTerms)) {
-      filesChanged.push(forbiddenTerms);
     }
     return logFiles(filesChanged);
   }

--- a/build-system/tasks/lint.js
+++ b/build-system/tasks/lint.js
@@ -132,6 +132,8 @@ function summarizeResults(results, fixedFiles) {
 /**
  * Checks files for formatting (and optionally fixes them) with Eslint.
  * Explicitly makes sure the API doesn't check files in `.eslintignore`.
+ * When local changes are linted (e.g. during CI), we also check if the list of
+ * forbidden terms needs to be updated.
  */
 async function lint() {
   const filesToCheck = getFilesToCheck(
@@ -141,6 +143,10 @@ async function lint() {
   );
   if (filesToCheck.length == 0) {
     return;
+  }
+  const forbiddenTerms = 'build-system/test-configs/forbidden-terms.js';
+  if (argv.local_changes && !filesToCheck.includes(forbiddenTerms)) {
+    filesToCheck.push(forbiddenTerms);
   }
   await runLinter(filesToCheck);
 }


### PR DESCRIPTION
Some time ago CI was updated to run lint with the `local_changes` flag to speed up the process. However, the issues related to usage of "forbidden terms" are only displayed when the `forbidden-terms` file is linted. This meant that any change that involved "forbidden terms" would pass initially, then fail when a full lint was run on main.
I solved this issue in #34897 by updating the `getFilesToCheck` helper function to ensure that the `forbidden-terms` file is always checked. What I did not know was that the function is also used by the `check-owners` task which now fails when it is called with the `local_changes` flag (if an OWNERS file has actually been changed).

Before:
![image](https://user-images.githubusercontent.com/78179109/123145720-fa12ca00-d411-11eb-80c6-3f7f6db190e0.png)


After:
![image](https://user-images.githubusercontent.com/78179109/123145839-19115c00-d412-11eb-9414-46f65bc89bec.png)

#34986
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
