### PR TITLE
Update ad example for remote auto ads config

### DIFF
--- a/examples/amp-story/ads/remote.json
+++ b/examples/amp-story/ads/remote.json
@@ -1,6 +1,6 @@
 {
   "ad-attributes": {
     "type": "doubleclick",
-    "data-slot": "/30497360/a4a/story_360"
+    "data-slot": "/30497360/a4a/amp_story_dfp_example"
   }
 }

--- a/examples/amp-story/story-ad-remote-config.html
+++ b/examples/amp-story/story-ad-remote-config.html
@@ -29,7 +29,7 @@
 <body>
   <amp-story standalone supports-landscape>
     <!--
-      This is an example of JSON retrived from a source file.
+      This is an example of JSON retrieved from a source file.
     -->
     <amp-story-auto-ads src="/examples/amp-story/ads/remote.json" >
     </amp-story-auto-ads>

--- a/src/utils/dom-ancestor-visitor.js
+++ b/src/utils/dom-ancestor-visitor.js
@@ -28,7 +28,7 @@ export let VisitorCallbackTypeDef;
  * Utility class that will visit every ancestor of a given element, and call
  * the provided callback functions on each element, passing in the element and
  * its computed styles as arguments to the callbacks. Callbacks may cease
- * visiting further nodes by returning a value, which may later be retrived by
+ * visiting further nodes by returning a value, which may later be retrieved by
  * calling 'getValueFor(visitorName)'. Once all visitors have returned or hit
  * their maximum nodes to visit, no more nodes will be visited.
  *


### PR DESCRIPTION
🐛 Bug fix

Updated ad example for remote auto ads config to use a working ad that will always show up,
regardless of user preferences or settings. This was due to the ad not showing up in the safari browser.
Tested and works now with chrome and safari.