### PR TITLE
🏗 Omit tilde (`~`) in Storybook output filenames

### DIFF
--- a/build-system/tasks/storybook/amp-env/main.js
+++ b/build-system/tasks/storybook/amp-env/main.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const {webpackConfigNoChunkTilde} = require('../env-utils');
+
 module.exports = {
   stories: [
     '../../../../src/builtins/storybook/*.amp.js',
@@ -29,7 +31,10 @@ module.exports = {
     '@storybook/addon-knobs',
     '@ampproject/storybook-addon',
   ],
-  webpackFinal: async (config) => {
+  managerWebpack: (config) => {
+    return webpackConfigNoChunkTilde(config);
+  },
+  webpackFinal: (config) => {
     // Disable entry point size warnings.
     config.performance.hints = false;
     return config;

--- a/build-system/tasks/storybook/amp-env/webpack.config.js
+++ b/build-system/tasks/storybook/amp-env/webpack.config.js
@@ -15,6 +15,7 @@
  */
 const path = require('path');
 const {getRelativeAliasMap} = require('../../../babel-config/import-resolver');
+const {webpackConfigNoChunkTilde} = require('../env-utils');
 
 const rootDir = path.join(__dirname, '../../../..');
 
@@ -60,5 +61,6 @@ module.exports = ({config}) => {
       },
     ],
   };
-  return config;
+
+  return webpackConfigNoChunkTilde(config);
 };

--- a/build-system/tasks/storybook/env-utils.js
+++ b/build-system/tasks/storybook/env-utils.js
@@ -23,11 +23,13 @@
  * @return {Object}
  */
 function webpackConfigNoChunkTilde(config) {
+  // Change runtime filenames (like runtime~main.*)
   if (config.optimization.runtimeChunk) {
     config.optimization.runtimeChunk = {
       name: ({name}) => `runtime-${name}`,
     };
   }
+  // Change all other chunked filenames (like vendors~main.*)
   if (config.optimization.splitChunks) {
     config.optimization.splitChunks.automaticNameDelimiter = '-';
   }

--- a/build-system/tasks/storybook/env-utils.js
+++ b/build-system/tasks/storybook/env-utils.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Change a Webpack config object so that filenames resulting from chunk
+ * splitting do not include a tilde (~) character.
+ * We do this since serving infrastructure does not play well with tildes.
+ * See https://go.amp.dev/issue/30954#issuecomment-868679665
+ * @param {Object} config
+ * @return {Object}
+ */
+function webpackConfigNoChunkTilde(config) {
+  if (config.optimization.runtimeChunk) {
+    config.optimization.runtimeChunk = {
+      name: ({name}) => `runtime-${name}`,
+    };
+  }
+  if (config.optimization.splitChunks) {
+    config.optimization.splitChunks.automaticNameDelimiter = '-';
+  }
+  return config;
+}
+
+module.exports = {
+  webpackConfigNoChunkTilde,
+};

--- a/build-system/tasks/storybook/preact-env/main.js
+++ b/build-system/tasks/storybook/preact-env/main.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+const {webpackConfigNoChunkTilde} = require('../env-utils');
+
 module.exports = {
   stories: [
     '../../../../src/**/storybook/!(*.amp).js',
@@ -24,6 +26,9 @@ module.exports = {
     '@storybook/addon-viewport/register',
     '@storybook/addon-knobs/register',
   ],
+  managerWebpack: (config) => {
+    return webpackConfigNoChunkTilde(config);
+  },
   webpackFinal: async (config) => {
     // Disable entry point size warnings.
     config.performance.hints = false;

--- a/build-system/tasks/storybook/preact-env/webpack.config.js
+++ b/build-system/tasks/storybook/preact-env/webpack.config.js
@@ -16,6 +16,7 @@
 const path = require('path');
 const {DefinePlugin} = require('webpack');
 const {getRelativeAliasMap} = require('../../../babel-config/import-resolver');
+const {webpackConfigNoChunkTilde} = require('../env-utils');
 
 const rootDir = path.join(__dirname, '../../../..');
 
@@ -72,5 +73,6 @@ module.exports = ({config}) => {
   // Replaced by minify-replace (babel) in the usual build pipeline
   // build-system/babel-config/helpers.js#getReplacePlugin
   config.plugins.push(new DefinePlugin({IS_ESM: false}));
-  return config;
+
+  return webpackConfigNoChunkTilde(config);
 };


### PR DESCRIPTION
https://github.com/ampproject/amphtml/issues/30954#issuecomment-868679665

```diff
  examples/storybook/preact:
  ...
- runtime~main.6bbc6c672e356009e233.manager.bundle.js
- runtime~main.b0af52cf.iframe.bundle.js
- vendors~main.3e7ae188.iframe.bundle.js
- vendors~main.3e7ae188.iframe.bundle.js.LICENSE.txt
- vendors~main.3e7ae188.iframe.bundle.js.map
- vendors~main.fb93791576556ba81a2a.manager.bundle.js
- vendors~main.fb93791576556ba81a2a.manager.bundle.js.LICENSE.txt
+ runtime-main.6bbc6c672e356009e233.manager.bundle.js
+ runtime-main.b0af52cf.iframe.bundle.js
+ vendors-main.3e7ae188.iframe.bundle.js
+ vendors-main.3e7ae188.iframe.bundle.js.LICENSE.txt
+ vendors-main.3e7ae188.iframe.bundle.js.map
+ vendors-main.fb93791576556ba81a2a.manager.bundle.js
+ vendors-main.fb93791576556ba81a2a.manager.bundle.js.LICENSE.txt
```
