### PR TITLE
Fix 3p integration deprecation warning

### DIFF
--- a/3p/integration.js
+++ b/3p/integration.js
@@ -312,12 +312,11 @@ import {zen} from '#ads/vendors/zen';
 import {zergnet} from '#ads/vendors/zergnet';
 import {zucks} from '#ads/vendors/zucks';
 
+init(window);
 user().warn(
   '3P-IFRAME',
   'f.js in iframe is being deprecated (see https://github.com/ampproject/amphtml/issues/35349 for details)'
 );
-
-init(window);
 
 if (getMode().test || getMode().localDev) {
   register('_ping_', _ping_);


### PR DESCRIPTION
The logger is not initialized until `init` call, so we need to warn afterwards.