### PR TITLE
babel: teach amp mode transformer about #core/mode

### DIFF
--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/no-transform/input.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/no-transform/input.js
@@ -18,6 +18,7 @@ const test = getMode().test;
 const localDev = getMode().localDev;
 const minified = getMode().minified;
 const development = getMode().development;
+const namespaceVersion = mode.version();
 
 function getMode() {
   return {};

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/no-transform/output.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/no-transform/output.js
@@ -17,6 +17,7 @@ const test = getMode().test;
 const localDev = getMode().localDev;
 const minified = getMode().minified;
 const development = getMode().development;
+const namespaceVersion = mode.version();
 
 function getMode() {
   return {};

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/input.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/input.js
@@ -15,12 +15,14 @@
  */
 
 import { getMode } from '../../../../../../../src/mode';
+import * as mode from '#core/mode';
 
 const test = getMode().test;
 const localDev = getMode().localDev;
 const minified = getMode().minified;
 const development = getMode().development;
 const version = getMode().version;
+const namespaceVersion = mode.version();
 
 function foo() {
   if (getMode().development == false) {

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/transform/output.mjs
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 import { getMode } from '../../../../../../../src/mode';
+import * as mode from '#core/mode';
 const test = false;
 const localDev = false;
 const minified = true;
 const development = false;
 const version = "$internalRuntimeVersion$";
+const namespaceVersion = "$internalRuntimeVersion$";
 
 function foo() {
   if (false == false) {


### PR DESCRIPTION
**summary**
Blocks https://github.com/ampproject/amphtml/pull/35298

Teaches amp mode transformer how to inline `mode.version()`.

cc @ampproject/wg-performance 