### PR TITLE
🐛 [amp-story] Don't set auto-advance when in control

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -51,6 +51,7 @@ import {LoadingSpinner} from './loading-spinner';
 import {LocalizedStringId} from '../../../src/localized-strings';
 import {MediaPool} from './media-pool';
 import {Services} from '#service';
+import {StoryAdSegmentTimes} from '#experiments/story-ad-progress-segment';
 import {VideoEvents, delegateAutoplay} from '../../../src/video-interface';
 import {addAttributesToElement, iterateCursor} from '#core/dom';
 import {
@@ -391,7 +392,12 @@ export class AmpStoryPage extends AMP.BaseElement {
     const storyNextUpParam = Services.viewerForDoc(this.element).getParam(
       'storyNextUp'
     );
-    if (autoAdvanceAttr !== null || storyNextUpParam === null) {
+    if (
+      autoAdvanceAttr !== null ||
+      storyNextUpParam === null ||
+      // This is a special value that indicates we are in the viewer indicated control group.
+      storyNextUpParam === StoryAdSegmentTimes.SENTINEL
+    ) {
       return;
     }
     addAttributesToElement(

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -452,6 +452,15 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     expect(element.getAttribute('auto-advance-after')).to.be.equal('20000ms');
   });
 
+  it('should not use storyNextUp when in viewer control group', () => {
+    env.sandbox
+      .stub(Services.viewerForDoc(element), 'getParam')
+      .withArgs('storyNextUp')
+      .returns('999999ms');
+    page.buildCallback();
+    expect(element).not.to.have.attribute('auto-advance-after');
+  });
+
   it('should stop the advancement when state becomes not active', async () => {
     page.buildCallback();
     const advancementStopStub = env.sandbox.stub(page.advancement_, 'stop');


### PR DESCRIPTION
`999999ms` is a special value passed from the viewer as the `storyNextUp` param that indicates we are in the control group of the auto advance experiment.

#33969