### PR TITLE
✅ Fix failing 3p unit test

### DIFF
--- a/test/unit/test-3p.js
+++ b/test/unit/test-3p.js
@@ -291,11 +291,10 @@ describes.sandboxed('3p', {}, (env) => {
       expect(s.src).to.equal(url);
     });
 
-    // TODO(#35315): disabled in #35314
-    it.skip('should handle onSuccess callback', (done) => {
+    it('should handle onSuccess callback', (done) => {
       loadScript(
         window,
-        'http://localhost:9876/test/unit/test-3p.js',
+        'http://localhost:9876/examples/amp-ad/sticky.js',
         () => {
           done();
         },


### PR DESCRIPTION
It fails because test-3p.js uses modules and is not loadable to the browser. It changes to use a browser side JS.

Close https://github.com/ampproject/amphtml/issues/35315