### PR TITLE
Added logic to delay resize requests to be made after an invalid request for amp ad context.requestRezise

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -46,12 +46,9 @@ export class AbstractAmpContext {
     // This varaible keeps keeps track when an invalid resize request is made, and
     // is associated with each iframe. If the request is invalid, then a new request
     // cannot be made until a certain amount of time has passed, 500 ms by default
-    //(see msecRepeatedRequestDelay_). Once the timer has cooled down, a new request can be made.
+    //(see msecRepeatedRequestDelay). Once the timer has cooled down, a new request can be made.
     /** @private {?boolean} */
     this.blockRepeatedInvalidRequests_ = false;
-
-    /** @private {?number} */
-    this.msecRepeatedRequestDelay_ = 500;
 
     /** @protected {?string} */
     this.embedType_ = null;
@@ -276,9 +273,10 @@ export class AbstractAmpContext {
       const id = data['id'];
       if (id !== undefined) {
         this.blockRepeatedInvalidRequests_ = true;
+        const msecRepeatedRequestDelay = 500;
         setTimeout(() => {
           this.blockRepeatedInvalidRequests_ = false;
-        }, this.msecRepeatedRequestDelay_);
+        }, msecRepeatedRequestDelay);
 
         this.resizeIdToDeferred_[id].reject('Resizing is denied');
         delete this.resizeIdToDeferred_[id];

--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -43,7 +43,7 @@ export class AbstractAmpContext {
     /** @private {?string} */
     this.cachedFrameName_ = this.win_.name || null;
 
-    // This varaible keeps keeps track when an invalid resize request is made, and
+    // This variable keeps keeps track when an invalid resize request is made, and
     // is associated with each iframe. If the request is invalid, then a new request
     // cannot be made until a certain amount of time has passed, 500 ms by default
     //(see msecRepeatedRequestDelay). Once the timer has cooled down, a new request can be made.

--- a/test/unit/test-amp-context.js
+++ b/test/unit/test-amp-context.js
@@ -347,6 +347,14 @@ describes.sandboxed('3p ampcontext.js', {}, (env) => {
       //will block requests for the next 500ms since the last request was invalid.
       expect(context.blockRepeatedInvalidRequests_).equal(true);
 
+      env.sandbox
+        .stub(context, 'requestResize')
+        .returns(
+          Promise.reject(
+            'Resizing is denied, recent invalid request parameters'
+          )
+        );
+
       clock.tick(100);
       expect(context.blockRepeatedInvalidRequests_).equal(true);
       clock.tick(100);

--- a/test/unit/test-amp-context.js
+++ b/test/unit/test-amp-context.js
@@ -354,18 +354,11 @@ describes.sandboxed('3p ampcontext.js', {}, (env) => {
             'Resizing is denied, recent invalid request parameters'
           )
         );
-
-      clock.tick(100);
-      expect(context.blockRepeatedInvalidRequests_).equal(true);
-      clock.tick(100);
-      expect(context.blockRepeatedInvalidRequests_).equal(true);
-      clock.tick(100);
-      expect(context.blockRepeatedInvalidRequests_).equal(true);
-      clock.tick(100);
-      expect(context.blockRepeatedInvalidRequests_).equal(true);
-      clock.tick(100);
-      //after 500msec delay (context.msecRepeatedRequestDelay_), requests should be clear to go again.
+      clock.tick(500);
       expect(context.blockRepeatedInvalidRequests_).equal(false);
+
+      //after 500msec delay (context.msecRepeatedRequestDelay_), requests should be clear to go again.
+      env.sandbox.stub(context, 'requestResize').returns(Promise.accept());
     });
 
     // send a resize success message down

--- a/test/unit/test-amp-context.js
+++ b/test/unit/test-amp-context.js
@@ -355,10 +355,8 @@ describes.sandboxed('3p ampcontext.js', {}, (env) => {
           )
         );
       clock.tick(500);
-      expect(context.blockRepeatedInvalidRequests_).equal(false);
-
       //after 500msec delay (context.msecRepeatedRequestDelay_), requests should be clear to go again.
-      env.sandbox.stub(context, 'requestResize').returns(Promise.accept());
+      expect(context.blockRepeatedInvalidRequests_).equal(false);
     });
 
     // send a resize success message down


### PR DESCRIPTION
✨ New feature

Added logic to delay resize requests to be made after an invalid request is made until 500ms passes, to prevent the iframe from making multiple invalid requests in a row.

See #25894