### PR TITLE
Improve screen orientation locking for stories

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -965,6 +965,7 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     const lockOrientation =
+      screen.orientation.lock ||
       screen.lockOrientation ||
       screen.mozLockOrientation ||
       screen.msLockOrientation ||


### PR DESCRIPTION
Prefer [`screen.orientation.lock`](https://developer.mozilla.org/en-US/docs/Web/API/ScreenOrientation/lock) to [`screen.lockOrientation`](https://developer.mozilla.org/en-US/docs/Web/API/Screen/lockOrientation).