### PR TITLE
Added logic to delay resize requests to be made after an invalid request is made until 500ms passes

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -44,6 +44,9 @@ const MIN_INABOX_POSITION_EVENT_INTERVAL = 100;
 /** @type {string} */
 const TAG = 'amp-ad-xorigin-iframe';
 
+/** @type {number} */
+const MSEC_REPEATED_REQUEST_DELAY = 500;
+
 export class AmpAdXOriginIframeHandler {
   /**
    * @param {!./amp-ad-3p-impl.AmpAd3PImpl|!../../amp-a4a/0.1/amp-a4a.AmpA4A} baseInstance
@@ -63,6 +66,16 @@ export class AmpAdXOriginIframeHandler {
 
     /** @type {?HTMLIFrameElement} iframe instance */
     this.iframe = null;
+
+    // This variable keeps keeps track when an invalid resize request is made, and
+    // is associated with each iframe. If the request is invalid, then a new request
+    // cannot be made until a certain amount of time has passed, 500 ms by default
+    //(see MSEC_REPEATED_REQUEST_DELAY). Once the timer has cooled down, a new request can be made.
+    /** @type {boolean} */
+    this.resizeRequestsEnabled_ = true;
+
+    /** @type {number} */
+    this.lastRejectedResizeTime_ = 0.0;
 
     /** @private {?LegacyAdIntersectionObserverHost} */
     this.legacyIntersectionObserverApiHost_ = null;
@@ -170,14 +183,32 @@ export class AmpAdXOriginIframeHandler {
           if (!!data['hasOverflow']) {
             this.element_.warnOnMissingOverflow = false;
           }
-          this.handleResize_(
-            data['id'],
-            data['height'],
-            data['width'],
-            source,
-            origin,
-            event
-          );
+          if (
+            Date.now() - this.lastRejectedResizeTime_ >=
+            MSEC_REPEATED_REQUEST_DELAY
+          ) {
+            this.resizeRequestsEnabled_ = true;
+          }
+          if (this.resizeRequestsEnabled_) {
+            this.handleResize_(
+              data['id'],
+              data['height'],
+              data['width'],
+              source,
+              origin,
+              event
+            );
+          } else {
+            //  need to wait 500ms until next resize request is allowed.
+            this.sendEmbedSizeResponse_(
+              false,
+              data['id'],
+              data['width'],
+              data['height'],
+              source,
+              origin
+            );
+          }
         },
         true,
         true
@@ -455,6 +486,11 @@ export class AmpAdXOriginIframeHandler {
         .updateSize(height, width, iframeHeight, iframeWidth, event)
         .then(
           (info) => {
+            if (!info.success) {
+              //invalid request parameters disable requests for 500ms
+              this.resizeRequestsEnabled_ = false;
+              this.lastRejectedResizeTime_ = Date.now();
+            }
             this.uiHandler_.onResizeSuccess();
             this.sendEmbedSizeResponse_(
               info.success,

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -482,7 +482,7 @@ export class AmpAdXOriginIframeHandler {
         .then(
           (info) => {
             if (!info.success) {
-              // invalid request parameters disable requests for 500ms
+              // invalid request parameters, disable requests for 500ms
               this.lastRejectedResizeTime_ = Date.now();
             } else {
               this.lastRejectedResizeTime_ = 0.0;

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -69,8 +69,8 @@ export class AmpAdXOriginIframeHandler {
 
     /* This variable keeps keeps track when an invalid resize request is made, and
      * is associated with each iframe. If the request is invalid, then a new request
-     *cannot be made until a certain amount of time has passed, 500 ms by default
-     *(see MSEC_REPEATED_REQUEST_DELAY). Once the timer has cooled down, a new request can be made.
+     * cannot be made until a certain amount of time has passed, 500 ms by default
+     * (see MSEC_REPEATED_REQUEST_DELAY). Once the timer has cooled down, a new request can be made.
      */
     /** @type {number} */
     this.lastRejectedResizeTime_ = 0.0;
@@ -484,6 +484,8 @@ export class AmpAdXOriginIframeHandler {
             if (!info.success) {
               // invalid request parameters disable requests for 500ms
               this.lastRejectedResizeTime_ = Date.now();
+            } else {
+              this.lastRejectedResizeTime_ = 0.0;
             }
             this.uiHandler_.onResizeSuccess();
             this.sendEmbedSizeResponse_(

--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -67,13 +67,11 @@ export class AmpAdXOriginIframeHandler {
     /** @type {?HTMLIFrameElement} iframe instance */
     this.iframe = null;
 
-    // This variable keeps keeps track when an invalid resize request is made, and
-    // is associated with each iframe. If the request is invalid, then a new request
-    // cannot be made until a certain amount of time has passed, 500 ms by default
-    //(see MSEC_REPEATED_REQUEST_DELAY). Once the timer has cooled down, a new request can be made.
-    /** @type {boolean} */
-    this.resizeRequestsEnabled_ = true;
-
+    /* This variable keeps keeps track when an invalid resize request is made, and
+     * is associated with each iframe. If the request is invalid, then a new request
+     *cannot be made until a certain amount of time has passed, 500 ms by default
+     *(see MSEC_REPEATED_REQUEST_DELAY). Once the timer has cooled down, a new request can be made.
+     */
     /** @type {number} */
     this.lastRejectedResizeTime_ = 0.0;
 
@@ -187,9 +185,6 @@ export class AmpAdXOriginIframeHandler {
             Date.now() - this.lastRejectedResizeTime_ >=
             MSEC_REPEATED_REQUEST_DELAY
           ) {
-            this.resizeRequestsEnabled_ = true;
-          }
-          if (this.resizeRequestsEnabled_) {
             this.handleResize_(
               data['id'],
               data['height'],
@@ -199,7 +194,7 @@ export class AmpAdXOriginIframeHandler {
               event
             );
           } else {
-            //  need to wait 500ms until next resize request is allowed.
+            // need to wait 500ms until next resize request is allowed.
             this.sendEmbedSizeResponse_(
               false,
               data['id'],
@@ -487,8 +482,7 @@ export class AmpAdXOriginIframeHandler {
         .then(
           (info) => {
             if (!info.success) {
-              //invalid request parameters disable requests for 500ms
-              this.resizeRequestsEnabled_ = false;
+              // invalid request parameters disable requests for 500ms
               this.lastRejectedResizeTime_ = Date.now();
             }
             this.uiHandler_.onResizeSuccess();

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -339,10 +339,9 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
         });
     });
 
-    describe('Initialized iframe', async () => {
+    describe('request valid and invalid ad resize useing embed-size API', async () => {
       beforeEach(async () => {
         clock = env.sandbox.useFakeTimers();
-        clock.tick(0);
         const updateSizeWrapper = env.sandbox.stub(
           adImpl.uiHandler,
           'updateSize'

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -503,7 +503,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
       });
       iframe.postMessageToParent({
         width: 114,
-        height: 217,
+        height: '217', // should be tolerant to string number
         type: 'embed-size',
         sentinel: 'amp3ptest' + testIndex,
       });
@@ -516,6 +516,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
             type: 'embed-size-changed',
             sentinel: 'amp3ptest' + testIndex,
           });
+          expect(adImpl.uiHandler.onResizeSuccess).to.be.called;
         });
     });
 
@@ -541,6 +542,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
             type: 'embed-size-changed',
             sentinel: 'amp3ptest' + testIndex,
           });
+          expect(adImpl.uiHandler.onResizeSuccess).to.be.called;
         });
     });
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -347,15 +347,13 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
           'updateSize'
         );
 
-        const dataPromise = iframe.expectMessageFromParent('embed-size-denied');
-
         updateSizeWrapper.resolves({
           success: false,
           newWidth: 114,
           newHeight: 217,
         });
 
-        //expect to fail, first call invalid request
+        // expect to fail, first call invalid request
         iframe.postMessageToParent({
           width: 114,
           height: 217,
@@ -363,7 +361,8 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
           sentinel: 'amp3ptest' + testIndex,
         });
 
-        const data = await dataPromise;
+        const data = await iframe.expectMessageFromParent('embed-size-denied');
+
         expect(data).to.jsonEqual({
           requestedWidth: 114,
           requestedHeight: 217,
@@ -377,10 +376,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
           newHeight: 217,
         });
 
-        //expect to fail invalid request right before 500ms
-        const data2Promise =
-          iframe.expectMessageFromParent('embed-size-denied');
-
+        // expect to fail invalid request right before 500ms
         iframe.postMessageToParent({
           width: 120,
           height: 217,
@@ -388,7 +384,8 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
           sentinel: 'amp3ptest' + testIndex,
         });
 
-        const data2 = await data2Promise;
+        const data2 = await iframe.expectMessageFromParent('embed-size-denied');
+
         expect(data2).to.jsonEqual({
           requestedWidth: 120,
           requestedHeight: 217,
@@ -398,10 +395,8 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
       });
 
       it('should be able to use embed-size API, change size deny repeated attempts, but then denies valid attempt before 500ms delay', async () => {
-        //expect to fail, valid request, but called before 500ms
+        // expect to fail, valid request, but called before 500ms
         clock.tick(250);
-        const data3Promise =
-          iframe.expectMessageFromParent('embed-size-denied');
 
         iframe.postMessageToParent({
           width: 114,
@@ -410,7 +405,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
           sentinel: 'amp3ptest' + testIndex,
         });
 
-        const data3 = await data3Promise;
+        const data3 = await iframe.expectMessageFromParent('embed-size-denied');
         expect(data3).to.jsonEqual({
           requestedWidth: 114,
           requestedHeight: 217,
@@ -420,10 +415,8 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
       });
 
       it('should be able to use embed-size API, change size deny repeated attempts, but then works after 500ms delay', async () => {
-        //expect to succeed: valid request right after 500ms
+        // expect to succeed: valid request right after 500ms
         clock.tick(500);
-        const data3Promise =
-          iframe.expectMessageFromParent('embed-size-changed');
 
         iframe.postMessageToParent({
           width: 114,
@@ -432,7 +425,10 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
           sentinel: 'amp3ptest' + testIndex,
         });
 
-        const data3 = await data3Promise;
+        const data3 = await iframe.expectMessageFromParent(
+          'embed-size-changed'
+        );
+
         expect(data3).to.jsonEqual({
           requestedWidth: 114,
           requestedHeight: 217,


### PR DESCRIPTION
✨ New feature

Added logic to delay resize requests to be made after an invalid request is made until 500ms passes, to prevent the iframe from making multiple invalid requests in a row.

See #25894