### PR TITLE
🏗  Add GitHub Action to sync cherry-picks with status page

### DIFF
--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -12,20 +12,19 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
-          registry-url: https://registry.npmjs.org
+          node-version: lts/*
       - uses: actions/checkout@v2
       - name: Add progress comment to cherry-pick issue for Stable and LTS
         if: github.event_name == 'issues' && github.event.action == 'opened'
         run: |
-          npm install
+          npm ci
           node ./build-system/status-page/comment.js ${{ github.event.issue.number }} '${{ github.event.issue.body }}' ${{ github.actor }}
         env:
           GITHUB_TOKEN: ${{ secrets.AMPPROJECTBOT }}
       - name: Sync status page with cherry-pick progress
         if: github.event_name == 'issue_comment' && github.event.action == 'edited' && contains(github.event.comment.body, '🌸 Cherry-pick Progress 🌸')
         run: |
-          npm install
+          npm ci
           node ./build-system/status-page/incident.js ${{ github.event.issue.number }} '${{ github.event.issue.body }}' '${{ github.event.changes.body.from }}' '${{ github.event.comment.body}}'
         env:
           STATUS_PAGE_ID: ${{ secrets.STATUS_PAGE_ID }}

--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -1,0 +1,32 @@
+name: Update status.amp.dev
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [edited]
+jobs:
+  status-page:
+    if: contains(github.event.issue.title, '🌸 Cherry-pick request')
+    runs-on: ubuntu-latest
+    environment: status_page
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+          registry-url: https://registry.npmjs.org
+      - uses: actions/checkout@v2
+      - name: Add progress comment to cherry-pick issue for Stable and LTS
+        if: github.event_name == 'issues' && github.event.action == 'opened'
+        run: |
+          npm install
+          node ./build-system/status-page/comment.js ${{ github.event.issue.number }} '${{ github.event.issue.body }}' ${{ github.actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.AMPPROJECTBOT }}
+      - name: Sync status page with cherry-pick progress
+        if: github.event_name == 'issue_comment' && github.event.action == 'edited' && contains(github.event.comment.body, '🌸 Cherry-pick Progress 🌸')
+        run: |
+          npm install
+          node ./build-system/status-page/incident.js ${{ github.event.issue.number }} '${{ github.event.issue.body }}' '${{ github.event.changes.body.from }}' '${{ github.event.comment.body}}'
+        env:
+          STATUS_PAGE_ID: ${{ secrets.STATUS_PAGE_ID }}
+          STATUS_PAGE_TOKEN: ${{ secrets.STATUS_PAGE_TOKEN }}


### PR DESCRIPTION
Step 4 of https://github.com/ampproject/amphtml/issues/35065
- Adds a `🌸 Cherry-Pick Progress 🌸` comment when cherry-pick request issues are open for stable/lts. 
- Creates, updates, and resolves incidents on status.amp.dev when on-duty edits the comment.

![image](https://user-images.githubusercontent.com/44627152/125116613-fa21f380-e0ba-11eb-93d6-e024cbc09803.png)
