### PR TITLE
update re2 master to main

### DIFF
--- a/validator/cpp/engine/WORKSPACE
+++ b/validator/cpp/engine/WORKSPACE
@@ -32,8 +32,8 @@ http_archive(
 
 http_archive(
     name = "com_github_re2",
-    strip_prefix = "re2-master",
-    urls = ["https://github.com/google/re2/archive/master.zip"],
+    strip_prefix = "re2-main",
+    urls = ["https://github.com/google/re2/archive/main.zip"],
 )
 
 http_archive(

--- a/validator/cpp/htmlparser/WORKSPACE
+++ b/validator/cpp/htmlparser/WORKSPACE
@@ -23,8 +23,8 @@ http_archive(
 
 http_archive(
     name = "com_github_re2",
-    strip_prefix = "re2-master",
-    urls = ["https://github.com/google/re2/archive/master.zip"],
+    strip_prefix = "re2-main",
+    urls = ["https://github.com/google/re2/archive/main.zip"],
 )
 
 http_archive(


### PR DESCRIPTION
`re2` updated from `master` to `main` causing a breakage. use `main` instead for `http_archive` of `re2`

see `re2` [commit here](https://github.com/google/re2/commit/ccdbd348259434cca6c66c66a35c5ef71ff3ee1a)