### PR TITLE
✅ Fix FIE unit test failure

### DIFF
--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -669,10 +669,6 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
   it('should call for remeasure upon resize', async () => {
     const iframe = document.createElement('iframe');
     const {promise, resolve} = new Deferred();
-    const mutateSpy = env.sandbox.stub(
-      Services.mutatorForDoc(env.ampdoc),
-      'mutateElement'
-    );
 
     await installFriendlyIframeEmbed(iframe, document.body, {
       url: 'https://acme.org/url1',
@@ -680,6 +676,10 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       extensions: [],
     });
 
+    const mutateSpy = env.sandbox.stub(
+      Services.mutatorForDoc(env.ampdoc),
+      'mutateElement'
+    );
     expect(mutateSpy).to.not.be.called;
     setStyles(iframe, {height: '100px', width: '100px'});
     // Need to wait for resize event.


### PR DESCRIPTION
The browser somehow triggers a resize event after iframe is being created, therefore causes a mutateElement call (https://github.com/ampproject/amphtml/blob/main/src/friendly-iframe-embed.js#L412). The event emits probabilistically.

Moving spy to after iframe being created will prevent browser resize event from affecting the test.