### PR TITLE
build-constants/mode: rename from isForTesting --> isProd

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,7 @@ module.exports = {
     'IS_ESM': 'readonly',
     'IS_SXG': 'readonly',
     'IS_MINIFIED': 'readonly',
-    'IS_FOR_DISTRIBUTION': 'readonly',
+    'IS_PROD': 'readonly',
     'INTERNAL_RUNTIME_VERSION': 'readonly',
     'AMP': 'readonly',
     'context': 'readonly',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,7 @@ module.exports = {
     'IS_ESM': 'readonly',
     'IS_SXG': 'readonly',
     'IS_MINIFIED': 'readonly',
-    'IS_FORTESTING': 'readonly',
+    'IS_FOR_DISTRIBUTION': 'readonly',
     'INTERNAL_RUNTIME_VERSION': 'readonly',
     'AMP': 'readonly',
     'context': 'readonly',

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -71,9 +71,8 @@ function getPreClosureConfig() {
     // argv.esm
     //? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
     //: null,
-    !isCheckTypes
-      ? './build-system/babel-plugins/babel-plugin-transform-json-configuration'
-      : null,
+    !isCheckTypes &&
+      './build-system/babel-plugins/babel-plugin-transform-json-configuration',
     isForDistribution && [
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
       {isEsmBuild: !!argv.esm},

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -25,8 +25,8 @@ const {getReplacePlugin} = require('./helpers');
  * @return {!Object}
  */
 function getPreClosureConfig() {
-  const isCheckTypes = !argv.fortesting && argv._.includes('check-types');
-  const isForDistribution = !argv.fortesting && argv._.includes('dist');
+  const isCheckTypes = argv._.includes('check-types');
+  const isProd = argv._.includes('dist') && !argv.fortesting;
 
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',
@@ -73,7 +73,7 @@ function getPreClosureConfig() {
     //: null,
     !isCheckTypes &&
       './build-system/babel-plugins/babel-plugin-transform-json-configuration',
-    isForDistribution && [
+    isProd && [
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
       {isEsmBuild: !!argv.esm},
     ],

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -25,7 +25,8 @@ const {getReplacePlugin} = require('./helpers');
  * @return {!Object}
  */
 function getPreClosureConfig() {
-  const isCheckTypes = argv._.includes('check-types');
+  const isCheckTypes = !argv.fortesting && argv._.includes('check-types');
+  const isForDistribution = !argv.fortesting && argv._.includes('dist');
 
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',
@@ -73,7 +74,7 @@ function getPreClosureConfig() {
     !isCheckTypes
       ? './build-system/babel-plugins/babel-plugin-transform-json-configuration'
       : null,
-    [
+    isForDistribution && [
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
       {isEsmBuild: !!argv.esm},
     ],

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -26,9 +26,6 @@ const {getReplacePlugin} = require('./helpers');
  */
 function getPreClosureConfig() {
   const isCheckTypes = argv._.includes('check-types');
-  const testTasks = ['e2e', 'integration', 'visual-diff'];
-  const isTestTask = testTasks.some((task) => argv._.includes(task));
-  const isFortesting = argv.fortesting || isTestTask;
 
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',
@@ -76,12 +73,10 @@ function getPreClosureConfig() {
     !isCheckTypes
       ? './build-system/babel-plugins/babel-plugin-transform-json-configuration'
       : null,
-    !(isFortesting || isCheckTypes)
-      ? [
-          './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
-          {isEsmBuild: !!argv.esm},
-        ]
-      : null,
+    [
+      './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
+      {isEsmBuild: !!argv.esm},
+    ],
   ].filter(Boolean);
   const presetEnv = [
     '@babel/preset-env',

--- a/build-system/compile/build-constants.js
+++ b/build-system/compile/build-constants.js
@@ -18,7 +18,7 @@ const {VERSION} = require('./internal-version');
 
 const testTasks = ['e2e', 'integration', 'visual-diff', 'unit', 'check-types'];
 const isTestTask = testTasks.some((task) => argv._.includes(task));
-const isForDistribution = argv._.includes('dist') && !argv.fortesting;
+const isProd = argv._.includes('dist') && !argv.fortesting;
 const isMinified = argv._.includes('dist') || !!argv.compiled;
 
 /**
@@ -30,7 +30,7 @@ const isMinified = argv._.includes('dist') || !!argv.compiled;
  * @type {Object<string, boolean|string>}
  */
 const BUILD_CONSTANTS = {
-  IS_FOR_DISTRIBUTION: isForDistribution,
+  IS_PROD: isProd,
   IS_MINIFIED: isMinified,
   INTERNAL_RUNTIME_VERSION: isTestTask ? '$internalRuntimeVersion$' : VERSION,
 

--- a/build-system/compile/build-constants.js
+++ b/build-system/compile/build-constants.js
@@ -18,7 +18,7 @@ const {VERSION} = require('./internal-version');
 
 const testTasks = ['e2e', 'integration', 'visual-diff', 'unit', 'check-types'];
 const isTestTask = testTasks.some((task) => argv._.includes(task));
-const isForTesting = argv.fortesting || !argv._.includes('dist');
+const isForDistribution = argv._.includes('dist') && !argv.fortesting;
 const isMinified = argv._.includes('dist') || !!argv.compiled;
 
 /**
@@ -30,7 +30,7 @@ const isMinified = argv._.includes('dist') || !!argv.compiled;
  * @type {Object<string, boolean|string>}
  */
 const BUILD_CONSTANTS = {
-  IS_FORTESTING: isForTesting,
+  IS_FOR_DISTRIBUTION: isForDistribution,
   IS_MINIFIED: isMinified,
   INTERNAL_RUNTIME_VERSION: isTestTask ? '$internalRuntimeVersion$' : VERSION,
 

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -287,7 +287,7 @@ function generateCompilerOptions(outputFilename, options) {
     // Some optimizations get turned off when pseudo_names is on.
     // This causes some errors caused by the babel transformations
     // that we apply like unreachable code because we turn a conditional
-    // falsey. (ex. is IS_FOR_DISTRIBUTION transformation which causes some conditionals
+    // falsey. (ex. is IS_PROD transformation which causes some conditionals
     // to be unreachable/suspicious code since the whole expression is
     // falsey)
     compilerOptions.jscomp_off.push('uselessCode', 'externsValidation');

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -287,7 +287,7 @@ function generateCompilerOptions(outputFilename, options) {
     // Some optimizations get turned off when pseudo_names is on.
     // This causes some errors caused by the babel transformations
     // that we apply like unreachable code because we turn a conditional
-    // falsey. (ex. is IS_FORTESTING transformation which causes some conditionals
+    // falsey. (ex. is IS_FOR_DISTRIBUTION transformation which causes some conditionals
     // to be unreachable/suspicious code since the whole expression is
     // falsey)
     compilerOptions.jscomp_off.push('uselessCode', 'externsValidation');

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -146,13 +146,13 @@ const forbiddenTermsGlobal = {
     message: realiasGetMode,
     allowlist: ['src/mode-object.js', 'src/iframe-attributes.js'],
   },
-  'INTERNAL_RUNTIME_VERSION|IS_(FORTESTING|MINIFIED)': {
+  'INTERNAL_RUNTIME_VERSION|IS_(FOR_DISTRIBUTION|MINIFIED)': {
     message:
       'Do not use build constants directly. Instead, use the helpers in `#core/mode`.',
     allowlist: [
       'src/internal-version.js',
       'src/core/mode/minified.js',
-      'src/core/mode/for-testing.js',
+      'src/core/mode/for-distribution.js',
       'build-system/compile/build-constants.js',
     ],
   },

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -146,13 +146,13 @@ const forbiddenTermsGlobal = {
     message: realiasGetMode,
     allowlist: ['src/mode-object.js', 'src/iframe-attributes.js'],
   },
-  'INTERNAL_RUNTIME_VERSION|IS_(FOR_DISTRIBUTION|MINIFIED)': {
+  'INTERNAL_RUNTIME_VERSION|IS_(PROD|MINIFIED)': {
     message:
       'Do not use build constants directly. Instead, use the helpers in `#core/mode`.',
     allowlist: [
       'src/internal-version.js',
       'src/core/mode/minified.js',
-      'src/core/mode/for-distribution.js',
+      'src/core/mode/prod.js',
       'build-system/compile/build-constants.js',
     ],
   },

--- a/src/core/mode/for-distribution.js
+++ b/src/core/mode/for-distribution.js
@@ -15,12 +15,14 @@
  */
 
 /**
- * Returns true whenever --fortesting is used.
+ * Returns true when the build is meant for distribution.
+ * This means `amp dist` was called _without_ the --fortesting flag.
+ * 
  * This is a magic constant replaced by babel.
  *
  * Calls are DCE'd when compiled.
  * @return {boolean}
  */
-export function isFortesting() {
-  return IS_FORTESTING;
+export function isForDistribution() {
+  return IS_FOR_DISTRIBUTION;
 }

--- a/src/core/mode/for-distribution.js
+++ b/src/core/mode/for-distribution.js
@@ -17,7 +17,7 @@
 /**
  * Returns true when the build is meant for distribution.
  * This means `amp dist` was called _without_ the --fortesting flag.
- * 
+ *
  * This is a magic constant replaced by babel.
  *
  * Calls are DCE'd when compiled.

--- a/src/core/mode/index.js
+++ b/src/core/mode/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export {isForDistribution} from './for-distribution';
+export {isProd} from './prod';
 export {isLocalDev} from './local-dev';
 export {isMinified} from './minified';
 export {isTest} from './test';

--- a/src/core/mode/index.js
+++ b/src/core/mode/index.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export {isFortesting} from './for-testing';
+export {isForDistribution} from './for-distribution';
 export {isLocalDev} from './local-dev';
 export {isMinified} from './minified';
 export {isTest} from './test';

--- a/src/core/mode/local-dev.js
+++ b/src/core/mode/local-dev.js
@@ -14,15 +14,20 @@
  * limitations under the License.
  */
 
-import {isFortesting} from './for-testing';
+import {isForDistribution} from './for-distribution';
 import {isTest} from './test';
 
 /**
  * Returns true if executing in a local development or testing environment.
- * Calls may be DCE'd when compiled based on isFortesting and isTest.
+ * Calls may be DCE'd when compiled based on isForDistribution and isTest.
+ *
  * @param {!Window=} opt_win
  * @return {boolean}
  */
 export function isLocalDev(opt_win) {
-  return isFortesting() && (!!self.AMP_CONFIG?.localDev || isTest(opt_win));
+  if (isForDistribution()) {
+    return false;
+  }
+
+  return !!self.AMP_CONFIG?.localDev || isTest(opt_win);
 }

--- a/src/core/mode/local-dev.js
+++ b/src/core/mode/local-dev.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {isForDistribution} from './for-distribution';
+import {isProd} from './prod';
 import {isTest} from './test';
 
 /**
@@ -25,7 +25,7 @@ import {isTest} from './test';
  * @return {boolean}
  */
 export function isLocalDev(opt_win) {
-  if (isForDistribution()) {
+  if (isProd()) {
     return false;
   }
 

--- a/src/core/mode/prod.js
+++ b/src/core/mode/prod.js
@@ -23,6 +23,6 @@
  * Calls are DCE'd when compiled.
  * @return {boolean}
  */
-export function isForDistribution() {
-  return IS_FOR_DISTRIBUTION;
+export function isProd() {
+  return IS_PROD;
 }

--- a/src/core/mode/test.js
+++ b/src/core/mode/test.js
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import {isFortesting} from './for-testing';
+import {isForDistribution} from './for-distribution';
 
 /**
  * Returns true if executing in a testing environment. Calls may be DCE'd when
- * compiled based on isFortesting.
+ * compiled based on isForDistribution.
  * @param {!Window=} opt_win
  * @return {boolean}
  */
 export function isTest(opt_win) {
-  if (!isFortesting()) {
+  if (isForDistribution()) {
     return false;
   }
   const win = opt_win || self;

--- a/src/core/mode/test.js
+++ b/src/core/mode/test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {isForDistribution} from './for-distribution';
+import {isProd} from './prod';
 
 /**
  * Returns true if executing in a testing environment. Calls may be DCE'd when
@@ -23,7 +23,7 @@ import {isForDistribution} from './for-distribution';
  * @return {boolean}
  */
 export function isTest(opt_win) {
-  if (isForDistribution()) {
+  if (isProd()) {
     return false;
   }
   const win = opt_win || self;


### PR DESCRIPTION
**summary**

The `IS_FORTESTING` variable is set to false _only_ when `amp dist` is called without `--fortesting`.
It doesn't directly have anything to do with "testing" (i.e. `amp unit`, `amp integration` etc).

This PR flips the variable name to `IS_PROD`, which IMO ends up clearer.



Alternative/supplementary fix for https://github.com/ampproject/amphtml/issues/35325