### PR TITLE
Fix `IframeMessagingClient` unit tests

### DIFF
--- a/3p/iframe-messaging-client.js
+++ b/3p/iframe-messaging-client.js
@@ -36,7 +36,7 @@ export class IframeMessagingClient {
     /** @private {!Window} */
     this.win_ = win;
     /** @private {?string} */
-    this.rtvVersion_ = getMode().rtvVersion || null;
+    this.rtvVersion_ = getMode(win).rtvVersion || null;
     /** @private {?Window} */
     this.hostWindow_ = hostWindow || null;
     /** @private {?string} */

--- a/test/unit/3p/test-iframe-messaging-client.js
+++ b/test/unit/3p/test-iframe-messaging-client.js
@@ -15,7 +15,6 @@
  */
 
 import {IframeMessagingClient} from '#3p/iframe-messaging-client';
-import {getMode} from '../../../src/mode';
 import {serializeMessage} from '../../../src/3p-frame-messaging';
 
 describes.realWin('iframe-messaging-client', {}, (env) => {
@@ -51,7 +50,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
 
@@ -80,7 +79,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
 
@@ -109,7 +108,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
 
@@ -138,7 +137,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
 
@@ -175,7 +174,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
 
@@ -201,7 +200,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
 
@@ -366,7 +365,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {x: 1, y: 'abc'},
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
       });
@@ -400,7 +399,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
         expect(postMessageStub2).to.be.calledWith(
@@ -408,7 +407,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            getMode().rtvVersion
+            '01$internalRuntimeVersion$'
           )
         );
 

--- a/test/unit/3p/test-iframe-messaging-client.js
+++ b/test/unit/3p/test-iframe-messaging-client.js
@@ -15,6 +15,7 @@
  */
 
 import {IframeMessagingClient} from '#3p/iframe-messaging-client';
+import {getMode} from '../../../src/mode';
 import {serializeMessage} from '../../../src/3p-frame-messaging';
 
 describes.realWin('iframe-messaging-client', {}, (env) => {
@@ -50,7 +51,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
 
@@ -79,7 +80,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
 
@@ -108,7 +109,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
 
@@ -137,7 +138,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
               },
               'messageId': 1,
             },
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
 
@@ -174,7 +175,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
 
@@ -200,7 +201,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
 
@@ -365,7 +366,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {x: 1, y: 'abc'},
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
       });
@@ -399,7 +400,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
         expect(postMessageStub2).to.be.calledWith(
@@ -407,7 +408,7 @@ describes.realWin('iframe-messaging-client', {}, (env) => {
             'request-type',
             'sentinel-123',
             {},
-            '01$internalRuntimeVersion$'
+            getMode().rtvVersion
           )
         );
 

--- a/test/unit/test-amp-context.js
+++ b/test/unit/test-amp-context.js
@@ -39,6 +39,9 @@ describes.sandboxed('3p ampcontext.js', {}, (env) => {
       // makes nextTick behavior synchronous for test assertions.
       setTimeout: (cb) => cb(),
 
+      // location is needed for getMode(win)
+      location: {},
+
       // we don't care about window events for these tests since that behavior
       // is deprecated.
       document: {


### PR DESCRIPTION
Some of the tests in `test/unit/3p/test-iframe-messaging-client.js` appear to be failing in `main`: 
- https://app.circleci.com/pipelines/github/ampproject/amphtml/12017/workflows/f918dec7-2e72-4bd2-86b2-513c3e202ab8/jobs/191125
- https://app.circleci.com/pipelines/github/ampproject/amphtml/11962/workflows/9e005a18-eb36-468d-b0e8-facc95e5b962/jobs/191153

This appears to be due to the `rtvVersion_` being passed to `serializeMessage` in the fn under test resolving to `null`:
https://github.com/ampproject/amphtml/blob/5e85bd194205ffc8e51666c29cb0c2a429c06bbb/3p/iframe-messaging-client.js#L132-L137

While this PR fixes the test failures, it appears to contradict that we do appear to expect `$internalRuntimVersion$` not to be replaced, as evidenced by this test which does not fail:
https://github.com/ampproject/amphtml/blob/5e85bd194205ffc8e51666c29cb0c2a429c06bbb/test/unit/test-mode.js#L60-L65