### PR TITLE
build: run amp lint --fix to address import order of jixie

### DIFF
--- a/3p/vendors/jixie.js
+++ b/3p/vendors/jixie.js
@@ -17,8 +17,8 @@
 // src/polyfills.js must be the first import.
 import '#3p/polyfills';
 
-import {draw3p, init} from '#3p/integration-lib';
 import {register} from '#3p/3p';
+import {draw3p, init} from '#3p/integration-lib';
 
 import {jixie} from '#ads/vendors/jixie';
 init(window);


### PR DESCRIPTION
**summary**
Generated via `amp lint --fix`

**timeline**
- Jixie PR is created and makes modifications (https://github.com/ampproject/amphtml/pull/35128)
- `eslint`  rules update PR is created (https://github.com/ampproject/amphtml/pull/35454)
- Jixie PR merges (https://github.com/ampproject/amphtml/commit/2d970c1c465c9529c583d470865d71fef10df774)
- `eslint` PR merges...but new rules weren't checked against recent changes (https://github.com/ampproject/amphtml/commit/2d970c1c465c9529c583d470865d71fef10df774).


Fix after created a new lint rule.

![Screen Shot 2021-08-03 at 4 47 45 PM](https://user-images.githubusercontent.com/4656974/128084025-3e0ee2cb-9d47-4892-ad24-88f337b0f7d7.png)
