### PR TITLE
🚀  [Story performance] Make images count towards LCP by adding 1px transparent border

### DIFF
--- a/examples/amp-story/performance/bgimage.html
+++ b/examples/amp-story/performance/bgimage.html
@@ -86,7 +86,7 @@
             id="img2"
             width="400"
             height="750"
-            src="https://images.unsplash.com/photo-1502318217862-aa4e294ba657?w=1080&q=100&fm=webp"
+            src="https://images.unsplash.com/photo-1502318217862-aa4e294ba657?w=1080&q=30&fm=webp"
             layout="fill">
           </amp-img>
         </amp-story-grid-layer>

--- a/examples/amp-story/performance/bgimage.html
+++ b/examples/amp-story/performance/bgimage.html
@@ -1,0 +1,96 @@
+<!-- Use #load=first to enable the experiment. -->
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="bgimage.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <title>LCP bg image test</title>
+
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+  <script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Source+Code+Pro&family=Source+Sans+Pro:wght@400;600&display=swap" rel="stylesheet">
+
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    * {
+      box-sizing: border-box;
+    }
+    amp-story-page {
+      font-family: 'Source Sans Pro', sans-serif;
+      color: white;
+      background: black;
+    }
+    code {
+      font-family: 'Source Code Pro', monospace;
+      background: #fff2;
+    }
+    amp-story p {
+      line-height: 1.5;
+    }
+    .bold {
+      font-weight: bold;
+    }
+    .bottom {
+      align-content: end;
+    }
+    .last {
+      padding-bottom: 8.83vh;
+    }
+    .byline {
+      letter-spacing: 1.28px;
+    }
+    p:not([class]) {
+      font-size: .6em;
+    }
+  </style>
+</head>
+  <body>
+    <script>
+      const toggle = location.hash.includes('border=true');
+      (self.AMP = self.AMP || []).push(function(AMP) {
+        AMP.toggleExperiment('story-add-lcp-borders-to-imgs', toggle);
+      });
+    </script>
+    <amp-story standalone id="cats"
+        title="LCP test" publisher="The AMP team"
+        publisher-logo-src="./img/amplogo.png"
+        poster-portrait-src="./img/overview.jpg">
+
+      <amp-story-page id="page-1" title="Lorem ipsum dolor sit amet">
+        <amp-story-grid-layer template="fill">
+          <amp-img
+            id="img1"
+            width="400"
+            height="750"
+            src="https://images.unsplash.com/photo-1515705576963-95cad62945b6?w=1750&q=30&fm=webp"
+            layout="fill">
+          </amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical" class="bottom">
+          <div animate-in="fade-in" animate-in-duration="2s" style="opacity: 0">
+            <p class="bold">LCP for background images</p>
+            <p class="byline">Add <code>#border=true</code> to activate experiment.</p>
+            <p>Adds a 1px border to the images before loading so they don't take the whole screen.</p>
+          </div>
+        </amp-story-grid-layer>
+      </amp-story-page>
+
+      <amp-story-page id="page-2">
+        <amp-story-grid-layer template="fill">
+          <amp-img
+            id="img2"
+            width="400"
+            height="750"
+            src="https://images.unsplash.com/photo-1502318217862-aa4e294ba657?w=1080&q=100&fm=webp"
+            layout="fill">
+          </amp-img>
+        </amp-story-grid-layer>
+      </amp-story-page>
+    </amp-story>
+  </body>
+</html>

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -995,3 +995,9 @@ amp-story-interactive-results[theme="dark"][chip-style="transparent"] {
 amp-story-page.i-amphtml-story-desktop-panels .i-amphtml-story-interactive-component {
   --i-amphtml-interactive-animation-delay: 350ms !important;
 }
+
+/* For LCP purposes, add a 1px border to fullscreen images when they are not loaded so they can be LCP candidates */
+amp-story-page.i-amphtml-experiment-story-add-lcp-borders-to-imgs amp-img:where([layout="fill"], [layout="responsive"]):not(.i-amphtml-loaded) img {
+  box-sizing: border-box !important;
+  border: 1px solid transparent !important;
+}


### PR DESCRIPTION
By adding 1px transparent borders to images, we can force them to not take the whole screen, which will make then non-background, allowing them to be considered as LCP candidates