### PR TITLE
🐛 Fix broken link & invalid AMP page on amp.dev amp-video-iframe component documentation

### DIFF
--- a/extensions/amp-video-iframe/amp-video-iframe.md
+++ b/extensions/amp-video-iframe/amp-video-iframe.md
@@ -426,7 +426,7 @@ prefixed with `custom_`, i.e. the object `{myVar: 'foo'}` will be available as
 #### <a name="getConsentData"></a> `getConsentData(callback)`
 
 The iframe document can request user consent data when the host document uses
-[`amp-consent`](hhttps://amp.dev/documentation/components/amp-consent/).
+[`amp-consent`](https://amp.dev/documentation/components/amp-consent/).
 
 Note: If you only require to block the iframe from loading when consent is not given, it's preferable to [set the `data-block-on-consent` attribute](https://amp.dev/documentation/components/amp-consent/#basic-blocking-behaviors) instead of calling `getConsentData()`
 


### PR DESCRIPTION
On the the [amp.dev component page for `amp-video-iframe`](https://amp.dev/documentation/components/amp-video-iframe/), the AMP page is invalid due to "Invalid URL protocol 'hhttps:' for attribute 'href' in tag 'a'.". This change fixes the broken URL.

https://amp.dev/documentation/components/amp-video-iframe/