### PR TITLE
🐛  [Story animation] Fix error thrown when user pauses before animation runs.

### DIFF
--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -398,8 +398,7 @@ export class AnimationRunner {
       try {
         this.runner_.pause();
       } catch (e) {
-        // This fails when the story was not initialized and the user pauses.
-        // Eg: visibilityState=prerender and long press before page becomes active.
+        // This fails when the story animations are not initialized and pause is called. Context on #35161.
       }
     }
   }

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -395,7 +395,12 @@ export class AnimationRunner {
     }
 
     if (this.runner_) {
-      this.runner_.pause();
+      try {
+        this.runner_.pause();
+      } catch (e) {
+        // This fails when the story was not initialized and the user pauses.
+        // Eg: visibilityState=prerender and long press before page becomes active.
+      }
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/ampproject/error-reporting/issues/94

When the story animations are not initialized (eg: because the story page is not visible yet, due to prerender mode), calling `pause` will throw an error because `this.players_ == null`.

There was a try/catch that was catching this error that was removed in #34466 that is needed.

https://github.com/ampproject/amphtml/pull/34466/files#diff-c5a86c80a77ae2a9abb4ac5ff1e9ef10f58c0e9262baa64273be1b4424d7161bL383-L388

We can re-introduce this try-catch and prevent these errors from surfacing, which is ok since the story is not initialized when the pause method is called. Changing the comment to more clearly explain why the method call can fail

An alternative is to change the behavior of pause by doing `if (!this.players_) {return;}` (silently fail the pause) but it will alter the API. Another alternative is to call init before calling pause but it would be extra work for initializing the animations when users pause the story, which could introduce delays in the rest of the pausing code.