### PR TITLE
🏗 Fix bug in instantiation of babel cache

### DIFF
--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -40,10 +40,6 @@ function getEsbuildBabelPlugin(
   preSetup = () => {},
   postLoad = () => {}
 ) {
-  if (!transformCache) {
-    transformCache = new TransformCache('.babel-cache', '.js');
-  }
-
   /**
    * @param {string} filename
    * @param {string} contents
@@ -53,6 +49,9 @@ function getEsbuildBabelPlugin(
    */
   async function transformContents(filename, contents, hash, babelOptions) {
     if (enableCache) {
+      if (!transformCache) {
+        transformCache = new TransformCache('.babel-cache', '.js');
+      }
       const cached = transformCache.get(hash);
       if (cached) {
         return cached;

--- a/build-system/tasks/runtime-test/helpers.js
+++ b/build-system/tasks/runtime-test/helpers.js
@@ -136,7 +136,7 @@ function maybePrintArgvMessages() {
       green('to run tests in a headless Chrome window.')
     );
   }
-  if (argv.compiled || !argv.nobuild) {
+  if (argv.compiled) {
     log(green('Running tests against minified code.'));
   } else {
     log(green('Running tests against unminified code.'));


### PR DESCRIPTION
We're seeing occasional errors during integration tests because the step that cleans old build artifacts can clash with the (too eager) instantiation of the babel cache. See https://github.com/ampproject/amphtml/issues/35257#issuecomment-881592688.

**PR highlights:**
- Delay instantiation of the babel cache to just before its first use. (Artifact cleanup is guaranteed to be done by then.)
- **Bonus fix:** Cosmetic fix to the logging statement that says what kind of build is being tested against.

Fixes #35257