### PR TITLE
Updated document with use cases of remote config

### DIFF
--- a/extensions/amp-story-auto-ads/amp-story-auto-ads.md
+++ b/extensions/amp-story-auto-ads/amp-story-auto-ads.md
@@ -51,7 +51,7 @@ right part of the screen.
 
 There are two ways of configuring an ad:
 **Inline**
-and 
+and
 **Remote**
 
 ### Inline Ad Config
@@ -119,7 +119,6 @@ in the `<amp-story-auto-ads>` element as shown here:
       This is an example of JSON retrieved from a source file.
     -->
     <amp-story-auto-ads src="/examples/amp-story/ads/remote.json" ></amp-story-auto-ads>
-    
     <amp-story-page id="page-1">
     .
     .

--- a/extensions/amp-story-auto-ads/amp-story-auto-ads.md
+++ b/extensions/amp-story-auto-ads/amp-story-auto-ads.md
@@ -49,7 +49,10 @@ right part of the screen.
 
 ## Configuration
 
-There are two ways of configuring an ad: inline and remote:
+There are two ways of configuring an ad: 
+**Inline**
+and 
+**Remote**
 
 ### Inline Ad Config
 

--- a/extensions/amp-story-auto-ads/amp-story-auto-ads.md
+++ b/extensions/amp-story-auto-ads/amp-story-auto-ads.md
@@ -95,7 +95,7 @@ here, as ads in stories will only be displayed once fully rendered.
 Instead of adding in the JSON configuration file inside a script tag (as shown in the Inline Ad Config section),
 One may also host the remote URL using a
 
-[emote JSON ad configuration file](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/ads/remote.json)
+[Remote JSON ad configuration file](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/ads/remote.json)
 
 ```json
 {

--- a/extensions/amp-story-auto-ads/amp-story-auto-ads.md
+++ b/extensions/amp-story-auto-ads/amp-story-auto-ads.md
@@ -49,6 +49,10 @@ right part of the screen.
 
 ## Configuration
 
+There are two ways of configuring an ad: inline and remote:
+
+### Inline Ad Config
+
 In the `<amp-story-auto-ads>` element, you specify a JSON configuration object
 that contains the details for how ads should be fetched and displayed, which
 looks like the following:
@@ -82,6 +86,43 @@ a [ad served by doubleclick](../../extensions/amp-ad-network-doubleclick-impl/am
 
 Unlike normal `amp-ad`, no `<fallback>` or `<placeholder>` needs to be specified
 here, as ads in stories will only be displayed once fully rendered.
+
+### Remote Ad Config
+
+Instead of adding in the JSON configuration file inside a script tag (as shown in the Inline Ad Config section),
+One may also host the remote URL using a
+
+[remote JSON ad Configuration file](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/ads/remote.json) 
+
+```json
+{
+  "ad-attributes": {
+    "type": "doubleclick",
+    "data-slot": "/30497360/a4a/amp_story_dfp_example"
+  }
+}
+
+```
+
+Once you have your JSON configuration file setup, simply use the
+
+[html ad config code to retrive the remote URL:]( https://github.com/ampproject/amphtml/blob/main/examples/amp-story/story-ad-remote-config.html )
+
+in the `<amp-story-auto-ads>` element as shown here:
+
+```html
+<amp-story standalone supports-landscape>
+    <!--
+      This is an example of JSON retrieved from a source file.
+    -->
+    <amp-story-auto-ads src="/examples/amp-story/ads/remote.json" ></amp-story-auto-ads>
+    
+    <amp-story-page id="page-1">
+    .
+    .
+    .
+</amp-story>
+```
 
 ### Passing additional attributes (RTC, Targeting, etc.)
 

--- a/extensions/amp-story-auto-ads/amp-story-auto-ads.md
+++ b/extensions/amp-story-auto-ads/amp-story-auto-ads.md
@@ -49,7 +49,7 @@ right part of the screen.
 
 ## Configuration
 
-There are two ways of configuring an ad: 
+There are two ways of configuring an ad:
 **Inline**
 and 
 **Remote**
@@ -95,7 +95,7 @@ here, as ads in stories will only be displayed once fully rendered.
 Instead of adding in the JSON configuration file inside a script tag (as shown in the Inline Ad Config section),
 One may also host the remote URL using a
 
-[remote JSON ad Configuration file](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/ads/remote.json) 
+[emote JSON ad configuration file](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/ads/remote.json)
 
 ```json
 {
@@ -109,7 +109,7 @@ One may also host the remote URL using a
 
 Once you have your JSON configuration file setup, simply use the
 
-[html ad config code to retrive the remote URL:]( https://github.com/ampproject/amphtml/blob/main/examples/amp-story/story-ad-remote-config.html )
+[html ad config code to retrive the remote URL:](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/story-ad-remote-config.html)
 
 in the `<amp-story-auto-ads>` element as shown here:
 


### PR DESCRIPTION
📖 Documentation

Fixes #35425 by adding in an example of who to use the remote config for the amp story auto ads component.