### PR TITLE
🏗 Allow the bundle-size job to run even if the builds were skipped

### DIFF
--- a/build-system/pr-check/bundle-size-module-build.js
+++ b/build-system/pr-check/bundle-size-module-build.js
@@ -44,7 +44,11 @@ function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME)) {
     pushBuildWorkflow();
   } else {
-    skipDependentJobs(jobName, 'this PR does not affect the runtime');
+    skipDependentJobs(
+      jobName,
+      'this PR does not affect the runtime',
+      /* gracefullyHaltNextJobs= */ false
+    );
   }
 }
 

--- a/build-system/pr-check/bundle-size-nomodule-build.js
+++ b/build-system/pr-check/bundle-size-nomodule-build.js
@@ -44,7 +44,11 @@ function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME)) {
     pushBuildWorkflow();
   } else {
-    skipDependentJobs(jobName, 'this PR does not affect the runtime');
+    skipDependentJobs(
+      jobName,
+      'this PR does not affect the runtime',
+      /* gracefullyHaltNextJobs= */ false
+    );
   }
 }
 

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -138,13 +138,16 @@ function signalGracefulHalt() {
  * for skipping.
  * @param {string} jobName
  * @param {string} skipReason
+ * @param {boolean} gracefullyHaltNextJobs true to signal to downstreams jobs that they too should be skipped.
  */
-function skipDependentJobs(jobName, skipReason) {
+function skipDependentJobs(jobName, skipReason, gracefullyHaltNextJobs = true) {
   const loggingPrefix = getLoggingPrefix();
   logWithoutTimestamp(
     `${loggingPrefix} Skipping ${cyan(jobName)} because ${skipReason}.`
   );
-  signalGracefulHalt();
+  if (gracefullyHaltNextJobs) {
+    signalGracefulHalt();
+  }
 }
 
 /**


### PR DESCRIPTION
This is required for PRs that _do not_ change the RUNTIME target, because we still need to call `amp bundle-size --on_skipped_build`

/cc @samouri 