### PR TITLE
🏗 Move deployment of PR output (minified + storybook) to a separate CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,14 @@ push_builds_only: &push_builds_only
         - main
         - /^amp-release-.*$/
 
+pr_builds_only: &pr_builds_only
+  filters:
+    branches:
+      ignore:
+        - main
+        - /^amp-release-.*$/
+        - nightly
+
 experiment_job: &experiment_job
   parameters:
     exp:
@@ -169,13 +177,8 @@ jobs:
     steps:
       - setup_vm
       - run:
-          name: 'Create Artifacts Directory'
-          command: mkdir -p /tmp/artifacts
-      - run:
           name: '⭐ Nomodule Build ⭐'
           command: node build-system/pr-check/nomodule-build.js
-      - store_artifacts:
-          path: /tmp/artifacts/amp_nomodule_build.tar.gz
       - teardown_vm
   'Module Build - Test':
     executor:
@@ -203,6 +206,17 @@ jobs:
       - run:
           name: '⭐ Module Build ⭐'
           command: node build-system/pr-check/bundle-size-module-build.js
+      - teardown_vm
+  'PR Deploy':
+    executor:
+      name: node-docker-medium
+    steps:
+      - setup_vm
+      - run:
+          name: '⭐ PR Deploy ⭐'
+          command: node build-system/pr-check/pr-deploy.js
+      - store_artifacts:
+          path: /tmp/artifacts/amp_nomodule_build.tar.gz
       - teardown_vm
   'Bundle Size':
     executor:
@@ -408,6 +422,10 @@ workflows:
           <<: *push_and_pr_builds
           requires:
             - 'Initialize Repository'
+      - 'PR Deploy':
+          <<: *pr_builds_only
+          requires:
+            - 'Nomodule Build (Test)'
       - 'Bundle Size':
           <<: *push_and_pr_builds
           requires:

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -19,10 +19,8 @@
  * @fileoverview Script that builds the nomodule AMP runtime during CI.
  */
 
-const atob = require('atob');
 const {
   abortTimedJob,
-  processAndStoreBuildToArtifacts,
   skipDependentJobs,
   startTimer,
   storeNomoduleBuildToWorkspace,
@@ -68,19 +66,10 @@ async function prBuildWorkflow() {
       await signalPrDeployUpload('errored');
       return abortTimedJob(jobName, startTime);
     }
-    timedExecOrDie('amp storybook --build');
-    await processAndStoreBuildToArtifacts();
-    await signalPrDeployUpload('success');
     storeNomoduleBuildToWorkspace();
   } else {
     await signalPrDeployUpload('skipped');
-
-    // Special case for visual diffs - Percy is a required check and must pass,
-    // but we just called `skipDependentJobs` so the Visual Diffs job will not
-    // run. Instead, we create an empty, passing check on Percy here.
-    process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED);
     timedExecOrDie('amp visual-diff --empty');
-
     skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -43,13 +43,13 @@ const UNMINIFIED_CONTAINER_DIRECTORY = 'unminified';
 const NOMODULE_CONTAINER_DIRECTORY = 'nomodule';
 const MODULE_CONTAINER_DIRECTORY = 'module';
 
-const ARTIFACT_FILE_NAME = '/tmp/artifacts/amp_nomodule_build.tar.gz';
+const ARTIFACT_DIRECTORY = '/tmp/artifacts/';
+const ARTIFACT_FILE_NAME = `${ARTIFACT_DIRECTORY}/amp_nomodule_build.tar.gz`;
 const TEST_FILES_LIST_FILE_NAME = '/tmp/testfiles.txt';
 
-const BUILD_OUTPUT_DIRS = ['build', 'dist', 'dist.3p'];
+const BUILD_OUTPUT_DIRS = ['build', 'dist', 'dist.3p', 'dist.tools'];
 const APP_SERVING_DIRS = [
   ...BUILD_OUTPUT_DIRS,
-  'dist.tools',
   'examples',
   'test/manual',
   'test/fixtures/e2e',
@@ -251,10 +251,13 @@ function storeBuildToWorkspace_(containerDirectory) {
   if (isCircleciBuild()) {
     fs.ensureDirSync(`/tmp/workspace/builds/${containerDirectory}`);
     for (const outputDir of BUILD_OUTPUT_DIRS) {
-      fs.moveSync(
-        `${outputDir}/`,
-        `/tmp/workspace/builds/${containerDirectory}/${outputDir}`
-      );
+      const outputPath = `${outputDir}/`;
+      if (fs.existsSync(outputPath)) {
+        fs.moveSync(
+          outputPath,
+          `/tmp/workspace/builds/${containerDirectory}/${outputDir}`
+        );
+      }
     }
     // Bento components are compiled inside the extension source file.
     for (const componentFile of globby.sync('extensions/*/?.?/dist/*.js')) {
@@ -321,6 +324,7 @@ async function processAndStoreBuildToArtifacts() {
       cyan(ARTIFACT_FILE_NAME) +
       '...'
   );
+  await fs.ensureDir(ARTIFACT_DIRECTORY);
   execOrDie(`tar -czf ${ARTIFACT_FILE_NAME} ${APP_SERVING_DIRS.join('/ ')}/`);
   execOrDie(`du -sh ${ARTIFACT_FILE_NAME}`);
 }

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const atob = require('atob');
 const fs = require('fs');
 const JSON5 = require('json5');
 const path = require('path');
@@ -134,6 +135,15 @@ let TestErrorDef;
  * }}
  */
 let WebpageDef;
+
+/**
+ * Decode the write-only Percy token during CI builds.
+ */
+function decodePercyTokenForCi() {
+  if (isCiBuild()) {
+    process.env['PERCY_TOKEN'] = atob(process.env.PERCY_TOKEN_ENCODED || '');
+  }
+}
 
 /**
  * Override PERCY_* environment variables if passed via amp task parameters.
@@ -752,6 +762,7 @@ async function visualDiff() {
   const handlerProcess = createCtrlcHandler('visual-diff');
   await ensureOrBuildAmpRuntimeInTestMode_();
   const browserFetcher = await loadBrowserFetcher_();
+  decodePercyTokenForCi();
   maybeOverridePercyEnvironmentVariables();
   setPercyBranch();
   setPercyTargetCommit();


### PR DESCRIPTION
Most of AMP's testing jobs depend on the nomodule (test) build during CI, and cannot start until that job completes.

**PR Highlights:**
- Move the PR deploy steps out of the critical path, allowing tests to begin a couple mins sooner
- Create a separate `PR Deploy` job to carry out those steps only during PR builds
- **Bonus:** Move `PERCY_TOKEN` extraction into the visual testing task (co-locate with related code and reduce repetition)

Addresses https://github.com/ampproject/amphtml/pull/35455#discussion_r685362997