### PR TITLE
Remove 'esm' from getMode()

### DIFF
--- a/src/core/mode/esm.js
+++ b/src/core/mode/esm.js
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 
-export {isFortesting} from './for-testing';
-export {isLocalDev} from './local-dev';
-export {isMinified} from './minified';
-export {isTest} from './test';
-export {isEsm} from './esm';
+/**
+ * Returns true whenever --esm is used.
+ * Calls are DCE'd when compiled.
+ *
+ * @return {boolean}
+ */
+export function isEsm() {
+  return IS_ESM;
+}

--- a/src/mode.js
+++ b/src/mode.js
@@ -73,7 +73,7 @@ function getMode_(win) {
   return {
     localDev: coreMode.isLocalDev(win),
     development: isModeDevelopment(win),
-    esm: IS_ESM,
+
     // amp-geo override
     geoOverride: hashQuery['amp-geo'],
     minified: coreMode.isMinified(),

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import {isEsm} from '#core/mode';
 import {getMode} from '../mode';
 import {urls} from '../config';
 
@@ -55,7 +56,7 @@ export function calculateExtensionScriptUrl(
   version,
   opt_isLocalDev
 ) {
-  const fileExtension = getMode().esm ? '.mjs' : '.js';
+  const fileExtension = isEsm() ? '.mjs' : '.js';
   const base = calculateScriptBaseUrl(location, opt_isLocalDev);
   const rtv = getMode().rtvVersion;
   const extensionVersion = version ? '-' + version : '';
@@ -77,7 +78,7 @@ export function calculateEntryPointScriptUrl(
   isLocalDev,
   opt_rtv
 ) {
-  const fileExtension = getMode().esm ? '.mjs' : '.js';
+  const fileExtension = isEsm() ? '.mjs' : '.js';
   const base = calculateScriptBaseUrl(location, isLocalDev);
   if (isLocalDev) {
     return `${base}/${entryPoint}${fileExtension}`;
@@ -131,7 +132,7 @@ export function createExtensionScript(win, extensionId, version) {
   }
   scriptElement.setAttribute('data-script', extensionId);
   scriptElement.setAttribute('i-amphtml-inserted', '');
-  if (getMode().esm) {
+  if (isEsm()) {
     scriptElement.setAttribute('type', 'module');
   }
 


### PR DESCRIPTION
**summary**

In general it would be nice to remove items from the mode-object, especially if they are used in incredibly few places.
Using `core/mode` drags in as little as possible to a binary, as well as plays nicely with DCE (without resorting to amp-mode-transform)