### PR TITLE
Change deprecation to soft failure

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -17,12 +17,14 @@
 import {Services} from '#service';
 import {ancestorElementsByTag} from '#core/dom/query';
 import {createElementWithAttributes, removeElement} from '#core/dom';
-import {devAssert, userAssert} from '../../../src/log';
+import {devAssert, user, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 
 import {getAdContainer} from '../../../src/ad-helper';
 import {listen} from '../../../src/event-helper';
 import {setStyle, setStyles} from '#core/dom/style';
+
+const TAG = 'amp-ad-ui';
 
 const STICKY_AD_MAX_SIZE_LIMIT = 0.2;
 const STICKY_AD_MAX_HEIGHT_LIMIT = 0.5;
@@ -66,10 +68,12 @@ export class AmpAdUIHandler {
     if (this.element_.hasAttribute(STICKY_AD_PROP)) {
       // TODO(powerivq@) Kargo is currently running an experiment using empty sticky attribute, so
       // we default the position to bottom right. Remove this default afterwards.
-      userAssert(
-        this.element_.getAttribute(STICKY_AD_PROP),
-        'amp-ad sticky is deprecating empty attribute value, please use <amp-ad sticky="bottom" instead'
-      );
+      if (!this.element_.getAttribute(STICKY_AD_PROP)) {
+        user().error(
+          TAG,
+          'amp-ad sticky is deprecating empty attribute value, please use <amp-ad sticky="bottom" instead'
+        );
+      }
 
       this.stickyAdPosition_ =
         this.element_.getAttribute(STICKY_AD_PROP) ||


### PR DESCRIPTION
The previous version would cause a hard error and the ad is no longer loaded. This PR changes to a soft error message. I do not think it is currently being used by kargo on a campaign though.