### PR TITLE
Video caching: rewrite /i/ URLs to /mbv/.

### DIFF
--- a/extensions/amp-video/0.1/test/test-video-cache.js
+++ b/extensions/amp-video/0.1/test/test-video-cache.js
@@ -119,6 +119,17 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
         'https://example-com.cdn.ampproject.org/mbv/s/example.com/video.html?amp_video_host_url=https%3A%2F%2Fcanonical.com'
       );
     });
+
+    it('should send the request to the correct address if the video has a .gif extension', async () => {
+      const videoEl = createVideo([{'src': 'https://website.com/video.gif'}]);
+      const xhrSpy = env.sandbox.spy(xhrService, 'fetch');
+
+      await fetchCachedSources(videoEl, env.ampdoc);
+
+      expect(xhrSpy).to.have.been.calledWith(
+        'https://website-com.cdn.ampproject.org/mbv/s/website.com/video.gif?amp_video_host_url=https%3A%2F%2Fcanonical.com'
+      );
+    });
   });
 
   describe('add sources', () => {

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -51,7 +51,7 @@ export function fetchCachedSources(videoEl, ampdoc) {
   return getCacheUrlService(videoEl, ampdoc)
     .then((service) => service.createCacheUrl(videoUrl))
     .then((cacheUrl) => {
-      const requestUrl = addParamsToUrl(cacheUrl.replace('/c/', '/mbv/'), {
+      const requestUrl = addParamsToUrl(cacheUrl.replace(/\/[ic]\//, '/mbv/'), {
         'amp_video_host_url':
           /* document url that contains the video */ canonicalUrl,
       });


### PR DESCRIPTION
Video caching: rewrite `/i/` URLs to `/mbv/`.

If a video source is an image extension, e.g. `.gif`, the Cache URL service would return an URL containing `/i/` instead of the expected `/c/`.

cc @Gregable FYI