### PR TITLE
🏗 Parallelize bundle-size build jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
           name: 'Unminified Build'
           command: node build-system/pr-check/unminified-build.js
       - teardown_vm
-  'Nomodule Build':
+  'Testable Nomodule Build':
     executor:
       name: amphtml-xlarge-executor
     steps:
@@ -167,7 +167,7 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts/amp_nomodule_build.tar.gz
       - teardown_vm
-  'Module Build':
+  'Testable Module Build':
     executor:
       name: amphtml-xlarge-executor
     steps:
@@ -176,9 +176,27 @@ jobs:
           name: 'Module Build'
           command: node build-system/pr-check/module-build.js
       - teardown_vm
-  'Bundle Size':
+  'Production Nomodule Build':
     executor:
       name: amphtml-xlarge-executor
+    steps:
+      - setup_vm
+      - run:
+          name: 'Nomodule Build'
+          command: node build-system/pr-check/bundle-size-nomodule-build.js
+      - teardown_vm
+  'Production Module Build':
+    executor:
+      name: amphtml-xlarge-executor
+    steps:
+      - setup_vm
+      - run:
+          name: 'Module Build'
+          command: node build-system/pr-check/bundle-size-module-build.js
+      - teardown_vm
+  'Bundle Size':
+    executor:
+      name: amphtml-medium-executor
     steps:
       - setup_vm
       - run:
@@ -345,21 +363,35 @@ workflows:
           requires:
             - 'Initialize Repository'
       - 'Unminified Build':
+          name: 'Unminified Build (debug)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
-      - 'Nomodule Build':
+      - 'Testable Nomodule Build':
+          name: 'Nomodule Build (debug)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
-      - 'Module Build':
+      - 'Testable Module Build':
+          name: 'Module Build (debug)'
+          <<: *push_and_pr_builds
+          requires:
+            - 'Initialize Repository'
+      - 'Production Nomodule Build':
+          name: 'Nomodule Build (release)'
+          <<: *push_and_pr_builds
+          requires:
+            - 'Initialize Repository'
+      - 'Production Module Build':
+          name: 'Module Build (release)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
       - 'Bundle Size':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Repository'
+            - 'Nomodule Build (release)'
+            - 'Module Build (release)'
       - 'Validator Tests':
           <<: *push_and_pr_builds
           requires:
@@ -367,7 +399,7 @@ workflows:
       - 'Visual Diff Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build'
+            - 'Nomodule Build (debug)'
       - 'Local Unit Tests':
           <<: *push_and_pr_builds
           requires:
@@ -380,7 +412,7 @@ workflows:
       - 'Unminified Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Unminified Build'
+            - 'Unminified Build (debug)'
       - 'Nomodule Tests':
           name: 'Nomodule Tests (<< matrix.config >>)'
           matrix:
@@ -388,7 +420,7 @@ workflows:
               config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build'
+            - 'Nomodule Build (debug)'
       - 'Module Tests':
           name: 'Module Tests (<< matrix.config >>)'
           matrix:
@@ -396,13 +428,13 @@ workflows:
               config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build'
-            - 'Module Build'
+            - 'Nomodule Build (debug)'
+            - 'Module Build (debug)'
       - 'End-to-End Tests':
           name: '⛓️ End-to-End Tests'
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build'
+            - 'Nomodule Build (debug)'
       - 'Experiment Build':
           name: 'Experiment << matrix.exp >> Build'
           matrix:
@@ -431,4 +463,4 @@ workflows:
       # - 'Performance Tests':
       #     <<: *push_builds_only
       #     requires:
-      #       - 'Nomodule Build'
+      #       - 'Nomodule Build (debug)'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
           name: 'Unminified Build'
           command: node build-system/pr-check/unminified-build.js
       - teardown_vm
-  'Testable Nomodule Build':
+  'Nomodule Build - Test':
     executor:
       name: amphtml-xlarge-executor
     steps:
@@ -167,7 +167,7 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts/amp_nomodule_build.tar.gz
       - teardown_vm
-  'Testable Module Build':
+  'Module Build - Test':
     executor:
       name: amphtml-xlarge-executor
     steps:
@@ -176,7 +176,7 @@ jobs:
           name: 'Module Build'
           command: node build-system/pr-check/module-build.js
       - teardown_vm
-  'Production Nomodule Build':
+  'Nomodule Build - Prod':
     executor:
       name: amphtml-xlarge-executor
     steps:
@@ -185,7 +185,7 @@ jobs:
           name: 'Nomodule Build'
           command: node build-system/pr-check/bundle-size-nomodule-build.js
       - teardown_vm
-  'Production Module Build':
+  'Module Build - Prod':
     executor:
       name: amphtml-xlarge-executor
     steps:
@@ -363,35 +363,35 @@ workflows:
           requires:
             - 'Initialize Repository'
       - 'Unminified Build':
-          name: 'Unminified Build (debug)'
+          name: 'Unminified Build (Test)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
-      - 'Testable Nomodule Build':
-          name: 'Nomodule Build (debug)'
+      - 'Nomodule Build - Test':
+          name: 'Nomodule Build (Test)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
-      - 'Testable Module Build':
-          name: 'Module Build (debug)'
+      - 'Module Build - Test':
+          name: 'Module Build (Test)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
-      - 'Production Nomodule Build':
-          name: 'Nomodule Build (release)'
+      - 'Nomodule Build - Prod':
+          name: 'Nomodule Build (Prod)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
-      - 'Production Module Build':
-          name: 'Module Build (release)'
+      - 'Module Build - Prod':
+          name: 'Module Build (Prod)'
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
       - 'Bundle Size':
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build (release)'
-            - 'Module Build (release)'
+            - 'Nomodule Build (Prod)'
+            - 'Module Build (Prod)'
       - 'Validator Tests':
           <<: *push_and_pr_builds
           requires:
@@ -399,7 +399,7 @@ workflows:
       - 'Visual Diff Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build (debug)'
+            - 'Nomodule Build (Test)'
       - 'Local Unit Tests':
           <<: *push_and_pr_builds
           requires:
@@ -412,7 +412,7 @@ workflows:
       - 'Unminified Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Unminified Build (debug)'
+            - 'Unminified Build (Test)'
       - 'Nomodule Tests':
           name: 'Nomodule Tests (<< matrix.config >>)'
           matrix:
@@ -420,7 +420,7 @@ workflows:
               config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build (debug)'
+            - 'Nomodule Build (Test)'
       - 'Module Tests':
           name: 'Module Tests (<< matrix.config >>)'
           matrix:
@@ -428,13 +428,13 @@ workflows:
               config: ['prod', 'canary']
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build (debug)'
-            - 'Module Build (debug)'
+            - 'Nomodule Build (Test)'
+            - 'Module Build (Test)'
       - 'End-to-End Tests':
           name: '⛓️ End-to-End Tests'
           <<: *push_and_pr_builds
           requires:
-            - 'Nomodule Build (debug)'
+            - 'Nomodule Build (Test)'
       - 'Experiment Build':
           name: 'Experiment << matrix.exp >> Build'
           matrix:
@@ -463,4 +463,4 @@ workflows:
       # - 'Performance Tests':
       #     <<: *push_builds_only
       #     requires:
-      #       - 'Nomodule Build (debug)'
+      #       - 'Nomodule Build (Test)'

--- a/.circleci/restore_build_output.sh
+++ b/.circleci/restore_build_output.sh
@@ -31,20 +31,13 @@ if [[ -d "${WORKSPACE_DIR}/builds" ]]; then
   sudo apt update && sudo apt install rsync
 
   echo $(GREEN "Restoring build output from workspace")
-  for RESTORED_BUILD_DIR in ${WORKSPACE_DIR}/builds/*; do
+  for CONTAINER_DIR in ${WORKSPACE_DIR}/builds/*; do
     for OUTPUT_DIR in ${MERGABLE_OUTPUT_DIRS}; do
-      RESTORED_DIR="${RESTORED_BUILD_DIR}/${OUTPUT_DIR}"
+      RESTORED_DIR="${CONTAINER_DIR}/${OUTPUT_DIR}"
       if [[ -d "${RESTORED_DIR}" ]]; then
         echo "*" $(GREEN "Merging") $(CYAN "${RESTORED_DIR}") $(GREEN "into") $(CYAN "./${OUTPUT_DIR}")
         rsync -a "${RESTORED_DIR}/" "./${OUTPUT_DIR}"
       fi
-    done
-    # Bento components are compiled inside the extension source file.
-    for RESTORED_COMPONENT_DIR in ${RESTORED_BUILD_DIR}/extensions/*/?.?/dist; do
-      OUTPUT_DIR=${RESTORED_COMPONENT_DIR##$RESTORED_BUILD_DIR/}
-      echo "*" $(GREEN "Merging") $(CYAN "${RESTORED_COMPONENT_DIR}") $(GREEN "into") $(CYAN "./${OUTPUT_DIR}")
-      mkdir -p $RESTORED_DIR
-      rsync -a "${RESTORED_COMPONENT_DIR}/" "./${OUTPUT_DIR}"
     done
   done
 else

--- a/.circleci/restore_build_output.sh
+++ b/.circleci/restore_build_output.sh
@@ -31,13 +31,20 @@ if [[ -d "${WORKSPACE_DIR}/builds" ]]; then
   sudo apt update && sudo apt install rsync
 
   echo $(GREEN "Restoring build output from workspace")
-  for CONTAINER_DIR in ${WORKSPACE_DIR}/builds/*; do
+  for RESTORED_BUILD_DIR in ${WORKSPACE_DIR}/builds/*; do
     for OUTPUT_DIR in ${MERGABLE_OUTPUT_DIRS}; do
-      RESTORED_DIR="${CONTAINER_DIR}/${OUTPUT_DIR}"
+      RESTORED_DIR="${RESTORED_BUILD_DIR}/${OUTPUT_DIR}"
       if [[ -d "${RESTORED_DIR}" ]]; then
         echo "*" $(GREEN "Merging") $(CYAN "${RESTORED_DIR}") $(GREEN "into") $(CYAN "./${OUTPUT_DIR}")
         rsync -a "${RESTORED_DIR}/" "./${OUTPUT_DIR}"
       fi
+    done
+    # Bento components are compiled inside the extension source file.
+    for RESTORED_COMPONENT_DIR in ${RESTORED_BUILD_DIR}/extensions/*/?.?/dist; do
+      OUTPUT_DIR=${RESTORED_COMPONENT_DIR##$RESTORED_BUILD_DIR/}
+      echo "*" $(GREEN "Merging") $(CYAN "${RESTORED_COMPONENT_DIR}") $(GREEN "into") $(CYAN "./${OUTPUT_DIR}")
+      mkdir -p $RESTORED_DIR
+      rsync -a "${RESTORED_COMPONENT_DIR}/" "./${OUTPUT_DIR}"
     done
   done
 else

--- a/build-system/pr-check/bundle-size-module-build.js
+++ b/build-system/pr-check/bundle-size-module-build.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,25 @@
 'use strict';
 
 /**
- * @fileoverview Script that runs the bundle-size checks during CI.
+ * @fileoverview Script that builds the module AMP runtime for bundle-size during CI.
  */
 
+const {
+  skipDependentJobs,
+  storeModuleBuildToWorkspace,
+  timedExecOrDie,
+} = require('./utils');
 const {runCiJob} = require('./ci-job');
-const {skipDependentJobs, timedExecOrDie} = require('./utils');
 const {Targets, buildTargetsInclude} = require('./build-targets');
 
-const jobName = 'bundle-size.js';
+const jobName = 'bundle-size-module-build.js';
 
 /**
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp bundle-size --on_push_build');
+  timedExecOrDie('amp dist --noconfig --esm');
+  storeModuleBuildToWorkspace();
 }
 
 /**
@@ -37,9 +42,8 @@ function pushBuildWorkflow() {
  */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME)) {
-    timedExecOrDie('amp bundle-size --on_pr_build');
+    pushBuildWorkflow();
   } else {
-    timedExecOrDie('amp bundle-size --on_skipped_build');
     skipDependentJobs(jobName, 'this PR does not affect the runtime');
   }
 }

--- a/build-system/pr-check/bundle-size-nomodule-build.js
+++ b/build-system/pr-check/bundle-size-nomodule-build.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,25 @@
 'use strict';
 
 /**
- * @fileoverview Script that runs the bundle-size checks during CI.
+ * @fileoverview Script that builds the nomodule AMP runtime for bundle-size during CI.
  */
 
+const {
+  skipDependentJobs,
+  storeNomoduleBuildToWorkspace,
+  timedExecOrDie,
+} = require('./utils');
 const {runCiJob} = require('./ci-job');
-const {skipDependentJobs, timedExecOrDie} = require('./utils');
 const {Targets, buildTargetsInclude} = require('./build-targets');
 
-const jobName = 'bundle-size.js';
+const jobName = 'bundle-size-nomodule-build.js';
 
 /**
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp bundle-size --on_push_build');
+  timedExecOrDie('amp dist --noconfig');
+  storeNomoduleBuildToWorkspace();
 }
 
 /**
@@ -37,9 +42,8 @@ function pushBuildWorkflow() {
  */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME)) {
-    timedExecOrDie('amp bundle-size --on_pr_build');
+    pushBuildWorkflow();
   } else {
-    timedExecOrDie('amp bundle-size --on_skipped_build');
     skipDependentJobs(jobName, 'this PR does not affect the runtime');
   }
 }

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -16,8 +16,6 @@
 'use strict';
 
 const fs = require('fs-extra');
-const globby = require('globby');
-const path = require('path');
 const {
   ciPullRequestSha,
   circleciBuildNumber,
@@ -251,18 +249,6 @@ function storeBuildToWorkspace_(containerDirectory) {
       fs.moveSync(
         `${outputDir}/`,
         `/tmp/workspace/builds/${containerDirectory}/${outputDir}`
-      );
-    }
-    // Bento components are compiled inside the extension source file.
-    for (const componentFile of globby.sync('extensions/*/?.?/dist/*.js')) {
-      fs.ensureDirSync(
-        `/tmp/workspace/builds/${containerDirectory}/${path.dirname(
-          componentFile
-        )}`
-      );
-      fs.moveSync(
-        componentFile,
-        `/tmp/workspace/builds/${containerDirectory}/${componentFile}`
       );
     }
   }

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -16,6 +16,8 @@
 'use strict';
 
 const fs = require('fs-extra');
+const globby = require('globby');
+const path = require('path');
 const {
   ciPullRequestSha,
   circleciBuildNumber,
@@ -249,6 +251,18 @@ function storeBuildToWorkspace_(containerDirectory) {
       fs.moveSync(
         `${outputDir}/`,
         `/tmp/workspace/builds/${containerDirectory}/${outputDir}`
+      );
+    }
+    // Bento components are compiled inside the extension source file.
+    for (const componentFile of globby.sync('extensions/*/?.?/dist/*.js')) {
+      fs.ensureDirSync(
+        `/tmp/workspace/builds/${containerDirectory}/${path.dirname(
+          componentFile
+        )}`
+      );
+      fs.moveSync(
+        componentFile,
+        `/tmp/workspace/builds/${containerDirectory}/${componentFile}`
       );
     }
   }


### PR DESCRIPTION
The bundle-size job is now the longest running single job, and takes longer than the rest of the job layers combined. This PR splits the production-ready build steps into to separate jobs, and moves the actual bundle-size calculation to its own separate sub-job (running on a medium docker container instead of xlarge)

Runtime improves significantly (from ~13:58 to ~11:47 on average, 19% faster) with a marginal decrease in credit use (2,241 to 2,235, should be dismissed as the measurements' margin of error)

![Duration / Credits Used](https://user-images.githubusercontent.com/1839738/127045026-302dbb00-f6e3-48d1-bad3-25a8ff9c73cc.png)

Raw data: https://docs.google.com/spreadsheets/d/1X_ge9s172IH7ilBQUWhak7Srk4KICv05SmdkYp5RbbY/edit