### PR TITLE
🚀 [Story performance] Launch first page load experiment to 10%

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -21,6 +21,6 @@
   "3p-vendor-split": 1,
   "story-ad-auto-advance": 1,
   "story-ad-placements": 1,
-  "amp-story-load-first-page-only": 0.1,
+  "story-load-first-page-only": 0.1,
   "amp-story-page-attachment-ui-v2": 1
 }

--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -21,5 +21,6 @@
   "3p-vendor-split": 1,
   "story-ad-auto-advance": 1,
   "story-ad-placements": 1,
+  "amp-story-load-first-page-only": 0.1,
   "amp-story-page-attachment-ui-v2": 1
 }

--- a/build-system/global-configs/client-side-experiments-config.json
+++ b/build-system/global-configs/client-side-experiments-config.json
@@ -3,10 +3,6 @@
     {
       "name": "flexible-bitrate",
       "percentage": 0.1
-    },
-    {
-      "name": "amp-story-load-first-page-only",
-      "percentage": 0.1
     }
   ]
 }

--- a/build-system/global-configs/client-side-experiments-config.json
+++ b/build-system/global-configs/client-side-experiments-config.json
@@ -3,6 +3,10 @@
     {
       "name": "flexible-bitrate",
       "percentage": 0.1
+    },
+    {
+      "name": "amp-story-load-first-page-only",
+      "percentage": 0.1
     }
   ]
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -18,6 +18,6 @@
   "amp-cid-backup": 1,
   "3p-vendor-split": 1,
   "story-ad-placements": 0.01,
-  "amp-story-load-first-page-only": 0.1,
+  "story-load-first-page-only": 0.1,
   "amp-story-page-attachment-ui-v2": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -18,5 +18,6 @@
   "amp-cid-backup": 1,
   "3p-vendor-split": 1,
   "story-ad-placements": 0.01,
+  "amp-story-load-first-page-only": 0.1,
   "amp-story-page-attachment-ui-v2": 1
 }

--- a/examples/amp-story/performance/lcp-compressed.html
+++ b/examples/amp-story/performance/lcp-compressed.html
@@ -53,7 +53,7 @@
     <script>
       const loadFirst = location.hash.includes('load=first');
       (self.AMP = self.AMP || []).push(function(AMP) {
-        AMP.toggleExperiment('amp-story-load-first-page-only', loadFirst);
+        AMP.toggleExperiment('story-load-first-page-only', loadFirst);
       });
     </script>
     <amp-story standalone id="cats"

--- a/examples/amp-story/performance/lcp.html
+++ b/examples/amp-story/performance/lcp.html
@@ -53,7 +53,7 @@
     <script>
       const loadFirst = location.hash.includes('load=first');
       (self.AMP = self.AMP || []).push(function(AMP) {
-        AMP.toggleExperiment('amp-story-load-first-page-only', loadFirst);
+        AMP.toggleExperiment('story-load-first-page-only', loadFirst);
       });
     </script>
     <amp-story standalone id="cats"

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -460,9 +460,9 @@ export class AmpStory extends AMP.BaseElement {
         );
       });
     }
-    if (isExperimentOn(this.win, 'amp-story-load-first-page-only')) {
+    if (isExperimentOn(this.win, 'story-load-first-page-only')) {
       Services.performanceFor(this.win).addEnabledExperiment(
-        'amp-story-load-first-page-only'
+        'story-load-first-page-only'
       );
     }
 
@@ -2246,7 +2246,7 @@ export class AmpStory extends AMP.BaseElement {
 
     this.mutateElement(() => {
       if (
-        !isExperimentOn(this.win, 'amp-story-load-first-page-only') ||
+        !isExperimentOn(this.win, 'story-load-first-page-only') ||
         !prioritizeActivePage
       ) {
         return preloadAllPages();

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1842,11 +1842,11 @@ describes.realWin(
       });
     });
 
-    describe('experiment for amp-story-load-first-page-only', () => {
+    describe('experiment for story-load-first-page-only', () => {
       let pages;
       let performanceImpl;
       beforeEach(async () => {
-        toggleExperiment(win, 'amp-story-load-first-page-only', true);
+        toggleExperiment(win, 'story-load-first-page-only', true);
         performanceImpl = new Performance(env.win);
         env.sandbox.stub(Services, 'performanceFor').returns(performanceImpl);
         pages = await createStoryWithPages(2, ['page-1', 'page-2'], false);
@@ -1895,7 +1895,7 @@ describes.realWin(
         story.buildCallback();
         await story.layoutCallback();
 
-        expect(enableSpy).to.be.calledWith('amp-story-load-first-page-only');
+        expect(enableSpy).to.be.calledWith('story-load-first-page-only');
       });
     });
   }


### PR DESCRIPTION
Launches the `story-load-first-page-only` experiment to 10%.
Also, since experiments don't start with `amp-` (everything is amp), removed the prefix `amp-` from the experiment name