### PR TITLE
Fix AMP-AD sticky validator rule

### DIFF
--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -66,9 +66,7 @@ tags: {  # <amp-ad>
   attrs: { name: "type" mandatory: true }
   attrs: {
     name: "sticky"
-    value: ""
-    value: "top"
-    value: "bottom"
+    value_regex: "(|top|bottom)"
   }
   attrs: { name: "always-serve-npa" }
   attrs: { name: "block-rtc" }


### PR DESCRIPTION
When we added top and bottom to the permissible sticky attributes, we are not aware that it won't work. This PR will fix it.