### PR TITLE
`amp-lightbox-gallery`: Support bento- prefixed selectors

### DIFF
--- a/extensions/amp-lightbox-gallery/1.0/base-element.js
+++ b/extensions/amp-lightbox-gallery/1.0/base-element.js
@@ -38,6 +38,8 @@ const LIGHTBOX_ELIGIBLE_TAGS = ['AMP-IMG', 'IMG'];
 const LIGHTBOX_ELIGIBLE_GROUP_SELECTORS = [
   'AMP-BASE-CAROUSEL[lightbox]',
   'AMP-STREAM-GALLERY[lightbox]',
+  'BENTO-BASE-CAROUSEL[lightbox]',
+  'BENTO-STREAM-GALLERY[lightbox]',
 ];
 
 /** @const {string} */
@@ -67,7 +69,7 @@ export class BaseElement extends PreactBaseElement {
     if (count++) {
       console /*OK */
         .warn(
-          `<amp-lightbox-gallery> already exists in the document. Removing additional instance: ${this.element}`
+          `${this.element.tagName} already exists in the document. Removing additional instance: ${this.element}`
         );
       this.element.parentNode?.removeChild(this.element);
     }


### PR DESCRIPTION
`amp-lightbox-gallery` allows `lightbox`-ing a few AMP components. Given #34820 allows some Bento components to have either `amp-` or `bento-` prefix depending on its mode of usage, `amp-lightbox-gallery` should support both varieties of these components.

Note that while `amp-lightbox-gallery` supports `amp-img`, this PR does not add `bento-img` tag to its img tag list because the Bento version of `amp-img` is `img`.