### PR TITLE
Bento `amp-lightbox-gallery`: Support analytics events

### DIFF
--- a/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
@@ -23,7 +23,6 @@ import {elementByTag} from '#core/dom/query';
 import {isExperimentOn} from '#experiments';
 import {userAssert} from '../../../src/log';
 import {triggerAnalyticsEvent} from '../../../src/analytics';
-import {dict} from '#core/types/object';
 
 /** @const {string} */
 const TAG = 'amp-lightbox-gallery';
@@ -75,7 +74,7 @@ class AmpLightboxGallery extends BaseElement {
     super.afterOpen();
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
     this.setAsContainer?.(scroller);
-    triggerAnalyticsEvent(this.element, 'lightboxOpened', dict({}));
+    triggerAnalyticsEvent(this.element, 'lightboxOpened');
   }
 
   /** @override */
@@ -87,13 +86,13 @@ class AmpLightboxGallery extends BaseElement {
   /** @override */
   onViewGrid() {
     super.onViewGrid();
-    triggerAnalyticsEvent(this.element, 'thumbnailsViewToggled', dict({}));
+    triggerAnalyticsEvent(this.element, 'thumbnailsViewToggled');
   }
 
   /** @override */
   onToggleCaption() {
     super.onToggleCaption();
-    triggerAnalyticsEvent(this.element, 'descriptionOverflowToggled', dict({}));
+    triggerAnalyticsEvent(this.element, 'descriptionOverflowToggled');
   }
 
   /** @override */

--- a/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/amp-lightbox-gallery.js
@@ -22,6 +22,8 @@ import {createElementWithAttributes} from '#core/dom';
 import {elementByTag} from '#core/dom/query';
 import {isExperimentOn} from '#experiments';
 import {userAssert} from '../../../src/log';
+import {triggerAnalyticsEvent} from '../../../src/analytics';
+import {dict} from '#core/types/object';
 
 /** @const {string} */
 const TAG = 'amp-lightbox-gallery';
@@ -73,12 +75,25 @@ class AmpLightboxGallery extends BaseElement {
     super.afterOpen();
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
     this.setAsContainer?.(scroller);
+    triggerAnalyticsEvent(this.element, 'lightboxOpened', dict({}));
   }
 
   /** @override */
   afterClose() {
     super.afterClose();
     this.removeAsContainer?.();
+  }
+
+  /** @override */
+  onViewGrid() {
+    super.onViewGrid();
+    triggerAnalyticsEvent(this.element, 'thumbnailsViewToggled', dict({}));
+  }
+
+  /** @override */
+  onToggleCaption() {
+    super.onToggleCaption();
+    triggerAnalyticsEvent(this.element, 'descriptionOverflowToggled', dict({}));
   }
 
   /** @override */

--- a/extensions/amp-lightbox-gallery/1.0/base-element.js
+++ b/extensions/amp-lightbox-gallery/1.0/base-element.js
@@ -83,6 +83,8 @@ export class BaseElement extends PreactBaseElement {
       'onBeforeOpen': () => this.beforeOpen(),
       'onAfterOpen': () => this.afterOpen(),
       'onAfterClose': () => this.afterClose(),
+      'onViewGrid': () => this.onViewGrid(),
+      'onToggleCaption': () => this.onToggleCaption(),
       'render': () => lightboxElements,
     });
   }
@@ -108,6 +110,12 @@ export class BaseElement extends PreactBaseElement {
     toggleAttribute(this.element, 'open', false);
     toggle(this.element, false);
   }
+
+  /** @protected */
+  onViewGrid() {}
+
+  /** @protected */
+  onToggleCaption() {}
 
   /** @override */
   mutationObserverCallback() {

--- a/extensions/amp-lightbox-gallery/1.0/component.type.js
+++ b/extensions/amp-lightbox-gallery/1.0/component.type.js
@@ -22,6 +22,11 @@ var LightboxGalleryDef = {};
 /**
  * @typedef {{
  *   children: (PreactDef.Renderable),
+ *   onBeforeOpen: (function():void|undefined),
+ *   onAfterOpen: (function():void|undefined),
+ *   onAfterClose: (function():void|undefined),
+ *   onViewGrid: (function():void|undefined),
+ *   onToggleCaption: (function():void|undefined),
  *   render: (function():PreactDef.Renderable|undefined),
  * }}
  */

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -54,7 +54,15 @@ const CAPTION_PROPS = {
  * @return {PreactDef.Renderable}
  */
 export function LightboxGalleryProviderWithRef(
-  {children, onAfterClose, onAfterOpen, onBeforeOpen, render},
+  {
+    children,
+    onAfterClose,
+    onAfterOpen,
+    onBeforeOpen,
+    onToggleCaption,
+    onViewGrid,
+    render,
+  },
   ref
 ) {
   const classes = useStyles();
@@ -198,7 +206,12 @@ export function LightboxGalleryProviderWithRef(
       >
         <div className={classes.controlsPanel}>
           <ToggleViewIcon
-            onClick={() => setShowCarousel(!showCarousel)}
+            onClick={() => {
+              if (showCarousel) {
+                onViewGrid?.();
+              }
+              setShowCarousel(!showCarousel);
+            }}
             showCarousel={showCarousel}
           />
         </div>
@@ -227,6 +240,7 @@ export function LightboxGalleryProviderWithRef(
             ? null
             : {
                 onClick: () => {
+                  onToggleCaption?.();
                   if (captionState === CaptionState.CLIP) {
                     setCaptionState(CaptionState.EXPAND);
                   } else {

--- a/extensions/amp-lightbox-gallery/1.0/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-amp-lightbox-gallery.js
@@ -170,8 +170,7 @@ describes.realWin(
         await whenCalled(element.setAsContainerInternal);
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
-          'lightboxOpened',
-          env.sandbox.match({})
+          'lightboxOpened'
         );
 
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
@@ -258,8 +257,7 @@ describes.realWin(
         await whenCalled(element.setAsContainerInternal);
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
-          'lightboxOpened',
-          env.sandbox.match({})
+          'lightboxOpened'
         );
 
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
@@ -293,8 +291,7 @@ describes.realWin(
         await whenCalled(element.setAsContainerInternal);
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
-          'lightboxOpened',
-          env.sandbox.match({})
+          'lightboxOpened'
         );
 
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
@@ -325,8 +322,7 @@ describes.realWin(
           .dispatchEvent(event);
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
-          'thumbnailsViewToggled',
-          env.sandbox.match({})
+          'thumbnailsViewToggled'
         );
       });
     });
@@ -719,8 +715,7 @@ describes.realWin(
           .click();
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
-          'descriptionOverflowToggled',
-          env.sandbox.match({})
+          'descriptionOverflowToggled'
         );
       });
     });

--- a/extensions/amp-lightbox-gallery/1.0/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-amp-lightbox-gallery.js
@@ -20,6 +20,7 @@ import {ActionTrust, DEFAULT_ACTION} from '#core/constants/action-constants';
 import {createElementWithAttributes} from '#core/dom';
 import {htmlFor} from '#core/dom/static-template';
 import {installLightboxGallery} from '../amp-lightbox-gallery';
+import * as analytics from '../../../../src/analytics';
 import {poll} from '#testing/iframe';
 import {toggleExperiment} from '#experiments';
 import {waitFor, whenCalled} from '#testing/test-helper';
@@ -143,6 +144,10 @@ describes.realWin(
       });
 
       it('should open when writing "open" attribute', async () => {
+        const triggerAnalyticsStub = env.sandbox.stub(
+          analytics,
+          'triggerAnalyticsEvent'
+        );
         env.sandbox.stub(element, 'setAsContainerInternal');
         env.sandbox.stub(element, 'removeAsContainerInternal');
 
@@ -163,6 +168,12 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
+          element,
+          'lightboxOpened',
+          env.sandbox.match({})
+        );
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledWith(scroller);
@@ -223,6 +234,10 @@ describes.realWin(
       });
 
       it('should open with default action', async () => {
+        const triggerAnalyticsStub = env.sandbox.stub(
+          analytics,
+          'triggerAnalyticsEvent'
+        );
         env.sandbox.stub(element, 'setAsContainerInternal');
         env.sandbox.stub(element, 'removeAsContainerInternal');
 
@@ -241,6 +256,12 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
+          element,
+          'lightboxOpened',
+          env.sandbox.match({})
+        );
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledWith(scroller);
@@ -248,6 +269,10 @@ describes.realWin(
       });
 
       it('should open with "open" action', async () => {
+        const triggerAnalyticsStub = env.sandbox.stub(
+          analytics,
+          'triggerAnalyticsEvent'
+        );
         env.sandbox.stub(element, 'setAsContainerInternal');
         env.sandbox.stub(element, 'removeAsContainerInternal');
 
@@ -266,10 +291,43 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
+          element,
+          'lightboxOpened',
+          env.sandbox.match({})
+        );
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledWith(scroller);
         expect(element.removeAsContainerInternal).to.not.be.called;
+      });
+
+      it('should open with "open" action and toggle to grid view', async () => {
+        env.sandbox.stub(element, 'setAsContainerInternal');
+        env.sandbox.stub(element, 'removeAsContainerInternal');
+
+        expect(element.hasAttribute('open')).to.be.false;
+        expect(element.hasAttribute('hidden')).to.be.true;
+
+        element.enqueAction(invocation(element, 'open'));
+        await waitForOpen(element, true);
+        expect(element.hasAttribute('hidden')).to.be.false;
+
+        const triggerAnalyticsStub = env.sandbox.stub(
+          analytics,
+          'triggerAnalyticsEvent'
+        );
+        const event = document.createEvent('SVGEvents');
+        event.initEvent('click');
+        element.shadowRoot
+          .querySelector('[aria-label="Switch to grid view"]')
+          .dispatchEvent(event);
+        expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
+          element,
+          'thumbnailsViewToggled',
+          env.sandbox.match({})
+        );
       });
     });
 
@@ -622,6 +680,48 @@ describes.realWin(
           element.shadowRoot.querySelector('.amp-lightbox-gallery-caption')
             .textContent
         ).to.equal('alt img');
+      });
+
+      it('should toggle overflowing caption on click', async () => {
+        const img = html` <figure>
+          <img lightbox src="img.jpg" />
+          <figcaption>
+            This is the caption for the first image. Lorem Ipsum is simply dummy
+            text of the printing and typesetting industry. Lorem Ipsum has been
+            the industry's standard dummy text ever since the 1500s, when an
+            unknown printer took a galley of type and scrambled it to make a
+            type specimen book. It has survived not only five centuries, but
+            also the leap into electronic typesetting, remaining essentially
+            unchanged. It was popularised in the 1960s with the release of
+            Letraset sheets containing Lorem Ipsum passages, and more recently
+            with desktop publishing software like Aldus PageMaker including
+            versions of Lorem Ipsum. Lorem Ipsum is simply dummy text of the
+            printing and typesetting industry. Lorem Ipsum is simply dummy text
+            of the printing and typesetting industry. Lorem Ipsum is simply
+            dummy text of the printing and typesetting industry.
+          </figcaption>
+        </figure>`;
+        doc.body.appendChild(img);
+        await installLightboxGallery(env.ampdoc);
+        element = doc.getElementById(TAG);
+        await element.buildInternal();
+
+        element.enqueAction(invocation(element, DEFAULT_ACTION));
+        await waitForOpen(element, true);
+        expect(element.hasAttribute('hidden')).to.be.false;
+
+        const triggerAnalyticsStub = env.sandbox.stub(
+          analytics,
+          'triggerAnalyticsEvent'
+        );
+        element.shadowRoot
+          .querySelector('.amp-lightbox-gallery-caption')
+          .click();
+        expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
+          element,
+          'descriptionOverflowToggled',
+          env.sandbox.match({})
+        );
       });
     });
   }


### PR DESCRIPTION
Partial for #32759, this PR supports the following pre-existing analytics events on `amp-lightbox-gallery`:
- `lightboxOpened`
- `thumbnailsViewToggled`
- `descriptionOverflowToggled`