### PR TITLE
🏗 Add 3p iframe vendor files to depCheck targets

### DIFF
--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -178,7 +178,11 @@ async function getEntryPointModule() {
     .map((x) => `extensions/${x}`)
     .filter((x) => fs.statSync(x).isDirectory())
     .map(getEntryPoint);
-  const allEntryPoints = flatten(extensionEntryPoints).concat(coreBinaries);
+  const vendors = await fs.promises.readdir('3p/vendors');
+  const vendorEntryPoints = vendors.map((x) => `3p/vendors/${x}`);
+  const allEntryPoints = flatten(extensionEntryPoints)
+    .concat(coreBinaries)
+    .concat(vendorEntryPoints);
   const entryPointData = allEntryPoints
     .map((file) => `import './${file}';`)
     .join('\n');


### PR DESCRIPTION
Currently, depCheck does not take into account 3p vendor entrypoints. This PR adds them so that these entrypoints are gone through by the depCheck.