### PR TITLE
Bento `amp-lightbox-gallery` grouping behavior

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -240,8 +240,7 @@ exports.rules = [
       'extensions/amp-stream-gallery/1.0/component.js->extensions/amp-base-carousel/1.0/component.js',
 
       // Autolightboxing dependencies
-      'extensions/amp-base-carousel/1.0/component.js->extensions/amp-lightbox-gallery/1.0/component.js',
-      'extensions/amp-base-carousel/1.0/scroller.js->extensions/amp-lightbox-gallery/1.0/context.js',
+      'extensions/amp-base-carousel/1.0/scroller.js->extensions/amp-lightbox-gallery/1.0/component.js',
       'extensions/amp-lightbox-gallery/1.0/provider.js->extensions/amp-lightbox/1.0/component.js',
       'extensions/amp-lightbox-gallery/1.0/provider.js->extensions/amp-base-carousel/1.0/component.js',
       'extensions/amp-lightbox-gallery/1.0/base-element.js->extensions/amp-lightbox/1.0/component.jss.js',

--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -354,8 +354,8 @@ function BaseCarouselWithRef(
         {childrenArray.map((child, index) => (
           <WithAmpContext
             key={index}
-            renderable={index == currentSlide}
-            playable={index == currentSlide}
+            renderable={index === currentSlide}
+            playable={index === currentSlide}
           >
             {child}
           </WithAmpContext>

--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -27,10 +27,9 @@ import {CarouselContext} from './carousel-context';
 import {ContainWrapper} from '#preact/component';
 import {Scroller} from './scroller';
 import {WithAmpContext} from '#preact/context';
-import {WithLightbox} from '../../amp-lightbox-gallery/1.0/component';
 import {forwardRef, toChildArray} from '#preact/compat';
 import {isRTL} from '#core/dom';
-import {mod} from '#core/math';
+import {sequentialIdGenerator} from '#core/math/id-generator';
 import {toWin} from '#core/window';
 import {
   useCallback,
@@ -74,6 +73,8 @@ const Direction = {
 };
 
 const MIN_AUTO_ADVANCE_INTERVAL = 1000;
+
+const generateCarouselKey = sequentialIdGenerator();
 
 /**
  * @param {!BaseCarouselDef.Props} props
@@ -128,6 +129,7 @@ function BaseCarouselWithRef(
     : setGlobalCurrentSlide;
   const currentSlideRef = useRef(currentSlide);
   const axis = orientation == Orientation.HORIZONTAL ? Axis.X : Axis.Y;
+  const [id] = useState(generateCarouselKey);
 
   useLayoutEffect(() => {
     // noop if !_thumbnails || !carouselContext.
@@ -320,12 +322,7 @@ function BaseCarouselWithRef(
       }}
       tabIndex="0"
       wrapperClassName={classes.carousel}
-      contentAs={lightbox ? WithLightbox : 'div'}
       contentRef={contentRef}
-      contentProps={{
-        enableActivation: false,
-        render: () => children,
-      }}
       {...rest}
     >
       {!hideControls && (
@@ -342,7 +339,7 @@ function BaseCarouselWithRef(
         advanceCount={advanceCount}
         alignment={snapAlign}
         axis={axis}
-        lightbox={lightbox}
+        lightboxGroup={lightbox && 'carousel' + id}
         loop={loop}
         mixedLength={mixedLength}
         onClick={onClick}
@@ -354,36 +351,15 @@ function BaseCarouselWithRef(
         visibleCount={mixedLength ? 1 : visibleCount}
         _thumbnails={_thumbnails}
       >
-        {/*
-          TODO(#30283): TBD: this is an interesting concept. We could decide
-          to render only N slides at a time and for others just output an empty
-          placeholder. When a slide's slot is unrendered, the slide
-          automatically gets unslotted and gets CanRender=false w/o any extra
-          state management code.
-
-          Note: We naively display all slides for mixedLength as multiple
-          can be visible within the carousel viewport - eventually these can also
-          be optimized to only display the minimum necessary for the current
-          and next viewport.
-        */}
-        {childrenArray.map((child, index) =>
-          Math.min(
-            // Distance from currentSlide.
-            Math.abs(index - currentSlide),
-            // Account for wraparound when looping.
-            loop ? mod(length + currentSlide - index, length) : length
-          ) < Math.ceil(visibleCount * 3) || mixedLength ? (
-            <WithAmpContext
-              key={index}
-              renderable={index == currentSlide}
-              playable={index == currentSlide}
-            >
-              {child}
-            </WithAmpContext>
-          ) : (
-            <></>
-          )
-        )}
+        {childrenArray.map((child, index) => (
+          <WithAmpContext
+            key={index}
+            renderable={index == currentSlide}
+            playable={index == currentSlide}
+          >
+            {child}
+          </WithAmpContext>
+        ))}
       </Scroller>
       {!hideControls && (
         <Arrow

--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -29,7 +29,7 @@ import {Scroller} from './scroller';
 import {WithAmpContext} from '#preact/context';
 import {forwardRef, toChildArray} from '#preact/compat';
 import {isRTL} from '#core/dom';
-import {sequentialIdGenerator} from '#core/math/id-generator';
+import {sequentialIdGenerator} from '#core/data-structures/id-generator';
 import {toWin} from '#core/window';
 import {
   useCallback,
@@ -354,8 +354,8 @@ function BaseCarouselWithRef(
         {childrenArray.map((child, index) => (
           <WithAmpContext
             key={index}
-            renderable={index === currentSlide}
-            playable={index === currentSlide}
+            renderable={index == currentSlide}
+            playable={index == currentSlide}
           >
             {child}
           </WithAmpContext>

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -21,7 +21,7 @@ import {
   getPercentageOffsetFromAlignment,
   scrollContainerToElement,
 } from './dimensions';
-import {LightboxGalleryContext} from '../../amp-lightbox-gallery/1.0/context';
+import {WithLightbox} from '../../amp-lightbox-gallery/1.0/component';
 import {debounce} from '#core/types/function';
 import {forwardRef} from '#preact/compat';
 import {mod} from '#core/math';
@@ -29,7 +29,6 @@ import {setStyle} from '#core/dom/style';
 import {toWin} from '#core/window';
 import {
   useCallback,
-  useContext,
   useImperativeHandle,
   useLayoutEffect,
   useMemo,
@@ -60,7 +59,7 @@ function ScrollerWithRef(
     alignment,
     axis,
     children,
-    lightbox,
+    lightboxGroup,
     loop,
     mixedLength,
     restingIndex,
@@ -138,7 +137,6 @@ function ScrollerWithRef(
    */
   const scrollOffset = useRef(0);
 
-  const {open: openLightbox} = useContext(LightboxGalleryContext);
   const slides = renderSlides(
     {
       alignment,
@@ -146,7 +144,7 @@ function ScrollerWithRef(
       loop,
       mixedLength,
       offsetRef,
-      openLightbox: lightbox && openLightbox,
+      lightboxGroup,
       pivotIndex,
       restingIndex,
       snap,
@@ -343,10 +341,10 @@ function renderSlides(
     _thumbnails,
     alignment,
     children,
+    lightboxGroup,
     loop,
     mixedLength,
     offsetRef,
-    openLightbox,
     pivotIndex,
     restingIndex,
     snap,
@@ -356,15 +354,11 @@ function renderSlides(
   classes
 ) {
   const {length} = children;
-  const lightboxProps = openLightbox && {
-    role: 'button',
-    tabindex: '0',
-    onClick: () => openLightbox(),
-  };
+  const Comp = lightboxGroup ? WithLightbox : 'div';
   const slides = children.map((child, index) => {
     const key = `slide-${child.key || index}`;
     return (
-      <div
+      <Comp
         key={key}
         data-slide={index}
         class={`${classes.slideSizing} ${classes.slideElement} ${
@@ -376,14 +370,14 @@ function renderSlides(
             ? classes.centerAlign
             : classes.startAlign
         } ${_thumbnails ? classes.thumbnails : ''} `}
+        group={lightboxGroup}
         part="slide"
         style={{
           flex: mixedLength ? '0 0 auto' : `0 0 ${100 / visibleCount}%`,
         }}
-        {...lightboxProps}
       >
         {child}
-      </div>
+      </Comp>
     );
   });
 

--- a/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
@@ -50,8 +50,7 @@ class AmpLightboxGallery extends BaseElement {
    * @param {*} invocation
    */
   openAction(api, invocation) {
-    const args = invocation.args || {};
-    const id = args['id'];
+    const id = invocation?.args?.['id'];
     if (id) {
       this.getAmpDoc().getElementById(id)?.click();
     } else {

--- a/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
@@ -34,11 +34,29 @@ class AmpLightboxGallery extends BaseElement {
   init() {
     this.registerApiAction(
       DEFAULT_ACTION,
-      (api) => api.open(),
+      (api, invocation) => this.openAction(api, invocation),
       ActionTrust.HIGH
     );
-    this.registerApiAction('open', (api) => api.open(), ActionTrust.HIGH);
+    this.registerApiAction(
+      'open',
+      (api, invocation) => this.openAction(api, invocation),
+      ActionTrust.HIGH
+    );
     return super.init();
+  }
+
+  /**
+   * @param {*} api
+   * @param {*} invocation
+   */
+  openAction(api, invocation) {
+    const args = invocation.args || {};
+    const id = args['id'];
+    if (id) {
+      this.getAmpDoc().getElementById(id)?.click();
+    } else {
+      api.open();
+    }
   }
 
   /** @override */

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -44,35 +44,42 @@ export function WithLightbox({
   as: Comp = 'div',
   children,
   enableActivation = true,
+  group,
   render: renderProp,
+  srcset,
   ...rest
 }) {
   const [genKey] = useState(generateLightboxItemKey);
   const {deregister, open, register} = useContext(LightboxGalleryContext);
   const render = useCallback(
     () =>
-      renderProp
-        ? renderProp()
-        : toChildArray(children).map((child) => cloneElement(child)),
-    [children, renderProp]
+      renderProp ? (
+        renderProp()
+      ) : children ? (
+        toChildArray(children).map((child) => cloneElement(child))
+      ) : (
+        <Comp srcset={srcset} />
+      ),
+    [children, renderProp, srcset]
   );
 
   useLayoutEffect(() => {
-    register(genKey, render);
-    return () => deregister(genKey);
-  }, [genKey, deregister, register, render]);
+    register(genKey, group, render);
+    return () => deregister(genKey, group);
+  }, [genKey, group, deregister, register, render]);
 
   const activationProps = useMemo(
     () =>
       enableActivation && {
         ...DEFAULT_ACTIVATION_PROPS,
         /* genKey is 1-indexed, gallery is 0-indexed */
-        onClick: () => open(Number(genKey) - 1),
+        onClick: () => open(Number(genKey) - 1, group),
       },
-    [enableActivation, genKey, open]
+    [enableActivation, genKey, group, open]
   );
+
   return (
-    <Comp {...activationProps} {...rest}>
+    <Comp {...activationProps} srcset={srcset} {...rest}>
       {children}
     </Comp>
   );

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -29,12 +29,22 @@ import {toChildArray} from '#preact/compat';
 
 const generateLightboxItemKey = sequentialIdGenerator();
 
+/** @const {string} */
 const DEFAULT_ARIA_LABEL = 'Open content in a lightbox view.';
+
+/** @const {!Object<string, *>} */
 const DEFAULT_ACTIVATION_PROPS = {
   'aria-label': DEFAULT_ARIA_LABEL,
   role: 'button',
-  tabIndex: '0',
+  tabIndex: 0,
 };
+
+/**
+ *
+ * @param {!PreactDef.Renderable} child
+ * @return {!PreactDef.Renderable}
+ */
+const CLONE_CHILD = (child) => cloneElement(child);
 
 /**
  * @param {!LightboxGalleryDef.WithLightboxProps} props
@@ -51,17 +61,15 @@ export function WithLightbox({
 }) {
   const [genKey] = useState(generateLightboxItemKey);
   const {deregister, open, register} = useContext(LightboxGalleryContext);
-  const render = useCallback(
-    () =>
-      renderProp ? (
-        renderProp()
-      ) : children ? (
-        toChildArray(children).map((child) => cloneElement(child))
-      ) : (
-        <Comp srcset={srcset} />
-      ),
-    [children, renderProp, srcset]
-  );
+  const render = useCallback(() => {
+    if (renderProp) {
+      return renderProp();
+    }
+    if (children) {
+      return toChildArray(children).map(CLONE_CHILD);
+    }
+    return <Comp srcset={srcset} />;
+  }, [children, renderProp, srcset]);
 
   useLayoutEffect(() => {
     register(genKey, group, render);

--- a/extensions/amp-lightbox-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox-gallery/1.0/storybook/Basic.amp.js
@@ -36,6 +36,9 @@ export const Default = () => {
   return (
     <>
       <div lightbox> invalid lightboxed div element </div>
+      <button on="tap:amp-lightbox-gallery.open(id='my-img')">
+        open lightbox on second image
+      </button>
       <img
         width="360"
         height="240"
@@ -43,6 +46,7 @@ export const Default = () => {
         lightbox
       />
       <amp-img
+        id="my-img"
         width="360"
         height="240"
         src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
@@ -157,12 +161,27 @@ export const Grouping = () => {
         Note: The standalone img/amp-img elements are lightboxed in a separate
         lightbox-gallery group than the carousel elements.
       </p>
+      <div>
+        <button on="tap:amp-lightbox-gallery.open(id='my-img')">
+          open lightbox on second image
+        </button>
+        <button on="tap:amp-lightbox-gallery.open(id='last-slide-img')">
+          open lightbox on last carousel slide
+        </button>
+      </div>
       <img
         width="360"
         height="240"
         src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1498&q=80"
         lightbox
       />
+      <amp-img
+        id="my-img"
+        width="360"
+        height="240"
+        src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+        lightbox
+      ></amp-img>
       <amp-base-carousel lightbox width="360" height="240">
         <amp-img
           width="360"
@@ -175,17 +194,12 @@ export const Grouping = () => {
           src="https://images.unsplash.com/photo-1598133893773-de3574464ef0?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
         />
         <amp-img
+          id="last-slide-img"
           width="360"
           height="240"
           src="https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
         ></amp-img>
       </amp-base-carousel>
-      <amp-img
-        width="360"
-        height="240"
-        src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
-        lightbox
-      ></amp-img>
       <img
         width="360"
         height="240"

--- a/extensions/amp-lightbox-gallery/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-lightbox-gallery/1.0/storybook/Basic.amp.js
@@ -149,3 +149,49 @@ export const StreamGallery = () => {
     </amp-stream-gallery>
   );
 };
+
+export const Grouping = () => {
+  return (
+    <>
+      <p>
+        Note: The standalone img/amp-img elements are lightboxed in a separate
+        lightbox-gallery group than the carousel elements.
+      </p>
+      <img
+        width="360"
+        height="240"
+        src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1498&q=80"
+        lightbox
+      />
+      <amp-base-carousel lightbox width="360" height="240">
+        <amp-img
+          width="360"
+          height="240"
+          src="https://images.unsplash.com/photo-1583512603806-077998240c7a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+        ></amp-img>
+        <img
+          width="360"
+          height="240"
+          src="https://images.unsplash.com/photo-1598133893773-de3574464ef0?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+        />
+        <amp-img
+          width="360"
+          height="240"
+          src="https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+        ></amp-img>
+      </amp-base-carousel>
+      <amp-img
+        width="360"
+        height="240"
+        src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+        lightbox
+      ></amp-img>
+      <img
+        width="360"
+        height="240"
+        lightbox
+        src="https://images.unsplash.com/photo-1599839575945-a9e5af0c3fa5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjQwMzA0fQ&auto=format&fit=crop&w=1498&q=80"
+      />
+    </>
+  );
+};

--- a/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
+++ b/extensions/amp-lightbox-gallery/1.0/storybook/Basic.js
@@ -109,3 +109,54 @@ export const carousel = () => {
     </>
   );
 };
+
+export const grouping = () => {
+  return (
+    <>
+      <style>{`
+    img {
+      width: 240px;
+      height: 160px;
+    }
+  `}</style>
+      <p>
+        Note: The standalone img/amp-img elements are lightboxed in a separate
+        lightbox-gallery group than the carousel elements.
+      </p>
+      <LightboxGalleryProvider>
+        <WithLightbox>
+          <img src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1498&q=80" />
+        </WithLightbox>
+        <WithLightbox
+          as="img"
+          alt="larger img"
+          id="foo"
+          src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+          render={() => (
+            <img
+              alt="smaller img"
+              src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80"
+            />
+          )}
+        />
+        <WithLightbox>
+          <img src="https://images.unsplash.com/photo-1599839575945-a9e5af0c3fa5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjQwMzA0fQ&auto=format&fit=crop&w=1498&q=80" />
+        </WithLightbox>
+        <BaseCarousel lightbox style={{width: '240px', height: '160px'}}>
+          <img
+            src="https://images.unsplash.com/photo-1583512603806-077998240c7a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+            thumbnailSrc="https://images.unsplash.com/photo-1583512603806-077998240c7a?ixlib=rb-1.2.1&auto=format&fit=crop&w=120&q=80"
+          />
+          <img
+            src="https://images.unsplash.com/photo-1598133893773-de3574464ef0?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+            thumbnailSrc="https://images.unsplash.com/photo-1598133893773-de3574464ef0?ixlib=rb-1.2.1&auto=format&fit=crop&w=120&q=80"
+          />
+          <img
+            src="https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+            thumbnailSrc="https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=120&q=80"
+          />
+        </BaseCarousel>
+      </LightboxGalleryProvider>
+    </>
+  );
+};

--- a/extensions/amp-lightbox-gallery/1.0/test/test-component.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-component.js
@@ -15,6 +15,7 @@
  */
 
 import * as Preact from '#preact';
+import {BaseCarousel} from '../../../amp-base-carousel/1.0/component';
 import {LightboxGalleryProvider, WithLightbox} from '../component';
 import {mount} from 'enzyme';
 import {useStyles} from '../component.jss';
@@ -722,6 +723,171 @@ describes.sandboxed('LightboxGallery preact component', {}, () => {
       wrapper.update();
       expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
       expect(wrapper.find('BaseCarousel').prop('hidden')).to.be.false;
+    });
+  });
+
+  describe('Grouping', () => {
+    it('renders with WithLightbox', () => {
+      const wrapper = mount(
+        <LightboxGalleryProvider>
+          <WithLightbox key="1" id="standard">
+            <img />
+          </WithLightbox>
+          <img key="2" id="no-lightbox" />
+          <div key="3">
+            <div>
+              <WithLightbox id="deeply-nested">
+                <img />
+              </WithLightbox>
+            </div>
+          </div>
+          <BaseCarousel lightbox>
+            <img key="4"></img>
+            <img key="5"></img>
+            <img key="6"></img>
+          </BaseCarousel>
+        </LightboxGalleryProvider>
+      );
+
+      // Children are rendered inside provider.
+      const providers = wrapper.find('Provider');
+      // One from Lightbox, three for each carousel slide.
+      expect(providers).to.have.lengthOf(4);
+      const provider = providers.first();
+      expect(provider.children()).to.have.lengthOf(4);
+
+      // Elements are not rendered inside lightbox (closed).
+      const lightbox = wrapper.find('Lightbox');
+      expect(lightbox).to.have.lengthOf(1);
+      expect(lightbox.children()).to.have.lengthOf(0);
+    });
+
+    it('opens with clones when clicking on a lightboxed element in default group', () => {
+      const classes = useStyles();
+      const wrapper = mount(
+        <LightboxGalleryProvider>
+          <WithLightbox key="1" id="standard">
+            <img />
+          </WithLightbox>
+          <img key="2" id="no-lightbox" />
+          <div key="3">
+            <div>
+              <WithLightbox id="deeply-nested">
+                <img />
+              </WithLightbox>
+            </div>
+          </div>
+          <BaseCarousel lightbox>
+            <img key="4"></img>
+            <img key="5"></img>
+            <img key="6"></img>
+          </BaseCarousel>
+        </LightboxGalleryProvider>
+      );
+
+      // Children are rendered inside provider.
+      const providers = wrapper.find('Provider');
+      // One from Lightbox, three for each carousel slide.
+      expect(providers).to.have.lengthOf(4);
+      const provider = providers.first();
+      expect(provider.children()).to.have.lengthOf(4);
+
+      // Elements are not rendered inside lightbox (closed).
+      let lightbox = wrapper.find('Lightbox');
+      expect(lightbox).to.have.lengthOf(1);
+      expect(lightbox.children()).to.have.lengthOf(0);
+
+      // Note: We would normally click the first `img` element,
+      // not its generated `div` wrapper. However, enzyme's
+      // shallow renderer does not support event propagation as
+      // we would expect in a real environment.
+      wrapper.find('div').first().simulate('click');
+      wrapper.update();
+
+      // Render provided children in the "default" (non-carousel) group
+      lightbox = wrapper.find('Lightbox');
+      expect(lightbox).to.have.lengthOf(1);
+      expect(lightbox.prop('closeButtonAs').name).to.equal('CloseButtonIcon');
+      expect(lightbox.children()).to.have.lengthOf(1);
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+
+      // Carousel UI
+      const carousel = lightbox.find('BaseCarousel');
+      expect(carousel).to.have.lengthOf(1);
+      expect(carousel.prop('arrowPrevAs').name).to.equal('NavButtonIcon');
+      expect(carousel.prop('arrowNextAs').name).to.equal('NavButtonIcon');
+      expect(carousel.find('img')).to.have.lengthOf(2);
+    });
+
+    it('opens with clones when clicking on a lightboxed element in carousel group', () => {
+      const classes = useStyles();
+      const wrapper = mount(
+        <LightboxGalleryProvider>
+          <WithLightbox key="1" id="standard">
+            <img />
+          </WithLightbox>
+          <img key="2" id="no-lightbox" />
+          <div key="3">
+            <div>
+              <WithLightbox id="deeply-nested">
+                <img />
+              </WithLightbox>
+            </div>
+          </div>
+          <BaseCarousel lightbox>
+            <img key="4"></img>
+            <img key="5"></img>
+            <img key="6"></img>
+          </BaseCarousel>
+        </LightboxGalleryProvider>
+      );
+
+      // Children are rendered inside provider.
+      const providers = wrapper.find('Provider');
+      // One from Lightbox, three for each carousel slide.
+      expect(providers).to.have.lengthOf(4);
+      const provider = providers.first();
+      expect(provider.children()).to.have.lengthOf(4);
+
+      // Elements are not rendered inside lightbox (closed).
+      let lightbox = wrapper.find('Lightbox');
+      expect(lightbox).to.have.lengthOf(1);
+      expect(lightbox.children()).to.have.lengthOf(0);
+
+      // Note: We would normally click the first `img` element,
+      // not its generated `div` wrapper. However, enzyme's
+      // shallow renderer does not support event propagation as
+      // we would expect in a real environment.
+      wrapper.find('div[part="slide"]').first().simulate('click');
+      wrapper.update();
+
+      // Render provided children in the carousel group
+      lightbox = wrapper.find('Lightbox');
+      expect(lightbox).to.have.lengthOf(1);
+      expect(lightbox.prop('closeButtonAs').name).to.equal('CloseButtonIcon');
+      expect(lightbox.children()).to.have.lengthOf(1);
+
+      // Toggle control is rendered
+      const toggleViewIcon = wrapper.find('ToggleViewIcon');
+      expect(toggleViewIcon).to.have.lengthOf(1);
+      expect(toggleViewIcon.prop('showCarousel')).to.be.true;
+
+      // Grid UI not rendered
+      expect(wrapper.find(`.${classes.grid}`)).to.have.lengthOf(0);
+
+      // Carousel UI
+      const carousel = lightbox.find('BaseCarousel');
+      expect(carousel).to.have.lengthOf(1);
+      expect(carousel.prop('arrowPrevAs').name).to.equal('NavButtonIcon');
+      expect(carousel.prop('arrowNextAs').name).to.equal('NavButtonIcon');
+      expect(carousel.find('img')).to.have.lengthOf(3);
     });
   });
 });


### PR DESCRIPTION
This PR supports grouping functionality in `amp-lightbox-gallery` and `LightboxGallery` as part of #32759. It behaves as follows:
- Any `img` or `amp-img` with the `lightbox` attribute get grouped in a single group by default, called `"default"`.
- All `img` or `amp-img` inside `amp-base-carousel` or `amp-stream-gallery` with the `lightbox` attribute get grouped in their own encapsulated lightbox group. You can think of this as one distinct group per lightboxed carousel. These are named `carousel0`, `carousel1`, etc. by default.
- Groups can be named with a non-default value by giving the `lightbox` attribute a value. This doesn't appear to be documented currently but is a behavior of 0.1. One perk of doing this for standalone `img` and `amp-img` elements is that they can be subdivided into conceptual groups without having to use a carousel.

To support the grouping feature in the ways above, the following changes were also made:
- Support for the `id` argument on the AMP `amp-lightbox-gallery.open` action
- Modifications to `BaseCarousel` to:
  - render all elements instead of a smaller subset. All images must be rendered in order to support them being visible in the lightbox gallery's grid view, and instead of adding an additional exception to the cases where we will render all elements, I decided to remove the experimental feature altogether. This also improves cases of image pop-in on debounced scroll.
  - use `WithLightbox` per slide instead of per component, without which the grid UI would layer all images on top of each other