### PR TITLE
 🐛 detect if it is an iife and allow the function declaration to arrow transform

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-function-declarations/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-function-declarations/index.js
@@ -150,6 +150,11 @@ module.exports = function ({types: t}) {
     (path) => {
       const callExpression = path.findParent((p) => p.isCallExpression());
       if (callExpression) {
+        // If the Callee is the FunctionExpresion itself, then that means it is
+        // a Immediately Invoked Function Expression which we can transform.
+        if (callExpression.node && callExpression.node.callee === path.node) {
+          return false;
+        }
         const {name, property} = (callExpression.node &&
           callExpression.node.callee) || {
           name: null,

--- a/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/function-expression/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/function-expression/input.js
@@ -31,3 +31,7 @@ let y;
 let fixedEncodeURIComponentArrowAssignment = str => encodeURIComponent(str).replace(/[!'()*]/g, y = function (c) {
   return '%' + c.charCodeAt(0).toString(16);
 });
+
+(function() {
+  return 'iife';
+})()

--- a/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/function-expression/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-function-declarations/test/fixtures/transform-assertions/function-expression/output.js
@@ -22,3 +22,5 @@ let fixedEncodeURIComponentArrow = str => encodeURIComponent(str).replace(/[!'()
 let y;
 
 let fixedEncodeURIComponentArrowAssignment = str => encodeURIComponent(str).replace(/[!'()*]/g, y = c => '%' + c.charCodeAt(0).toString(16));
+
+(() => 'iife')();


### PR DESCRIPTION
Fix handling of Immediately invoked function expressions in transformer.

Currently this throws an error during the transformation process when it tries to transforms IIFE's

I'll turn the transformer back on in a separate PR as I still need to test the transformed output
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
