### PR TITLE
🧪 Remove enabled experiment based on boilerplate

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -132,9 +132,6 @@ startupChunk(self.document, function initial() {
   installPerformanceService(self);
   /** @const {!./service/performance-impl.Performance} */
   const perf = Services.performanceFor(self);
-  if (self.document.documentElement.hasAttribute('i-amphtml-no-boilerplate')) {
-    perf.addEnabledExperiment('no-boilerplate');
-  }
   if (IS_ESM) {
     perf.addEnabledExperiment('esm');
   }


### PR DESCRIPTION
Removes experiment enabling for `no-boilerplate`.