### PR TITLE
buildDom: simplify interface, improve docs

### DIFF
--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -77,10 +77,7 @@ class AmpFitText extends AMP.BaseElement {
   buildCallback() {
     const {element} = this;
 
-    const {content, contentWrapper, measurer} = buildDom(
-      element.ownerDocument,
-      element
-    );
+    const {content, contentWrapper, measurer} = buildDom(element);
     this.content_ = content;
     this.contentWrapper_ = contentWrapper;
     this.measurer_ = measurer;
@@ -224,21 +221,22 @@ export function updateOverflow_(content, measurer, maxHeight, fontSize) {
 }
 
 /**
+ * @see amphtml/compiler/types.js for full description
  *
- * @param {!Document} document
  * @param {!Element} element
  * @return {{content: !Element, contentWrapper: !Element, measurer: !Element}}
  */
-export function buildDom(document, element) {
-  const content = document.createElement('div');
+export function buildDom(element) {
+  const doc = element.ownerDocument;
+  const content = doc.createElement('div');
   applyFillContent(content);
   content.classList.add(CONTENT_CLASS);
 
-  const contentWrapper = document.createElement('div');
+  const contentWrapper = doc.createElement('div');
   contentWrapper.classList.add(CONTENT_WRAPPER_CLASS);
   content.appendChild(contentWrapper);
 
-  const measurer = document.createElement('div');
+  const measurer = doc.createElement('div');
   measurer.classList.add(MEASURER_CLASS);
 
   realChildNodes(element).forEach((node) => contentWrapper.appendChild(node));

--- a/src/builtins/amp-layout/amp-layout.js
+++ b/src/builtins/amp-layout/amp-layout.js
@@ -35,22 +35,23 @@ class AmpLayout extends BaseElement {
 
   /** @override */
   buildCallback() {
-    buildDom(this.win.document, this.element);
+    buildDom(this.element);
   }
 }
 
 /**
+ * @see amphtml/compiler/types.js for full description
  *
- * @param {!Document} document
  * @param {!Element} element
  */
-export function buildDom(document, element) {
+export function buildDom(element) {
   const layout = getEffectiveLayout(element);
   if (layout == Layout.CONTAINER) {
     return;
   }
 
-  const container = document.createElement('div');
+  const doc = element.ownerDocument;
+  const container = doc.createElement('div');
   applyFillContent(container);
   realChildNodes(element).forEach((child) => {
     container.appendChild(child);

--- a/src/compiler/types.js
+++ b/src/compiler/types.js
@@ -22,5 +22,8 @@
  * - It must not perform any side effects, such as adding event listeners or assigning instance variables.
  * - It must not perform any of the operations involved with layoutCallback (loading).
  *
+ * The return value is set to *, so that we may optionally return any DOM nodes
+ * created during a client-side render. These nodes are often needed for ivars.
+ *
  * @typedef {function(!Element):*} BuildDom
  */

--- a/src/compiler/types.js
+++ b/src/compiler/types.js
@@ -15,11 +15,12 @@
  */
 
 /**
- * AMP Components must implement this function in order to be server-rendered.
+ * AMP Components must implement this "buildDom" function in order to be server-rendered.
  *
- * - The BuildDomFunction should perform all of the DOM manipulations necessary
- *   in order to render a components.
- * - It cannot perform any side effects, such as adding event listeners.
+ * - It must perform all of the DOM manipulations necessary to render a component.
+ *   Note: this is a subset of the responsibilities of buildCallback.
+ * - It must not perform any side effects, such as adding event listeners or assigning instance variables.
+ * - It must not perform any of the operations involved with layoutCallback (loading).
  *
- * @typedef {function(element:!Element): *} BuildDom
+ * @typedef {function(!Element):*} BuildDom
  */

--- a/src/compiler/types.js
+++ b/src/compiler/types.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * AMP Components must implement this function in order to be server-rendered.
+ *
+ * - The BuildDomFunction should perform all of the DOM manipulations necessary
+ *   in order to render a components.
+ * - It cannot perform any side effects, such as adding event listeners.
+ *
+ * @typedef {function(element:!Element): *} BuildDom
+ */


### PR DESCRIPTION
**summary**
- Creates docs for `buildDom`. Could not get a `@see` or `@{link}` working...no matter what I tried. If anyone knows how to make a link actually work in VS Code...I'm all ears. 
- Simplifies the function signature from `(Document, Element) => *` to `Element => *`