### PR TITLE
✨ [Amp story player] [Desktop panels player] Hide buttons if full-bleed story.

### DIFF
--- a/css/amp-story-player-shadow.css
+++ b/css/amp-story-player-shadow.css
@@ -141,6 +141,12 @@
     cursor: initial;
   }
 
+  .i-amphtml-story-player-full-bleed-story .i-amphtml-story-player-desktop-panel-prev,
+  .i-amphtml-story-player-full-bleed-story .i-amphtml-story-player-desktop-panel-next {
+    opacity: 0;
+    pointer-events: none;
+  }
+
   .i-amphtml-story-player-desktop-panel-prev {
     margin-inline-start: calc(var(--i-amphtml-story-player-desktop-panel-button-margin));
     background-image: url('data:image/svg+xml;charset=utf-8,<svg width="16" height="16" viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.66667 8L16 16V0L4.66667 8ZM0 16H2.66667V0H0V16Z"/><path fill-rule="evenodd" clip-rule="evenodd" d="M4.66667 8L16 16V0L4.66667 8ZM0 16H2.66667V0H0V16Z"/></svg>')!important;

--- a/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
@@ -58,6 +58,10 @@ const GET_STATE_CONFIGURATIONS = {
     dataSource: DataSources.STORE_SERVICE,
     property: StateProperty.PAGE_ATTACHMENT_STATE,
   },
+  'UI_STATE': {
+    dataSource: DataSources.STORE_SERVICE,
+    property: StateProperty.UI_STATE,
+  },
   'STORY_PROGRESS': {
     dataSource: DataSources.VARIABLE_SERVICE,
     property: AnalyticsVariable.STORY_PROGRESS,

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -980,14 +980,14 @@ export class AmpStoryPlayer {
 
     if (this.isDesktopPanelExperimentOn_) {
       this.checkButtonsDisabled_();
+      this.getUiState_();
     }
     this.signalNavigation_(navigation);
     this.maybeFetchMoreStories_(remaining);
-    this.getUiState_();
   }
 
   /**
-   * Shows or hides one panel UI on state update.
+   * Gets UI state from active story.
    * @private
    */
   getUiState_() {
@@ -1006,6 +1006,10 @@ export class AmpStoryPlayer {
     });
   }
 
+  /**
+   * Shows or hides one panel UI on state update.
+   * @private
+   */
   onUiStateUpdate_(uiTypeNumber) {
     const isFullBleedDesktop =
       uiTypeNumber === UIType.DESKTOP_FULLBLEED ||
@@ -1568,7 +1572,9 @@ export class AmpStoryPlayer {
         this.onMutedStateUpdate_(/** @type {string} */ (data.value));
         break;
       case STORY_MESSAGE_STATE_TYPE.UI_STATE:
-        this.onUiStateUpdate_(/** @type {number} */ (data.value));
+        if (this.isDesktopPanelExperimentOn_) {
+          this.onUiStateUpdate_(/** @type {number} */ (data.value));
+        }
         break;
       case AMP_STORY_PLAYER_EVENT:
         this.onPlayerEvent_(/** @type {string} */ (data.value));

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -189,18 +189,6 @@ const LOG_TYPE = {
 };
 
 /**
- * Different UI experiences to display the story.
- * @const @enum {number}
- */
-export const UIType = {
-  MOBILE: 0,
-  DESKTOP_PANELS: 1, // Default desktop UI displaying previous and next pages.
-  DESKTOP_FULLBLEED: 2, // Desktop UI if landscape mode is enabled.
-  DESKTOP_ONE_PANEL: 4, // Desktop UI with one panel and space around story.
-  VERTICAL: 3, // Vertical scrolling versions, for search engine bots indexing.
-};
-
-/**
  * NOTE: If udpated here, update in amp-story.js
  * @private @const {number}
  */
@@ -1011,12 +999,12 @@ export class AmpStoryPlayer {
    * @private
    */
   onUiStateUpdate_(uiTypeNumber) {
-    const isFullBleedDesktop =
-      uiTypeNumber === UIType.DESKTOP_FULLBLEED ||
-      uiTypeNumber === UIType.MOBILE;
+    const isFullbleed =
+      uiTypeNumber === 2 /** DESKTOP_FULLBLEED */ ||
+      uiTypeNumber === 0; /** MOBILE */
     this.rootEl_.classList.toggle(
       'i-amphtml-story-player-full-bleed-story',
-      isFullBleedDesktop
+      isFullbleed
     );
   }
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -999,7 +999,7 @@ export class AmpStoryPlayer {
 
   /**
    * Shows or hides one panel UI on state update.
-   * @param number uiTypeNumber
+   * @param {number} uiTypeNumber
    * @private
    */
   onUiStateUpdate_(uiTypeNumber) {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -968,7 +968,9 @@ export class AmpStoryPlayer {
 
     if (this.isDesktopPanelExperimentOn_) {
       this.checkButtonsDisabled_();
-      this.getUiState_();
+      this.getUiState_().then((uiTypeNumber) =>
+        this.onUiStateUpdate_(uiTypeNumber)
+      );
     }
     this.signalNavigation_(navigation);
     this.maybeFetchMoreStories_(remaining);
@@ -977,20 +979,23 @@ export class AmpStoryPlayer {
   /**
    * Gets UI state from active story.
    * @private
+   * @return {Promise}
    */
   getUiState_() {
     const story = this.stories_[this.currentIdx_];
 
-    story.messagingPromise.then((messaging) => {
-      messaging
-        .sendRequest(
-          'getDocumentState',
-          {state: STORY_MESSAGE_STATE_TYPE.UI_STATE},
-          true
-        )
-        .then((event) => {
-          this.onUiStateUpdate_(event.value);
-        });
+    return new Promise((resolve) => {
+      story.messagingPromise.then((messaging) => {
+        messaging
+          .sendRequest(
+            'getDocumentState',
+            {state: STORY_MESSAGE_STATE_TYPE.UI_STATE},
+            true
+          )
+          .then((event) => {
+            resolve(event.value);
+          });
+      });
     });
   }
 
@@ -1561,6 +1566,7 @@ export class AmpStoryPlayer {
         break;
       case STORY_MESSAGE_STATE_TYPE.UI_STATE:
         if (this.isDesktopPanelExperimentOn_) {
+          // Handles UI state updates on window resize.
           this.onUiStateUpdate_(/** @type {number} */ (data.value));
         }
         break;

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -999,6 +999,7 @@ export class AmpStoryPlayer {
 
   /**
    * Shows or hides one panel UI on state update.
+   * @param number uiTypeNumber
    * @private
    */
   onUiStateUpdate_(uiTypeNumber) {

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -110,6 +110,7 @@ const STORY_STATE_TYPE = {
 /** @enum {string} */
 const STORY_MESSAGE_STATE_TYPE = {
   PAGE_ATTACHMENT_STATE: 'PAGE_ATTACHMENT_STATE',
+  UI_STATE: 'UI_STATE',
   MUTED_STATE: 'MUTED_STATE',
   CURRENT_PAGE_ID: 'CURRENT_PAGE_ID',
   STORY_PROGRESS: 'STORY_PROGRESS',
@@ -188,9 +189,16 @@ const LOG_TYPE = {
 };
 
 /**
- * Flag to show or hide the desktop panels player experiment.
- * @const {boolean}
+ * Different UI experiences to display the story.
+ * @const @enum {number}
  */
+export const UIType = {
+  MOBILE: 0,
+  DESKTOP_PANELS: 1, // Default desktop UI displaying previous and next pages.
+  DESKTOP_FULLBLEED: 2, // Desktop UI if landscape mode is enabled.
+  DESKTOP_ONE_PANEL: 4, // Desktop UI with one panel and space around story.
+  VERTICAL: 3, // Vertical scrolling versions, for search engine bots indexing.
+};
 
 /**
  * NOTE: If udpated here, update in amp-story.js
@@ -652,6 +660,11 @@ export class AmpStoryPlayer {
             dict({'state': STORY_MESSAGE_STATE_TYPE.MUTED_STATE})
           );
 
+          messaging.sendRequest(
+            'onDocumentState',
+            dict({'state': STORY_MESSAGE_STATE_TYPE.UI_STATE})
+          );
+
           messaging.registerHandler('documentStateUpdate', (event, data) => {
             this.onDocumentStateUpdate_(
               /** @type {!DocumentStateTypeDef} */ (data),
@@ -970,6 +983,37 @@ export class AmpStoryPlayer {
     }
     this.signalNavigation_(navigation);
     this.maybeFetchMoreStories_(remaining);
+    this.getUiState_();
+  }
+
+  /**
+   * Shows or hides one panel UI on state update.
+   * @private
+   */
+  getUiState_() {
+    const story = this.stories_[this.currentIdx_];
+
+    story.messagingPromise.then((messaging) => {
+      messaging
+        .sendRequest(
+          'getDocumentState',
+          {state: STORY_MESSAGE_STATE_TYPE.UI_STATE},
+          true
+        )
+        .then((event) => {
+          this.onUiStateUpdate_(event.value);
+        });
+    });
+  }
+
+  onUiStateUpdate_(uiTypeNumber) {
+    const isFullBleedDesktop =
+      uiTypeNumber === UIType.DESKTOP_FULLBLEED ||
+      uiTypeNumber === UIType.MOBILE;
+    this.rootEl_.classList.toggle(
+      'i-amphtml-story-player-full-bleed-story',
+      isFullBleedDesktop
+    );
   }
 
   /**
@@ -1522,6 +1566,9 @@ export class AmpStoryPlayer {
         break;
       case STORY_MESSAGE_STATE_TYPE.MUTED_STATE:
         this.onMutedStateUpdate_(/** @type {string} */ (data.value));
+        break;
+      case STORY_MESSAGE_STATE_TYPE.UI_STATE:
+        this.onUiStateUpdate_(/** @type {number} */ (data.value));
         break;
       case AMP_STORY_PLAYER_EVENT:
         this.onPlayerEvent_(/** @type {string} */ (data.value));

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -992,9 +992,7 @@ export class AmpStoryPlayer {
             {state: STORY_MESSAGE_STATE_TYPE.UI_STATE},
             true
           )
-          .then((event) => {
-            resolve(event.value);
-          });
+          .then((event) => resolve(event.value));
       });
     });
   }

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -19,7 +19,7 @@ import {AmpStoryPlayer} from '../../src/amp-story-player/amp-story-player-impl';
 import {Messaging} from '@ampproject/viewer-messaging';
 import {PageScroller} from '../../src/amp-story-player/page-scroller';
 import {expect} from 'chai';
-import {listenOncePromise} from '../../src/event-helper';
+import {createCustomEvent, listenOncePromise} from '../../src/event-helper';
 import {macroTask} from '#testing/yield';
 
 describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
@@ -1526,6 +1526,25 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       expect(
         playerEl.querySelector('.i-amphtml-story-player-desktop-panel-next')
       ).to.exist;
+    });
+
+    it('Should get UI state on resize', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+
+      attachPlayerWithStories(playerEl, 5);
+      win.DESKTOP_PANEL_STORY_PLAYER_EXP_ON = true;
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      await player.load();
+
+      const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
+
+      win.dispatchEvent(createCustomEvent(win, 'resize', null));
+      await nextTick();
+
+      expect(sendRequestSpy).to.have.been.calledWith('onDocumentState', {
+        'state': 'UI_STATE',
+      });
     });
   });
 });


### PR DESCRIPTION
Uses story viewer messaging service to listen to ui state update events.
Toggles visibility of the prev and next story buttons on the component based on UI state. 
Hides code behind experiment.
Removes old comment.

https://user-images.githubusercontent.com/3860311/127017462-9d1ce22f-b8e8-487c-86d6-8c4cdd942017.mp4

