### PR TITLE
Validate `amp-base-carousel` and friends to enable `loop` on empty value

### DIFF
--- a/examples/bento/lazy-v0.html
+++ b/examples/bento/lazy-v0.html
@@ -46,7 +46,7 @@
     ></amp-social-share>
   </div>
 
-  <amp-base-carousel id="carousel-1" width="400" height="300" layout="responsive" loop="true">
+  <amp-base-carousel id="carousel-1" width="400" height="300" layout="responsive" loop>
     <img src="img/hero@1x.jpg">
     <img src="img/sea@1x.jpg">
   </amp-base-carousel>

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -137,7 +137,7 @@ class AmpCarousel extends AMP.BaseElement {
         this.carousel_.updateHorizontal(newValue === 'true');
       },
       'loop': (newValue) => {
-        this.carousel_.updateLoop(newValue === 'true');
+        this.carousel_.updateLoop(newValue === 'true' || newValue === '');
       },
       'mixed-length': (newValue) => {
         this.carousel_.updateMixedLength(newValue === 'true');

--- a/extensions/amp-base-carousel/0.1/test/validator-amp-base-carousel.html
+++ b/extensions/amp-base-carousel/0.1/test/validator-amp-base-carousel.html
@@ -70,6 +70,9 @@
     <!-- Valid: integer values with multiple media queries -->
     <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
     </amp-base-carousel>
+    <!-- Valid: no value for loop -->
+    <amp-base-carousel width="4" height="3" loop>
+    </amp-base-carousel>
     <!-- Invalid: no default value-->
     <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) 3">
     </amp-base-carousel>

--- a/extensions/amp-base-carousel/0.1/test/validator-amp-base-carousel.out
+++ b/extensions/amp-base-carousel/0.1/test/validator-amp-base-carousel.out
@@ -79,25 +79,28 @@ amp-base-carousel/0.1/test/validator-amp-base-carousel.html:55:4 The attribute '
 |      <!-- Valid: integer values with multiple media queries -->
 |      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
 |      </amp-base-carousel>
+|      <!-- Valid: no value for loop -->
+|      <amp-base-carousel width="4" height="3" loop>
+|      </amp-base-carousel>
 |      <!-- Invalid: no default value-->
 |      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) 3">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:74:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:77:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no value -->
 |      <amp-base-carousel width="4" height="3" advance-count>
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:77:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:80:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: floating point value -->
 |      <amp-base-carousel width="4" height="3" advance-count="3.2">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:80:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '3.2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:83:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '3.2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: floating point value in media query -->
 |      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3.2, 1">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:83:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3.2, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:86:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3.2, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |
@@ -118,27 +121,27 @@ amp-base-carousel/0.1/test/validator-amp-base-carousel.html:83:4 The attribute '
 |      <!-- Invalid: negative integer value -->
 |      <amp-base-carousel width="4" height="3" visible-count="-2">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:102:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '-2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:105:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '-2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no default value-->
 |      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:105:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:108:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no value -->
 |      <amp-base-carousel width="4" height="3" visible-count>
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:108:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:111:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: string value -->
 |      <amp-base-carousel width="4" height="3" visible-count="foo">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:111:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:114:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: negative value in media query -->
 |      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:114:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:117:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |
@@ -153,7 +156,7 @@ amp-base-carousel/0.1/test/validator-amp-base-carousel.html:114:4 The attribute 
 |      <!-- Invalid: no space between media query and value -->
 |      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px)true, false">
 >>     ^~~~~~~~~
-amp-base-carousel/0.1/test/validator-amp-base-carousel.html:127:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px)true, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/0.1/test/validator-amp-base-carousel.html:130:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px)true, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |  </body>

--- a/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.html
+++ b/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.html
@@ -42,6 +42,9 @@
     <!-- Valid: booleans with multiple media queries -->
     <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, (max-height: 1000px) true, false">
     </amp-base-carousel>
+    <!-- Valid: no value for loop -->
+    <amp-base-carousel width="4" height="3" loop>
+    </amp-base-carousel>
     <!-- Invalid: no default value-->
     <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true">
     </amp-base-carousel>

--- a/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.out
+++ b/extensions/amp-base-carousel/1.0/test/validator-amp-base-carousel.out
@@ -43,25 +43,28 @@ FAIL
 |      <!-- Valid: booleans with multiple media queries -->
 |      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, (max-height: 1000px) true, false">
 |      </amp-base-carousel>
+|      <!-- Valid: no value for loop -->
+|      <amp-base-carousel width="4" height="3" loop>
+|      </amp-base-carousel>
 |      <!-- Invalid: no default value-->
 |      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:46:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) true'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:49:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) true'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no value -->
 |      <amp-base-carousel width="4" height="3" auto-advance>
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:49:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:52:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: incorrect value -->
 |      <amp-base-carousel width="4" height="3" auto-advance="5">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:52:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '5'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:55:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '5'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: incorrect in media query -->
 |      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px) true, (max-height: 1000px) 5, false">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:55:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) true, (max-height: 1000px) 5, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:58:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) true, (max-height: 1000px) 5, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |
@@ -82,22 +85,22 @@ amp-base-carousel/1.0/test/validator-amp-base-carousel.html:55:4 The attribute '
 |      <!-- Invalid: no default value-->
 |      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) 3">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:74:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:77:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no value -->
 |      <amp-base-carousel width="4" height="3" advance-count>
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:77:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:80:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: floating point value -->
 |      <amp-base-carousel width="4" height="3" advance-count="3.2">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:80:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '3.2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:83:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '3.2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: floating point value in media query -->
 |      <amp-base-carousel width="4" height="3" advance-count="(min-width: 800px) -3, (max-height: 1000px) 3.2, 1">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:83:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3.2, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:86:4 The attribute 'advance-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3.2, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |
@@ -118,27 +121,27 @@ amp-base-carousel/1.0/test/validator-amp-base-carousel.html:83:4 The attribute '
 |      <!-- Invalid: negative integer value -->
 |      <amp-base-carousel width="4" height="3" visible-count="-2">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:102:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '-2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:105:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '-2'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no default value-->
 |      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) 3">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:105:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:108:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) 3'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no value -->
 |      <amp-base-carousel width="4" height="3" visible-count>
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:108:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:111:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: string value -->
 |      <amp-base-carousel width="4" height="3" visible-count="foo">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:111:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:114:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value 'foo'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: negative value in media query -->
 |      <amp-base-carousel width="4" height="3" visible-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:114:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:117:4 The attribute 'visible-count' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |
@@ -159,22 +162,22 @@ amp-base-carousel/1.0/test/validator-amp-base-carousel.html:114:4 The attribute 
 |      <!-- Invalid: no default value-->
 |      <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) horizontal">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:133:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) horizontal'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:136:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) horizontal'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: no value -->
 |      <amp-base-carousel width="4" height="3" orientation>
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:136:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:139:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: incorrect value -->
 |      <amp-base-carousel width="4" height="3" orientation="true">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:139:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value 'true'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:142:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value 'true'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |      <!-- Invalid: incorrect in media query -->
 |      <amp-base-carousel width="4" height="3" orientation="(min-width: 800px) vertical, (max-height: 1000px) true, horizontal">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:142:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) vertical, (max-height: 1000px) true, horizontal'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:145:4 The attribute 'orientation' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px) vertical, (max-height: 1000px) true, horizontal'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |
@@ -189,7 +192,7 @@ amp-base-carousel/1.0/test/validator-amp-base-carousel.html:142:4 The attribute 
 |      <!-- Invalid: no space between media query and value -->
 |      <amp-base-carousel width="4" height="3" auto-advance="(min-width: 800px)true, false">
 >>     ^~~~~~~~~
-amp-base-carousel/1.0/test/validator-amp-base-carousel.html:155:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px)true, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
+amp-base-carousel/1.0/test/validator-amp-base-carousel.html:158:4 The attribute 'auto-advance' in tag 'amp-base-carousel' is set to the invalid value '(min-width: 800px)true, false'. (see https://amp.dev/documentation/components/amp-base-carousel/)
 |      </amp-base-carousel>
 |    </section>
 |  </body>

--- a/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
+++ b/extensions/amp-base-carousel/validator-amp-base-carousel.protoascii
@@ -70,7 +70,7 @@ attr_lists: {
   attrs: {
     name: "loop"
     # Media query / boolean pairs
-    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false|^$)"
   }
   attrs: {
     name: "mixed-length"

--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery.md
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery.md
@@ -38,7 +38,7 @@ The `<amp-inline-gallery>` component uses an `<amp-base-carousel>` to display sl
     width="3.6"
     height="2"
     snap-align="center"
-    loop="true"
+    loop
     visible-count="1.2"
     lightbox
   >
@@ -133,7 +133,7 @@ The example below demonstrates a gallery with thumbnails visible at larger resol
       width="3"
       height="2"
       snap-align="center"
-      loop="true"
+      loop
     >
       <amp-img
         class="slide"

--- a/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html
+++ b/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html
@@ -51,9 +51,9 @@
     <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0.00" aspect-ratio-width="3">
     </amp-inline-gallery-thumbnails>
   </amp-inline-gallery>
-  <!-- Invalid: Loop attribute without value -->
+  <!-- Invalid: Snap attribute without value -->
   <amp-inline-gallery layout="container">
-    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" snap>
     </amp-inline-gallery-thumbnails>
   </amp-inline-gallery>
   <!-- Valid: Wrapped with a parent div -->
@@ -71,6 +71,11 @@
   <!-- Valid: Loop attribute specified -->
   <amp-inline-gallery layout="container">
     <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
+  <!-- Valid: Loop attribute specified with no value -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
     </amp-inline-gallery-thumbnails>
   </amp-inline-gallery>
 </body>

--- a/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.out
+++ b/extensions/amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.out
@@ -62,11 +62,11 @@ amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:46:4 Th
 amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:51:4 The attribute 'aspect-ratio-height' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0.00'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
-|    <!-- Invalid: Loop attribute without value -->
+|    <!-- Invalid: Snap attribute without value -->
 |    <amp-inline-gallery layout="container">
-|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" snap>
 >>     ^~~~~~~~~
-amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:56:4 The attribute 'loop' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:56:4 The attribute 'snap' may not appear in tag 'amp-inline-gallery-thumbnails'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
 |    <!-- Valid: Wrapped with a parent div -->
@@ -84,6 +84,11 @@ amp-inline-gallery/0.1/test/validator-amp-inline-gallery-thumbnails.html:56:4 Th
 |    <!-- Valid: Loop attribute specified -->
 |    <amp-inline-gallery layout="container">
 |      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
+|    <!-- Valid: Loop attribute specified with no value -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
 |  </body>

--- a/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html
+++ b/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html
@@ -40,6 +40,11 @@
     <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
     </amp-inline-gallery-thumbnails>
   </amp-inline-gallery>
+  <!-- Valid: Loop attribute specified with no value -->
+  <amp-inline-gallery layout="container">
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+    </amp-inline-gallery-thumbnails>
+  </amp-inline-gallery>
   <!-- Valid: Aspect ratio -->
   <amp-inline-gallery layout="container">
     <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="3">
@@ -68,9 +73,9 @@
     <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0.00">
     </amp-inline-gallery-thumbnails>
   </amp-inline-gallery>
-  <!-- Invalid: Loop attribute without value -->
+  <!-- Invalid: Snap attribute without value -->
   <amp-inline-gallery layout="container">
-    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+    <amp-inline-gallery-thumbnails layout="fixed-height" height="96" snap>
     </amp-inline-gallery-thumbnails>
   </amp-inline-gallery>
 </body>

--- a/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.out
+++ b/extensions/amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.out
@@ -41,6 +41,11 @@ FAIL
 |      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop="true">
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
+|    <!-- Valid: Loop attribute specified with no value -->
+|    <amp-inline-gallery layout="container">
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+|      </amp-inline-gallery-thumbnails>
+|    </amp-inline-gallery>
 |    <!-- Valid: Aspect ratio -->
 |    <amp-inline-gallery layout="container">
 |      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="3">
@@ -54,34 +59,34 @@ FAIL
 |    <!-- Invalid: Not in a gallery -->
 |    <amp-inline-gallery-thumbnails layout="fixed-height" height="96">
 >>   ^~~~~~~~~
-amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:54:2 The tag 'amp-inline-gallery-thumbnails' may only appear as a descendant of tag 'amp-inline-gallery'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:59:2 The tag 'amp-inline-gallery-thumbnails' may only appear as a descendant of tag 'amp-inline-gallery'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
 |    </amp-inline-gallery-thumbnails>
 |    <!-- Invalid: Non-number aspect ratio-->
 |    <amp-inline-gallery layout="container">
 |      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="two">
 >>     ^~~~~~~~~
-amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:58:4 The attribute 'aspect-ratio' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value 'two'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:63:4 The attribute 'aspect-ratio' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value 'two'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
 |    <!-- Invalid: Aspect ratio of zero -->
 |    <amp-inline-gallery layout="container">
 |      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio="0">
 >>     ^~~~~~~~~
-amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:63:4 The attribute 'aspect-ratio' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:68:4 The attribute 'aspect-ratio' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
 |    <!-- Invalid: Aspect ratio of zero (float) -->
 |    <amp-inline-gallery layout="container">
 |      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" aspect-ratio-height="0.00">
 >>     ^~~~~~~~~
-amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:68:4 The attribute 'aspect-ratio-height' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0.00'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:73:4 The attribute 'aspect-ratio-height' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value '0.00'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
-|    <!-- Invalid: Loop attribute without value -->
+|    <!-- Invalid: Snap attribute without value -->
 |    <amp-inline-gallery layout="container">
-|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" loop>
+|      <amp-inline-gallery-thumbnails layout="fixed-height" height="96" snap>
 >>     ^~~~~~~~~
-amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:73:4 The attribute 'loop' in tag 'amp-inline-gallery-thumbnails' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-inline-gallery/)
+amp-inline-gallery/1.0/test/validator-amp-inline-gallery-thumbnails.html:78:4 The attribute 'snap' may not appear in tag 'amp-inline-gallery-thumbnails'. (see https://amp.dev/documentation/components/amp-inline-gallery/)
 |      </amp-inline-gallery-thumbnails>
 |    </amp-inline-gallery>
 |  </body>

--- a/extensions/amp-inline-gallery/amp-inline-gallery.md
+++ b/extensions/amp-inline-gallery/amp-inline-gallery.md
@@ -40,7 +40,7 @@ The `<amp-inline-gallery>` component uses an `<amp-base-carousel>` to display sl
     width="3.6"
     height="2"
     snap-align="center"
-    loop="true"
+    loop
     visible-count="1.2"
   >
     <amp-img
@@ -271,7 +271,7 @@ The example below demonstrates a gallery with thumbnails visible at larger resol
       width="3"
       height="2"
       snap-align="center"
-      loop="true"
+      loop
     >
       <amp-img
         class="slide"

--- a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
+++ b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
@@ -101,6 +101,7 @@ tags: {  # <amp-inline-gallery-thumbnails>
     name: "loop"
     value: "true"
     value: "false"
+    value: ""
   }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-inline-gallery/"

--- a/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html
+++ b/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html
@@ -32,7 +32,6 @@
   <section>
     <!-- Valid: true -->
     <amp-stream-gallery width="4" height="3" loop="true">
-    </amp-stream-gallery>
     <!-- Valid: false -->
     <amp-stream-gallery width="4" height="3" loop="false">
     </amp-stream-gallery>
@@ -42,11 +41,14 @@
     <!-- Valid: booleans with multiple media queries -->
     <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, (max-height: 1000px) true, false">
     </amp-stream-gallery>
+    <!-- Valid: no value for loop -->
+    <amp-stream-gallery width="4" height="3" loop>
+    </amp-stream-gallery>
     <!-- Invalid: no default value-->
     <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true">
     </amp-stream-gallery>
     <!-- Invalid: no value -->
-    <amp-stream-gallery width="4" height="3" loop>
+    <amp-stream-gallery width="4" height="3" snap>
     </amp-stream-gallery>
     <!-- Invalid: incorrect value -->
     <amp-stream-gallery width="4" height="3" loop="5">

--- a/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.out
+++ b/extensions/amp-stream-gallery/1.0/test/validator-amp-stream-gallery.out
@@ -33,7 +33,6 @@ FAIL
 |    <section>
 |      <!-- Valid: true -->
 |      <amp-stream-gallery width="4" height="3" loop="true">
-|      </amp-stream-gallery>
 |      <!-- Valid: false -->
 |      <amp-stream-gallery width="4" height="3" loop="false">
 |      </amp-stream-gallery>
@@ -43,25 +42,28 @@ FAIL
 |      <!-- Valid: booleans with multiple media queries -->
 |      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, (max-height: 1000px) true, false">
 |      </amp-stream-gallery>
+|      <!-- Valid: no value for loop -->
+|      <amp-stream-gallery width="4" height="3" loop>
+|      </amp-stream-gallery>
 |      <!-- Invalid: no default value-->
 |      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:46:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) true'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:48:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) true'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: no value -->
-|      <amp-stream-gallery width="4" height="3" loop>
+|      <amp-stream-gallery width="4" height="3" snap>
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:49:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:51:4 The attribute 'snap' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: incorrect value -->
 |      <amp-stream-gallery width="4" height="3" loop="5">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:52:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '5'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:54:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '5'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: incorrect in media query -->
 |      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px) true, (max-height: 1000px) 5, false">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:55:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) true, (max-height: 1000px) 5, false'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:57:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) true, (max-height: 1000px) 5, false'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |    </section>
 |
@@ -79,27 +81,27 @@ amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:55:4 The attribute
 |      <!-- Invalid: no default value-->
 |      <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) 300">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:71:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) 300'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:73:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) 300'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: no value -->
 |      <amp-stream-gallery width="4" height="3" min-item-width>
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:74:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:76:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: negative integer value -->
 |      <amp-stream-gallery width="4" height="3" min-item-width="-2">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:77:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '-2'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:79:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '-2'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: floating point value -->
 |      <amp-stream-gallery width="4" height="3" min-item-width="300.5">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:80:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '300.5'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:82:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '300.5'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: floating point value in media query -->
 |      <amp-stream-gallery width="4" height="3" min-item-width="(min-width: 800px) -300, (max-height: 1000px) 300.5, 1">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:83:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) -300, (max-height: 1000px) 300.5, 1'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:85:4 The attribute 'min-item-width' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) -300, (max-height: 1000px) 300.5, 1'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |    </section>
 |
@@ -120,27 +122,27 @@ amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:83:4 The attribute
 |      <!-- Invalid: negative integer value -->
 |      <amp-stream-gallery width="4" height="3" min-visible-count="-2">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:102:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '-2'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:104:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '-2'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: no default value-->
 |      <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) 3">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:105:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) 3'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:107:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) 3'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: no value -->
 |      <amp-stream-gallery width="4" height="3" min-visible-count>
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:108:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:110:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: string value -->
 |      <amp-stream-gallery width="4" height="3" min-visible-count="foo">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:111:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value 'foo'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:113:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value 'foo'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: negative value in media query -->
 |      <amp-stream-gallery width="4" height="3" min-visible-count="(min-width: 800px) -3, (max-height: 1000px) 3, 1">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:114:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:116:4 The attribute 'min-visible-count' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) -3, (max-height: 1000px) 3, 1'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |    </section>
 |
@@ -164,22 +166,22 @@ amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:114:4 The attribut
 |      <!-- Invalid: no default value-->
 |      <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) always">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:136:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) always'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:138:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) always'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: no value -->
 |      <amp-stream-gallery width="4" height="3" controls>
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:139:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:141:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value ''. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: incorrect value -->
 |      <amp-stream-gallery width="4" height="3" controls="true">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:142:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value 'true'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:144:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value 'true'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |      <!-- Invalid: incorrect in media query -->
 |      <amp-stream-gallery width="4" height="3" controls="(min-width: 800px) auto, (max-height: 1000px) true, never">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:145:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) auto, (max-height: 1000px) true, never'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:147:4 The attribute 'controls' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px) auto, (max-height: 1000px) true, never'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |    </section>
 |
@@ -194,7 +196,7 @@ amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:145:4 The attribut
 |      <!-- Invalid: no space between media query and value -->
 |      <amp-stream-gallery width="4" height="3" loop="(min-width: 800px)true, false">
 >>     ^~~~~~~~~
-amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:158:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px)true, false'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
+amp-stream-gallery/1.0/test/validator-amp-stream-gallery.html:160:4 The attribute 'loop' in tag 'amp-stream-gallery' is set to the invalid value '(min-width: 800px)true, false'. (see https://github.com/ampproject/amphtml/blob/master/extensions/amp-stream-gallery/amp-stream-gallery.md)
 |      </amp-stream-gallery>
 |    </section>
 |  </body>

--- a/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii
+++ b/extensions/amp-stream-gallery/validator-amp-stream-gallery.protoascii
@@ -60,7 +60,7 @@ attr_lists: {
   attrs: {
     name: "loop"
     # Media query / boolean pairs
-    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false)"
+    value_regex: "([^,]+\\s+(true|false),\\s*)*(true|false|^$)"
   }
   attrs: {
     name: "min-visible-count"


### PR DESCRIPTION
Fixes #35555