### PR TITLE
🏗 Update forbidden terms for matching and check in test folders

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -52,7 +52,8 @@ const realiasGetMode =
  *   check term in files whose path includes /test/ (false by default)
  *
  * - checkProse:
- *   check term in comments and documentation (.md) (false by default)
+ *   check term in comments and documentation (.md)
+ *   (false by default, implies `checkInTestFolder`)
  */
 let ForbiddenTermDef;
 
@@ -64,15 +65,15 @@ const forbiddenTermsGlobal = {
   'DO NOT SUBMIT': {
     checkProse: true,
   },
-  'whitelist|white-list': {
+  'white[-\\s]*list': {
     message: 'Please use the term allowlist instead',
     checkProse: true,
   },
-  'blacklist|black-list': {
+  'black[-\\s]*list': {
     message: 'Please use the term denylist instead',
     checkProse: true,
   },
-  'grandfather|grandfathered': {
+  'grandfather': {
     message: 'Please use the term legacy instead',
     checkProse: true,
   },
@@ -1129,7 +1130,7 @@ function matchForbiddenTerms(srcFile, contents, terms) {
       // if needed but that might be too permissive.
       if (
         (Array.isArray(allowlist) && allowlist.indexOf(srcFile) != -1) ||
-        (isInTestFolder(srcFile) && !checkInTestFolder) ||
+        (isInTestFolder(srcFile) && !checkInTestFolder && !checkProse) ||
         (srcFile.endsWith('.md') && !checkProse)
       ) {
         return [];

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -111,9 +111,9 @@ describes.realWin(
         });
         const iframe = yt.querySelector('iframe');
         expect(iframe.src).to.contain('myParam=hello%20world');
-        // data-param-autoplay is black listed in favor of just autoplay
+        // data-param-autoplay is disallowed in favor of just autoplay
         expect(iframe.src).to.not.contain('autoplay=1');
-        // data-param-loop is black listed in favor of just loop for single videos
+        // data-param-loop is disallowed in favor of just loop for single videos
         expect(iframe.src).to.not.contain('loop=1');
         // playsinline should default to 1 if not provided.
         expect(iframe.src).to.contain('playsinline=1');

--- a/extensions/amp-youtube/1.0/test/test-component.js
+++ b/extensions/amp-youtube/1.0/test/test-component.js
@@ -78,8 +78,9 @@ describes.realWin('YouTube preact component v1.0', {}, (env) => {
     const iframe = wrapper.find('iframe');
 
     expect(iframe.prop('src')).to.contain('&myparam=hello%20world');
+    // data-param-autoplay is disallowed in favor of just autoplay
     expect(iframe.prop('src')).to.not.contain('autoplay=1');
-    // data-param-loop is black listed in favor of just loop for single videos
+    // data-param-loop is disallowed in favor of just loop for single videos
     expect(iframe.prop('src')).to.not.contain('loop=1');
     // playsinline should default to 1 if not provided.
     expect(iframe.prop('src')).to.contain('playsinline=1');


### PR DESCRIPTION
1. Update some non-inclusive terms to match spellings that were missed.
1. Update `checkProse` so that it implies `checkInTestFolder`, since prose can occur anywhere.
1. Update files to remove non-inclusive terms.
