### PR TITLE
🏗 Move macOS testing from GH Actions to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.1.3
-  node: circleci/node@4.6.0
+  node: circleci/node@4.7.0
 
 push_and_pr_builds: &push_and_pr_builds
   filters:
@@ -27,19 +27,19 @@ experiment_job: &experiment_job
     EXP: << parameters.exp >>
 
 executors:
-  docker-small:
+  base-docker-small:
     docker:
       - image: cimg/base:stable
     resource_class: small
-  docker-medium:
+  node-docker-medium:
     docker:
       - image: cimg/node:lts-browsers
     resource_class: medium
-  docker-large:
+  node-docker-large:
     docker:
       - image: cimg/node:lts-browsers
     resource_class: large
-  docker-xlarge:
+  node-docker-xlarge:
     docker:
       - image: cimg/node:lts-browsers
     resource_class: xlarge
@@ -134,7 +134,7 @@ commands:
 jobs:
   'Initialize Repository':
     executor:
-      name: docker-small
+      name: base-docker-small
     steps:
       - checkout_repo
       - run:
@@ -146,7 +146,7 @@ jobs:
       - teardown_vm
   'Checks':
     executor:
-      name: docker-medium
+      name: node-docker-medium
     steps:
       - setup_vm
       - install_chrome
@@ -156,7 +156,7 @@ jobs:
       - teardown_vm
   'Unminified Build':
     executor:
-      name: docker-xlarge
+      name: node-docker-xlarge
     steps:
       - setup_vm
       - run:
@@ -165,7 +165,7 @@ jobs:
       - teardown_vm
   'Nomodule Build - Test':
     executor:
-      name: docker-xlarge
+      name: node-docker-xlarge
     steps:
       - setup_vm
       - run:
@@ -179,7 +179,7 @@ jobs:
       - teardown_vm
   'Module Build - Test':
     executor:
-      name: docker-xlarge
+      name: node-docker-xlarge
     steps:
       - setup_vm
       - run:
@@ -188,7 +188,7 @@ jobs:
       - teardown_vm
   'Nomodule Build - Prod':
     executor:
-      name: docker-xlarge
+      name: node-docker-xlarge
     steps:
       - setup_vm
       - run:
@@ -197,7 +197,7 @@ jobs:
       - teardown_vm
   'Module Build - Prod':
     executor:
-      name: docker-xlarge
+      name: node-docker-xlarge
     steps:
       - setup_vm
       - run:
@@ -206,7 +206,7 @@ jobs:
       - teardown_vm
   'Bundle Size':
     executor:
-      name: docker-medium
+      name: node-docker-medium
     steps:
       - setup_vm
       - run:
@@ -228,7 +228,7 @@ jobs:
       - teardown_vm
   'Visual Diff Tests':
     executor:
-      name: docker-large
+      name: node-docker-large
     steps:
       - setup_vm
       - install_chrome
@@ -239,7 +239,7 @@ jobs:
       - teardown_vm
   'Local Unit Tests':
     executor:
-      name: docker-large
+      name: node-docker-large
     steps:
       - skip_on_push_builds
       - setup_vm
@@ -251,7 +251,7 @@ jobs:
       - teardown_vm
   'All Unit Tests':
     executor:
-      name: docker-medium
+      name: node-docker-medium
     parallelism: 6
     steps:
       - setup_vm
@@ -263,7 +263,7 @@ jobs:
       - teardown_vm
   'Unminified Tests':
     executor:
-      name: docker-large
+      name: node-docker-large
     steps:
       - setup_vm
       - install_chrome
@@ -274,7 +274,7 @@ jobs:
       - teardown_vm
   'Nomodule Tests':
     executor:
-      name: docker-large
+      name: node-docker-large
     parameters:
       config:
         description: 'Which config file to use'
@@ -290,7 +290,7 @@ jobs:
       - teardown_vm
   'Module Tests':
     executor:
-      name: docker-large
+      name: node-docker-large
     parameters:
       config:
         description: 'Which config file to use'
@@ -306,7 +306,7 @@ jobs:
       - teardown_vm
   'End-to-End Tests':
     executor:
-      name: docker-medium
+      name: node-docker-medium
     parallelism: 6
     steps:
       - setup_vm
@@ -329,7 +329,7 @@ jobs:
       - teardown_vm
   'Performance Tests':
     executor:
-      name: docker-xlarge
+      name: node-docker-xlarge
     steps:
       - setup_vm
       - install_chrome
@@ -340,7 +340,7 @@ jobs:
       - teardown_vm
   'Experiment Build':
     executor:
-      name: docker-xlarge
+      name: node-docker-xlarge
     <<: *experiment_job
     steps:
       - setup_vm
@@ -350,7 +350,7 @@ jobs:
       - teardown_vm
   'Experiment Integration Tests':
     executor:
-      name: docker-large
+      name: node-docker-large
     <<: *experiment_job
     steps:
       - setup_vm
@@ -362,7 +362,7 @@ jobs:
       - teardown_vm
   'Experiment End-to-End Tests':
     executor:
-      name: docker-large
+      name: node-docker-large
     <<: *experiment_job
     parallelism: 6
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   browser-tools: circleci/browser-tools@1.1.3
-  node: circleci/node@4.5.1
+  node: circleci/node@4.6.0
 
 push_and_pr_builds: &push_and_pr_builds
   filters:
@@ -27,28 +27,52 @@ experiment_job: &experiment_job
     EXP: << parameters.exp >>
 
 executors:
-  amphtml-small-executor:
+  docker-small:
     docker:
       - image: cimg/base:stable
     resource_class: small
-  amphtml-medium-executor:
+  docker-medium:
     docker:
       - image: cimg/node:lts-browsers
     resource_class: medium
-  amphtml-large-executor:
+  docker-large:
     docker:
       - image: cimg/node:lts-browsers
     resource_class: large
-  amphtml-xlarge-executor:
+  docker-xlarge:
     docker:
       - image: cimg/node:lts-browsers
     resource_class: xlarge
-  validator-xlarge-executor:
+  jdk-docker-xlarge:
     docker:
       - image: cimg/openjdk:16.0-node
     resource_class: xlarge
+  macos-medium:
+    macos:
+      xcode: 12.4.0
+    resource_class: medium
 
 commands:
+  checkout_repo:
+    steps:
+      - restore_cache:
+          name: 'Restore Git Cache'
+          keys:
+            - git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+            - git-cache-{{ arch }}-{{ .Branch }}-
+            - git-cache-{{ arch }}-
+      - checkout
+      - save_cache:
+          name: 'Save Git Cache'
+          key: git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .git
+  setup_node_environment:
+    steps:
+      - node/install:
+          lts: true
+          install-npm: false
+      - node/install-packages
   setup_vm:
     steps:
       - attach_workspace:
@@ -61,12 +85,7 @@ commands:
       - run:
           name: 'Maybe Gracefully Halt'
           command: /tmp/restored-workspace/maybe_gracefully_halt.sh
-      - restore_cache:
-          keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
-      - checkout
+      - checkout_repo
       - run:
           name: 'Configure Development Environment'
           command: |
@@ -74,9 +93,7 @@ commands:
             ./.circleci/check_config.sh
             ./.circleci/restore_build_output.sh
             cat ./build-system/test-configs/hosts | sudo tee -a /etc/hosts
-      # TODO(danielrozenberg): consolidate the extra steps.
-      - node/install-packages:
-          override-ci-command: npm config set prefix $HOME && npm ci
+      - setup_node_environment
   teardown_vm:
     steps:
       - persist_to_workspace:
@@ -88,6 +105,14 @@ commands:
       - browser-tools/install-chrome:
           replace-existing: true
       - browser-tools/install-chromedriver
+  enable_safari_automation:
+    steps:
+      - run:
+          name: 'Enable Safari Automation'
+          command: |
+            defaults write com.apple.Safari AllowRemoteAutomation 1
+            defaults write com.apple.Safari IncludeDevelopMenu 1
+            sudo safaridriver --enable
   store_test_output:
     steps:
       - store_artifacts:
@@ -103,24 +128,15 @@ commands:
               value: << pipeline.git.branch >>
           steps:
             - run:
-                name: 'Skip Local Unit Test on Push Builds'
+                name: 'Skip Job on Push Builds'
                 command: circleci-agent step halt
 
 jobs:
   'Initialize Repository':
     executor:
-      name: amphtml-small-executor
+      name: docker-small
     steps:
-      - restore_cache:
-          keys:
-            - source-v1-{{ .Branch }}-{{ .Revision }}
-            - source-v1-{{ .Branch }}-
-            - source-v1-
-      - checkout
-      - save_cache:
-          key: source-v1-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - .git
+      - checkout_repo
       - run:
           name: 'Initialize Repository'
           command: ./.circleci/initialize_repo.sh
@@ -130,135 +146,135 @@ jobs:
       - teardown_vm
   'Checks':
     executor:
-      name: amphtml-medium-executor
+      name: docker-medium
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Checks'
+          name: '⭐ Checks ⭐'
           command: node build-system/pr-check/checks.js
       - teardown_vm
   'Unminified Build':
     executor:
-      name: amphtml-xlarge-executor
+      name: docker-xlarge
     steps:
       - setup_vm
       - run:
-          name: 'Unminified Build'
+          name: '⭐ Unminified Build ⭐'
           command: node build-system/pr-check/unminified-build.js
       - teardown_vm
   'Nomodule Build - Test':
     executor:
-      name: amphtml-xlarge-executor
+      name: docker-xlarge
     steps:
       - setup_vm
       - run:
           name: 'Create Artifacts Directory'
           command: mkdir -p /tmp/artifacts
       - run:
-          name: 'Nomodule Build'
+          name: '⭐ Nomodule Build ⭐'
           command: node build-system/pr-check/nomodule-build.js
       - store_artifacts:
           path: /tmp/artifacts/amp_nomodule_build.tar.gz
       - teardown_vm
   'Module Build - Test':
     executor:
-      name: amphtml-xlarge-executor
+      name: docker-xlarge
     steps:
       - setup_vm
       - run:
-          name: 'Module Build'
+          name: '⭐ Module Build ⭐'
           command: node build-system/pr-check/module-build.js
       - teardown_vm
   'Nomodule Build - Prod':
     executor:
-      name: amphtml-xlarge-executor
+      name: docker-xlarge
     steps:
       - setup_vm
       - run:
-          name: 'Nomodule Build'
+          name: '⭐ Nomodule Build ⭐'
           command: node build-system/pr-check/bundle-size-nomodule-build.js
       - teardown_vm
   'Module Build - Prod':
     executor:
-      name: amphtml-xlarge-executor
+      name: docker-xlarge
     steps:
       - setup_vm
       - run:
-          name: 'Module Build'
+          name: '⭐ Module Build ⭐'
           command: node build-system/pr-check/bundle-size-module-build.js
       - teardown_vm
   'Bundle Size':
     executor:
-      name: amphtml-medium-executor
+      name: docker-medium
     steps:
       - setup_vm
       - run:
-          name: 'Bundle Size'
+          name: '⭐ Bundle Size ⭐'
           command: node build-system/pr-check/bundle-size.js
       - teardown_vm
   'Validator Tests':
     executor:
-      name: validator-xlarge-executor
+      name: jdk-docker-xlarge
     steps:
       - setup_vm
       - run:
           name: 'Install Validator Dependencies'
           command: ./.circleci/install_validator_dependencies.sh
       - run:
-          name: 'Validator Tests'
+          name: '⭐ Validator Tests ⭐'
           command: node build-system/pr-check/validator-tests.js
       - store_test_output
       - teardown_vm
   'Visual Diff Tests':
     executor:
-      name: amphtml-large-executor
+      name: docker-large
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Visual Diff Tests'
+          name: '⭐ Visual Diff Tests ⭐'
           command: node build-system/pr-check/visual-diff-tests.js
       - store_test_output
       - teardown_vm
   'Local Unit Tests':
     executor:
-      name: amphtml-large-executor
+      name: docker-large
     steps:
       - skip_on_push_builds
       - setup_vm
       - install_chrome
       - run:
-          name: 'Local Unit Tests'
+          name: '⭐ Local Unit Tests ⭐'
           command: node build-system/pr-check/unit-tests-local.js
       - store_test_output
       - teardown_vm
   'All Unit Tests':
     executor:
-      name: amphtml-medium-executor
+      name: docker-medium
     parallelism: 6
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'All Unit Tests'
+          name: '⭐ All Unit Tests ⭐'
           command: node build-system/pr-check/unit-tests.js
       - store_test_output
       - teardown_vm
   'Unminified Tests':
     executor:
-      name: amphtml-large-executor
+      name: docker-large
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Unminified Tests'
+          name: '⭐ Unminified Tests ⭐'
           command: node build-system/pr-check/unminified-tests.js
       - store_test_output
       - teardown_vm
   'Nomodule Tests':
     executor:
-      name: amphtml-large-executor
+      name: docker-large
     parameters:
       config:
         description: 'Which config file to use'
@@ -268,13 +284,13 @@ jobs:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Nomodule Tests (<< parameters.config >>)'
+          name: '⭐ Nomodule Tests (<< parameters.config >>) ⭐'
           command: node build-system/pr-check/nomodule-tests.js --config=<< parameters.config >>
       - store_test_output
       - teardown_vm
   'Module Tests':
     executor:
-      name: amphtml-large-executor
+      name: docker-large
     parameters:
       config:
         description: 'Which config file to use'
@@ -284,65 +300,76 @@ jobs:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Module Tests (<< parameters.config >>)'
+          name: '⭐ Module Tests (<< parameters.config >>) ⭐'
           command: node build-system/pr-check/module-tests.js --config=<< parameters.config >>
       - store_test_output
       - teardown_vm
   'End-to-End Tests':
     executor:
-      name: amphtml-medium-executor
+      name: docker-medium
     parallelism: 6
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'End-to-End Tests'
+          name: '⭐ End-to-End Tests ⭐'
           command: node build-system/pr-check/e2e-tests.js
+      - store_test_output
+      - teardown_vm
+  'Safari Tests':
+    executor:
+      name: macos-medium
+    steps:
+      - setup_vm
+      - enable_safari_automation
+      - run:
+          name: '⭐ Safari Tests ⭐'
+          command: node build-system/pr-check/safari-tests.js
       - store_test_output
       - teardown_vm
   'Performance Tests':
     executor:
-      name: amphtml-xlarge-executor
+      name: docker-xlarge
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Performance Tests'
+          name: '⭐ Performance Tests ⭐'
           command: node build-system/pr-check/performance-tests.js
       - store_test_output
       - teardown_vm
   'Experiment Build':
     executor:
-      name: amphtml-xlarge-executor
+      name: docker-xlarge
     <<: *experiment_job
     steps:
       - setup_vm
       - run:
-          name: 'Experiment << parameters.exp >> Build'
+          name: '⭐ Experiment << parameters.exp >> Build ⭐'
           command: node build-system/pr-check/experiment-build.js --experiment=experiment<< parameters.exp >>
       - teardown_vm
   'Experiment Integration Tests':
     executor:
-      name: amphtml-large-executor
+      name: docker-large
     <<: *experiment_job
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Experiment << parameters.exp >> Integration Tests'
+          name: '⭐ Experiment << parameters.exp >> Integration Tests ⭐'
           command: node build-system/pr-check/experiment-integration-tests.js --experiment=experiment<< parameters.exp >>
       - store_test_output
       - teardown_vm
   'Experiment End-to-End Tests':
     executor:
-      name: amphtml-large-executor
+      name: docker-large
     <<: *experiment_job
     parallelism: 6
     steps:
       - setup_vm
       - install_chrome
       - run:
-          name: 'Experiment << parameters.exp >> End-to-End Tests'
+          name: '⭐ Experiment << parameters.exp >> End-to-End Tests ⭐'
           command: node build-system/pr-check/experiment-e2e-tests.js --experiment=experiment<< parameters.exp >>
       - store_test_output
       - teardown_vm
@@ -426,6 +453,11 @@ workflows:
             - 'Module Build (Test)'
       - 'End-to-End Tests':
           name: '⛓️ End-to-End Tests'
+          <<: *push_and_pr_builds
+          requires:
+            - 'Nomodule Build (Test)'
+      - 'Safari Tests':
+          name: 'Safari Tests'
           <<: *push_and_pr_builds
           requires:
             - 'Nomodule Build (Test)'

--- a/.github/workflows/cross-browser-tests.yml
+++ b/.github/workflows/cross-browser-tests.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'ampproject/amphtml'
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout Repo

--- a/build-system/pr-check/safari-tests.js
+++ b/build-system/pr-check/safari-tests.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview Script that runs tests on Safari during CI.
+ */
+
+const {
+  skipDependentJobs,
+  timedExecOrDie,
+  timedExecOrThrow,
+} = require('./utils');
+const {runCiJob} = require('./ci-job');
+const {Targets, buildTargetsInclude} = require('./build-targets');
+
+const jobName = 'safari-tests.js';
+
+/**
+ * Steps to run during push builds.
+ */
+function pushBuildWorkflow() {
+  try {
+    timedExecOrThrow('amp unit --report --safari', 'Unit tests failed!');
+    timedExecOrThrow(
+      'amp integration --report --nobuild --compiled --safari',
+      'Integration tests failed!'
+    );
+    timedExecOrThrow(
+      'amp e2e --report --nobuild --compiled --browsers=safari',
+      'End-to-end tests failed!'
+    );
+  } catch (e) {
+    if (e.status) {
+      process.exitCode = e.status;
+    }
+  } finally {
+    timedExecOrDie('amp test-report-upload');
+  }
+}
+
+/**
+ * Steps to run during PR builds.
+ */
+function prBuildWorkflow() {
+  if (
+    !buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.UNIT_TEST,
+      Targets.E2E_TEST,
+      Targets.INTEGRATION_TEST
+    )
+  ) {
+    skipDependentJobs(
+      jobName,
+      'this PR does not affect the runtime, unit tests, integration tests, or end-to-end tests'
+    );
+    return;
+  }
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
+    timedExecOrDie('amp unit --safari');
+  }
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
+    timedExecOrDie('amp integration --nobuild --compiled --safari');
+  }
+  if (buildTargetsInclude(Targets.RUNTIME, Targets.E2E_TEST)) {
+    timedExecOrDie('amp e2e --nobuild --compiled --browsers=safari');
+  }
+}
+
+runCiJob(jobName, pushBuildWorkflow, prBuildWorkflow);


### PR DESCRIPTION
With all the recent work done to speed up CI, the coast is clear to start moving our cross browser tests from GH Actions to CircleCI.

**PR Highlights:**

- Move all macOS testing to CircleCI
- Reuse build output from the previous stage
- **Bonus:**
    - Clean up / standardize executor names
    - Consolidate some setup steps
    - Surround the main step of each job with ⭐ to make it easy to spot

There's no need for parallelization since only a subset of tests are run on macOS.

**References:**
- https://support.circleci.com/hc/en-us/articles/360047639331-Node-version-on-macOS-images
- https://support.circleci.com/hc/en-us/articles/360056920051--Error-untarring-cache-when-running-a-macOS-job
- https://support.circleci.com/hc/en-us/articles/360056461992-Enabling-safaridriver-support-on-macOS
