### PR TITLE
🏗  Publish stable releases that have cherrypicks

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -59,6 +59,11 @@ jobs:
         run: |
           NPM_PACKAGE=$(jq -r .name ./extensions/${{ matrix.extension }}/${{ matrix.version }}/package.json)
           NPM_VERSION=$(jq -r .version ./extensions/${{ matrix.extension }}/${{ matrix.version }}/package.json)
-          npm dist-tag add ${NPM_PACKAGE}@${NPM_VERSION} latest
+          echo "Processing ${NPM_PACKAGE}@${NPM_VERSION}"
+          if [[ $(npm view ${NPM_PACKAGE}@${NPM_VERSION}) ]]; then
+            npm dist-tag add ${NPM_PACKAGE}@${NPM_VERSION} latest
+          else
+            npm publish ./extensions/${{ matrix.extension }}/${{ matrix.version }} --access public --tag latest
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fix bug where stable releases were expected to already exist on npm when they were published as nightly. This is not always true in the case of cherry-picks.

(Below you'll see me trying to test on this branch. The environment protection rules where you can only run a GitHub action on `main` worked. I was able to test this on my own repo)