### PR TITLE
🐛 Make amp-apester-media use user error

### DIFF
--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -325,6 +325,7 @@ class AmpApesterMedia extends AMP.BaseElement {
             vsync.mutatePromise(() => {
               if (this.iframe_) {
                 this.iframe_.classList.add('i-amphtml-apester-iframe-ready');
+
                 const campaignData = media['campaignData'];
                 if (campaignData) {
                   const bottomAdOptions = campaignData['bottomAdOptions'];
@@ -339,6 +340,7 @@ class AmpApesterMedia extends AMP.BaseElement {
                       '*'
                     );
                   }
+
                   this.iframe_.contentWindow./*OK*/ postMessage(
                     /** @type {JsonObject} */ ({
                       type: 'campaigns',
@@ -348,6 +350,7 @@ class AmpApesterMedia extends AMP.BaseElement {
                   );
                 }
               }
+
               const height = media?.['data']?.['size'] ?? 0;
               if (height != this.height_) {
                 this.height_ = height;

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -351,7 +351,7 @@ class AmpApesterMedia extends AMP.BaseElement {
                 }
               }
 
-              const height = media?.['data']?.['size'] ?? 0;
+              const height = media?.['data']?.['size']?.['height'] ?? 0;
               if (height != this.height_) {
                 this.height_ = height;
                 if (this.random_) {

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -286,8 +286,8 @@ class AmpApesterMedia extends AMP.BaseElement {
   layoutCallback() {
     this.element.classList.add('amp-apester-container');
     const vsync = Services.vsyncFor(this.win);
-    return this.queryMedia_().then(
-      (response) => {
+    return this.queryMedia_()
+      .then((response) => {
         if (!response || response['status'] === 204) {
           dev().warn(TAG, 'Display', 'No Content for provided tag');
           return this.unlayoutCallback();
@@ -320,64 +320,54 @@ class AmpApesterMedia extends AMP.BaseElement {
             this.element.appendChild(iframe);
             handleCompanionAds(media, this.element);
           })
-          .then(() => {
-            return this.loadPromise(iframe).then(() => {
-              return vsync.mutatePromise(() => {
-                if (this.iframe_) {
-                  this.iframe_.classList.add('i-amphtml-apester-iframe-ready');
-                  const campaignData = media['campaignData'];
-                  if (campaignData) {
-                    const bottomAdOptions = campaignData['bottomAdOptions'];
-                    if (bottomAdOptions && bottomAdOptions.enabled) {
-                      this.hasBottomAd_ = true;
-                      const ampdoc = this.getAmpDoc();
-                      Services.extensionsFor(
-                        this.win
-                      )./*OK*/ installExtensionForDoc(ampdoc, AD_TAG);
-                      this.iframe_.contentWindow./*OK*/ postMessage(
-                        BOTTOM_AD_MESSAGE,
-                        '*'
-                      );
-                    }
+          .then(() => this.loadPromise(iframe))
+          .then(() =>
+            vsync.mutatePromise(() => {
+              if (this.iframe_) {
+                this.iframe_.classList.add('i-amphtml-apester-iframe-ready');
+                const campaignData = media['campaignData'];
+                if (campaignData) {
+                  const bottomAdOptions = campaignData['bottomAdOptions'];
+                  if (bottomAdOptions?.enabled) {
+                    this.hasBottomAd_ = true;
+                    const ampdoc = this.getAmpDoc();
+                    Services.extensionsFor(
+                      this.win
+                    )./*OK*/ installExtensionForDoc(ampdoc, AD_TAG);
                     this.iframe_.contentWindow./*OK*/ postMessage(
-                      /** @type {JsonObject} */ ({
-                        type: 'campaigns',
-                        data: campaignData,
-                      }),
+                      BOTTOM_AD_MESSAGE,
                       '*'
                     );
                   }
+                  this.iframe_.contentWindow./*OK*/ postMessage(
+                    /** @type {JsonObject} */ ({
+                      type: 'campaigns',
+                      data: campaignData,
+                    }),
+                    '*'
+                  );
                 }
-                let height = 0;
-                if (media && media['data'] && media['data']['size']) {
-                  height = media['data']['size']['height'];
+              }
+              const height = media?.['data']?.['size'] ?? 0;
+              if (height != this.height_) {
+                this.height_ = height;
+                if (this.random_) {
+                  this.attemptChangeHeight(height);
+                } else {
+                  this.forceChangeHeight(height);
                 }
-                if (height != this.height_) {
-                  this.height_ = height;
-                  if (this.random_) {
-                    this.attemptChangeHeight(height);
-                  } else {
-                    this.forceChangeHeight(height);
-                  }
-                }
-              });
-            });
-          })
+              }
+            })
+          )
           .then(() => {
             observeWithSharedInOb(this.element, (inViewport) =>
               this.viewportCallback_(inViewport)
             );
-          })
-          .catch((error) => {
-            dev().error(TAG, 'Display', error);
-            return undefined;
           });
-      },
-      (error) => {
-        dev().error(TAG, 'Display', error);
-        return undefined;
-      }
-    );
+      })
+      .catch((error) => {
+        user().error(TAG, 'Display', error);
+      });
   }
 
   /** @override */

--- a/extensions/amp-apester-media/0.1/amp-apester-media.js
+++ b/extensions/amp-apester-media/0.1/amp-apester-media.js
@@ -22,7 +22,7 @@ import {
   getLengthNumeral,
   isLayoutSizeDefined,
 } from '#core/dom/layout';
-import {dev, userAssert} from '../../../src/log';
+import {dev, user, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {
   extractTags,


### PR DESCRIPTION
Makes #35457 a user error.

Also, there were a lot of nested promises. This PR turns them into chained promises. Took a stab at it, feel free to take over the PR.
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
