### PR TITLE
Replace f.js with twitter.js for 3p iframe

### DIFF
--- a/extensions/amp-twitter/1.0/storybook/Basic.js
+++ b/extensions/amp-twitter/1.0/storybook/Basic.js
@@ -34,7 +34,7 @@ export const _default = () => {
   const conversation = boolean('show conversation', false) ? undefined : 'none';
   return (
     <Twitter
-      bootstrap="https://3p.ampproject.net/2104170104001/f.js"
+      bootstrap="https://3p.ampproject.net/2104170104001/vendor/twitter.js"
       options={{cards, conversation}}
       tweetid={tweetId}
       src="https://d-41929527682976137678.ampproject.net/2104170104001/frame.html"
@@ -47,7 +47,7 @@ export const moments = () => {
   const limit = number('limit to', 2);
   return (
     <Twitter
-      bootstrap="https://3p.ampproject.net/2104170104001/f.js"
+      bootstrap="https://3p.ampproject.net/2104170104001/vendor/twitter.js"
       options={{limit}}
       momentid="1009149991452135424"
       src="https://d-41929527682976137678.ampproject.net/2104170104001/frame.html"
@@ -67,7 +67,7 @@ export const timelines = () => {
   const timelineUserId = '3450662892';
   return (
     <Twitter
-      bootstrap="https://3p.ampproject.net/2104170104001/f.js"
+      bootstrap="https://3p.ampproject.net/2104170104001/vendor/twitter.js"
       options={{
         tweetLimit,
         timelineSourceType,


### PR DESCRIPTION
 We are trying to deprecate f.js (https://github.com/ampproject/amphtml/issues/35349), in favor of vendor-specific js for better performance. PTAL