### PR TITLE
✨Introduce new ATTRIBUTION_REPORTING_STATUS macro for amp-ad-exit

### DIFF
--- a/examples/amp-ad-exit-conversion.html
+++ b/examples/amp-ad-exit-conversion.html
@@ -26,7 +26,7 @@
       {
         "targets": {
           "landingPage": {
-            "finalUrl": "https://example.com",
+            "finalUrl": "https://example.com?nis=ATTRIBUTION_REPORTING_STATUS",
             "behaviors": {
               "browserAdConversion" : {
                 "attributiondestination": "https://example.com",

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {AmpAdExit} from '../amp-ad-exit';
+import {AmpAdExit, getAttributionReportingStatus} from '../amp-ad-exit';
 import {FilterType} from '../filters/filter';
 import {IFRAME_TRANSPORTS} from '../../../amp-analytics/0.1/iframe-transport-vendors';
 import {installPlatformService} from '#service/platform-impl';
@@ -980,6 +980,56 @@ describes.realWin(
         'http://localhost:8000/tracking?numVar=0&boolVar=false',
         ''
       );
+    });
+
+    describe('ATTRIBUTION_REPORTING_STATUS macro', () => {
+      it('should return ATTRIBUTION_DATA_PRESENT_AND_POLICY_ENABLED if browserAdConfig is present and browser supported', () => {
+        const target = {
+          behaviors: {
+            browserAdConversion: {
+              attributiondestination: 'https://example.com',
+              attributionsourceeventid: 'EFnZ8GunL1xrwNTIHbXrvQ==',
+              attributionreportto: 'https://google.com',
+            },
+          },
+        };
+        expect(
+          getAttributionReportingStatus(
+            true /* isAttributionReportingSupported*/,
+            target
+          )
+        ).to.equal(3);
+      });
+
+      it('should return ATTRIBUTION_DATA_PRESENT if browserAdConfig is present and no browser support', () => {
+        const target = {
+          behaviors: {
+            browserAdConversion: {
+              attributiondestination: 'https://example.com',
+              attributionsourceeventid: 'EFnZ8GunL1xrwNTIHbXrvQ==',
+              attributionreportto: 'https://google.com',
+            },
+          },
+        };
+        expect(
+          getAttributionReportingStatus(
+            false /* isAttributionReportingSupported*/,
+            target
+          )
+        ).to.equal(2);
+      });
+
+      it('should return ATTRIBUTION_MACRO_PRESENT if browserAdConfig not present', () => {
+        const target = {
+          behaviors: {},
+        };
+        expect(
+          getAttributionReportingStatus(
+            false /* isAttributionReportingSupported*/,
+            target
+          )
+        ).to.equal(1);
+      });
     });
   }
 );


### PR DESCRIPTION
This allows ad networks to monitor the status of the new `attribution-reporting` API rollout.

Partial #35347