### PR TITLE
✨ Prevent multiple sticky ads from being loaded on one page

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -432,6 +432,7 @@ export class AmpA4A extends AMP.BaseElement {
     );
 
     this.uiHandler = new AMP.AmpAdUIHandler(this);
+    this.uiHandler.validateStickyAd();
 
     const verifier = signatureVerifierFor(this.win);
     this.keysetPromise_ = this.getAmpDoc()

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -212,6 +212,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     userAssert(this.config, `Type "${this.type_}" is not supported in amp-ad`);
 
     this.uiHandler = new AmpAdUIHandler(this);
+    this.uiHandler.validateStickyAd();
 
     this.isFullWidthRequested_ = this.shouldRequestFullWidth_();
 

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -214,6 +214,18 @@ export class AmpAdUIHandler {
   }
 
   /**
+   * Verify that the limits for sticky ads are not exceeded
+   */
+  validateStickyAd() {
+    userAssert(
+      this.doc_.querySelectorAll(
+        'amp-sticky-ad.i-amphtml-built, amp-ad[sticky].i-amphtml-built'
+      ).length <= 1,
+      'At most one sticky ad can be loaded per page'
+    );
+  }
+
+  /**
    * @return {boolean}
    */
   isStickyAd() {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -344,6 +344,20 @@ describes.realWin(
         uiHandler.onResizeSuccess();
         expect(uiHandler.topStickyAdScrollListener_).to.not.be.undefined;
       });
+
+      it('should refuse to load the second sticky ads', () => {
+        for (let i = 0; i < 2; i++) {
+          const adElement = env.win.document.createElement('amp-ad');
+          adElement.setAttribute('sticky', 'top');
+          adElement.setAttribute('class', 'i-amphtml-built');
+          env.win.document.body.insertBefore(adElement, null);
+        }
+        allowConsoleError(() => {
+          expect(() => {
+            uiHandler.validateStickyAd();
+          }).to.throw();
+        });
+      });
     });
   }
 );

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -57,6 +57,12 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    userAssert(
+      this.win.document.querySelectorAll(
+        'amp-sticky-ad.i-amphtml-built, amp-ad[sticky].i-amphtml-built'
+      ).length <= 1,
+      'At most one sticky ad can be loaded per page'
+    );
     this.viewport_ = this.getViewport();
     this.element.classList.add('i-amphtml-sticky-ad-layout');
 


### PR DESCRIPTION
Send a client error when loading the second (and after) sticky ads.