### PR TITLE
🐛 Update regex to match google3 version.

### DIFF
--- a/extensions/amp-tiktok/validator-amp-tiktok.protoascii
+++ b/extensions/amp-tiktok/validator-amp-tiktok.protoascii
@@ -32,7 +32,7 @@ tags: {  # <amp-tiktok>
   attr_lists: "extended-amp-global"
   attrs: {
     name: "data-src";
-    value_regex: "\d";
+    value_regex: "\\d";
     mandatory: true
   }
   spec_url: "https://amp.dev/documentation/components/amp-tiktok"


### PR DESCRIPTION
Google3 version of this file was fixed to have the correct regex "\\d" vs. "\d". Making this change here to make sure the files match.
