### PR TITLE
Wrap preact.Fragment with preact.createElement

### DIFF
--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -64,7 +64,7 @@ export function hydrate(vnode, container) {
  * @return {PreactDef.Renderable}
  */
 export function Fragment(props) {
-  return preact.Fragment(props);
+  return preact.createElement(preact.Fragment, props);
 }
 
 /**

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -64,7 +64,7 @@ export function hydrate(vnode, container) {
  * @return {PreactDef.Renderable}
  */
 export function Fragment(props) {
-  return preact.createElement(preact.Fragment, props);
+  return props.children;
 }
 
 /**


### PR DESCRIPTION
While `preact.Fragment` is a function, `react.Fragment` is not. This PR nests with `preact.createElement` to account for remapping `preact` -> `react`. Fixes #35412.