### PR TITLE
🧪 Expand AMP_EXP experimentation to include nightly channel (correctly)

### DIFF
--- a/build-system/global-configs/client-side-experiments-config.json
+++ b/build-system/global-configs/client-side-experiments-config.json
@@ -4,7 +4,7 @@
       "name": "test-amp-exp",
       "percentage": 0.5,
       "rtvPrefix": [
-        "05"
+        "04"
       ]
     }
   ]


### PR DESCRIPTION
#35076 used 05 prefix, but that's Nightly-Control. Nightly is 04. My bad!