### PR TITLE
dep-check: change to use sync methods

### DIFF
--- a/build-system/tasks/dep-check.js
+++ b/build-system/tasks/dep-check.js
@@ -173,12 +173,12 @@ const rules = depCheckConfig.rules.map((config) => new Rule(config));
  */
 async function getEntryPointModule() {
   const coreBinaries = ['src/amp.js', '3p/integration.js'];
-  const extensions = await fs.promises.readdir('extensions');
+  const extensions = fs.readdirSync('extensions');
   const extensionEntryPoints = extensions
     .map((x) => `extensions/${x}`)
     .filter((x) => fs.statSync(x).isDirectory())
     .map(getEntryPoint);
-  const vendors = await fs.promises.readdir('3p/vendors');
+  const vendors = fs.readdirSync('3p/vendors');
   const vendorEntryPoints = vendors.map((x) => `3p/vendors/${x}`);
   const allEntryPoints = flatten(extensionEntryPoints)
     .concat(coreBinaries)


### PR DESCRIPTION
Did not notice comments on https://github.com/ampproject/amphtml/pull/35367

This PR addresses it.