### PR TITLE
amp-mode-transformer: transform two more keys

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const {BUILD_CONSTANTS} = require('../compile/build-constants');
 const {getImportResolverPlugin} = require('./import-resolver');
 const {getReplacePlugin} = require('./helpers');
 
@@ -71,7 +72,7 @@ function getMinifiedConfig() {
       ? null
       : [
           './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
-          {isEsmBuild: !!argv.esm},
+          BUILD_CONSTANTS,
         ],
   ].filter(Boolean);
   const presetEnv = [

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const {BUILD_CONSTANTS} = require('../compile/build-constants');
 const {getImportResolverPlugin} = require('./import-resolver');
 const {getReplacePlugin} = require('./helpers');
 
@@ -75,7 +76,7 @@ function getPreClosureConfig() {
       './build-system/babel-plugins/babel-plugin-transform-json-configuration',
     isProd && [
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
-      {isEsmBuild: !!argv.esm},
+      BUILD_CONSTANTS,
     ],
   ].filter(Boolean);
   const presetEnv = [

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
@@ -51,7 +51,7 @@ module.exports = function ({types: t}) {
         const {node} = path;
         const {object: obj, property} = node;
         const {callee} = obj;
-        const {INTERNAL_RUNTIME_VERSION, IS_ESM} = this.opts;
+        const {INTERNAL_RUNTIME_VERSION} = this.opts;
 
         if (callee && callee.name === 'getMode') {
           if (property.name === 'test' || property.name === 'localDev') {
@@ -60,8 +60,6 @@ module.exports = function ({types: t}) {
             path.replaceWith(t.booleanLiteral(false));
           } else if (property.name === 'minified') {
             path.replaceWith(t.booleanLiteral(true));
-          } else if (property.name === 'esm') {
-            path.replaceWith(t.booleanLiteral(IS_ESM));
           } else if (property.name === 'version') {
             path.replaceWith(t.stringLiteral(INTERNAL_RUNTIME_VERSION));
           }

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
@@ -19,6 +19,7 @@
  * and getMode().localDev to true.
  * @param {Object} babelTypes
  */
+const {BUILD_CONSTANTS} = require('../../compile/build-constants');
 const {dirname, join, relative, resolve} = require('path').posix;
 
 let shouldResolveDevelopmentMode = true;
@@ -60,6 +61,9 @@ module.exports = function ({types: t}) {
         const {object: obj, property} = node;
         const {callee} = obj;
         if (callee && callee.name === 'getMode') {
+          const {INTERNAL_RUNTIME_VERSION, IS_ESM, IS_MINIFIED} =
+            BUILD_CONSTANTS;
+
           if (property.name === 'test' || property.name === 'localDev') {
             path.replaceWith(t.booleanLiteral(false));
           }
@@ -67,7 +71,13 @@ module.exports = function ({types: t}) {
             path.replaceWith(t.booleanLiteral(false));
           }
           if (property.name === 'minified') {
-            path.replaceWith(t.booleanLiteral(true));
+            path.replaceWith(t.booleanLiteral(IS_MINIFIED));
+          }
+          if (property.name === 'esm') {
+            path.replaceWith(t.booleanLiteral(IS_ESM));
+          }
+          if (property.name === 'version') {
+            path.replaceWith(t.stringLiteral(INTERNAL_RUNTIME_VERSION));
           }
         }
       },

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/no-transform/options.json
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/no-transform/options.json
@@ -1,5 +1,11 @@
 {
   "plugins": [
-    "../../../.."
+    [
+      "../../../..",
+      {
+        "IS_ESM": false,
+        "INTERNAL_RUNTIME_VERSION": "$internalRuntimeVersion$"
+      }
+    ]
   ]
 }

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/input.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/input.js
@@ -20,6 +20,7 @@ const test = getMode().test;
 const localDev = getMode().localDev;
 const minified = getMode().minified;
 const development = getMode().development;
+const version = getMode().version;
 
 function foo() {
   if (getMode().development == false) {

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/options.json
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/options.json
@@ -3,7 +3,8 @@
     [
       "../../../..",
       {
-        "isEsmBuild": false
+        "IS_ESM": false,
+        "INTERNAL_RUNTIME_VERSION": "$internalRuntimeVersion$"
       }
     ]
   ],

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/output.mjs
@@ -17,10 +17,11 @@ import { getMode } from '../../../../../../../src/mode';
 const test = false;
 const localDev = false;
 const minified = true;
-const development = getMode().development;
+const development = false;
+const version = "$internalRuntimeVersion$";
 
 function foo() {
-  if (getMode().development == false) {
+  if (false == false) {
     return false;
   }
 }

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/input.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/input.js
@@ -20,6 +20,7 @@ const test = getMode().test;
 const localDev = getMode().localDev;
 const minified = getMode().minified;
 const development = getMode().development;
+const version = getMode().version;
 
 function foo() {
   if (getMode().development == false) {

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/options.json
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/options.json
@@ -1,6 +1,12 @@
 {
   "plugins": [
-    "../../../.."
+    [
+      "../../../..",
+      {
+        "IS_ESM": true,
+        "INTERNAL_RUNTIME_VERSION": "$internalRuntimeVersion$"
+      }
+    ]
   ],
   "sourceType": "module"
 }

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/output.mjs
@@ -18,6 +18,7 @@ const test = false;
 const localDev = false;
 const minified = true;
 const development = false;
+const version = "$internalRuntimeVersion$";
 
 function foo() {
   if (false == false) {

--- a/build-system/compile/build-constants.js
+++ b/build-system/compile/build-constants.js
@@ -16,7 +16,14 @@
 const argv = require('minimist')(process.argv.slice(2));
 const {VERSION} = require('./internal-version');
 
-const testTasks = ['e2e', 'integration', 'visual-diff', 'unit', 'check-types'];
+const testTasks = [
+  'e2e',
+  'integration',
+  'visual-diff',
+  'unit',
+  'check-types',
+  'babel-plugin-tests',
+];
 const isTestTask = testTasks.some((task) => argv._.includes(task));
 const isProd = argv._.includes('dist') && !argv.fortesting;
 const isMinified = argv._.includes('dist') || !!argv.compiled;

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -154,6 +154,7 @@ const forbiddenTermsGlobal = {
       'src/core/mode/minified.js',
       'src/core/mode/prod.js',
       'build-system/compile/build-constants.js',
+      'build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js',
     ],
   },
   '\\.prefetch\\(': {


### PR DESCRIPTION
**summary**
- amp-mode-transformer now runs for both .mjs and .js output
- `.version` and `.isEsm` are now transformed
- the babel plugin receives `BUILD_CONSTANTS` as an argument
- updates tests

**results**

Double digit changes copy/pasted below:

```
dist/v0/amp-install-serviceworker-0.1.js: Δ -0.35KB
dist/v0/amp-access-poool-0.1.js: Δ -0.32KB
dist/v0/amp-access-laterpay-0.1.js: Δ -0.33KB
dist/v0/amp-access-laterpay-0.2.js
dist/v0/amp-access-scroll-0.1.js: Δ -0.20KB
dist/v0/amp-next-page-0.1.js: Δ -0.19KB
dist/shadow-v0.js: Δ -0.12KB
dist/v0.js: Δ -0.15KB
dist/v0/amp-story-0.1.js: Δ -0.79KB
dist/v0/amp-story-1.0.js: Δ -0.79KB
```


@ampproject/wg-performance 