### PR TITLE
🏗 Fix errors emitted by the VSCode typescript plugin

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "allowJs": true,
     "baseUrl": ".",
+    "outDir": "dist",
+    "noEmit": true,
     "paths": {
       "#3p/*": ["./3p/*"],
       "#ads/*": ["./ads/*"],
@@ -22,5 +24,5 @@
       "#third_party/*": ["./third_party/*"]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
The built-in VSCode typescript extension is showing what looks like a bogus error in `tsconfig.json` that mentions a random source file each time it appears.

![image](https://user-images.githubusercontent.com/26553114/123471617-0c346a00-d5c4-11eb-810d-e21832bbf418.png)

Since this is an error from the extension and we don't actually generate any TS -> JS output for `amphtml` source, this PR updates the settings in `tsconfig.json` to avoid emitting any output, and if necessary, use the `dist` directory instead of overwriting source files. These two changes appear to have silenced the error above.

**References:**
- https://www.typescriptlang.org/tsconfig
- https://github.com/Microsoft/TypeScript/issues/14538
- https://stackoverflow.com/questions/42609768/typescript-error-cannot-write-file-because-it-would-overwrite-input-file
