### PR TITLE
amp-fit-text: avoid innerHTML serialize/parse

### DIFF
--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -261,7 +261,8 @@ function mirrorNode(source, dest) {
 
   // Then copy all the source's child nodes into destination node.
   const {childNodes} = source;
-  for (let i = 0; i < childNodes.length; i++) {
+  const len = childNodes.length;
+  for (let i = 0; i < len; i++) {
     dest.appendChild(childNodes[i].cloneNode(true));
   }
 }

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -23,7 +23,7 @@ import {
 import {px, setImportantStyles, setStyle, setStyles} from '#core/dom/style';
 import {realChildNodes} from '#core/dom/query';
 import {throttle} from '#core/types/function';
-import {removeChildren} from '#core/dom';
+import {copyChildren, removeChildren} from '#core/dom';
 
 const TAG = 'amp-fit-text';
 const LINE_HEIGHT_EM_ = 1.15; // WARNING: when updating this ensure you also update the css values for line-height.
@@ -252,19 +252,15 @@ export function buildDom(document, element) {
 /**
  * Make a destination node a clone of the source.
  *
- * @param {!Node} source
- * @param {!Node} dest
+ * @param {!Node} from
+ * @param {!Node} to
  */
-function mirrorNode(source, dest) {
+function mirrorNode(from, to) {
   // First clear out the destination node.
-  removeChildren(dest);
+  removeChildren(to);
 
   // Then copy all the source's child nodes into destination node.
-  const {childNodes} = source;
-  const len = childNodes.length;
-  for (let i = 0; i < len; i++) {
-    dest.appendChild(childNodes[i].cloneNode(true));
-  }
+  copyChildren(from, to);
 }
 
 AMP.extension(TAG, '0.1', (AMP) => {

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -23,6 +23,7 @@ import {
 import {px, setImportantStyles, setStyle, setStyles} from '#core/dom/style';
 import {realChildNodes} from '#core/dom/query';
 import {throttle} from '#core/types/function';
+import {removeChildren} from '#core/dom';
 
 const TAG = 'amp-fit-text';
 const LINE_HEIGHT_EM_ = 1.15; // WARNING: when updating this ensure you also update the css values for line-height.
@@ -151,7 +152,7 @@ class AmpFitText extends AMP.BaseElement {
    * Copies text from the displayed content to the measurer element.
    */
   updateMeasurerContent_() {
-    this.measurer_./*OK*/ innerHTML = this.contentWrapper_./*OK*/ innerHTML;
+    mirrorNode(this.contentWrapper_, this.measurer_);
   }
 
   /** @private */
@@ -241,11 +242,27 @@ export function buildDom(document, element) {
   measurer.classList.add(MEASURER_CLASS);
 
   realChildNodes(element).forEach((node) => contentWrapper.appendChild(node));
-  measurer./*OK*/ innerHTML = contentWrapper./*OK*/ innerHTML;
+  mirrorNode(contentWrapper, measurer);
   element.appendChild(content);
   element.appendChild(measurer);
 
   return {content, contentWrapper, measurer};
+}
+
+/**
+ * Make a destination node a clone of the source.
+ *
+ * @param {!Node} source
+ * @param {!Node} dest
+ */
+function mirrorNode(source, dest) {
+  // First clear out the destination node.
+  removeChildren(dest);
+
+  const {childNodes} = source;
+  for (let i = 0; i < childNodes.length; i++) {
+    dest.appendChild(childNodes[i].cloneNode(true));
+  }
 }
 
 AMP.extension(TAG, '0.1', (AMP) => {

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -259,6 +259,7 @@ function mirrorNode(source, dest) {
   // First clear out the destination node.
   removeChildren(dest);
 
+  // Then copy all the source's child nodes into destination node.
   const {childNodes} = source;
   for (let i = 0; i < childNodes.length; i++) {
     dest.appendChild(childNodes[i].cloneNode(true));


### PR DESCRIPTION
**summary**

Using the clone API is both faster and more worker-dom friendly than using `innerHTML`

cc @ampproject/wg-performance 