### PR TITLE
✅  ♻️  Reduce default e2e test timeout

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -38,8 +38,8 @@ const {Builder, Capabilities, logging} = selenium;
 
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';
-const TEST_TIMEOUT = 40000;
-const SETUP_TIMEOUT = 30000;
+const TEST_TIMEOUT = 5000;
+const SETUP_TIMEOUT = 3000;
 const SETUP_RETRIES = 3;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
 const COV_REPORT_PATH = '/coverage/client';

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -38,8 +38,8 @@ const {Builder, Capabilities, logging} = selenium;
 
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';
-const TEST_TIMEOUT = 5000;
-const SETUP_TIMEOUT = 3000;
+const TEST_TIMEOUT = 3000;
+const SETUP_TIMEOUT = 2000;
 const SETUP_RETRIES = 3;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
 const COV_REPORT_PATH = '/coverage/client';

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -39,7 +39,9 @@ const {Builder, Capabilities, logging} = selenium;
 /** Should have something in the name, otherwise nothing is shown. */
 const SUB = ' ';
 const TEST_TIMEOUT = 3000;
-const SETUP_TIMEOUT = 2000;
+// This can be much lower when the OSX container can be sped up allowing tests
+// in extensions/amp-script/0.1/test-e2e/test-amp-script.js to run faster
+const SETUP_TIMEOUT = 10000;
 const SETUP_RETRIES = 3;
 const DEFAULT_E2E_INITIAL_RECT = {width: 800, height: 600};
 const COV_REPORT_PATH = '/coverage/client';

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
@@ -41,7 +41,8 @@ describes.endtoend(
     // TODO(sparhami): fails on shadow demo
     it.configure()
       .skipShadowDemo()
-      .run('should move forwards', async () => {
+      .run('should move forwards', async function () {
+        this.timeout(10000);
         const slides = await getSlides(controller);
 
         await expect(rect(slides[1])).to.include({x: 0});

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-multi-visible-single-advance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-multi-visible-single-advance.js
@@ -38,7 +38,8 @@ describes.endtoend(
       prevArrow = await getPrevArrow(controller);
     });
 
-    it('should not go forward past end and it should be able to go back correctly', async () => {
+    it('should not go forward past end and it should be able to go back correctly', async function () {
+      this.timeout(10000);
       const slideCount = 7;
       const slidesInView = 3;
       const slides = await getSlides(controller);

--- a/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
@@ -47,7 +47,8 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should fire low trust event for autoplay advance', async () => {
+    it('should fire low trust event for autoplay advance', async function () {
+      this.timeout(5000);
       for (let i = 0; i < 3; i++) {
         const event = await slideChangeEventAfterClicking(/* autoplay */);
         await expect(event.actionTrust).to.equal(1); // ActionTrust.LOW

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-client-side.js
@@ -36,7 +36,8 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should work with client side decision', async () => {
+    it('should work with client side decision', async function () {
+      this.timeout(5000);
       resetAllElements();
       const currentUrl = await controller.getCurrentUrl();
 

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side-expire-cache.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side-expire-cache.js
@@ -36,7 +36,8 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should respect server side decision and clear on next visit', async () => {
+    it('should respect server side decision and clear on next visit', async function () {
+      this.timeout(10000);
       resetAllElements();
       const currentUrl = await controller.getCurrentUrl();
       const nextGeoUrl = currentUrl.replace('mx', 'ca');

--- a/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-amp-consent-server-side.js
@@ -36,7 +36,8 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should respect server side decision and persist it', async () => {
+    it('should respect server side decision and persist it', async function () {
+      this.timeout(5000);
       resetAllElements();
 
       const currentUrl = await controller.getCurrentUrl();

--- a/extensions/amp-consent/0.1/test-e2e/test-cmp-ui-interaction.js
+++ b/extensions/amp-consent/0.1/test-e2e/test-cmp-ui-interaction.js
@@ -29,7 +29,8 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should restrict fullscreen until user interaction', async () => {
+    it('should restrict fullscreen until user interaction', async function () {
+      this.timeout(10000);
       // Await the CMP to load
       await sleep(3000);
 

--- a/extensions/amp-date-picker/0.1/test-e2e/test-blocked-dates.js
+++ b/extensions/amp-date-picker/0.1/test-e2e/test-blocked-dates.js
@@ -90,7 +90,8 @@ describes.endtoend(
 
     describe('without allow-blocked-end-date', () => {
       const ID = 'disallow-blocked';
-      it('should NOT be able to select the first blocked date', async () => {
+      it('should NOT be able to select the first blocked date', async function () {
+        this.timeout(5000);
         const today = new Date();
         const nextWeek = new Date(new Date().setDate(today.getDate() + 7));
         const todayCell = await selectDate(controller, ID, today);

--- a/extensions/amp-script/0.1/test-e2e/test-amp-script.js
+++ b/extensions/amp-script/0.1/test-e2e/test-amp-script.js
@@ -30,7 +30,7 @@ describes.endtoend(
     });
 
     it('should support local scripts', async function () {
-      this.timeout(5000);
+      this.timeout(10000);
       const element = await controller.findElement('amp-script#local');
       await expect(controller.getElementAttribute(element, 'class')).to.contain(
         'i-amphtml-hydrated'

--- a/extensions/amp-script/0.1/test-e2e/test-amp-script.js
+++ b/extensions/amp-script/0.1/test-e2e/test-amp-script.js
@@ -29,7 +29,8 @@ describes.endtoend(
       controller = env.controller;
     });
 
-    it('should support local scripts', async () => {
+    it('should support local scripts', async function () {
+      this.timeout(5000);
       const element = await controller.findElement('amp-script#local');
       await expect(controller.getElementAttribute(element, 'class')).to.contain(
         'i-amphtml-hydrated'

--- a/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test-e2e/test-amp-story-auto-ads.js
@@ -43,7 +43,8 @@ describes.endtoend(
     });
 
     // TODO(#35241): flaky test disabled in #35176
-    it.skip('should render correctly', async () => {
+    it.skip('should render correctly', async function () {
+      this.timeout(10000);
       await clickThroughPages(controller, /* numPages */ 7);
       const activePage = await controller.findElement('[active]');
       await expect(controller.getElementAttribute(activePage, 'ad')).to.exist;

--- a/extensions/amp-story-player/0.1/test/test-e2e/test-amp-story-player-prerender.js
+++ b/extensions/amp-story-player/0.1/test/test-e2e/test-amp-story-player-prerender.js
@@ -93,7 +93,8 @@ describes.endtoend(
       await expect(storyEl).to.exist;
     });
 
-    it('when player becomes visible in viewport and first story finishes loading, second story starts preloading', async () => {
+    it('when player becomes visible in viewport and first story finishes loading, second story starts preloading', async function () {
+      this.timeout(10000);
       const doc = await controller.getDocumentElement();
       const playerRect = await controller.getElementRect(player);
 

--- a/test/e2e/test-amp-story-player-prerender.js
+++ b/test/e2e/test-amp-story-player-prerender.js
@@ -129,7 +129,8 @@ describes.endtoend(
       await expect(storyEl).to.exist;
     });
 
-    it('when player becomes visible in viewport and first story finishes loading, second story starts preloading', async () => {
+    it('when player becomes visible in viewport and first story finishes loading, second story starts preloading', async function () {
+      this.timeout(10000);
       const doc = await controller.getDocumentElement();
       const playerRect = await controller.getElementRect(player);
 


### PR DESCRIPTION
Reducing the maximum test timeout (and overriding it in the tests that currently exceeded it) is the first step in preventing new long running tests from being introduced. In the future I would like to disallow usage of `this.timeout` to control newly added slow running tests.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
