### PR TITLE
✨ Added remote JSON functionality for amp story ads config.

### DIFF
--- a/examples/amp-story/ads/remote.json
+++ b/examples/amp-story/ads/remote.json
@@ -1,0 +1,6 @@
+{
+    "ad-attributes": {
+      "type": "doubleclick",
+      "data-slot": "/30497360/a4a/story_360"
+    }
+}

--- a/examples/amp-story/story-ad-remote-config.html
+++ b/examples/amp-story/story-ad-remote-config.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html amp lang="en">
+ 
+<head>
+  <meta charset="utf-8">
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+  <script async custom-element="amp-story-auto-ads" src="https://cdn.ampproject.org/v0/amp-story-auto-ads-0.1.js"></script>
+  <title>AMP Story</title>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link rel="canonical" href="amp-story.amp.html">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <link href="https://fonts.googleapis.com/css?family=Lilita+One&display=swap" rel="stylesheet">
+  <style amp-custom>
+    amp-story-page {
+      background: slateblue;
+    }
+ 
+    .container {
+      justify-content: center;
+      align-content: center;
+    }
+ 
+    .num {
+      text-align: center;
+      color: white;
+      font-size: 300px;
+      font-family: 'Lilita One', cursive;
+    }
+  </style>
+</head>
+ 
+<body>
+  <amp-story standalone supports-landscape>
+    <amp-story-auto-ads src="/examples/amp-story/ads/remote.json" >
+      <!--
+        above is an example of JSON retrived from a source file
+        below is an example of inline code (commented out).
+      -->
+      <!-- <script type="application/json">
+        {
+          "ad-attributes": {
+            "type": "doubleclick",
+            "data-slot": "/30497360/a4a/story_360"
+          }
+        }
+      </script>  -->
+    </amp-story-auto-ads>
+ 
+    <amp-story-page id="page-1">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">1</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-2">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">2</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-3">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">3</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-4">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">4</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-5">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">5</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-6">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">6</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+ 
+    <amp-story-page id="page-7">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">7</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-8">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">8</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-9">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">9</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-10">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">10</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-11">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">11</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-12">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">12</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-13">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">13</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-14">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">14</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-15">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">15</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-16">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">16</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-17">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">17</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-18">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">18</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-19">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">19</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+    <amp-story-page id="page-20">
+      <amp-story-grid-layer class="container" template="vertical">
+        <p class="num">20</p>
+      </amp-story-grid-layer>
+    </amp-story-page>
+ 
+  </amp-story>
+</body>
+ 
+</html>

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -146,8 +146,8 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     return this.ampStory_
       .signals()
       .whenSignal(CommonSignals.INI_LOAD)
+      .then(() => this.handleConfig_())
       .then(() => {
-        this.handleConfig_();
         this.adPageManager_ = new StoryAdPageManager(
           this.ampStory_,
           this.config_
@@ -215,16 +215,22 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * Sets config and installs additional extensions if necessary.
    * @private
+   * @return {Promise}
    */
   handleConfig_() {
-    this.config_ = new StoryAdConfig(this.element).getConfig();
-    if (this.config_['type'] === 'custom') {
-      Services.extensionsFor(this.win)./*OK*/ installExtensionForDoc(
-        this.element.getAmpDoc(),
-        MUSTACHE_TAG,
-        'latest'
-      );
-    }
+    return new StoryAdConfig(this.element, this.win)
+      .getConfig()
+      .then((config) => {
+        this.config_ = config;
+        if (config['type'] === 'custom') {
+          Services.extensionsFor(this.win)./*OK*/ installExtensionForDoc(
+            this.element.getAmpDoc(),
+            MUSTACHE_TAG,
+            'latest'
+          );
+        }
+        return config;
+      });
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/story-ad-config.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-config.js
@@ -92,10 +92,7 @@ export class StoryAdConfig {
         delete adAttributes[attr];
       }
     }
-    return /** @type {!JsonObject} */ ({
-      ...adAttributes,
-      ...requiredAttrs,
-    });
+    return /** @type {!JsonObject} */ ({...adAttributes, ...requiredAttrs});
   }
 
   /**

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -220,7 +220,6 @@ describes.realWin(
       });
 
       it('should create glassPane', () => {
-        // this is failing
         const pane = doc.querySelector('.i-amphtml-glass-pane');
         expect(pane).to.exist;
       });

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -216,10 +216,11 @@ describes.realWin(
         new MockStoryImpl(storyElement);
         addStoryAutoAdsConfig(adElement);
         await autoAds.buildCallback();
-        autoAds.layoutCallback();
+        await autoAds.layoutCallback();
       });
 
       it('should create glassPane', () => {
+        // this is failing
         const pane = doc.querySelector('.i-amphtml-glass-pane');
         expect(pane).to.exist;
       });
@@ -500,6 +501,19 @@ describes.realWin(
           env.sandbox.match(payload),
           env.sandbox.match(eventInit)
         );
+      });
+    });
+
+    describe('Test if Handle Config assigns a new conifg and returns a promise', async () => {
+      const handleConfig = await new this.handleConfig_();
+      handleConfig.then((result) => {
+        expect(result).to.eql({
+          'amp-story': '',
+          class: 'i-amphtml-story-ad',
+          'data-slot': '/30497360/a4a/amp_story_dfp_example',
+          layout: 'fill',
+          type: 'doubleclick',
+        });
       });
     });
   }

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-config.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-config.js
@@ -18,242 +18,28 @@ import {Services} from '#service';
 import {StoryAdConfig} from '../story-ad-config';
 import {createStoryAdElementAndConfig} from './story-mock';
 
-describes.realWin(
-  'amp-story-auto-ads:config',
-  {
-    amp: true,
-  },
-  (env) => {
-    let win;
-    let doc;
+describes.realWin('amp-story-auto-ads:config', {amp: true}, (env) => {
+  let win;
+  let doc;
 
-    beforeEach(() => {
-      win = env.win;
-      doc = win.document;
-    });
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+  });
 
-    describe('story ad config', () => {
-      it('handles valid doubleclick config', async () => {
-        const config = {
-          type: 'doubleclick',
-          'data-slot': '/30497360/a4a/amp_story_dfp_example',
-        };
-        const storyAdEl = createStoryAdElementAndConfig(
-          doc,
-          doc.body, // Parent.
-          config
-        );
-        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
-
-        expect(result).to.eql({
-          'amp-story': '',
-          class: 'i-amphtml-story-ad',
-          'data-slot': '/30497360/a4a/amp_story_dfp_example',
-          layout: 'fill',
-          type: 'doubleclick',
-        });
-      });
-
-      it('handles valid adsense config', async () => {
-        const config = {
-          type: 'adsense',
-          'data-ad-client': 'ca-pub-8588820008944775',
-        };
-        const storyAdEl = createStoryAdElementAndConfig(
-          doc,
-          doc.body, // Parent.
-          config
-        );
-        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
-        expect(result).to.eql({
-          'amp-story': '',
-          class: 'i-amphtml-story-ad',
-          layout: 'fill',
-          'data-ad-client': 'ca-pub-8588820008944775',
-          type: 'adsense',
-        });
-      });
-
-      it('stringifies additional attributes passed in as objects', async () => {
-        const config = {
-          type: 'doubleclick',
-          'data-slot': '/30497360/a4a/amp_story_dfp_example',
-          'rtc-config': {
-            vendors: {
-              vendor1: {
-                'SLOT_ID': 1,
-              },
-              vendor2: {
-                'PAGE_ID': 'abc',
-              },
-            },
-          },
-        };
-        const storyAdEl = createStoryAdElementAndConfig(
-          doc,
-          doc.body, // Parent.
-          config
-        );
-        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
-        expect(result['rtc-config']).to.equal(
-          '{"vendors":{"vendor1":{"SLOT_ID":1},"vendor2":{"PAGE_ID":"abc"}}}'
-        );
-      });
-
-      it('throws on no config', () => {
-        const storyAdEl = doc.createElement('amp-story-auto-ads');
-        doc.body.appendChild(storyAdEl);
-        allowConsoleError(() => {
-          expect(() => {
-            new StoryAdConfig(storyAdEl, win).getConfig();
-          }).to.throw(
-            /The amp-story-auto-ads:config should be inside a <script> tag with type=\"application\/json\"​​​/
-          );
-        });
-      });
-
-      it('throws on missing ad-attributes', async () => {
-        const storyAdEl = doc.createElement('amp-story-auto-ads');
-        storyAdEl.innerHTML = `
-        <script type="application/json">
-          { "type": "doubleclick" }
-        </script>
-      `;
-        doc.body.appendChild(storyAdEl);
-        expectAsyncConsoleError(async () => {
-          expect(async () => {
-            await new StoryAdConfig(storyAdEl, win).getConfig();
-          }).to.throw(
-            /amp-story-auto-ads:config Error reading config\. Top level JSON should have an \"ad-attributes\" key​​​/
-          );
-        });
-      });
-
-      it('sanitizes unallowed attributes', async () => {
-        const config = {
-          type: 'doubleclick',
-          'data-slot': '/30497360/a4a/amp_story_dfp_example',
-          height: '1000px', // Should scrub.
-          width: '1000px', // Should scrub.
-          layout: 'intrinsic', // Should overwrite to fill.
-        };
-        const storyAdEl = createStoryAdElementAndConfig(
-          doc,
-          doc.body, // Parent.
-          config
-        );
-        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
-        expect(result).to.eql({
-          'amp-story': '',
-          class: 'i-amphtml-story-ad',
-          'data-slot': '/30497360/a4a/amp_story_dfp_example',
-          layout: 'fill',
-          type: 'doubleclick',
-        });
-      });
-
-      it('throws on invalid ad type', async () => {
-        const config = {
-          type: 'unsupported',
-          'data-slot': '/30497360/a4a/amp_story_dfp_example',
-        };
-        const storyAdEl = createStoryAdElementAndConfig(
-          doc,
-          doc.body, // Parent.
-          config
-        );
-        expectAsyncConsoleError(async () => {
-          expect(async () => {
-            await new StoryAdConfig(storyAdEl, win).getConfig();
-          }).to.throw(
-            /amp-story-auto-ads:config \"unsupported\" ad type is missing or not supported/
-          );
-        });
-      });
-
-      it('throws when using fake ad without making doc invalid', async () => {
-        const config = {
-          type: 'fake',
-          'src': '/examples/amp-story/ads/app-install.html',
-          'a4a-conversion': true,
-        };
-        const storyAdEl = createStoryAdElementAndConfig(
-          doc,
-          doc.body, // Parent.
-          config
-        );
-        expectAsyncConsoleError(async () => {
-          expect(async () => {
-            await new StoryAdConfig(storyAdEl, win).getConfig();
-          }).to.throw(
-            /amp-story-auto-ads:config id must start with i-amphtml-demo- to use fake ads/
-          );
-        });
-      });
-
-      it('works when using fake ad while making doc invalid', async () => {
-        const config = {
-          type: 'fake',
-          'src': '/examples/amp-story/ads/app-install.html',
-          'a4a-conversion': true,
-        };
-        const storyAdEl = createStoryAdElementAndConfig(
-          doc,
-          doc.body, // Parent.
-          config
-        );
-        storyAdEl.id = 'i-amphtml-demo-foo';
-
-        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
-        expect(result).to.eql({
-          type: 'fake',
-          src: '/examples/amp-story/ads/app-install.html',
-          'a4a-conversion': true,
-          class: 'i-amphtml-story-ad',
-          layout: 'fill',
-          'amp-story': '',
-        });
-      });
-    });
-
-    it('does use remote config when src attribute is provided', async () => {
+  describe('story ad config', () => {
+    it('handles valid doubleclick config', async () => {
       const config = {
         type: 'doubleclick',
         'data-slot': '/30497360/a4a/amp_story_dfp_example',
       };
-      const exampleURL = 'foo.example';
-      const xhrService = Services.xhrFor(win);
-      const fetchStub = env.sandbox.stub(xhrService, 'fetchJson').resolves({
-        json: () => Promise.resolve({'ad-attributes': config}),
-      });
-
-      const storyAutoAdsElem = doc.createElement('amp-story-auto-ads');
-      storyAutoAdsElem.setAttribute('src', exampleURL);
-
-      const result = await new StoryAdConfig(storyAutoAdsElem, win).getConfig();
-      expect(fetchStub).to.be.calledWith(exampleURL);
-      expect(result).to.eql({
-        'amp-story': '',
-        class: 'i-amphtml-story-ad',
-        'data-slot': '/30497360/a4a/amp_story_dfp_example',
-        layout: 'fill',
-        type: 'doubleclick',
-      });
-    });
-
-    it('uses inline config when src attribute is not provided', async () => {
-      const config = {
-        type: 'doubleclick',
-        'data-slot': '/30497360/a4a/amp_story_dfp_example',
-      };
-
-      const storyAutoAdsElem = createStoryAdElementAndConfig(
+      const storyAdEl = createStoryAdElementAndConfig(
         doc,
         doc.body, // Parent.
         config
       );
+      const result = await new StoryAdConfig(storyAdEl, win).getConfig();
 
-      const result = await new StoryAdConfig(storyAutoAdsElem, win).getConfig();
       expect(result).to.eql({
         'amp-story': '',
         class: 'i-amphtml-story-ad',
@@ -262,5 +48,213 @@ describes.realWin(
         type: 'doubleclick',
       });
     });
-  }
-);
+
+    it('handles valid adsense config', async () => {
+      const config = {
+        type: 'adsense',
+        'data-ad-client': 'ca-pub-8588820008944775',
+      };
+      const storyAdEl = createStoryAdElementAndConfig(
+        doc,
+        doc.body, // Parent.
+        config
+      );
+      const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+      expect(result).to.eql({
+        'amp-story': '',
+        class: 'i-amphtml-story-ad',
+        layout: 'fill',
+        'data-ad-client': 'ca-pub-8588820008944775',
+        type: 'adsense',
+      });
+    });
+
+    it('stringifies additional attributes passed in as objects', async () => {
+      const config = {
+        type: 'doubleclick',
+        'data-slot': '/30497360/a4a/amp_story_dfp_example',
+        'rtc-config': {
+          vendors: {
+            vendor1: {
+              'SLOT_ID': 1,
+            },
+            vendor2: {
+              'PAGE_ID': 'abc',
+            },
+          },
+        },
+      };
+      const storyAdEl = createStoryAdElementAndConfig(
+        doc,
+        doc.body, // Parent.
+        config
+      );
+      const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+      expect(result['rtc-config']).to.equal(
+        '{"vendors":{"vendor1":{"SLOT_ID":1},"vendor2":{"PAGE_ID":"abc"}}}'
+      );
+    });
+
+    it('throws on no config', () => {
+      const storyAdEl = doc.createElement('amp-story-auto-ads');
+      doc.body.appendChild(storyAdEl);
+      allowConsoleError(() => {
+        expect(() => {
+          new StoryAdConfig(storyAdEl, win).getConfig();
+        }).to.throw(
+          /The amp-story-auto-ads:config should be inside a <script> tag with type=\"application\/json\"​​​/
+        );
+      });
+    });
+
+    it('throws on missing ad-attributes', async () => {
+      const storyAdEl = doc.createElement('amp-story-auto-ads');
+      storyAdEl.innerHTML = `
+        <script type="application/json">
+          { "type": "doubleclick" }
+        </script>
+      `;
+      doc.body.appendChild(storyAdEl);
+      expectAsyncConsoleError(async () => {
+        expect(async () => {
+          await new StoryAdConfig(storyAdEl, win).getConfig();
+        }).to.throw(
+          /amp-story-auto-ads:config Error reading config\. Top level JSON should have an \"ad-attributes\" key​​​/
+        );
+      });
+    });
+
+    it('sanitizes unallowed attributes', async () => {
+      const config = {
+        type: 'doubleclick',
+        'data-slot': '/30497360/a4a/amp_story_dfp_example',
+        height: '1000px', // Should scrub.
+        width: '1000px', // Should scrub.
+        layout: 'intrinsic', // Should overwrite to fill.
+      };
+      const storyAdEl = createStoryAdElementAndConfig(
+        doc,
+        doc.body, // Parent.
+        config
+      );
+      const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+      expect(result).to.eql({
+        'amp-story': '',
+        class: 'i-amphtml-story-ad',
+        'data-slot': '/30497360/a4a/amp_story_dfp_example',
+        layout: 'fill',
+        type: 'doubleclick',
+      });
+    });
+
+    it('throws on invalid ad type', async () => {
+      const config = {
+        type: 'unsupported',
+        'data-slot': '/30497360/a4a/amp_story_dfp_example',
+      };
+      const storyAdEl = createStoryAdElementAndConfig(
+        doc,
+        doc.body, // Parent.
+        config
+      );
+      expectAsyncConsoleError(async () => {
+        expect(async () => {
+          await new StoryAdConfig(storyAdEl, win).getConfig();
+        }).to.throw(
+          /amp-story-auto-ads:config \"unsupported\" ad type is missing or not supported/
+        );
+      });
+    });
+
+    it('throws when using fake ad without making doc invalid', async () => {
+      const config = {
+        type: 'fake',
+        'src': '/examples/amp-story/ads/app-install.html',
+        'a4a-conversion': true,
+      };
+      const storyAdEl = createStoryAdElementAndConfig(
+        doc,
+        doc.body, // Parent.
+        config
+      );
+      expectAsyncConsoleError(async () => {
+        expect(async () => {
+          await new StoryAdConfig(storyAdEl, win).getConfig();
+        }).to.throw(
+          /amp-story-auto-ads:config id must start with i-amphtml-demo- to use fake ads/
+        );
+      });
+    });
+
+    it('works when using fake ad while making doc invalid', async () => {
+      const config = {
+        type: 'fake',
+        'src': '/examples/amp-story/ads/app-install.html',
+        'a4a-conversion': true,
+      };
+      const storyAdEl = createStoryAdElementAndConfig(
+        doc,
+        doc.body, // Parent.
+        config
+      );
+      storyAdEl.id = 'i-amphtml-demo-foo';
+
+      const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+      expect(result).to.eql({
+        type: 'fake',
+        src: '/examples/amp-story/ads/app-install.html',
+        'a4a-conversion': true,
+        class: 'i-amphtml-story-ad',
+        layout: 'fill',
+        'amp-story': '',
+      });
+    });
+  });
+
+  it('does use remote config when src attribute is provided', async () => {
+    const config = {
+      type: 'doubleclick',
+      'data-slot': '/30497360/a4a/amp_story_dfp_example',
+    };
+    const exampleURL = 'foo.example';
+    const xhrService = Services.xhrFor(win);
+    const fetchStub = env.sandbox.stub(xhrService, 'fetchJson').resolves({
+      json: () => Promise.resolve({'ad-attributes': config}),
+    });
+
+    const storyAutoAdsElem = doc.createElement('amp-story-auto-ads');
+    storyAutoAdsElem.setAttribute('src', exampleURL);
+
+    const result = await new StoryAdConfig(storyAutoAdsElem, win).getConfig();
+    expect(fetchStub).to.be.calledWith(exampleURL);
+    expect(result).to.eql({
+      'amp-story': '',
+      class: 'i-amphtml-story-ad',
+      'data-slot': '/30497360/a4a/amp_story_dfp_example',
+      layout: 'fill',
+      type: 'doubleclick',
+    });
+  });
+
+  it('uses inline config when src attribute is not provided', async () => {
+    const config = {
+      type: 'doubleclick',
+      'data-slot': '/30497360/a4a/amp_story_dfp_example',
+    };
+
+    const storyAutoAdsElem = createStoryAdElementAndConfig(
+      doc,
+      doc.body, // Parent.
+      config
+    );
+
+    const result = await new StoryAdConfig(storyAutoAdsElem, win).getConfig();
+    expect(result).to.eql({
+      'amp-story': '',
+      class: 'i-amphtml-story-ad',
+      'data-slot': '/30497360/a4a/amp_story_dfp_example',
+      layout: 'fill',
+      type: 'doubleclick',
+    });
+  });
+});

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-config.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-config.js
@@ -39,7 +39,6 @@ describes.realWin('amp-story-auto-ads:config', {amp: true}, (env) => {
         config
       );
       const result = await new StoryAdConfig(storyAdEl, win).getConfig();
-
       expect(result).to.eql({
         'amp-story': '',
         class: 'i-amphtml-story-ad',
@@ -75,12 +74,8 @@ describes.realWin('amp-story-auto-ads:config', {amp: true}, (env) => {
         'data-slot': '/30497360/a4a/amp_story_dfp_example',
         'rtc-config': {
           vendors: {
-            vendor1: {
-              'SLOT_ID': 1,
-            },
-            vendor2: {
-              'PAGE_ID': 'abc',
-            },
+            vendor1: {'SLOT_ID': 1},
+            vendor2: {'PAGE_ID': 'abc'},
           },
         },
       };
@@ -198,7 +193,6 @@ describes.realWin('amp-story-auto-ads:config', {amp: true}, (env) => {
         config
       );
       storyAdEl.id = 'i-amphtml-demo-foo';
-
       const result = await new StoryAdConfig(storyAdEl, win).getConfig();
       expect(result).to.eql({
         type: 'fake',

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-config.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-config.js
@@ -14,124 +14,224 @@
  * limitations under the License.
  */
 
+import {Services} from '#service';
 import {StoryAdConfig} from '../story-ad-config';
 import {createStoryAdElementAndConfig} from './story-mock';
 
-describes.realWin('amp-story-auto-ads:config', {amp: true}, (env) => {
-  let win;
-  let doc;
+describes.realWin(
+  'amp-story-auto-ads:config',
+  {
+    amp: true,
+  },
+  (env) => {
+    let win;
+    let doc;
 
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-  });
-
-  describe('story ad config', () => {
-    it('handles valid doubleclick config', () => {
-      const config = {
-        type: 'doubleclick',
-        'data-slot': '/30497360/a4a/amp_story_dfp_example',
-      };
-      const storyAdEl = createStoryAdElementAndConfig(
-        doc,
-        doc.body, // Parent.
-        config
-      );
-      const result = new StoryAdConfig(storyAdEl).getConfig();
-      expect(result).to.eql({
-        'amp-story': '',
-        class: 'i-amphtml-story-ad',
-        'data-slot': '/30497360/a4a/amp_story_dfp_example',
-        layout: 'fill',
-        type: 'doubleclick',
-      });
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
     });
 
-    it('handles valid adsense config', () => {
-      const config = {
-        type: 'adsense',
-        'data-ad-client': 'ca-pub-8588820008944775',
-      };
-      const storyAdEl = createStoryAdElementAndConfig(
-        doc,
-        doc.body, // Parent.
-        config
-      );
-      const result = new StoryAdConfig(storyAdEl).getConfig();
-      expect(result).to.eql({
-        'amp-story': '',
-        class: 'i-amphtml-story-ad',
-        layout: 'fill',
-        'data-ad-client': 'ca-pub-8588820008944775',
-        type: 'adsense',
-      });
-    });
+    describe('story ad config', () => {
+      it('handles valid doubleclick config', async () => {
+        const config = {
+          type: 'doubleclick',
+          'data-slot': '/30497360/a4a/amp_story_dfp_example',
+        };
+        const storyAdEl = createStoryAdElementAndConfig(
+          doc,
+          doc.body, // Parent.
+          config
+        );
+        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
 
-    it('stringifies additional attributes passed in as objects', () => {
-      const config = {
-        type: 'doubleclick',
-        'data-slot': '/30497360/a4a/amp_story_dfp_example',
-        'rtc-config': {
-          vendors: {
-            vendor1: {'SLOT_ID': 1},
-            vendor2: {'PAGE_ID': 'abc'},
+        expect(result).to.eql({
+          'amp-story': '',
+          class: 'i-amphtml-story-ad',
+          'data-slot': '/30497360/a4a/amp_story_dfp_example',
+          layout: 'fill',
+          type: 'doubleclick',
+        });
+      });
+
+      it('handles valid adsense config', async () => {
+        const config = {
+          type: 'adsense',
+          'data-ad-client': 'ca-pub-8588820008944775',
+        };
+        const storyAdEl = createStoryAdElementAndConfig(
+          doc,
+          doc.body, // Parent.
+          config
+        );
+        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+        expect(result).to.eql({
+          'amp-story': '',
+          class: 'i-amphtml-story-ad',
+          layout: 'fill',
+          'data-ad-client': 'ca-pub-8588820008944775',
+          type: 'adsense',
+        });
+      });
+
+      it('stringifies additional attributes passed in as objects', async () => {
+        const config = {
+          type: 'doubleclick',
+          'data-slot': '/30497360/a4a/amp_story_dfp_example',
+          'rtc-config': {
+            vendors: {
+              vendor1: {
+                'SLOT_ID': 1,
+              },
+              vendor2: {
+                'PAGE_ID': 'abc',
+              },
+            },
           },
-        },
-      };
-      const storyAdEl = createStoryAdElementAndConfig(
-        doc,
-        doc.body, // Parent.
-        config
-      );
-      const result = new StoryAdConfig(storyAdEl).getConfig();
-      expect(result['rtc-config']).to.equal(
-        '{"vendors":{"vendor1":{"SLOT_ID":1},"vendor2":{"PAGE_ID":"abc"}}}'
-      );
-    });
-
-    it('throws on no config', () => {
-      const storyAdEl = doc.createElement('amp-story-auto-ads');
-      doc.body.appendChild(storyAdEl);
-      allowConsoleError(() => {
-        expect(() => {
-          new StoryAdConfig(storyAdEl).getConfig();
-        }).to.throw(
-          /The amp-story-auto-ads:config should be inside a <script> tag with type=\"application\/json\"​​​/
+        };
+        const storyAdEl = createStoryAdElementAndConfig(
+          doc,
+          doc.body, // Parent.
+          config
+        );
+        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+        expect(result['rtc-config']).to.equal(
+          '{"vendors":{"vendor1":{"SLOT_ID":1},"vendor2":{"PAGE_ID":"abc"}}}'
         );
       });
-    });
 
-    it('throws on missing ad-attributes', () => {
-      const storyAdEl = doc.createElement('amp-story-auto-ads');
-      storyAdEl.innerHTML = `
+      it('throws on no config', () => {
+        const storyAdEl = doc.createElement('amp-story-auto-ads');
+        doc.body.appendChild(storyAdEl);
+        allowConsoleError(() => {
+          expect(() => {
+            new StoryAdConfig(storyAdEl, win).getConfig();
+          }).to.throw(
+            /The amp-story-auto-ads:config should be inside a <script> tag with type=\"application\/json\"​​​/
+          );
+        });
+      });
+
+      it('throws on missing ad-attributes', async () => {
+        const storyAdEl = doc.createElement('amp-story-auto-ads');
+        storyAdEl.innerHTML = `
         <script type="application/json">
           { "type": "doubleclick" }
         </script>
       `;
-      doc.body.appendChild(storyAdEl);
-      allowConsoleError(() => {
-        expect(() => {
-          new StoryAdConfig(storyAdEl).getConfig();
-        }).to.throw(
-          /amp-story-auto-ads:config Error reading config\. Top level JSON should have an \"ad-attributes\" key​​​/
+        doc.body.appendChild(storyAdEl);
+        expectAsyncConsoleError(async () => {
+          expect(async () => {
+            await new StoryAdConfig(storyAdEl, win).getConfig();
+          }).to.throw(
+            /amp-story-auto-ads:config Error reading config\. Top level JSON should have an \"ad-attributes\" key​​​/
+          );
+        });
+      });
+
+      it('sanitizes unallowed attributes', async () => {
+        const config = {
+          type: 'doubleclick',
+          'data-slot': '/30497360/a4a/amp_story_dfp_example',
+          height: '1000px', // Should scrub.
+          width: '1000px', // Should scrub.
+          layout: 'intrinsic', // Should overwrite to fill.
+        };
+        const storyAdEl = createStoryAdElementAndConfig(
+          doc,
+          doc.body, // Parent.
+          config
         );
+        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+        expect(result).to.eql({
+          'amp-story': '',
+          class: 'i-amphtml-story-ad',
+          'data-slot': '/30497360/a4a/amp_story_dfp_example',
+          layout: 'fill',
+          type: 'doubleclick',
+        });
+      });
+
+      it('throws on invalid ad type', async () => {
+        const config = {
+          type: 'unsupported',
+          'data-slot': '/30497360/a4a/amp_story_dfp_example',
+        };
+        const storyAdEl = createStoryAdElementAndConfig(
+          doc,
+          doc.body, // Parent.
+          config
+        );
+        expectAsyncConsoleError(async () => {
+          expect(async () => {
+            await new StoryAdConfig(storyAdEl, win).getConfig();
+          }).to.throw(
+            /amp-story-auto-ads:config \"unsupported\" ad type is missing or not supported/
+          );
+        });
+      });
+
+      it('throws when using fake ad without making doc invalid', async () => {
+        const config = {
+          type: 'fake',
+          'src': '/examples/amp-story/ads/app-install.html',
+          'a4a-conversion': true,
+        };
+        const storyAdEl = createStoryAdElementAndConfig(
+          doc,
+          doc.body, // Parent.
+          config
+        );
+        expectAsyncConsoleError(async () => {
+          expect(async () => {
+            await new StoryAdConfig(storyAdEl, win).getConfig();
+          }).to.throw(
+            /amp-story-auto-ads:config id must start with i-amphtml-demo- to use fake ads/
+          );
+        });
+      });
+
+      it('works when using fake ad while making doc invalid', async () => {
+        const config = {
+          type: 'fake',
+          'src': '/examples/amp-story/ads/app-install.html',
+          'a4a-conversion': true,
+        };
+        const storyAdEl = createStoryAdElementAndConfig(
+          doc,
+          doc.body, // Parent.
+          config
+        );
+        storyAdEl.id = 'i-amphtml-demo-foo';
+
+        const result = await new StoryAdConfig(storyAdEl, win).getConfig();
+        expect(result).to.eql({
+          type: 'fake',
+          src: '/examples/amp-story/ads/app-install.html',
+          'a4a-conversion': true,
+          class: 'i-amphtml-story-ad',
+          layout: 'fill',
+          'amp-story': '',
+        });
       });
     });
 
-    it('sanitizes unallowed attributes', () => {
+    it('does use remote config when src attribute is provided', async () => {
       const config = {
         type: 'doubleclick',
         'data-slot': '/30497360/a4a/amp_story_dfp_example',
-        height: '1000px', // Should scrub.
-        width: '1000px', // Should scrub.
-        layout: 'intrinsic', // Should overwrite to fill.
       };
-      const storyAdEl = createStoryAdElementAndConfig(
-        doc,
-        doc.body, // Parent.
-        config
-      );
-      const result = new StoryAdConfig(storyAdEl).getConfig();
+      const exampleURL = 'foo.example';
+      const xhrService = Services.xhrFor(win);
+      const fetchStub = env.sandbox.stub(xhrService, 'fetchJson').resolves({
+        json: () => Promise.resolve({'ad-attributes': config}),
+      });
+
+      const storyAutoAdsElem = doc.createElement('amp-story-auto-ads');
+      storyAutoAdsElem.setAttribute('src', exampleURL);
+
+      const result = await new StoryAdConfig(storyAutoAdsElem, win).getConfig();
+      expect(fetchStub).to.be.calledWith(exampleURL);
       expect(result).to.eql({
         'amp-story': '',
         class: 'i-amphtml-story-ad',
@@ -141,67 +241,26 @@ describes.realWin('amp-story-auto-ads:config', {amp: true}, (env) => {
       });
     });
 
-    it('throws on invalid ad type', () => {
+    it('uses inline config when src attribute is not provided', async () => {
       const config = {
-        type: 'unsupported',
+        type: 'doubleclick',
         'data-slot': '/30497360/a4a/amp_story_dfp_example',
       };
-      const storyAdEl = createStoryAdElementAndConfig(
+
+      const storyAutoAdsElem = createStoryAdElementAndConfig(
         doc,
         doc.body, // Parent.
         config
       );
-      allowConsoleError(() => {
-        expect(() => {
-          new StoryAdConfig(storyAdEl).getConfig();
-        }).to.throw(
-          /amp-story-auto-ads:config \"unsupported\" ad type is missing or not supported/
-        );
-      });
-    });
 
-    it('throws when using fake ad without making doc invalid', () => {
-      const config = {
-        type: 'fake',
-        'src': '/examples/amp-story/ads/app-install.html',
-        'a4a-conversion': true,
-      };
-      const storyAdEl = createStoryAdElementAndConfig(
-        doc,
-        doc.body, // Parent.
-        config
-      );
-      allowConsoleError(() => {
-        expect(() => {
-          new StoryAdConfig(storyAdEl).getConfig();
-        }).to.throw(
-          /amp-story-auto-ads:config id must start with i-amphtml-demo- to use fake ads/
-        );
-      });
-    });
-
-    it('works when using fake ad while making doc invalid', () => {
-      const config = {
-        type: 'fake',
-        'src': '/examples/amp-story/ads/app-install.html',
-        'a4a-conversion': true,
-      };
-      const storyAdEl = createStoryAdElementAndConfig(
-        doc,
-        doc.body, // Parent.
-        config
-      );
-      storyAdEl.id = 'i-amphtml-demo-foo';
-
-      const result = new StoryAdConfig(storyAdEl).getConfig();
+      const result = await new StoryAdConfig(storyAutoAdsElem, win).getConfig();
       expect(result).to.eql({
-        type: 'fake',
-        src: '/examples/amp-story/ads/app-install.html',
-        'a4a-conversion': true,
-        class: 'i-amphtml-story-ad',
-        layout: 'fill',
         'amp-story': '',
+        class: 'i-amphtml-story-ad',
+        'data-slot': '/30497360/a4a/amp_story_dfp_example',
+        layout: 'fill',
+        type: 'doubleclick',
       });
     });
-  });
-});
+  }
+);


### PR DESCRIPTION
fixes #34192

Adds the ability to have remote URLS containing config JSON data 
for the <amp-story-auto-ads> component parsed and loaded 
with a remote URL specified by the src attribute, instead of inline JSON only. 
Both modes are still supported.

See the example included with this commit for a demo. 
The inline JSON is included in this example and is commented out for reference.