### PR TITLE
Sync for validator/cpp/engine and Validator rollup

### DIFF
--- a/validator/cpp/engine/validator-internal.cc
+++ b/validator/cpp/engine/validator-internal.cc
@@ -115,31 +115,45 @@ ABSL_FLAG(bool, allow_module_nomodule, true,
 
 namespace amp::validator {
 
-// Examples (note these are the same as kNomoduleLtsScriptPathRe):
-// /lts/v0.js
-// /lts/v0/amp-ad-0.1.js
+// LTS JavaScript (note these are the same as kNomoduleLtsScriptPathRe):
+// lts/v0.js
+// lts/v0/amp-ad-0.1.js
 static const LazyRE2 kLtsScriptPathRe = {
-    R"re(/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.js)re"};
-// Examples:
-// /v0.mjs
-// /v0/amp-ad-0.1.mjs
+    R"re(lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.js)re"};
+
+// Module JavaScript:
+// v0.mjs
+// v0/amp-ad-0.1.mjs
 static const LazyRE2 kModuleScriptPathRe = {
-    R"re(/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.mjs)re"};
-// Examples:
-// /v0.js
-// /v0/amp-ad-0.1.js
+    R"re((v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.mjs)re"};
+
+// Nomodule JavaScript:
+// v0.js
+// v0/amp-ad-0.1.js
 static const LazyRE2 kNomoduleScriptPathRe = {
-    R"re(/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.js)re"};
-// Examples:
-// /lts/v0.mjs
-// /lts/v0/amp-ad-0.1.mjs
+    R"re((v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.js)re"};
+
+// Module LTS JavaScript:
+// lts/v0.mjs
+// lts/v0/amp-ad-0.1.mjs
 static const LazyRE2 kModuleLtsScriptPathRe = {
-    R"re(/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.mjs)re"};
-// Examples (note these are the same as kLtsScriptPathRe):
-// /lts/v0.js
-// /lts/v0/amp-ad-0.1.js
+    R"re(lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.mjs)re"};
+
+// Nomodule LTS JavaScript (note these are the same as kLtsScriptPathRe):
+// lts/v0.js
+// lts/v0/amp-ad-0.1.js
 static const LazyRE2 kNomoduleLtsScriptPathRe = {
-    R"re(/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.js)re"};
+    R"re(lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\.js)re"};
+
+// Runtime JavaScript:
+// v0.js
+// v0.mjs
+// v0.mjs?f=sxg
+// lts/v0.js
+// lts/v0.js?f=sxg
+// lts/v0.mjs
+static const LazyRE2 kRuntimeScriptPathRe = {
+    R"re((lts/)?v0\.m?js(\?f=sxg)?)re"};
 
 namespace {
 
@@ -271,6 +285,71 @@ std::string ScriptReleaseVersionToString(ScriptReleaseVersion version) {
   return "";
 }
 
+inline constexpr string_view kAmpProjectDomain = "https://cdn.ampproject.org/";
+
+struct ScriptTag {
+  bool is_amp_domain = false;
+  bool is_extension = false;
+  bool is_runtime = false;
+  ScriptReleaseVersion release_version = ScriptReleaseVersion::UNKNOWN;
+};
+
+ScriptTag ParseScriptTag(htmlparser::Node* node) {
+  ScriptTag script_tag;
+  bool has_async_attr = false;
+  bool has_module_attr = false;
+  bool has_nomodule_attr = false;
+  string_view src;
+
+  for (const auto& attr : node->Attributes()) {
+    std::string attr_name = attr.KeyPart();
+    if (attr_name == "async") {
+      has_async_attr = true;
+    } else if ((attr_name == "custom-element") ||
+               (attr_name == "custom-template") ||
+               (attr_name == "host-service")) {
+      script_tag.is_extension = true;
+    } else if (attr_name == "nomodule") {
+      has_nomodule_attr = true;
+    } else if (attr_name == "src") {
+      src = attr.value;
+    } else if ((attr_name == "type") && (attr.value == "module")) {
+      has_module_attr = true;
+    }
+  }
+
+  // Determine if this has a valid AMP domain and separate the path from the
+  // attribute 'src'. Consumes the domain making src just the path.
+  if (absl::ConsumePrefix(&src, kAmpProjectDomain)) {
+    script_tag.is_amp_domain = true;
+
+    // Only look at script tags that have attribute 'async'.
+    if (has_async_attr) {
+      // Determine if this is the AMP Runtime.
+      if (!script_tag.is_extension &&
+          RE2::FullMatch(src, *kRuntimeScriptPathRe))
+        script_tag.is_runtime = true;
+
+      // Determine the release version (LTS, module, standard, etc).
+      if ((has_module_attr && RE2::FullMatch(src, *kModuleLtsScriptPathRe)) ||
+          (has_nomodule_attr &&
+           RE2::FullMatch(src, *kNomoduleLtsScriptPathRe))) {
+        script_tag.release_version = ScriptReleaseVersion::MODULE_NOMODULE_LTS;
+      } else if ((has_module_attr &&
+                  RE2::FullMatch(src, *kModuleScriptPathRe)) ||
+                 (has_nomodule_attr &&
+                  RE2::FullMatch(src, *kNomoduleScriptPathRe))) {
+        script_tag.release_version = ScriptReleaseVersion::MODULE_NOMODULE;
+      } else if (RE2::FullMatch(src, *kLtsScriptPathRe)) {
+        script_tag.release_version = ScriptReleaseVersion::LTS;
+      } else {
+        script_tag.release_version = ScriptReleaseVersion::STANDARD;
+      }
+    }
+  }
+  return script_tag;
+}
+
 class ParsedHtmlTag {
  public:
   explicit ParsedHtmlTag(htmlparser::Node* node) : node_(node) {
@@ -292,6 +371,8 @@ class ParsedHtmlTag {
     for (const auto& attr : node_->Attributes()) {
       attributes_.push_back(ParsedHtmlTagAttr{attr.KeyPart(), attr.value});
     }
+    if (node_->DataAtom() == htmlparser::Atom::SCRIPT)
+      script_tag_ = ParseScriptTag(node);
   }
 
   // New Methods
@@ -326,93 +407,14 @@ class ParsedHtmlTag {
 
   bool IsEmpty() const { return node_->Data().empty(); }
 
-  std::string ExtensionScriptNameAttribute() const {
-    if (UpperName() == "SCRIPT") {
-      for (const std::string& attribute :
-           {"custom-element", "custom-template", "host-service"}) {
-        if (GetAttr(attribute).has_value()) {
-          return attribute;
-        }
-      }
-    }
-    return "";
-  }
+  bool IsExtensionScript() const { return script_tag_.is_extension; }
 
-  bool IsExtensionScript() const {
-    return !ExtensionScriptNameAttribute().empty();
-  }
+  bool IsAmpDomain() const { return script_tag_.is_amp_domain; }
 
-  bool IsAmpCacheDomain(string_view src) const {
-    return StartsWith(src, "https://cdn.ampproject.org/");
-  }
+  bool IsAmpRuntimeScript() const { return script_tag_.is_runtime; }
 
-  bool IsAsyncScriptTag(string_view src) const {
-    return UpperName() == "SCRIPT" && GetAttr("async").has_value() &&
-           !src.empty();
-  }
-
-  bool IsAmpRuntimeScript() const {
-    const string_view src = GetAttr("src").value_or("");
-    return IsAsyncScriptTag(src) && !IsExtensionScript() &&
-           IsAmpCacheDomain(src) &&
-           (EndsWith(src, "/v0.js") || EndsWith(src, "/v0.mjs") ||
-            EndsWith(src, "/v0.mjs?f=sxg"));
-  }
-
-  // This does not validate the script src, that is handled in the tagspec.
-  // This is checking if the script src is an LTS script.
-  bool IsLtsScriptTag(string_view src) const {
-    return IsAsyncScriptTag(src) && IsAmpCacheDomain(src) &&
-           RE2::PartialMatch(GetAttr("src").value_or(""), *kLtsScriptPathRe);
-  }
-
-  // This does not validate the script src, that is handled in the tagspec.
-  // This is checking if the script src is a module script.
-  bool IsModuleScriptTag(string_view src) const {
-    return IsAsyncScriptTag(src) &&
-           (GetAttr("type").value_or("") == "module") &&
-           IsAmpCacheDomain(src) &&
-           RE2::PartialMatch(GetAttr("src").value_or(""), *kModuleScriptPathRe);
-  }
-
-  // This does not validate the script src, that is handled in the tagspec.
-  // This is checking if the script src is a nomodule script.
-  bool IsNomoduleScriptTag(string_view src) const {
-    return IsAsyncScriptTag(src) && GetAttr("nomodule").has_value() &&
-           IsAmpCacheDomain(src) &&
-           RE2::PartialMatch(GetAttr("src").value_or(""),
-                             *kNomoduleScriptPathRe);
-  }
-
-  // This does not validate the script src, that is handled in the tagspec.
-  // This is checking if the script src is a module LTS script.
-  bool IsModuleLtsScriptTag(string_view src) const {
-    return IsAsyncScriptTag(src) &&
-           (GetAttr("type").value_or("") == "module") &&
-           IsAmpCacheDomain(src) &&
-           RE2::PartialMatch(GetAttr("src").value_or(""),
-                             *kModuleLtsScriptPathRe);
-  }
-
-  // This does not validate the script src, that is handled in the tagspec.
-  // This is checking if the script src is a nomodule LTS script.
-  bool IsNomoduleLtsScriptTag(string_view src) const {
-    return IsAsyncScriptTag(src) && GetAttr("nomodule").has_value() &&
-           IsAmpCacheDomain(src) &&
-           RE2::PartialMatch(GetAttr("src").value_or(""),
-                             *kNomoduleLtsScriptPathRe);
-  }
-
-  // Inspects the separately validated src attribute to select its script
-  // release version: module/nomodule LTS, module/nomodule, LTS or standard.
   ScriptReleaseVersion GetScriptReleaseVersion() const {
-    const string_view src = GetAttr("src").value_or("");
-    if (IsModuleLtsScriptTag(src) || IsNomoduleLtsScriptTag(src))
-      return ScriptReleaseVersion::MODULE_NOMODULE_LTS;
-    if (IsModuleScriptTag(src) || IsNomoduleScriptTag(src))
-      return ScriptReleaseVersion::MODULE_NOMODULE;
-    if (IsLtsScriptTag(src)) return ScriptReleaseVersion::LTS;
-    return ScriptReleaseVersion::STANDARD;
+    return script_tag_.release_version;
   }
 
   const vector<ParsedHtmlTagAttr>& Attributes() const { return attributes_; }
@@ -441,6 +443,7 @@ class ParsedHtmlTag {
   htmlparser::Node* node_;
   std::string lower_tag_name_;
   std::string upper_tag_name_;
+  ScriptTag script_tag_;
   vector<ParsedHtmlTagAttr> attributes_;
   ParsedHtmlTag(const ParsedHtmlTag&) = delete;
   ParsedHtmlTag operator=(const ParsedHtmlTag&) = delete;
@@ -3997,10 +4000,20 @@ void ValidateClassAttr(const ParsedHtmlTagAttr& class_attr,
   }
 }
 
-// Validates the same script release version is used for all script sources.
+// Validates the script is using an AMP domain and that the same script release
+// version is used for all script sources.
 void ValidateScriptSrcAttr(const ParsedHtmlTag& tag, const TagSpec& tag_spec,
                            const Context& context, ValidationResult* result) {
   if (context.script_release_version() == ScriptReleaseVersion::UNKNOWN) return;
+
+  if (!tag.IsAmpDomain()) {
+    context.AddError(ValidationError::DISALLOWED_AMP_DOMAIN, context.line_col(),
+                     /*params=*/{},
+                     "https://amp.dev/documentation/guides-and-tutorials/learn/"
+                     "spec/amphtml#required-markup",
+                     result);
+    return;
+  }
 
   const ScriptReleaseVersion script_release_version =
       tag.GetScriptReleaseVersion();

--- a/validator/js/engine/htmlparser-interface.js
+++ b/validator/js/engine/htmlparser-interface.js
@@ -17,7 +17,6 @@
 
 goog.module('amp.htmlparser.interface');
 
-
 /**
  * @param {string} str The string to lower case.
  * @return {string} The str in lower case format.
@@ -73,6 +72,145 @@ const ParsedAttr = class {
 };
 exports.ParsedAttr = ParsedAttr;
 
+// If any script in the page uses a specific release version, then all scripts
+// must use that specific release version. This is used to record the first
+// seen script tag and ensure all following script tags follow the convention
+// set by it.
+/** @enum {string} */
+const ScriptReleaseVersion = {
+  UNKNOWN: 'unknown',
+  STANDARD: 'standard',
+  LTS: 'LTS',
+  MODULE_NOMODULE: 'module/nomodule',
+  MODULE_NOMODULE_LTS: 'module/nomodule LTS',
+};
+exports.ScriptReleaseVersion = ScriptReleaseVersion;
+
+// AMP domain
+const /** string */ ampProjectDomain = 'https://cdn.ampproject.org/';
+
+// LTS JavaScript:
+// lts/v0.js
+// lts/v0/amp-ad-0.1.js
+const /** !RegExp */ ltsScriptPathRegex =
+    new RegExp('lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
+
+// Module JavaScript:
+// v0.mjs
+// amp-ad-0.1.mjs
+const /** !RegExp */ moduleScriptPathRegex =
+    new RegExp('(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$', 'i');
+
+// Nomodule JavaScript:
+// v0.js
+// v0/amp-ad-0.1.js
+const /** !RegExp */ nomoduleScriptPathRegex =
+    new RegExp('(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
+
+// Module LTS JavaScript:
+// lts/v0.mjs
+// lts/v0/amp-ad-0.1.mjs
+const /** !RegExp */ moduleLtsScriptPathRegex =
+    new RegExp('lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$', 'i');
+
+// Nomodule LTS JavaScript:
+// lts/v0.js
+// lts/v0/amp-ad-0.1.js
+const /** !RegExp */ nomoduleLtsScriptPathRegex =
+    new RegExp('lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
+
+// Runtime JavaScript:
+// v0.js
+// v0.mjs
+// v0.mjs?f=sxg
+// lts/v0.js
+// lts/v0.js?f=sxg
+// lts/v0.mjs
+const /** !RegExp */ runtimeScriptPathRegex =
+    new RegExp('(lts/)?v0\\.m?js(\\?f=sxg)?', 'i');
+
+/**
+ * Represents the state of a script tag.
+ */
+const ScriptTag = class {
+  /**
+   * @param {string} tagName
+   * @param {!Array<!ParsedAttr>} attrs Array of attributes.
+   */
+  constructor(tagName, attrs) {
+    /** @type {boolean} */
+    this.is_amp_domain = false;
+    /** @type {boolean} */
+    this.is_extension = false;
+    /** @type {boolean} */
+    this.is_runtime = false;
+    /** @type {!ScriptReleaseVersion} */
+    this.release_version = ScriptReleaseVersion.UNKNOWN;
+
+    /** @type {boolean} */
+    let is_async = false;
+    /** @type {boolean} */
+    let is_module = false;
+    /** @type {boolean} */
+    let is_nomodule = false;
+    /** @type {string} */
+    let path = '';
+    /** @type {string} */
+    let src = '';
+
+    if (tagName !== 'SCRIPT') {
+      return;
+    }
+
+    for (const attr of attrs) {
+      if (attr.name === 'async') {
+        is_async = true;
+      } else if (
+          (attr.name === 'custom-element') ||
+          (attr.name === 'custom-template') || (attr.name === 'host-service')) {
+        this.is_extension = true;
+      } else if (attr.name === 'nomodule') {
+        is_nomodule = true;
+      } else if (attr.name === 'src') {
+        src = attr.value;
+      } else if ((attr.name === 'type') && (attr.value === 'module')) {
+        is_module = true;
+      }
+    }
+
+    // Determine if this has a valid AMP domain and separate the path from the
+    // attribute 'src'.
+    if (src.startsWith(ampProjectDomain)) {
+      this.is_amp_domain = true;
+      path = src.substr(ampProjectDomain.length);
+
+      // Only look at script tags that have attribute 'async'.
+      if (is_async) {
+        // Determine if this is the AMP Runtime.
+        if (!this.is_extension && runtimeScriptPathRegex.test(path)) {
+          this.is_runtime = true;
+        }
+
+        // Determine the release version (LTS, module, standard, etc).
+        if ((is_module && moduleLtsScriptPathRegex.test(path)) ||
+            (is_nomodule && nomoduleLtsScriptPathRegex.test(path))) {
+          this.release_version = ScriptReleaseVersion.MODULE_NOMODULE_LTS;
+        } else if (
+            (is_module && moduleScriptPathRegex.test(path)) ||
+            (is_nomodule && nomoduleScriptPathRegex.test(path))) {
+          this.release_version = ScriptReleaseVersion.MODULE_NOMODULE;
+        } else if (ltsScriptPathRegex.test(path)) {
+          this.release_version = ScriptReleaseVersion.LTS;
+        } else {
+          this.release_version = ScriptReleaseVersion.STANDARD;
+        }
+      }
+    }
+  }
+};
+exports.ScriptTag = ScriptTag;
+
+
 /**
  * An Html parser makes method calls with ParsedHtmlTags as arguments.
  */
@@ -124,6 +262,9 @@ const ParsedHtmlTag = class {
     // Lazily allocated map from attribute name to value.
     /** @private @type {?Object<string, string>} */
     this.attrsByKey_ = null;
+
+    /** @private @type {?ScriptTag} */
+    this.scriptTag_ = new ScriptTag(this.tagName_, this.attrs_);
   }
 
   /**
@@ -219,55 +360,19 @@ const ParsedHtmlTag = class {
   }
 
   /**
-   * @return {boolean}
+   * Returns the script release version, otherwise ScriptReleaseVersion.UNKNOWN.
+   * @return {!ScriptReleaseVersion}
    */
-  isEmpty() {
-    return this.tagName_.length === 0;
+  getScriptReleaseVersion() {
+    return this.scriptTag_.release_version;
   }
 
   /**
-   * Gets the name attribute for an extension script tag.
-   * @return {string}
-   * @private
-   */
-  extensionScriptNameAttribute_() {
-    if (this.upperName() == 'SCRIPT') {
-      for (const attribute
-               of ['custom-element', 'custom-template', 'host-service']) {
-        if (attribute in this.attrsByKey()) {
-          return attribute;
-        }
-      }
-    }
-    return '';
-  }
-
-  /**
-   * Tests if this is an extension script tag.
+   * Tests if this tag is a script with a src of an AMP domain.
    * @return {boolean}
    */
-  isExtensionScript() {
-    return !!this.extensionScriptNameAttribute_();
-  }
-
-  /**
-   * Tests if this is an AMP Cache domain.
-   * @param {string} src
-   * @return {boolean}
-   */
-  isAmpCacheDomain_(src) {
-    return src.startsWith('https://cdn.ampproject.org/');
-  }
-
-  /**
-   * Tests if this is an async script tag.
-   * @param {string} src
-   * @return {boolean}
-   * @private
-   */
-  isAsyncScriptTag_(src) {
-    return this.upperName() == 'SCRIPT' && 'async' in this.attrsByKey() &&
-        src !== null;
+  isAmpDomain() {
+    return this.scriptTag_.is_amp_domain;
   }
 
   /**
@@ -275,96 +380,22 @@ const ParsedHtmlTag = class {
    * @return {boolean}
    */
   isAmpRuntimeScript() {
-    const src = this.getAttrValueOrNull_('src');
-    if (src === null) return false;
-    return this.isAsyncScriptTag_(src) && !this.isExtensionScript() &&
-        this.isAmpCacheDomain_(src) &&
-        (src.endsWith('/v0.js') || src.endsWith('/v0.mjs') ||
-         src.endsWith('/v0.mjs?f=sxg'));
+    return this.scriptTag_.is_runtime;
   }
 
   /**
-   * Tests if this is the LTS version script tag.
    * @return {boolean}
    */
-  isLtsScriptTag() {
-    // Examples:
-    // https://cdn.ampproject.org/lts/v0.js
-    // https://cdn.ampproject.org/lts/v0/amp-ad-0.1.js
-    const src = this.getAttrValueOrNull_('src');
-    if (src === null) return false;
-    const ltsScriptPathRegex =
-        new RegExp('/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
-    return this.isAsyncScriptTag_(src) && this.isAmpCacheDomain_(src) &&
-        ltsScriptPathRegex.test(src);
+  isEmpty() {
+    return this.tagName_.length === 0;
   }
 
   /**
-   * Tests if this is the module version script tag.
+   * Tests if this is an extension script tag.
    * @return {boolean}
    */
-  isModuleScriptTag() {
-    // Examples:
-    // https://cdn.ampproject.org/v0.mjs
-    // https://cdn.ampproject.org/v0/amp-ad-0.1.mjs
-    const type = this.getAttrValueOrNull_('type');
-    if (type === null) return false;
-    const src = this.getAttrValueOrNull_('src');
-    if (src === null) return false;
-    const moduleScriptPathRegex =
-        new RegExp('/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$', 'i');
-    return this.isAsyncScriptTag_(src) && (type == 'module') &&
-        this.isAmpCacheDomain_(src) && moduleScriptPathRegex.test(src);
-  }
-
-  /**
-   * Tests if this is the nomodule version script tag.
-   * @return {boolean}
-   */
-  isNomoduleScriptTag() {
-    // Examples:
-    // https://cdn.ampproject.org/v0.js
-    // https://cdn.ampproject.org/v0/amp-ad-0.1.js
-    const src = this.getAttrValueOrNull_('src');
-    if (src === null) return false;
-    const nomoduleScriptPathRegex =
-        new RegExp('/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
-    return this.isAsyncScriptTag_(src) && 'nomodule' in this.attrsByKey() &&
-        this.isAmpCacheDomain_(src) && nomoduleScriptPathRegex.test(src);
-  }
-
-  /**
-   * Tests if this is the module LTS version script tag.
-   * @return {boolean}
-   */
-  isModuleLtsScriptTag() {
-    // Examples:
-    // https://cdn.ampproject.org/lts/v0.mjs
-    // https://cdn.ampproject.org/lts/v0/amp-ad-0.1.mjs
-    const type = this.getAttrValueOrNull_('type');
-    if (type === null) return false;
-    const src = this.getAttrValueOrNull_('src');
-    if (src === null) return false;
-    const moduleLtsScriptPathRegex =
-        new RegExp('lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.mjs$', 'i');
-    return this.isAsyncScriptTag_(src) && (type == 'module') &&
-        this.isAmpCacheDomain_(src) && moduleLtsScriptPathRegex.test(src);
-  }
-
-  /**
-   * Tests if this is the nomodule LTS version script tag.
-   * @return {boolean}
-   */
-  isNomoduleLtsScriptTag() {
-    // Examples:
-    // https://cdn.ampproject.org/lts/v0.js
-    // https://cdn.ampproject.org/lts/v0/amp-ad-0.1.js
-    const src = this.getAttrValueOrNull_('src');
-    if (src === null) return false;
-    const nomoduleLtsScriptPathRegex =
-        new RegExp('/lts/(v0|v0/amp-[a-z0-9-]*-[a-z0-9.]*)\\.js$', 'i');
-    return this.isAsyncScriptTag_(src) && 'nomodule' in this.attrsByKey() &&
-        this.isAmpCacheDomain_(src) && nomoduleLtsScriptPathRegex.test(src);
+  isExtensionScript() {
+    return this.scriptTag_.is_extension;
   }
 };
 exports.ParsedHtmlTag = ParsedHtmlTag;

--- a/validator/testdata/feature_tests/regexps.out
+++ b/validator/testdata/feature_tests/regexps.out
@@ -41,6 +41,8 @@ feature_tests/regexps.html:27:2 The mandatory attribute 'amp-custom' is missing 
 feature_tests/regexps.html:36:2 The attribute 'src' in tag 'amp-vine extension script' is set to the invalid value 'https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://amp.dev/documentation/components/amp-vine)
 |    <script async custom-element="amp-vine" src="http://xss.com/https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar"></script>
 >>   ^~~~~~~~~
+feature_tests/regexps.html:37:2 The script tag includes an invalid AMP domain in the src attribute. (see https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup)
+>>   ^~~~~~~~~
 feature_tests/regexps.html:37:2 The attribute 'src' in tag 'amp-vine extension script' is set to the invalid value 'http://xss.com/https://cdn.ampproject.org/v0/amp-vine-0.1.js?foobar'. (see https://amp.dev/documentation/components/amp-vine)
 |    <script async custom-element="amp-hulu" src="https://cdn.ampproject.org/v0/amp-hulu-latest.js"> Only whitespace is allowed here. </script>
 >>   ^~~~~~~~~


### PR DESCRIPTION
- cl/380257173 Adds error for invalid AMP cache domain.

This PR syncs cl/380257173 for the two folders in one time, because neither can pass circle ci test by itself.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
