### PR TITLE
🐛 amp-story-grid-layer: Fix AMP invalidation error in documentation

### DIFF
--- a/extensions/amp-story-interactive/amp-story-interactive.md
+++ b/extensions/amp-story-interactive/amp-story-interactive.md
@@ -30,11 +30,11 @@ limitations under the License.
 
 The `amp-story-interactive` component provides a set of experiences, such as quizzes or polls, in [Web Stories](https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/?format=stories).
 
-<div layout="container" width="3" height="2">
+<amp-layout layout="container" width="3" height="2">
 <div style="width:32%;display:inline-block"><amp-img src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-story-interactive/img/quiz-art.png" layout="responsive" width="200" height="350"/></div>
 <div style="width:32%;display:inline-block"><amp-img src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-story-interactive/img/animal-poll.png" layout="responsive" width="200" height="350"/></div>
 <div style="width:32%;display:inline-block"><amp-img src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-story-interactive/img/results-art.png" layout="responsive" width="200" height="350"/></div>
-</div>
+</amp-layout>
 
 ## Usage
 

--- a/extensions/amp-story/amp-story-grid-layer.md
+++ b/extensions/amp-story/amp-story-grid-layer.md
@@ -435,11 +435,11 @@ While this technique provides the most consistent user experience, it may crop u
 This preset may show letterboxing on devices that don't have conventional phone screen sizes, such as tablets or foldable phones. You may change the background color of your pages to match the background for the best visual outcome.
 [/tip]
 
-<div layout="container" width="3" height="2">
+<amp-layout layout="container" width="3" height="2">
   <div style="width:33%;display:inline-block">
     <amp-img src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-story/img/preset_story_scaled.gif" layout="responsive" alt="Animation showing how a perfectly scaled with a 7.2% bleed-area adapts to different screen aspect ratios, always keeping content visible" width="200" height="350"/>
   </div>
   <div style="width:66%;display:inline-block">
     <amp-img src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-story/img/preset_story_anchor.gif" layout="responsive" alt="Animation showing a background that remains anchored to the bottom of the viewport, regardless of screen aspect ratio/height" width="500" height="400"/>
   </div>
-</div>
+</amp-layout>


### PR DESCRIPTION
Use ```amp-layout``` instead of ```div``` to fix invalidation issues on https://amp.dev/documentation/components/amp-story-grid-layer/.

/cc @sebastianbenz @matthiasrohmer