### PR TITLE
🏗  Add node scripts for status page automation

### DIFF
--- a/build-system/status-page/comment.js
+++ b/build-system/status-page/comment.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * Add progress comment for Stable and LTS cherry-picks
+ */
+
+const fetch = require('node-fetch');
+const [number, body, user] = process.argv.slice(2);
+const {getChannels, steps} = require('./common');
+const {log} = require('../common/logging');
+
+const commentTemplate = (channels) => `
+  #### 🌸 Cherry-Pick Progress 🌸 
+  Hi @${user}, thanks for filing this cherry-pick request!
+  Seeing that this affects ${channels.join(
+    ' and '
+  )}, [status.amp.dev](https://status.amp.dev) will be updated with progress of the fix.
+  Please update this tracker as each step is completed.
+  - [ ] ${steps[0].text}
+  - [ ] ${steps[1].text}
+  - [ ] ${steps[2].text}
+  - [ ] ${steps[3].text}
+  `;
+
+/**
+ * Add progress comment for Stable and LTS cherry-picks
+ * @return {Promise<object>}
+ */
+async function addComment() {
+  const channels = getChannels(body);
+  if (channels.length == 0) {
+    return;
+  }
+
+  const apiUrl = `https://api.github.com/repos/ampproject/amphtml/issues/${number}/comments`;
+  const headers = {
+    Authorization: `token ${process.env.GITHUB_TOKEN}`,
+    Accept: 'application/vnd.github.v3+json',
+  };
+  const options = {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({body: commentTemplate(channels)}),
+  };
+
+  const response = await fetch(apiUrl, options);
+  log(await response.json());
+  return;
+}
+
+addComment();

--- a/build-system/status-page/comment.js
+++ b/build-system/status-page/comment.js
@@ -25,18 +25,21 @@ const {log} = require('../common/logging');
 
 const [number, body, user] = process.argv.slice(2);
 
-const commentTemplate = (channels) => `
+const commentTemplate = (channels) => {
+  const reducer = (current, step) => {
+    return current + `- [ ] <!-- status=${step.status} --> ${step.text} \n`;
+  };
+
+  return `
   #### 🌸 Cherry-Pick Progress 🌸 
   Hi @${user}, thanks for filing this cherry-pick request!
   Seeing that this affects ${channels.join(
     ' and '
   )}, [status.amp.dev](https://status.amp.dev) will be updated with progress of the fix.
   Please update this tracker as each step is completed.
-  - [ ] ${steps[0].text}
-  - [ ] ${steps[1].text}
-  - [ ] ${steps[2].text}
-  - [ ] ${steps[3].text}
+  ${steps.reduce(reducer, '')}
   `;
+};
 
 /**
  * Add progress comment for Stable and LTS cherry-picks

--- a/build-system/status-page/comment.js
+++ b/build-system/status-page/comment.js
@@ -40,7 +40,7 @@ const commentTemplate = (channels) => `
 
 /**
  * Add progress comment for Stable and LTS cherry-picks
- * @return {Promise<Object>}
+ * @return {Promise<void>}
  */
 async function addComment() {
   const channels = getChannels(body);
@@ -61,7 +61,6 @@ async function addComment() {
 
   const response = await fetch(apiUrl, options);
   log(await response.json());
-  return;
 }
 
 addComment();

--- a/build-system/status-page/comment.js
+++ b/build-system/status-page/comment.js
@@ -20,9 +20,10 @@
  */
 
 const fetch = require('node-fetch');
-const [number, body, user] = process.argv.slice(2);
 const {getChannels, steps} = require('./common');
 const {log} = require('../common/logging');
+
+const [number, body, user] = process.argv.slice(2);
 
 const commentTemplate = (channels) => `
   #### 🌸 Cherry-Pick Progress 🌸 
@@ -39,7 +40,7 @@ const commentTemplate = (channels) => `
 
 /**
  * Add progress comment for Stable and LTS cherry-picks
- * @return {Promise<object>}
+ * @return {Promise<Object>}
  */
 async function addComment() {
   const channels = getChannels(body);

--- a/build-system/status-page/common.js
+++ b/build-system/status-page/common.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * Common functions for comment.js and incident.js
+ */
+
+const steps = [
+  {
+    'text':
+      'Cherry-pick request approved *(this creates an incident on [status.amp.dev](https://status.amp.dev))*',
+    'status': 'investigating',
+  },
+  {
+    'text':
+      'Cherry-pick started *(this sets the incident status to "Identified")*',
+    'status': 'identified',
+  },
+  {
+    'text':
+      'Fix deployed to release channels *(this sets the incident status to "Monitoring")*',
+    'status': 'monitoring',
+  },
+  {
+    'text': 'Fix verified on release channels *(this resolves the incident)*',
+    'status': 'resolved',
+  },
+];
+
+/**
+ * Gets text between two headers
+ * @param {string }body
+ * @param {string} header
+ * @return {string}
+ */
+function getInnerText(body, header) {
+  const markdownHeader = `### ${header}`;
+  const start = body.indexOf(markdownHeader);
+  const end = body.indexOf('###', start + markdownHeader.length);
+  return body.substring(start + markdownHeader.length, end).trim();
+}
+
+/**
+ * Get channels from Channels section
+ * status.amp.dev only cares about Stable and LTS, so ignore other channels
+ * @param {string} body
+ * @return {Array<string>}
+ */
+function getChannels(body) {
+  const text = getInnerText(body, 'Channels');
+  const channels = [];
+  for (const channel of ['Stable', 'LTS']) {
+    if (text.includes(channel)) {
+      channels.push(channel);
+    }
+  }
+  return channels;
+}
+
+/**
+ * Gets formats from Formats section
+ * @param {string} body
+ * @return {Array<string>}
+ */
+function getFormats(body) {
+  const text = getInnerText(body, 'Formats');
+  const formats = [];
+  for (const format of ['Websites', 'Stories', 'Ads', 'Emails']) {
+    if (text.includes(format)) {
+      formats.push(format);
+    }
+  }
+  return formats;
+}
+
+module.exports = {
+  getChannels,
+  getFormats,
+  steps,
+};

--- a/build-system/status-page/incident.js
+++ b/build-system/status-page/incident.js
@@ -141,12 +141,12 @@ async function syncIncident() {
 
   // get step that was checked off
   let checked = -1;
-  for (const index of [3, 2, 1, 0]) {
+  for (let i = steps.length - 1; i >= 0; i--) {
     const regex = new RegExp(
-      `[x] <!-- status=${steps[index].status} -->`.replace(/[[\]\\]/g, '\\$&')
+      `[x] <!-- status=${steps[i].status} -->`.replace(/[[\]\\]/g, '\\$&')
     );
     if (regex.test(after) && !regex.test(before)) {
-      checked = index;
+      checked = i;
       break;
     }
   }

--- a/build-system/status-page/incident.js
+++ b/build-system/status-page/incident.js
@@ -130,7 +130,7 @@ async function updateIncident(formats, status) {
 
 /**
  * Syncs incident with cherry-pick progress
- * @return {Promise<any>}
+ * @return {Promise<void>}
  */
 async function syncIncident() {
   const formats = getFormats(body);
@@ -167,7 +167,6 @@ async function syncIncident() {
 
   const response = await updateIncident(formats, steps[checked].status);
   log(response);
-  return;
 }
 
 syncIncident();

--- a/build-system/status-page/incident.js
+++ b/build-system/status-page/incident.js
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview
+ * Sync status.amp.dev with cherry-pick progress
+ */
+
+const [number, body, before, after] = process.argv.slice(2);
+const fetch = require('node-fetch');
+const {getChannels, getFormats, steps} = require('./common');
+const {log} = require('../common/logging');
+const apiUrl = `https://api.statuspage.io/v1/pages/${process.env.STATUS_PAGE_ID}`;
+const headers = {
+  'Content-Type': 'application/json',
+  'Authorization': `OAuth ${process.env.STATUS_PAGE_TOKEN}`,
+};
+const componentsIds = {
+  'Websites': process.env.WEBSITES_ID || '7sg50qz95rt7',
+  'Stories': process.env.STORIES_ID || 'yy777zy1tzt4',
+  'Ads': process.env.ADS_ID || '9vglh2hndltg',
+  'Emails': process.env.EMAILS_ID || 'd3lmsf61qb52',
+};
+const updateBodies = {
+  'identified': 'The issue has been identified and a fix is underway.',
+  'monitoring': `The fix has been deployed and is being rolled out to the CDN.
+    Please allow up to 30 minutes for the CDN to pick up the fix.`,
+  'resolved': 'The fix has been verified.',
+};
+
+/**
+ * Create incident on status.amp.dev
+ * @param {Array<string>} channels
+ * @param {Array<string>} formats
+ * @param {string} status
+ * @return {Promise<Object>} response
+ */
+async function createIncident(channels, formats, status) {
+  const components = {};
+  formats.forEach((format) => {
+    components[componentsIds[format]] = 'degraded_performance';
+  });
+
+  const incident = {
+    'name': `Incident in ${channels.join(' and ').toUpperCase()}`,
+    'status': status,
+    'impact_override': 'minor',
+    'body': `We are investigating reports of a bug that is seen in ${channels
+      .join(' and ')
+      .toUpperCase()}.
+      https://github.com/ampproject/amphtml/issues/${number}`,
+    'components': components,
+    'metadata': {
+      'github': {
+        'cherry_pick_issue_number': number,
+      },
+    },
+  };
+
+  const response = await fetch(`${apiUrl}/incidents`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({'incident': incident}),
+  });
+
+  return await response.json();
+}
+
+/**
+ * Get unresolved incident by cherry-pick issue number
+ * @return {Promise<Object>}
+ */
+async function getIncident() {
+  const response = await fetch(`${apiUrl}/incidents/unresolved`, {
+    headers,
+  });
+
+  for (const incident of await response.json()) {
+    if (incident.metadata.github.cherry_pick_issue_number === number) {
+      return incident;
+    }
+  }
+
+  throw new Error(
+    `Could not find an unresolved incident for cherry-pick issue #${number}`
+  );
+}
+
+/**
+ * Updates incident on status.amp.dev
+ * @param {Array<string>} formats
+ * @param {string} status
+ * @return {Promise<Object>}
+ */
+async function updateIncident(formats, status) {
+  const components = {};
+  formats.forEach((format) => {
+    components[componentsIds[format]] =
+      status === 'resolved' ? 'operational' : 'degraded_performance';
+  });
+
+  const incident = await getIncident();
+  incident.body = updateBodies[status];
+  incident.status = status;
+  incident.components = components;
+
+  const response = await fetch(`${apiUrl}/incidents/${incident.id}`, {
+    method: 'PATCH',
+    headers,
+    body: JSON.stringify({'incident': incident}),
+  });
+
+  return await response.json();
+}
+
+/**
+ * Syncs incident with cherry-pick progress
+ * @return {Promise<any>}
+ */
+async function syncIncident() {
+  const formats = getFormats(body);
+  const channels = getChannels(body);
+  if (channels.length == 0) {
+    return;
+  }
+
+  // get step that was checked off
+  let checked = -1;
+  for (const step of [3, 2, 1, 0]) {
+    const indexBefore = before.indexOf(steps[step].text) - 3;
+    const indexAfter = after.indexOf(steps[step].text) - 3;
+    if (before[indexBefore] !== 'x' && after[indexAfter] === 'x') {
+      checked = step;
+      break;
+    }
+  }
+
+  if (checked === -1) {
+    return;
+  }
+
+  if (checked === 0) {
+    const response = await createIncident(
+      channels,
+      formats,
+      steps[checked].status
+    );
+    log(response);
+    return;
+  }
+
+  const response = await updateIncident(formats, steps[checked].status);
+  log(response);
+  return;
+}
+
+syncIncident();

--- a/build-system/status-page/incident.js
+++ b/build-system/status-page/incident.js
@@ -19,10 +19,12 @@
  * Sync status.amp.dev with cherry-pick progress
  */
 
-const [number, body, before, after] = process.argv.slice(2);
 const fetch = require('node-fetch');
 const {getChannels, getFormats, steps} = require('./common');
 const {log} = require('../common/logging');
+
+const [number, body, before, after] = process.argv.slice(2);
+
 const apiUrl = `https://api.statuspage.io/v1/pages/${process.env.STATUS_PAGE_ID}`;
 const headers = {
   'Content-Type': 'application/json',
@@ -140,9 +142,10 @@ async function syncIncident() {
   // get step that was checked off
   let checked = -1;
   for (const step of [3, 2, 1, 0]) {
-    const indexBefore = before.indexOf(steps[step].text) - 3;
-    const indexAfter = after.indexOf(steps[step].text) - 3;
-    if (before[indexBefore] !== 'x' && after[indexAfter] === 'x') {
+    const regex = new RegExp(
+      `[x] ${steps[step].text}`.replace(/[.*()[\]\\]/g, '\\$&')
+    );
+    if (regex.test(after) && !regex.test(before)) {
       checked = step;
       break;
     }

--- a/build-system/status-page/incident.js
+++ b/build-system/status-page/incident.js
@@ -141,12 +141,12 @@ async function syncIncident() {
 
   // get step that was checked off
   let checked = -1;
-  for (const step of [3, 2, 1, 0]) {
+  for (const index of [3, 2, 1, 0]) {
     const regex = new RegExp(
-      `[x] ${steps[step].text}`.replace(/[.*()[\]\\]/g, '\\$&')
+      `[x] <!-- status=${steps[index].status} -->`.replace(/[[\]\\]/g, '\\$&')
     );
     if (regex.test(after) && !regex.test(before)) {
-      checked = step;
+      checked = index;
       break;
     }
   }


### PR DESCRIPTION
Step 2 of https://github.com/ampproject/amphtml/issues/35065

- `comment.js` will be called when a cherry-pick request is created for stable and/or lts
- `incident.js` will be called when the progress comment is edited