### PR TITLE
✨ `amp-story-desktop-one-panel` `background-blur` Pre draw image to fade in

### DIFF
--- a/extensions/amp-story/1.0/background-blur.js
+++ b/extensions/amp-story/1.0/background-blur.js
@@ -148,7 +148,10 @@ export class BackgroundBlur {
   }
 
   /**
-   * Composes the image offscreen, then uses it for fading in.
+   * Composes the image offscreen at 100% opacity, then uses it for fading in.
+   * If these draw calls are done with opacity, a flash would be visible.
+   * This is due to the black fill being a high contrast compared to the image.
+   * The black fill is always needed in case the image is a transparent png.
    * @private
    * @param {?Element} fillElement
    */

--- a/extensions/amp-story/1.0/background-blur.js
+++ b/extensions/amp-story/1.0/background-blur.js
@@ -45,8 +45,8 @@ export class BackgroundBlur {
     this.canvas_ = null;
 
     /** @private @const {Element} */
-    this.offScreenCanvas_ = this.win_.document.createElement('canvas');
-    this.offScreenCanvas_.width = this.offScreenCanvas_.height = CANVAS_SIZE;
+    this.offscreenCanvas_ = this.win_.document.createElement('canvas');
+    this.offscreenCanvas_.width = this.offscreenCanvas_.height = CANVAS_SIZE;
 
     /**  @private {?number} */
     this.currentRAF_ = null;
@@ -144,7 +144,7 @@ export class BackgroundBlur {
   drawCanvas_(alphaPercentage) {
     const context = this.canvas_.getContext('2d');
     context.globalAlpha = alphaPercentage;
-    context.drawImage(this.offScreenCanvas_, 0, 0, CANVAS_SIZE, CANVAS_SIZE);
+    context.drawImage(this.offscreenCanvas_, 0, 0, CANVAS_SIZE, CANVAS_SIZE);
   }
 
   /**
@@ -153,7 +153,7 @@ export class BackgroundBlur {
    * @param {?Element} fillElement
    */
   drawOffscreenCanvas_(fillElement) {
-    const context = this.offScreenCanvas_.getContext('2d');
+    const context = this.offscreenCanvas_.getContext('2d');
     // A black background in drawn first in case the image is a transparent PNG.
     context.fillStyle = 'black';
     context.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);


### PR DESCRIPTION
- Pre draws image to an off-screen canvas, then fades in the composed image.
- Adjusts animation to match system layer progress bar.
- Separates draw logic into functions.

This creates a smooth transition:
https://user-images.githubusercontent.com/3860311/125135823-a2de4c00-e0d7-11eb-9130-0af69e84c219.mp4

Without this the image will flash as it's faded in:
https://user-images.githubusercontent.com/3860311/125135854-b12c6800-e0d7-11eb-8852-cae568d03dac.mp4


