### PR TITLE
🐛 [story-ads] Use ad slot size in spsa param

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -426,7 +426,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       // create ad.
       'pwprc': this.element.getAttribute('data-package'),
       'spsa': this.isSinglePageStoryAd
-        ? `${viewportSize.width}x${viewportSize.height}`
+        ? `${this.size_.width}x${this.size_.height}`
         : null,
     };
 

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -958,6 +958,13 @@ describes.realWin(
         });
       });
 
+      it('should set spsa param to amp-ad element layout box', () => {
+        impl.isSinglePageStoryAd = true;
+        return impl.getAdUrl().then((url) => {
+          expect(url).to.match(/spsa=320x50/);
+        });
+      });
+
       describe('module/nomodule', () => {
         it('should have module nomodule experiment id in url when runtime type is 2', () => {
           env.sandbox


### PR DESCRIPTION
Server side google ads are using this param value to serve the correct size ads. Before this change doubleclick would send the <amp-ad> element size, but adsense would send the viewport size. This changes adsense to also send element size.