### PR TITLE
✨ Message announcing IE Deprecation

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -150,6 +150,13 @@ startupChunk(self.document, function initial() {
       /* opt_isRuntimeCss */ true,
       /* opt_ext */ 'amp-runtime'
     );
+    // TODO(kbax) Remove this IE deprecation warning on 26 August 2021.
+    if (Services.platformFor(self).isIe() && self.console) {
+      (console.info || console.log).call(
+        console,
+        'IE Support is being deprecated, in September 2021 IE will no longer be supported. See https://github.com/ampproject/amphtml/issues/34453 for more details.'
+      );
+    }
   }
 });
 


### PR DESCRIPTION
This PR adds a message only visible when loading an AMP document in Internet Explorer to inform of deprecation.