### PR TITLE
🐛  fix build-constant isForTesting

### DIFF
--- a/build-system/compile/build-constants.js
+++ b/build-system/compile/build-constants.js
@@ -18,7 +18,7 @@ const {VERSION} = require('./internal-version');
 
 const testTasks = ['e2e', 'integration', 'visual-diff', 'unit', 'check-types'];
 const isTestTask = testTasks.some((task) => argv._.includes(task));
-const isForTesting = argv.fortesting || isTestTask;
+const isForTesting = argv.fortesting || !argv._.includes('dist');
 const isMinified = argv._.includes('dist') || !!argv.compiled;
 
 /**


### PR DESCRIPTION
**summary**
Fixes https://github.com/ampproject/amphtml/issues/35325

I created a bug in local development when merging https://github.com/ampproject/amphtml/pull/34327.
I had assumed `isForTesting` corresponded to when the flag `--fortesting` was passed, but really the value should always be true unless `amp dist` is used _without_ the fortesting flag.

cc @calebcordry 