### PR TITLE
amp-fit-text: fix cls by hiding until font size calculation

### DIFF
--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -74,7 +74,7 @@ class AmpFitText extends AMP.BaseElement {
     this.content_ = this.element.ownerDocument.createElement('div');
     applyFillContent(this.content_);
     this.content_.classList.add('i-amphtml-fit-text-content');
-    setStyles(this.content_, {zIndex: 2});
+    setStyles(this.content_, {zIndex: 2, visibility: 'hidden'});
 
     this.contentWrapper_ = this.element.ownerDocument.createElement('div');
     setStyles(this.contentWrapper_, {lineHeight: `${LINE_HEIGHT_EM_}em`});
@@ -149,6 +149,7 @@ class AmpFitText extends AMP.BaseElement {
     }
     return this.mutateElement(() => {
       this.updateFontSize_();
+      setStyles(this.content_, {visibility: 'visible'});
     });
   }
 


### PR DESCRIPTION
**summary**

This PR hides `amp-fit-text` until font size calculation is complete. 
For our example doc at `examples/amp-fit-text.amp.html`:
- before: 0.055 CLS
- after: 0.000 CLS


cc @ampproject/wg-performance 