### PR TITLE
🏗🐛 Change get-zindex to await on child process to close, not the child process's stdout stream

### DIFF
--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -156,12 +156,13 @@ function getZindexChainsInJs(glob, cwd = '.') {
 
     const result = {};
 
-    const {stderr, stdout} = jscodeshiftAsync([
+    const p = jscodeshiftAsync([
       '--dry',
       '--no-babel',
       `--transform=${__dirname}/jscodeshift/collect-zindex.js`,
       ...filesIncludingString,
     ]);
+    const {stderr, stdout} = p;
 
     stderr.on('data', (data) => {
       throw new Error(data.toString());
@@ -188,7 +189,7 @@ function getZindexChainsInJs(glob, cwd = '.') {
       } catch (_) {}
     });
 
-    stdout.on('close', () => {
+    p.on('close', () => {
       resolve(result);
     });
   });

--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -156,13 +156,13 @@ function getZindexChainsInJs(glob, cwd = '.') {
 
     const result = {};
 
-    const p = jscodeshiftAsync([
+    const process = jscodeshiftAsync([
       '--dry',
       '--no-babel',
       `--transform=${__dirname}/jscodeshift/collect-zindex.js`,
       ...filesIncludingString,
     ]);
-    const {stderr, stdout} = p;
+    const {stderr, stdout} = process;
 
     stderr.on('data', (data) => {
       throw new Error(data.toString());
@@ -189,7 +189,7 @@ function getZindexChainsInJs(glob, cwd = '.') {
       } catch (_) {}
     });
 
-    p.on('close', () => {
+    process.on('close', () => {
       resolve(result);
     });
   });


### PR DESCRIPTION
This should help avoid synchronization issues when running this inside Docker containers (#35176)