### PR TITLE
🏗 Cache .git directory in CircleCI builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
                 command: circleci-agent step halt
 
 jobs:
-  'Initialize Git':
+  'Initialize Repository':
     executor:
       name: amphtml-small-executor
     steps:
@@ -338,32 +338,32 @@ jobs:
 workflows:
   'CircleCI':
     jobs:
-      - 'Initialize Git':
+      - 'Initialize Repository':
           <<: *push_and_pr_builds
       - 'Checks':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'Unminified Build':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'Nomodule Build':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'Module Build':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'Bundle Size':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'Validator Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'Visual Diff Tests':
           <<: *push_and_pr_builds
           requires:
@@ -371,7 +371,7 @@ workflows:
       - 'Local Unit Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'All Unit Tests':
           name: '⛓️ All Unit Tests'
           <<: *push_and_pr_builds
@@ -410,7 +410,7 @@ workflows:
               exp: ['A', 'B', 'C']
           <<: *push_and_pr_builds
           requires:
-            - 'Initialize Git'
+            - 'Initialize Repository'
       - 'Experiment Integration Tests':
           name: 'Exp. << matrix.exp >> Integration Tests'
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ commands:
             mkdir -p /tmp/workspace
       - run:
           name: 'Maybe Gracefully Halt'
-          command: curl -sS https://raw.githubusercontent.com/ampproject/amphtml/main/.circleci/maybe_gracefully_halt.sh | bash
+          command: /tmp/restored-workspace/maybe_gracefully_halt.sh
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
@@ -128,6 +128,9 @@ jobs:
       - run:
           name: 'Initialize Git'
           command: ./.circleci/compute_merge_commit.sh
+      - run:
+          name: 'Store maybe_gracefully_halt.sh in Workspace'
+          command: cp .circleci/maybe_gracefully_halt.sh /tmp/workspace
       - teardown_vm
   'Checks':
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,13 +121,15 @@ jobs:
             - source-v1-{{ .Branch }}-
             - source-v1-
       - checkout
+      - run:
+          name: 'Compute and Fetch Merge Commit'
+          command: |
+            ./.circleci/compute_merge_commit.sh
+            ./.circleci/fetch_merge_commit.sh
       - save_cache:
           key: source-v1-{{ .Branch }}-{{ .Revision }}
           paths:
             - .git
-      - run:
-          name: 'Initialize Git'
-          command: ./.circleci/compute_merge_commit.sh
       - run:
           name: 'Store maybe_gracefully_halt.sh in Workspace'
           command: cp .circleci/maybe_gracefully_halt.sh /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
           paths:
             - .git
       - run:
-          name: 'Store maybe_gracefully_halt.sh in Workspace'
+          name: 'Initialize Workspace'
           command: cp .circleci/maybe_gracefully_halt.sh /tmp/workspace
       - teardown_vm
   'Checks':

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,16 @@ commands:
       - run:
           name: 'Maybe Gracefully Halt'
           command: curl -sS https://raw.githubusercontent.com/ampproject/amphtml/main/.circleci/maybe_gracefully_halt.sh | bash
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
       - checkout
+      - save_cache:
+          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .git
       - run:
           name: 'Configure Development Environment'
           command: |
@@ -106,9 +115,19 @@ jobs:
     executor:
       name: amphtml-small-executor
     steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+            - source-v1-{{ .Branch }}-
+            - source-v1-
+      - checkout
+      - save_cache:
+          key: source-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .git
       - run:
           name: 'Compute Merge Commit'
-          command: curl -sS https://raw.githubusercontent.com/ampproject/amphtml/main/.circleci/compute_merge_commit.sh | bash
+          command: ./.circleci/compute_merge_commit.sh
       - teardown_vm
   'Checks':
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
                 command: circleci-agent step halt
 
 jobs:
-  'Compute Merge Commit':
+  'Initialize Git':
     executor:
       name: amphtml-small-executor
     steps:
@@ -126,7 +126,7 @@ jobs:
           paths:
             - .git
       - run:
-          name: 'Compute Merge Commit'
+          name: 'Initialize Git'
           command: ./.circleci/compute_merge_commit.sh
       - teardown_vm
   'Checks':
@@ -333,32 +333,32 @@ jobs:
 workflows:
   'CircleCI':
     jobs:
-      - 'Compute Merge Commit':
+      - 'Initialize Git':
           <<: *push_and_pr_builds
       - 'Checks':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'Unminified Build':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'Nomodule Build':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'Module Build':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'Bundle Size':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'Validator Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'Visual Diff Tests':
           <<: *push_and_pr_builds
           requires:
@@ -366,7 +366,7 @@ workflows:
       - 'Local Unit Tests':
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'All Unit Tests':
           name: '⛓️ All Unit Tests'
           <<: *push_and_pr_builds
@@ -405,7 +405,7 @@ workflows:
               exp: ['A', 'B', 'C']
           <<: *push_and_pr_builds
           requires:
-            - 'Compute Merge Commit'
+            - 'Initialize Git'
       - 'Experiment Integration Tests':
           name: 'Exp. << matrix.exp >> Integration Tests'
           matrix:


### PR DESCRIPTION
As described in https://circleci.com/docs/2.0/caching/?section=pipelines#source-caching

Credits used and workflow duration are barely affected, but the upsides are:
* quicker restarts for flaky jobs (~10-15 seconds shorter due to having the git repository pre-cached)
* no longer need to `curl` the maybe_gracefully_halt.sh file
* being better citizens of the net by reducing the number of times we fetch the entire repo from GitHub 😃

![Duration _ Credits Used](https://user-images.githubusercontent.com/1839738/127035335-0c5b8b57-2ed2-4ac1-a732-e361d21a9f53.png)

Raw data: https://docs.google.com/spreadsheets/d/1R_rihHtAbf56eAj1dUvABjakyrDFy29Y6Vce2_dWG-A/edit