### PR TITLE
🐛 amp-minute-media-player: fix document formatting

### DIFF
--- a/extensions/amp-minute-media-player/amp-minute-media-player.md
+++ b/extensions/amp-minute-media-player/amp-minute-media-player.md
@@ -111,7 +111,7 @@ Example with FIXED layout - fixed width and height.
        <li>Multiple videos on the same page can be docked.</li>
      </ul>
      In order to use this attribute, the amp-video-docking extension script must be present:
-     <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"></script>
+     <code>&lt;script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"&gt;&lt;/script&gt;</code>
 </p>
     </td>
   </tr>


### PR DESCRIPTION
This fixes a false import in the documentation on amp.dev that causes the page to be invalid.

https://amp.dev/documentation/components/amp-minute-media-player/

/cc @sebastianbenz @matthiasrohmer