### PR TITLE
Use `setAsContainer` and `removeAsContainer` in AMP mode only

### DIFF
--- a/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
@@ -54,18 +54,18 @@ class AmpLightboxGallery extends BaseElement {
   /** @override */
   afterOpen_() {
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
-    this.setAsContainer(scroller);
+    this.setAsContainer?.(scroller);
   }
 
   /** @override */
   afterClose_() {
     super.afterClose_();
-    this.removeAsContainer();
+    this.removeAsContainer?.();
   }
 
   /** @override */
   unmountCallback() {
-    this.removeAsContainer();
+    this.removeAsContainer?.();
   }
 }
 

--- a/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
@@ -52,14 +52,14 @@ class AmpLightboxGallery extends BaseElement {
   }
 
   /** @override */
-  afterOpen_() {
+  afterOpen() {
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
     this.setAsContainer?.(scroller);
   }
 
   /** @override */
-  afterClose_() {
-    super.afterClose_();
+  afterClose() {
+    super.afterClose();
     this.removeAsContainer?.();
   }
 

--- a/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
@@ -50,6 +50,23 @@ class AmpLightboxGallery extends BaseElement {
     );
     return super.isLayoutSupported(layout);
   }
+
+  /** @override */
+  afterOpen_() {
+    const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
+    this.setAsContainer(scroller);
+  }
+
+  /** @override */
+  afterClose_() {
+    super.afterClose_();
+    this.removeAsContainer();
+  }
+
+  /** @override */
+  unmountCallback() {
+    this.removeAsContainer();
+  }
 }
 
 /**

--- a/extensions/amp-lightbox-gallery/1.0/base-element.js
+++ b/extensions/amp-lightbox-gallery/1.0/base-element.js
@@ -58,11 +58,6 @@ export class BaseElement extends PreactBaseElement {
     });
   }
 
-  /** @override */
-  unmountCallback() {
-    this.removeAsContainer();
-  }
-
   /** @private */
   beforeOpen_() {
     this.open_ = true;
@@ -71,18 +66,10 @@ export class BaseElement extends PreactBaseElement {
   }
 
   /** @private */
-  afterOpen_() {
-    const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
-    this.setAsContainer(scroller);
-  }
-
-  /** @private */
   afterClose_() {
     this.open_ = false;
     toggleAttribute(this.element, 'open', false);
     toggle(this.element, false);
-
-    this.removeAsContainer();
   }
 
   /** @override */

--- a/extensions/amp-lightbox-gallery/1.0/base-element.js
+++ b/extensions/amp-lightbox-gallery/1.0/base-element.js
@@ -48,9 +48,9 @@ export class BaseElement extends PreactBaseElement {
   /** @override */
   init() {
     return dict({
-      'onBeforeOpen': () => this.beforeOpen_(),
-      'onAfterOpen': () => this.afterOpen_(),
-      'onAfterClose': () => this.afterClose_(),
+      'onBeforeOpen': () => this.beforeOpen(),
+      'onAfterOpen': () => this.afterOpen(),
+      'onAfterClose': () => this.afterClose(),
       'render': () =>
         getLightboxElements(this.element.ownerDocument, (opt_index) =>
           this.api().open(opt_index)
@@ -58,15 +58,18 @@ export class BaseElement extends PreactBaseElement {
     });
   }
 
-  /** @private */
-  beforeOpen_() {
+  /** @protected */
+  beforeOpen() {
     this.open_ = true;
     toggleAttribute(this.element, 'open', true);
     toggle(this.element, true);
   }
 
-  /** @private */
-  afterClose_() {
+  /** @protected */
+  afterOpen() {}
+
+  /** @protected */
+  afterClose() {
     this.open_ = false;
     toggleAttribute(this.element, 'open', false);
     toggle(this.element, false);

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -67,6 +67,23 @@ class AmpLightbox extends BaseElement {
     );
     return super.isLayoutSupported(layout);
   }
+
+  /** @override */
+  afterOpen_() {
+    const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
+    this.setAsContainer(scroller);
+  }
+
+  /** @override */
+  afterClose_() {
+    super.afterClose_();
+    this.removeAsContainer();
+  }
+
+  /** @override */
+  unmountCallback() {
+    this.removeAsContainer();
+  }
 }
 
 AMP.extension(TAG, '1.0', (AMP) => {

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -69,14 +69,14 @@ class AmpLightbox extends BaseElement {
   }
 
   /** @override */
-  afterOpen_() {
+  afterOpen() {
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
     this.setAsContainer?.(scroller);
   }
 
   /** @override */
-  afterClose_() {
-    super.afterClose_();
+  afterClose() {
+    super.afterClose();
     this.removeAsContainer?.();
   }
 

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -71,18 +71,18 @@ class AmpLightbox extends BaseElement {
   /** @override */
   afterOpen_() {
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
-    this.setAsContainer(scroller);
+    this.setAsContainer?.(scroller);
   }
 
   /** @override */
   afterClose_() {
     super.afterClose_();
-    this.removeAsContainer();
+    this.removeAsContainer?.();
   }
 
   /** @override */
   unmountCallback() {
-    this.removeAsContainer();
+    this.removeAsContainer?.();
   }
 }
 

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -34,22 +34,25 @@ export class BaseElement extends PreactBaseElement {
   /** @override */
   init() {
     return dict({
-      'onBeforeOpen': () => this.beforeOpen_(),
-      'onAfterOpen': () => this.afterOpen_(),
-      'onAfterClose': () => this.afterClose_(),
+      'onBeforeOpen': () => this.beforeOpen(),
+      'onAfterOpen': () => this.afterOpen(),
+      'onAfterClose': () => this.afterClose(),
     });
   }
 
-  /** @private */
-  beforeOpen_() {
+  /** @protected */
+  beforeOpen() {
     this.open_ = true;
     toggleAttribute(this.element, 'open', true);
     toggle(this.element, true);
     this.triggerEvent(this.element, 'open');
   }
 
-  /** @private */
-  afterClose_() {
+  /** @protected */
+  afterOpen() {}
+
+  /** @protected */
+  afterClose() {
     this.open_ = false;
     toggleAttribute(this.element, 'open', false);
     toggle(this.element, false);

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -40,11 +40,6 @@ export class BaseElement extends PreactBaseElement {
     });
   }
 
-  /** @override */
-  unmountCallback() {
-    this.removeAsContainer();
-  }
-
   /** @private */
   beforeOpen_() {
     this.open_ = true;
@@ -54,19 +49,11 @@ export class BaseElement extends PreactBaseElement {
   }
 
   /** @private */
-  afterOpen_() {
-    const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
-    this.setAsContainer(scroller);
-  }
-
-  /** @private */
   afterClose_() {
     this.open_ = false;
     toggleAttribute(this.element, 'open', false);
     toggle(this.element, false);
     this.triggerEvent(this.element, 'close');
-
-    this.removeAsContainer();
 
     // Unmount all children when the lightbox is closed. They will automatically
     // remount when the lightbox is opened again.

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -60,18 +60,18 @@ class AmpSidebar extends BaseElement {
   /** @override */
   afterOpen_() {
     const sidebar = this.element.shadowRoot.querySelector('[part=sidebar]');
-    this.setAsContainer(sidebar);
+    this.setAsContainer?.(sidebar);
   }
 
   /** @override */
   afterClose_() {
     super.afterClose_();
-    this.removeAsContainer();
+    this.removeAsContainer?.();
   }
 
   /** @override */
   unmountCallback() {
-    this.removeAsContainer();
+    this.removeAsContainer?.();
   }
 }
 

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -56,6 +56,23 @@ class AmpSidebar extends BaseElement {
     );
     return true;
   }
+
+  /** @override */
+  afterOpen_() {
+    const sidebar = this.element.shadowRoot.querySelector('[part=sidebar]');
+    this.setAsContainer(sidebar);
+  }
+
+  /** @override */
+  afterClose_() {
+    super.afterClose_();
+    this.removeAsContainer();
+  }
+
+  /** @override */
+  unmountCallback() {
+    this.removeAsContainer();
+  }
 }
 
 AMP.extension(TAG, '1.0', (AMP) => {

--- a/extensions/amp-sidebar/1.0/amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/amp-sidebar.js
@@ -58,14 +58,14 @@ class AmpSidebar extends BaseElement {
   }
 
   /** @override */
-  afterOpen_() {
+  afterOpen() {
     const sidebar = this.element.shadowRoot.querySelector('[part=sidebar]');
     this.setAsContainer?.(sidebar);
   }
 
   /** @override */
-  afterClose_() {
-    super.afterClose_();
+  afterClose() {
+    super.afterClose();
     this.removeAsContainer?.();
   }
 

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -68,11 +68,6 @@ export class BaseElement extends PreactBaseElement {
     });
   }
 
-  /** @override */
-  unmountCallback() {
-    this.removeAsContainer();
-  }
-
   /** @private */
   beforeOpen_() {
     this.open_ = true;
@@ -81,18 +76,11 @@ export class BaseElement extends PreactBaseElement {
   }
 
   /** @private */
-  afterOpen_() {
-    const sidebar = this.element.shadowRoot.querySelector('[part=sidebar]');
-    this.setAsContainer(sidebar);
-  }
-
-  /** @private */
   afterClose_() {
     this.open_ = false;
     toggleAttribute(this.element, 'open', false);
     toggle(this.element, false);
 
-    this.removeAsContainer();
     pauseAll(this.element, /* includeSelf */ false);
   }
 

--- a/extensions/amp-sidebar/1.0/base-element.js
+++ b/extensions/amp-sidebar/1.0/base-element.js
@@ -43,9 +43,9 @@ export class BaseElement extends PreactBaseElement {
   /** @override */
   init() {
     return dict({
-      'onBeforeOpen': () => this.beforeOpen_(),
-      'onAfterOpen': () => this.afterOpen_(),
-      'onAfterClose': () => this.afterClose_(),
+      'onBeforeOpen': () => this.beforeOpen(),
+      'onAfterOpen': () => this.afterOpen(),
+      'onAfterClose': () => this.afterClose(),
     });
   }
 
@@ -68,15 +68,18 @@ export class BaseElement extends PreactBaseElement {
     });
   }
 
-  /** @private */
-  beforeOpen_() {
+  /** @protected */
+  beforeOpen() {
     this.open_ = true;
     toggleAttribute(this.element, 'open', true);
     toggle(this.element, true);
   }
 
-  /** @private */
-  afterClose_() {
+  /** @protected */
+  afterOpen() {}
+
+  /** @protected */
+  afterClose() {
     this.open_ = false;
     toggleAttribute(this.element, 'open', false);
     toggle(this.element, false);


### PR DESCRIPTION
Moves calls to `setAsContainer` and `removeAsContainer` to the AMP layer in the components that call them (`amp-lightbox`, `amp-lightbox-gallery`, `amp-sidebar`). Also makes these calls optional due to #34820. 

Note that tests already exist to ensure these are called at the precise time.