### PR TITLE
🐛  performance-impl: origin should use value directly from PO

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -736,8 +736,11 @@ export class Performance {
       opt_delta == undefined ? this.win.performance.now() : opt_delta;
     const end = this.timeOrigin_ + delta;
 
-    // Order is timeOrigin -> firstVisibleTime -> end.
-    const visibleTime = this.ampdoc_ && this.ampdoc_.getFirstVisibleTime();
+    // If on Origin, use timeOrigin
+    // If in a viewer, use firstVisibleTime
+    const visibleTime = this.viewer_?.isEmbedded()
+      ? this.ampdoc_ && this.ampdoc_.getFirstVisibleTime()
+      : this.timeOrigin_;
     const v = visibleTime ? Math.max(end - visibleTime, 0) : 0;
     this.tickDelta(label, v);
   }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -739,7 +739,7 @@ export class Performance {
     // If on Origin, use timeOrigin
     // If in a viewer, use firstVisibleTime
     const visibleTime = this.viewer_?.isEmbedded()
-      ? this.ampdoc_ && this.ampdoc_.getFirstVisibleTime()
+      ? this.ampdoc_?.getFirstVisibleTime()
       : this.timeOrigin_;
     const v = visibleTime ? Math.max(end - visibleTime, 0) : 0;
     this.tickDelta(label, v);

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -316,19 +316,20 @@ describes.realWin('performance', {amp: true}, (env) => {
           env.sandbox
             .stub(ampdoc, 'getFirstVisibleTime')
             .callsFake(() => firstVisibleTime);
+          perf.coreServicesAvailable();
+          perf.viewer_ = {isEmbedded: () => true};
         });
 
-        it('should always be zero before viewer is set', () => {
+        it('should not offset by visible time when viewer is not set', () => {
+          perf.viewer_ = {isEmbedded: () => false};
           clock.tick(10);
           perf.tickSinceVisible('test');
 
           expect(tickDeltaStub).to.have.been.calledOnce;
-          expect(tickDeltaStub.firstCall.args[1]).to.equal(0);
+          expect(tickDeltaStub.firstCall.args[1]).to.equal(10);
         });
 
         it('should always be zero before visible', () => {
-          perf.coreServicesAvailable();
-
           clock.tick(10);
           perf.tickSinceVisible('test');
 
@@ -337,7 +338,6 @@ describes.realWin('performance', {amp: true}, (env) => {
         });
 
         it('should calculate after visible', () => {
-          perf.coreServicesAvailable();
           firstVisibleTime = timeOrigin + 5;
 
           clock.tick(10);
@@ -348,7 +348,6 @@ describes.realWin('performance', {amp: true}, (env) => {
         });
 
         it('should be zero after visible but for earlier event', () => {
-          perf.coreServicesAvailable();
           firstVisibleTime = timeOrigin + 5;
 
           // An earlier event, since event time (4) is less than visible time (5).


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/34383.

As reported by @diasflack,
> Maybe, the solution will be to design slightly different logic for not Embedded pages.

cc @ampproject/wg-performance 