### PR TITLE
🏗 Disable .git caching for MacOS jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,26 +63,23 @@ executors:
 commands:
   checkout_repo:
     parameters:
-      cache:
+      save-git-cache:
         type: boolean
-        default: true
+        default: false
     steps:
-      - when:
-          condition: << parameters.cache >>
-          steps:
-            - restore_cache:
-                name: 'Restore Git Cache'
-                keys:
-                  - git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-                  - git-cache-{{ arch }}-{{ .Branch }}-
-                  - git-cache-{{ arch }}-
+      - restore_cache:
+          name: 'Restore Git Cache'
+          keys:
+            - git-cache-v2-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+            - git-cache-v2-{{ arch }}-{{ .Branch }}-
+            - git-cache-v2-{{ arch }}-
       - checkout
       - when:
-          condition: << parameters.cache >>
+          condition: << parameters.save-git-cache >>
           steps:
             - save_cache:
                 name: 'Save Git Cache'
-                key: git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                key: git-cache-v2-{{ arch }}-{{ .Branch }}-{{ .Revision }}
                 paths:
                   - .git
   setup_node_environment:
@@ -92,10 +89,6 @@ commands:
           install-npm: false
       - node/install-packages
   setup_vm:
-    parameters:
-      git-cache:
-        type: boolean
-        default: true
     steps:
       - attach_workspace:
           at: /tmp
@@ -107,8 +100,7 @@ commands:
       - run:
           name: 'Maybe Gracefully Halt'
           command: /tmp/restored-workspace/maybe_gracefully_halt.sh
-      - checkout_repo:
-          cache: << parameters.git-cache >>
+      - checkout_repo
       - run:
           name: 'Configure Development Environment'
           command: |
@@ -162,7 +154,8 @@ jobs:
     executor:
       name: base-docker-small
     steps:
-      - checkout_repo
+      - checkout_repo:
+          save-git-cache: true
       - run:
           name: 'Initialize Repository'
           command: ./.circleci/initialize_repo.sh
@@ -352,9 +345,7 @@ jobs:
     executor:
       name: macos-medium
     steps:
-      - setup_vm:
-          # Restoring/saving Git cache on MacOS ends up being slower than a cold `git clone`.
-          git-cache: false
+      - setup_vm
       - enable_safari_automation
       - run:
           name: '⭐ Browser Tests (Safari) ⭐'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,19 +62,29 @@ executors:
 
 commands:
   checkout_repo:
+    parameters:
+      cache:
+        type: boolean
+        default: true
     steps:
-      - restore_cache:
-          name: 'Restore Git Cache'
-          keys:
-            - git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-            - git-cache-{{ arch }}-{{ .Branch }}-
-            - git-cache-{{ arch }}-
+      - when:
+          condition: << parameters.cache >>
+          steps:
+            - restore_cache:
+                name: 'Restore Git Cache'
+                keys:
+                  - git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                  - git-cache-{{ arch }}-{{ .Branch }}-
+                  - git-cache-{{ arch }}-
       - checkout
-      - save_cache:
-          name: 'Save Git Cache'
-          key: git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - .git
+      - when:
+          condition: << parameters.cache >>
+          steps:
+            - save_cache:
+                name: 'Save Git Cache'
+                key: git-cache-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                paths:
+                  - .git
   setup_node_environment:
     steps:
       - node/install:
@@ -82,6 +92,10 @@ commands:
           install-npm: false
       - node/install-packages
   setup_vm:
+    parameters:
+      git-cache:
+        type: boolean
+        default: true
     steps:
       - attach_workspace:
           at: /tmp
@@ -93,7 +107,8 @@ commands:
       - run:
           name: 'Maybe Gracefully Halt'
           command: /tmp/restored-workspace/maybe_gracefully_halt.sh
-      - checkout_repo
+      - checkout_repo:
+          cache: << parameters.git-cache >>
       - run:
           name: 'Configure Development Environment'
           command: |
@@ -337,7 +352,9 @@ jobs:
     executor:
       name: macos-medium
     steps:
-      - setup_vm
+      - setup_vm:
+          # Restoring/saving Git cache on MacOS ends up being slower than a cold `git clone`.
+          git-cache: false
       - enable_safari_automation
       - run:
           name: '⭐ Browser Tests (Safari) ⭐'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,16 +70,16 @@ commands:
       - restore_cache:
           name: 'Restore Git Cache'
           keys:
-            - git-cache-v2-{{ arch }}-{{ .Branch }}-{{ .Revision }}
-            - git-cache-v2-{{ arch }}-{{ .Branch }}-
-            - git-cache-v2-{{ arch }}-
+            - git-cache-{{ arch }}-v2-{{ .Branch }}-{{ .Revision }}
+            - git-cache-{{ arch }}-v2-{{ .Branch }}-
+            - git-cache-{{ arch }}-v2-
       - checkout
       - when:
           condition: << parameters.save-git-cache >>
           steps:
             - save_cache:
                 name: 'Save Git Cache'
-                key: git-cache-v2-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+                key: git-cache-{{ arch }}-v2-{{ .Branch }}-{{ .Revision }}
                 paths:
                   - .git
   setup_node_environment:


### PR DESCRIPTION
Restoring/saving Git cache on MacOS ends up being slower than a cold `git clone`

Also disables the call to `check_config.sh` because it now [breaks the job](https://app.circleci.com/pipelines/github/ampproject/amphtml/14475/workflows/b1731fe2-ad13-4cd4-ac1c-d923ef6222d3/jobs/243293)

Before | After
--------- | ------
![image](https://user-images.githubusercontent.com/1839738/128932484-98372d64-4e78-4d3c-aed4-710593a997aa.png) | ![image](https://user-images.githubusercontent.com/1839738/128932394-260fc501-865b-484a-923e-2586fb43c07c.png)
