### PR TITLE
add capture for inpute[type=file] on AMP format only

### DIFF
--- a/validator/testdata/feature_tests/forms.html
+++ b/validator/testdata/feature_tests/forms.html
@@ -42,6 +42,10 @@
         <span>Your email</span>
         <input type="email" name="email" required>
       </label>
+      <label>
+        <span>Profile photo</span>
+        <input capture type="file">
+      </label>
       <input type="submit" value="Subscribe">
     </fieldset>
     <div submitting><template type="amp-mustache">Submitting</template></div>

--- a/validator/testdata/feature_tests/forms.out
+++ b/validator/testdata/feature_tests/forms.out
@@ -43,6 +43,10 @@ FAIL
 |          <span>Your email</span>
 |          <input type="email" name="email" required>
 |        </label>
+|        <label>
+|          <span>Profile photo</span>
+|          <input capture type="file">
+|        </label>
 |        <input type="submit" value="Subscribe">
 |      </fieldset>
 |      <div submitting><template type="amp-mustache">Submitting</template></div>
@@ -105,7 +109,7 @@ FAIL
 |    <!-- Invalid: form action must be https. -->
 |    <form method="post" action-xhr="http://example.com/subscribe" target="_blank">
 >>   ^~~~~~~~~
-feature_tests/forms.html:105:2 Invalid URL protocol 'http:' for attribute 'action-xhr' in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/forms.html:109:2 Invalid URL protocol 'http:' for attribute 'action-xhr' in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
 |      <input type="submit" value="Subscribe">
 |    </form>
 |    <!-- Invalid: form action must be a non-cdn link. -->
@@ -127,7 +131,7 @@ feature_tests/forms.html:105:2 Invalid URL protocol 'http:' for attribute 'actio
 |    <!-- Invalid: form target must be _blank or _top -->
 |    <form method="post" action-xhr="https://example/subscribe" target="_new">
 >>   ^~~~~~~~~
-feature_tests/forms.html:125:2 The attribute 'target' in tag 'form' is set to the invalid value '_new'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/forms.html:129:2 The attribute 'target' in tag 'form' is set to the invalid value '_new'. (see https://amp.dev/documentation/components/amp-form)
 |      <input type="submit" value="Subscribe">
 |    </form>
 |    <!-- Invalid: input, select, option and textarea must be children of form. -->
@@ -140,7 +144,7 @@ feature_tests/forms.html:125:2 The attribute 'target' in tag 'form' is set to th
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input type="image" name="image">
 >>     ^~~~~~~~~
-feature_tests/forms.html:136:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://amp.dev/documentation/components/amp-form/)
+feature_tests/forms.html:140:4 The attribute 'type' in tag 'input' is set to the invalid value 'image'. (see https://amp.dev/documentation/components/amp-form/)
 |    </form>
 |    <!-- Valid: input can be type="password" or type="file" in a post xhr form. -->
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
@@ -151,39 +155,39 @@ feature_tests/forms.html:136:4 The attribute 'type' in tag 'input' is set to the
 |    <form method="get" action="https://example.com/subscribe" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input type="password" name="password">
 >>     ^~~~~~~~~
-feature_tests/forms.html:145:4 The tag 'input' may only appear as a descendant of tag 'form [method=post]'. (see https://amp.dev/documentation/components/amp-form/)
+feature_tests/forms.html:149:4 The tag 'input' may only appear as a descendant of tag 'form [method=post]'. (see https://amp.dev/documentation/components/amp-form/)
 |    </form>
 |    <!-- Invalid: if validation-for is set on an element, then -->
 |    <!-- visible-when-invalid must also be set and vice versa. -->
 |    <form action="/foo" target="_blank">
 |      <div validation-for="bar"></div>
 >>     ^~~~~~~~~
-feature_tests/forms.html:150:4 The attribute 'visible-when-invalid' in tag 'div' is missing or incorrect, but required by attribute 'validation-for'.
+feature_tests/forms.html:154:4 The attribute 'visible-when-invalid' in tag 'div' is missing or incorrect, but required by attribute 'validation-for'.
 |      <div visibile-when-invalid="valueMissing"></div>
 >>     ^~~~~~~~~
-feature_tests/forms.html:151:4 The attribute 'visibile-when-invalid' may not appear in tag 'div'.
+feature_tests/forms.html:155:4 The attribute 'visibile-when-invalid' may not appear in tag 'div'.
 |    </form>
 |    <!-- Invalid: submit-success must be a div -->
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank"
 |      custom-validation-reporting="as-you-go">
 |      <span submit-success><template type="amp-mustache">Success</template></span>
 >>     ^~~~~~~~~
-feature_tests/forms.html:156:4 The attribute 'submit-success' may not appear in tag 'span'.
+feature_tests/forms.html:160:4 The attribute 'submit-success' may not appear in tag 'span'.
 |    </form>
 |    <!-- Invalid: post implies action-xhr -->
 |    <form method="post" action="https://example.com/subscribe" target="_top">
 >>   ^~~~~~~~~
-feature_tests/forms.html:159:2 The attribute 'action' may not appear in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/forms.html:163:2 The attribute 'action' may not appear in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
 |    </form>
 |    <!-- Invalid: get implies action -->
 |    <form method="get" action-xhr="https://example.com/subscribe" target="_top">
 >>   ^~~~~~~~~
-feature_tests/forms.html:162:2 The mandatory attribute 'action' is missing in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/forms.html:166:2 The mandatory attribute 'action' is missing in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
 |    </form>
 |    <!-- Invalid: get implies action, default method is get -->
 |    <form action-xhr="https://example.com/subscribe" target="_top">
 >>   ^~~~~~~~~
-feature_tests/forms.html:165:2 The mandatory attribute 'action' is missing in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
+feature_tests/forms.html:169:2 The mandatory attribute 'action' is missing in tag 'form'. (see https://amp.dev/documentation/components/amp-form)
 |    </form>
 |    <!-- Valid: inlined template, referenced template -->
 |    <template type="amp-mustache" id="submit_success_template">
@@ -204,22 +208,22 @@ feature_tests/forms.html:165:2 The mandatory attribute 'action' is missing in ta
 |      <div submitting template="submitting_template">
 |        <template type="amp-mustache">Submitting in inlined template</template>
 >>       ^~~~~~~~~
-feature_tests/forms.html:184:6 The tag 'template' may not appear as a descendant of tag 'form div [submitting][template]'. (see https://amp.dev/documentation/components/amp-mustache)
+feature_tests/forms.html:188:6 The tag 'template' may not appear as a descendant of tag 'form div [submitting][template]'. (see https://amp.dev/documentation/components/amp-mustache)
 |      </div>
 |      <div submit-success template="submit_success_template">
 |        <template type="amp-mustache">Success in inlined template</template>
 >>       ^~~~~~~~~
-feature_tests/forms.html:187:6 The tag 'template' may not appear as a descendant of tag 'form div [submit-success][template]'. (see https://amp.dev/documentation/components/amp-mustache)
+feature_tests/forms.html:191:6 The tag 'template' may not appear as a descendant of tag 'form div [submit-success][template]'. (see https://amp.dev/documentation/components/amp-mustache)
 |      </div>
 |      <div submit-error template="submit_error_template">
 |        <template type="amp-mustache">Error in inlined template</template>
 >>       ^~~~~~~~~
-feature_tests/forms.html:190:6 The tag 'template' may not appear as a descendant of tag 'form div [submit-error][template]'. (see https://amp.dev/documentation/components/amp-mustache)
+feature_tests/forms.html:194:6 The tag 'template' may not appear as a descendant of tag 'form div [submit-error][template]'. (see https://amp.dev/documentation/components/amp-mustache)
 |      </div>
 |      <div verify-error template="verify_error_template">
 |        <template type="amp-mustache">Verify in inlined template</template>
 >>       ^~~~~~~~~
-feature_tests/forms.html:193:6 The tag 'template' may not appear as a descendant of tag 'form div [verify-error][template]'. (see https://amp.dev/documentation/components/amp-mustache)
+feature_tests/forms.html:197:6 The tag 'template' may not appear as a descendant of tag 'form div [verify-error][template]'. (see https://amp.dev/documentation/components/amp-mustache)
 |      </div>
 |    </form>
 |    <!-- Valid: form with verify-xhr and input with no-verify-->
@@ -231,7 +235,7 @@ feature_tests/forms.html:193:6 The tag 'template' may not appear as a descendant
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">
 |      <input mask="L0L_0L0" type="tel">
 >>     ^~~~~~~~~
-feature_tests/forms.html:203:4 The tag 'input' requires including the 'amp-inputmask' extension JavaScript. (see https://amp.dev/documentation/components/amp-inputmask/)
+feature_tests/forms.html:207:4 The tag 'input' requires including the 'amp-inputmask' extension JavaScript. (see https://amp.dev/documentation/components/amp-inputmask/)
 |    </form>
 |    <!-- Valid: textarea within form -->
 |    <form method="post" action-xhr="https://example.com/subscribe" target="_blank">

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2719,7 +2719,12 @@ tags: {
   html_format: AMP
   tag_name: "INPUT"
   spec_name: "INPUT [type=file]"
-   attrs: {
+  attrs: {
+    disabled_by: "amp4email"
+    name: "capture"
+    value: ""
+  }
+  attrs: {
     disabled_by: "amp4email"
     name: "no-verify"
     value: ""


### PR DESCRIPTION
Fixes #35177

Allows `<input capture type=file>`.