### PR TITLE
🧪 Remove 3p-vendor-split experiment code path

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -18,7 +18,6 @@
   "tcf-post-message-proxy-api": 1,
   "amp-consent-granular-consent": 1,
   "disable-a4a-non-sd": 1,
-  "3p-vendor-split": 1,
   "story-ad-auto-advance": 1,
   "story-ad-placements": 1,
   "amp-story-page-attachment-ui-v2": 1

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -16,7 +16,6 @@
   "tcf-post-message-proxy-api": 1,
   "amp-consent-granular-consent": 1,
   "amp-cid-backup": 1,
-  "3p-vendor-split": 1,
   "story-ad-placements": 0.01,
   "amp-story-page-attachment-ui-v2": 1
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -342,7 +342,7 @@ describes.realWin(
           );
           expect(fetches[1]).to.have.property(
             'href',
-            'https://3p.ampproject.net/$internalRuntimeVersion$/f.js'
+            'https://3p.ampproject.net/$internalRuntimeVersion$/vendor/_ping_.js'
           );
 
           const preconnects = win.document.querySelectorAll(

--- a/extensions/amp-facebook-comments/1.0/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/1.0/amp-facebook-comments.js
@@ -43,7 +43,7 @@ class AmpFacebookComments extends BaseElement {
       // Base URL for 3p bootstrap iframes
       getBootstrapBaseUrl(win, ampdoc),
       // Script URL for iframe
-      getBootstrapUrl(TYPE, win),
+      getBootstrapUrl(TYPE),
       'https://facebook.com',
       // This domain serves the actual tweets as JSONP.
       'https://connect.facebook.net/' + locale + '/sdk.js',

--- a/extensions/amp-facebook-like/1.0/amp-facebook-like.js
+++ b/extensions/amp-facebook-like/1.0/amp-facebook-like.js
@@ -45,7 +45,7 @@ class AmpFacebookLike extends BaseElement {
       // Base URL for 3p bootstrap iframes
       getBootstrapBaseUrl(win, ampdoc),
       // Script URL for iframe
-      getBootstrapUrl(TYPE, win),
+      getBootstrapUrl(TYPE),
       'https://facebook.com',
       // This domain serves the actual tweets as JSONP.
       'https://connect.facebook.net/' + locale + '/sdk.js',

--- a/extensions/amp-facebook-page/1.0/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/1.0/amp-facebook-page.js
@@ -45,7 +45,7 @@ class AmpFacebookPage extends BaseElement {
       // Base URL for 3p bootstrap iframes
       getBootstrapBaseUrl(win, ampdoc),
       // Script URL for iframe
-      getBootstrapUrl(TYPE, win),
+      getBootstrapUrl(TYPE),
       'https://facebook.com',
       // This domain serves the actual tweets as JSONP.
       'https://connect.facebook.net/' + locale + '/sdk.js',

--- a/extensions/amp-facebook/1.0/amp-facebook.js
+++ b/extensions/amp-facebook/1.0/amp-facebook.js
@@ -43,7 +43,7 @@ class AmpFacebook extends BaseElement {
       // Base URL for 3p bootstrap iframes
       getBootstrapBaseUrl(win, ampdoc),
       // Script URL for iframe
-      getBootstrapUrl(TYPE, win),
+      getBootstrapUrl(TYPE),
       'https://facebook.com',
       // This domain serves the actual tweets as JSONP.
       'https://connect.facebook.net/' + locale + '/sdk.js',

--- a/extensions/amp-twitter/1.0/amp-twitter.js
+++ b/extensions/amp-twitter/1.0/amp-twitter.js
@@ -60,7 +60,7 @@ class AmpTwitter extends BaseElement {
       // Base URL for 3p bootstrap iframes
       getBootstrapBaseUrl(win, ampdoc),
       // Script URL for iframe
-      getBootstrapUrl(TYPE, win),
+      getBootstrapUrl(TYPE),
       // Hosts the script that renders tweets.
       'https://platform.twitter.com/widgets.js',
       // This domain serves the actual tweets as JSONP.

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -24,7 +24,6 @@ import {
   getRequiredSandboxFlags,
 } from './core/3p-frame';
 import {internalRuntimeVersion} from './internal-version';
-import {isExperimentOn} from './experiments';
 import {setStyle} from './core/dom/style';
 import {tryParseJson} from './core/types/object/json';
 import {urls} from './config';
@@ -120,7 +119,7 @@ export function getIframe(
   const name = JSON.stringify(
     dict({
       'host': host,
-      'bootstrap': getBootstrapUrl(attributes['type'], parentWindow),
+      'bootstrap': getBootstrapUrl(attributes['type']),
       'type': attributes['type'],
       // https://github.com/ampproject/amphtml/pull/2955
       'count': count[attributes['type']],
@@ -202,22 +201,19 @@ export function addDataAndJsonAttributes_(element, attributes) {
 /**
  * Get the bootstrap script URL for iframe.
  * @param {string} type
- * @param {!Window} win
  * @return {string}
  */
-export function getBootstrapUrl(type, win) {
+export function getBootstrapUrl(type) {
+  const extension = IS_ESM ? '.mjs' : '.js';
   if (getMode().localDev || getMode().test) {
     const filename = getMode().minified
-      ? `./vendor/${type}.`
-      : `./vendor/${type}.max.`;
-    return IS_ESM ? filename + 'mjs' : filename + 'js';
+      ? `./vendor/${type}`
+      : `./vendor/${type}.max`;
+    return filename + extension;
   }
-  if (isExperimentOn(win, '3p-vendor-split')) {
-    return IS_ESM
-      ? `${urls.thirdParty}/${internalRuntimeVersion()}/vendor/${type}.mjs`
-      : `${urls.thirdParty}/${internalRuntimeVersion()}/vendor/${type}.js`;
-  }
-  return `${urls.thirdParty}/${internalRuntimeVersion()}/f.js`;
+  return `${
+    urls.thirdParty
+  }/${internalRuntimeVersion()}/vendor/${type}${extension}`;
 }
 
 /**
@@ -233,7 +229,7 @@ export function preloadBootstrap(win, type, ampdoc, preconnect) {
 
   // While the URL may point to a custom domain, this URL will always be
   // fetched by it.
-  preconnect.preload(ampdoc, getBootstrapUrl(type, win), 'script');
+  preconnect.preload(ampdoc, getBootstrapUrl(type), 'script');
 }
 
 /**

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -131,7 +131,7 @@ function ProxyIframeEmbedWithRef(
       name: JSON.stringify(
         dict({
           'host': parseUrlDeprecated(src).hostname,
-          'bootstrap': bootstrap ?? getBootstrapUrl(type, win),
+          'bootstrap': bootstrap ?? getBootstrapUrl(type),
           'type': type,
           // "name" must be unique across iframes, so we add a count.
           // See: https://github.com/ampproject/amphtml/pull/2955

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -419,7 +419,6 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
 
       it('should prefetch bootstrap frame and JS', () => {
         mockMode({});
-        toggleExperiment(window, '3p-vendor-split', true);
         const ampdoc = Services.ampdoc(window.document);
         preloadBootstrap(window, 'avendor', ampdoc, preconnect);
         // Wait for visible promise.


### PR DESCRIPTION
Remove as no longer needed. The experiment was launched to 100%.