### PR TITLE
❄️ Fix incorrect usage of expectAsyncConsoleError(...) in tests

### DIFF
--- a/extensions/amp-experiment/0.1/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/0.1/test/test-amp-experiment.js
@@ -118,7 +118,7 @@ describes.realWin(
 
     it('should throw if the child script element has non-JSON content', () => {
       addConfigElement('script', 'application/json', '{not json}');
-      expectAsyncConsoleError();
+      expectAsyncConsoleError(/.*/);
       return experiment.buildCallback().then(
         () => {
           throw new Error('must have failed');

--- a/extensions/amp-experiment/1.0/test/test-amp-experiment.js
+++ b/extensions/amp-experiment/1.0/test/test-amp-experiment.js
@@ -145,7 +145,7 @@ describes.realWin(
 
     it('should throw if the child script element has non-JSON content', () => {
       addConfigElement('script', 'application/json', '{not json}');
-      expectAsyncConsoleError();
+      expectAsyncConsoleError(/.*/);
       return experiment.buildCallback().then(
         () => {
           throw new Error('must have failed');

--- a/extensions/amp-facebook/0.1/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/0.1/test/test-amp-facebook.js
@@ -102,7 +102,7 @@ describes.realWin(
     });
 
     it('rejects other supported and unsupported data-embed-as types', async () => {
-      expectAsyncConsoleError();
+      expectAsyncConsoleError(/.*/);
       await expect(getAmpFacebook(fbVideoHref, 'comments')).to.be.rejectedWith(
         /Attribute data-embed-as for <amp-facebook> value is wrong, should be "post", "video" or "comment" but was: comments/
       );


### PR DESCRIPTION
`expectAsyncConsoleError` requires at least one argument, the message string or regex to expect. The incorrect usage causes tests to silently fail due to known issue https://github.com/mochajs/mocha/issues/94