### PR TITLE
Revert: "amp-layout: extract buildDOM #compiler (#34770)"

### DIFF
--- a/builtins/amp-layout/amp-layout.js
+++ b/builtins/amp-layout/amp-layout.js
@@ -15,12 +15,7 @@
  */
 
 import {BaseElement} from '../../src/base-element';
-import {
-  Layout,
-  applyFillContent,
-  isLayoutSizeDefined,
-  parseLayout,
-} from '#core/dom/layout';
+import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
 import {realChildNodes} from '#core/dom/query';
 import {registerElement} from '#service/custom-element-registry';
 
@@ -37,27 +32,16 @@ class AmpLayout extends BaseElement {
 
   /** @override */
   buildCallback() {
-    buildDom(this.win.document, this.element);
+    if (this.getLayout() == Layout.CONTAINER) {
+      return;
+    }
+    const container = this.win.document.createElement('div');
+    applyFillContent(container);
+    realChildNodes(this.element).forEach((child) => {
+      container.appendChild(child);
+    });
+    this.element.appendChild(container);
   }
-}
-
-/**
- *
- * @param {!Document} document
- * @param {!Element} element
- */
-export function buildDom(document, element) {
-  const layout = parseLayout(element.getAttribute('layout'));
-  if (layout == Layout.CONTAINER) {
-    return;
-  }
-
-  const container = document.createElement('div');
-  applyFillContent(container);
-  realChildNodes(element).forEach((child) => {
-    container.appendChild(child);
-  });
-  element.appendChild(container);
 }
 
 /**


### PR DESCRIPTION
**summary**
Reverts the meaningful changes from https://github.com/ampproject/amphtml/pull/34770.
The root cause of the issue was that `parseLayout` _is not_ equivalent to `this.getLayout()`.

- parseLayout just ensures the input layout type is valid and returns a `Layout`
- `this.getLayout` would use the "effective layout" calculated by calling `applyStaticLayout`.