### PR TITLE
🐛 amp-subscriptions: Fix img attributes in documentation

### DIFF
--- a/extensions/amp-subscriptions/amp-subscriptions.md
+++ b/extensions/amp-subscriptions/amp-subscriptions.md
@@ -415,7 +415,7 @@ By default, as the body, pingback POST request receives the entitlement object r
 
 To accurately identify the Reader, the Publisher should associate the [AMP Reader ID][1] with any Publisher cookies relevant to the Reader.
 
-<amp-img alt="reader id cookie association" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-subscriptions/images/reader-id-assoociation.png">
+<amp-img alt="reader id cookie association" layout="responsive" width="1195" height="1148" src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-subscriptions/images/reader-id-assoociation.png">
   <noscript>
     <img alt="reader id cookie association" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-subscriptions/images/reader-id-assoociation.png">
   </noscript>

--- a/extensions/amp-subscriptions/amp-subscriptions.md
+++ b/extensions/amp-subscriptions/amp-subscriptions.md
@@ -417,7 +417,7 @@ To accurately identify the Reader, the Publisher should associate the [AMP Reade
 
 <amp-img alt="reader id cookie association" layout="responsive" width="1195" height="1148" src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-subscriptions/images/reader-id-assoociation.png">
   <noscript>
-    <img alt="reader id cookie association" layout="responsive" src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-subscriptions/images/reader-id-assoociation.png">
+    <img alt="reader id cookie association" src="https://github.com/ampproject/amphtml/raw/main/extensions/amp-subscriptions/images/reader-id-assoociation.png">
   </noscript>
 </amp-img>
 


### PR DESCRIPTION
* Removes unsupported ```layout="responsive"``` from ```img```-tag
* Adds mandatory ```width``` and ```height``` to ```amp-img```-tag

/cc @sebastianbenz @matthiasrohmer 