### PR TITLE
Create an experiment to turn amp-sticky-ad to amp-ad sticky implementation

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -21,5 +21,6 @@
   "story-ad-auto-advance": 1,
   "story-ad-placements": 1,
   "story-load-first-page-only": 0.1,
-  "amp-story-page-attachment-ui-v2": 1
+  "amp-story-page-attachment-ui-v2": 1,
+  "amp-sticky-ad-to-amp-ad": 0
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -18,5 +18,6 @@
   "amp-cid-backup": 1,
   "story-ad-placements": 0.01,
   "story-load-first-page-only": 0.1,
-  "amp-story-page-attachment-ui-v2": 1
+  "amp-story-page-attachment-ui-v2": 1,
+  "amp-sticky-ad-to-amp-ad": 0
 }

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -861,6 +861,7 @@ const forbiddenTermsSrcInclusive = {
     allowlist: [
       'src/service/extensions-impl.js',
       'extensions/amp-ad/0.1/amp-ad.js',
+      'extensions/amp-sticky-ad/1.0/amp-sticky-ad.js',
     ],
   },
   'reject\\(\\)': {

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -630,7 +630,10 @@ export class AmpA4A extends AMP.BaseElement {
       );
       return false;
     }
-    if (!isAdPositionAllowed(this.element, this.win)) {
+    if (
+      !this.uiHandler.isStickyAd() &&
+      !isAdPositionAllowed(this.element, this.win)
+    ) {
       user().warn(
         TAG,
         `<${this.element.tagName}> is not allowed to be ` +

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1702,12 +1702,12 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       env.sandbox
         .stub(a4a, 'maybeValidateAmpCreative')
         .returns(Promise.resolve());
-      a4a.onLayoutMeasure();
       a4a.uiHandler = {
         getScrollPromiseForStickyAd: () => Promise.resolve(null),
         isStickyAd: () => false,
         maybeInitStickyAd: () => {},
       };
+      a4a.onLayoutMeasure();
       await a4a.buildCallback();
       await a4a.layoutCallback();
       expect(
@@ -1781,6 +1781,9 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
       doc.head.appendChild(s);
       a4aElement.className = 'fixed';
       const a4a = new MockA4AImpl(a4aElement);
+      a4a.uiHandler = {
+        isStickyAd: () => false,
+      };
       a4a.onLayoutMeasure();
       expect(a4a.adPromise_).to.not.be.ok;
     });
@@ -2141,6 +2144,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
             unlayoutUISpy();
           },
           getScrollPromiseForStickyAd: () => Promise.resolve(null),
+          isStickyAd: () => false,
           maybeInitStickyAd: () => {},
           cleanup: () => {},
         };

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -188,6 +188,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
   });
 
   it('should contain sz=320x50 in ad request by default', () => {
+    impl.uiHandler = {
+      isStickyAd: () => false,
+    };
     impl.initiateAdRequest();
     return impl.adPromise_.then(() => {
       expect(impl.adUrl_).to.be.ok;
@@ -196,6 +199,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
   });
 
   it('should contain mulitple sizes in ad request', () => {
+    multiSizeImpl.uiHandler = {
+      isStickyAd: () => false,
+    };
     multiSizeImpl.initiateAdRequest();
     return multiSizeImpl.adPromise_.then(() => {
       expect(multiSizeImpl.adUrl_).to.be.ok;

--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -261,6 +261,11 @@ export class AmpAdUIHandler {
           )
         );
       }
+
+      if (!this.closeButtonRendered_) {
+        this.addCloseButton_();
+        this.closeButtonRendered_ = true;
+      }
     }
   }
 
@@ -286,11 +291,6 @@ export class AmpAdUIHandler {
    * When a sticky ad is shown, the close button should be rendered at the same time.
    */
   onResizeSuccess() {
-    if (this.isStickyAd() && !this.closeButtonRendered_) {
-      this.addCloseButton_();
-      this.closeButtonRendered_ = true;
-    }
-
     if (this.isStickyAd() && !this.topStickyAdScrollListener_) {
       const doc = this.element_.getAmpDoc();
       this.topStickyAdScrollListener_ = Services.viewportForDoc(doc).onScroll(

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -158,7 +158,9 @@ amp-ad[sticky='top'] {
 }
 
 amp-ad[sticky='bottom'] {
+  max-width: 100%;
   width: 100% !important;
+  max-height: 20%;
   padding-bottom: env(safe-area-inset-bottom, 0px);
   background: #fff;
   bottom: 0;

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -326,17 +326,13 @@ describes.realWin(
     });
 
     describe('sticky ads', () => {
-      it('should render close buttons on render once', () => {
+      it('should render close buttons', () => {
         expect(uiHandler.unlisteners_).to.be.empty;
         uiHandler.stickyAdPosition_ = 'bottom';
-        uiHandler.onResizeSuccess();
-        expect(uiHandler.closeButtonRendered_).to.be.true;
-        expect(uiHandler.unlisteners_.length).to.equal(2);
+        uiHandler.maybeInitStickyAd();
+        expect(uiHandler.unlisteners_.length).to.equal(1);
         expect(uiHandler.element_.querySelector('.amp-ad-close-button')).to.be
           .not.null;
-
-        uiHandler.onResizeSuccess();
-        expect(uiHandler.unlisteners_.length).to.equal(2);
       });
 
       it('onResizeSuccess top sticky ads shall cause padding top adjustment', () => {

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -142,11 +142,7 @@ class AmpStickyAd extends AMP.BaseElement {
     this.element.parentElement.replaceChild(ad, this.element);
     return Services.extensionsFor(this.win)
       .loadElementClass('amp-ad', '0.1')
-      .then((AmpAd) => {
-        const impl = new AmpAd(ad);
-        impl.upgradeCallback();
-        return impl;
-      });
+      .then((AmpAd) => new AmpAd(ad));
   }
 
   /** @override */


### PR DESCRIPTION
Create an experiment to turn amp-sticky-ad element into an amp-ad element. In theory they should act the same. Set the experiment group info for Adsense/Doubleclick.