### PR TITLE
🚮 Remove `tcf-post-message-proxy-api` experiment

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -15,7 +15,6 @@
   "amp-cid-backup": 1,
   "flexible-bitrate": 0.1,
   "layout-aspect-ratio-css": 1,
-  "tcf-post-message-proxy-api": 1,
   "disable-a4a-non-sd": 1,
   "story-ad-auto-advance": 1,
   "story-ad-placements": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -13,7 +13,6 @@
   "ios-fixed-no-transfer": 0,
   "layout-aspect-ratio-css": 0,
   "disable-a4a-non-sd": 1,
-  "tcf-post-message-proxy-api": 1,
   "amp-cid-backup": 1,
   "story-ad-placements": 0.01,
   "story-disable-animations-first-page": 0.5,

--- a/examples/amp-consent/amp-consent-3p-postmessage.html
+++ b/examples/amp-consent/amp-consent-3p-postmessage.html
@@ -8,11 +8,6 @@
     <script async custom-element="amp-video-iframe" src="https://cdn.ampproject.org/v0/amp-video-iframe-0.1.js"></script>
     <script async custom-element="amp-consent" src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"></script>
     <script async src="https://cdn.ampproject.org/v0.js"></script>
-    <script>
-      (self.AMP = self.AMP || []).push(function(AMP) {
-        AMP.toggleExperiment('tcf-post-message-proxy-api', true);
-      });
-    </script>
     <style amp-custom>
       body {
         max-width: 527px;

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -969,10 +969,10 @@ export class AmpConsent extends AMP.BaseElement {
     this.tcfApiCommandManager_ = new TcfApiCommandManager(
       this.consentPolicyManager_
     );
-    // Add window listener for 3p iframe PostMessages
+    // Add window listener for 3p iframe postMessages
     this.win.addEventListener('message', (e) => this.handleTcfMessages_(e));
 
-    // Set up the __tcfApiLocator window to singal PostMessage support
+    // Set up the __tcfApiLocator window to signal postMessage support
     const iframe = this.element.ownerDocument.createElement('iframe');
     iframe.setAttribute('name', TCF_API_LOCATOR);
     iframe.setAttribute('aria-hidden', 'true');

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -52,8 +52,6 @@ import {getServicePromiseForDoc} from '../../../src/service-helpers';
 import {isArray, isEnumValue, isObject} from '#core/types';
 import {realChildElements} from '#core/dom/query';
 
-import {isExperimentOn} from '#experiments';
-
 import {toggle} from '#core/dom/style';
 
 const CONSENT_STATE_MANAGER = 'consentStateManager';
@@ -125,10 +123,12 @@ export class AmpConsent extends AMP.BaseElement {
     this.matchedGeoGroup_ = null;
 
     /** @private {?boolean} */
-    this.isTcfPostMessageProxyExperimentOn_ = isExperimentOn(
+    this.isTcfPostMessageProxyExperimentOn_ =
+      /* isExperimentOn(
       this.win,
       'tcf-post-message-proxy-api'
-    );
+    ) // launched: true */
+      true;
 
     /** @private {?Promise<?Array>} */
     this.purposeConsentRequired_ = null;

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -970,7 +970,7 @@ export class AmpConsent extends AMP.BaseElement {
       this.consentPolicyManager_
     );
     // Add window listener for 3p iframe postMessages
-    this.win.addEventListener('message', (e) => this.handleTcfMessages_(e));
+    this.win.addEventListener('message', (e) => this.handleTcfMessage_(e));
 
     // Set up the __tcfApiLocator window to signal postMessage support
     const iframe = this.element.ownerDocument.createElement('iframe');
@@ -996,7 +996,7 @@ export class AmpConsent extends AMP.BaseElement {
    *
    * @param {!Event} event
    */
-  handleTcfMessages_(event) {
+  handleTcfMessage_(event) {
     const data = getData(event);
 
     if (!data || !data['__tcfapiCall']) {

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -937,13 +937,6 @@ describes.realWin(
       let ampConsent;
       let consentElement;
 
-      beforeEach(() => {});
-
-      afterEach(() => {
-        /* toggleExperiment(win, 'tcf-post-message-proxy-api', false) // launched: true */
-        false;
-      });
-
       describe('config', () => {
         it('shoud expose if in config', async () => {
           consentElement = createConsentElement(

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -35,7 +35,6 @@ import {
   resetServiceForTesting,
 } from '../../../../src/service-helpers';
 import {removeSearch} from '../../../../src/url';
-import {toggleExperiment} from '#experiments';
 import {xhrServiceForTesting} from '#service/xhr-impl';
 
 describes.realWin(
@@ -938,12 +937,11 @@ describes.realWin(
       let ampConsent;
       let consentElement;
 
-      beforeEach(() => {
-        toggleExperiment(win, 'tcf-post-message-proxy-api', true);
-      });
+      beforeEach(() => {});
 
       afterEach(() => {
-        toggleExperiment(win, 'tcf-post-message-proxy-api', false);
+        /* toggleExperiment(win, 'tcf-post-message-proxy-api', false) // launched: true */
+        false;
       });
 
       describe('config', () => {

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -179,11 +179,6 @@ export const EXPERIMENTS = [
     spec: 'https://github.com/ampproject/amphtml/issues/30291',
   },
   {
-    id: 'tcf-post-message-proxy-api',
-    name: 'Proxy for TCF PostMessageAPI to send TCData to 3p iframes',
-    spec: 'https://github.com/ampproject/amphtml/issues/30385',
-  },
-  {
     id: 'dfp-render-on-idle-cwv-exp',
     name: 'To measure the CWV impact of ads idle rendering',
     spec: 'https://github.com/ampproject/amphtml/issues/31436',


### PR DESCRIPTION
Launched ~5 months ago, getting ahead of the automated removal at the beginning of next month.
