### PR TITLE
bump worker-dom to 0.30.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,9 +105,9 @@
       "integrity": "sha512-oOlju4AQkgel/h4h8ZPRk0xIsE1xtFsn2IAvFOAB6GTa8IXLp+XNDzAUKKU/HpJbrbh/c+AUjYvcKds+c7C+uQ=="
     },
     "@ampproject/worker-dom": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.30.0.tgz",
-      "integrity": "sha512-g+eGRlyHfta+qjpZMqzHj1CpX3gI8d8b5BRme9vPuNGuyyLr7wEde83vdFLuPu2Z8bg5hmwpcVuCCHs7FqJWgQ=="
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.30.1.tgz",
+      "integrity": "sha512-P2EhgBuKGBhJkibbAm6SItbHPi1bRF5pdmDLgwFDiCfHUN4Oe7xkRlUVcqM1vfn8DvmArXEQP03ot7zvHcqm/A=="
     },
     "@babel/code-frame": {
       "version": "7.12.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -105,9 +105,9 @@
       "integrity": "sha512-oOlju4AQkgel/h4h8ZPRk0xIsE1xtFsn2IAvFOAB6GTa8IXLp+XNDzAUKKU/HpJbrbh/c+AUjYvcKds+c7C+uQ=="
     },
     "@ampproject/worker-dom": {
-      "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.29.3.tgz",
-      "integrity": "sha512-qVTmxOVaIeJ/94OymOfN/TZS2Z5IA/rXcGyRNusZEHk0P0qIAWnLu8bSx27wRkc3cCVn9HhBiLsXkMzxhL/UQA=="
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.30.0.tgz",
+      "integrity": "sha512-g+eGRlyHfta+qjpZMqzHj1CpX3gI8d8b5BRme9vPuNGuyyLr7wEde83vdFLuPu2Z8bg5hmwpcVuCCHs7FqJWgQ=="
     },
     "@babel/code-frame": {
       "version": "7.12.13",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.8.0",
     "@ampproject/viewer-messaging": "1.1.2",
-    "@ampproject/worker-dom": "0.30.0",
+    "@ampproject/worker-dom": "0.30.1",
     "@webcomponents/webcomponentsjs": "2.5.0",
     "dompurify": "2.2.9",
     "google-closure-library": "20210601.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@ampproject/animations": "0.2.2",
     "@ampproject/toolbox-cache-url": "2.8.0",
     "@ampproject/viewer-messaging": "1.1.2",
-    "@ampproject/worker-dom": "0.29.3",
+    "@ampproject/worker-dom": "0.30.0",
     "@webcomponents/webcomponentsjs": "2.5.0",
     "dompurify": "2.2.9",
     "google-closure-library": "20210601.0.0",


### PR DESCRIPTION
**summary**
- Bumps the version number to the latest worker-dom.
- This includes `localStorage` support in nodom mode.