### PR TITLE
Use history service in `amp-lightbox:1.0` and `amp-lightbox-gallery:1.0` in AMP layer

### DIFF
--- a/extensions/amp-lightbox-gallery/1.0/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/1.0/test/test-amp-lightbox-gallery.js
@@ -24,6 +24,7 @@ import * as analytics from '../../../../src/analytics';
 import {poll} from '#testing/iframe';
 import {toggleExperiment} from '#experiments';
 import {waitFor, whenCalled} from '#testing/test-helper';
+import {Services} from '#service/';
 
 const TAG = 'amp-lightbox-gallery';
 
@@ -39,6 +40,8 @@ describes.realWin(
     let doc;
     let html;
     let element;
+    let historyPopSpy;
+    let historyPushSpy;
 
     async function waitForOpen(el, open) {
       const isOpenOrNot = () => el.hasAttribute('open') === open;
@@ -67,6 +70,19 @@ describes.realWin(
       doc = win.document;
       html = htmlFor(doc);
       toggleExperiment(win, 'bento-lightbox-gallery', true, true);
+
+      historyPopSpy = env.sandbox.spy();
+      historyPushSpy = env.sandbox.spy();
+      env.sandbox.stub(Services, 'historyForDoc').returns({
+        push() {
+          historyPushSpy();
+          return Promise.resolve(11);
+        },
+        pop() {
+          historyPopSpy();
+          return Promise.resolve(11);
+        },
+      });
     });
 
     afterEach(() => {
@@ -168,6 +184,8 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
           'lightboxOpened'
@@ -200,6 +218,9 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledOnce;
@@ -218,6 +239,8 @@ describes.realWin(
 
         expect(element.setAsContainerInternal).to.be.calledOnce;
         expect(element.removeAsContainerInternal).to.be.calledOnce;
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.be.calledOnce;
       });
     });
 
@@ -255,6 +278,8 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
           'lightboxOpened'
@@ -289,6 +314,8 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
         expect(triggerAnalyticsStub).to.have.been.calledOnceWithExactly(
           element,
           'lightboxOpened'
@@ -372,6 +399,9 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledWith(scroller);
@@ -403,6 +433,9 @@ describes.realWin(
         expect(renderedImgs[2].srcset).to.equal('img3.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledWith(scroller);
@@ -434,6 +467,9 @@ describes.realWin(
         expect(renderedImgs[2].srcset).to.equal('img7.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledWith(scroller);
@@ -461,6 +497,9 @@ describes.realWin(
         expect(renderedImgs[0].srcset).to.equal('img4.jpg 1x');
 
         await whenCalled(element.setAsContainerInternal);
+        expect(historyPushSpy).to.be.calledOnce;
+        expect(historyPopSpy).to.have.not.been.called;
+
         const scroller = element.shadowRoot.querySelector('[part=scroller]');
         expect(scroller).not.to.be.null;
         expect(element.setAsContainerInternal).to.be.calledWith(scroller);

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -29,7 +29,20 @@ const TAG = 'amp-lightbox';
 /** @extends {PreactBaseElement<LightboxDef.Api>} */
 class AmpLightbox extends BaseElement {
   /** @override */
+  constructor(element) {
+    super(element);
+
+    /** @private {!../../../src/service/history-impl.History} */
+    this.history_ = null;
+
+    /** @private {number|null} */
+    this.historyId_ = null;
+  }
+
+  /** @override */
   init() {
+    this.history_ = Services.historyForDoc(this.getAmpDoc());
+
     this.registerApiAction(
       DEFAULT_ACTION,
       (api) => api.open(),
@@ -73,12 +86,21 @@ class AmpLightbox extends BaseElement {
     super.afterOpen();
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
     this.setAsContainer?.(scroller);
+
+    this.history_
+      .push(() => this.api().close())
+      .then((historyId) => (this.historyId_ = historyId));
   }
 
   /** @override */
   afterClose() {
     super.afterClose();
     this.removeAsContainer?.();
+
+    if (this.historyId_ != null) {
+      this.history_.pop(this.historyId_);
+      this.historyId_ = null;
+    }
   }
 
   /** @override */


### PR DESCRIPTION
Final feature for Bento `amp-lightbox` #31052 and partial for Bento `amp-lightbox-gallery` #32759, for feature conformance with 0.1 counterparts.