### PR TITLE
Prevent double navigation from page-outlink.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -276,6 +276,11 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     link.setAttribute('href', hrefAttr);
     const {openStringEl, urlStringEl} = htmlRefs(link);
 
+    // Navigation is handled programmatically. Disable clicks on the placeholder
+    // anchor to prevent from users triggering double navigations, which has
+    // side effects in native contexts opening webviews/CCTs.
+    link.addEventListener('click', (event) => event.preventDefault());
+
     // Set image.
     const openImgAttr = this.element.getAttribute('cta-image');
     if (openImgAttr && openImgAttr !== 'none') {


### PR DESCRIPTION
Users could swipe up and then click the anchor. We disable this to not trigger side effects like:
- native environments that intercept navigation events and open two webviews/CCTs
- potential different analytics triggering in web environment