### PR TITLE
[amp-story-share]: adjust buildProviderParams

### DIFF
--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -146,11 +146,11 @@ function buildProviderParams(opt_params) {
  * @return {!Node}
  */
 function buildProvider(doc, shareType, opt_params) {
-  const shareProviderLocalizedStringId = devAssert(
-    SHARE_PROVIDER_LOCALIZED_STRING_ID[shareType],
-    `No localized string to display name for share type ${shareType}.`
+  const shareProviderString = devAssert(
+    SHARE_PROVIDER_LOCALIZED_STRING_ID[shareType] || opt_params?.['aria-label'],
+    `No string to display name for share type ${shareType}.`
   );
-
+  
   return renderSimpleTemplate(
     doc,
     /** @type {!Array<!./simple-template.ElementDef>} */ ([
@@ -171,7 +171,8 @@ function buildProvider(doc, shareType, opt_params) {
           {
             tag: 'span',
             attrs: dict({'class': 'i-amphtml-story-share-label'}),
-            localizedStringId: shareProviderLocalizedStringId,
+            localizedStringId: SHARE_PROVIDER_LOCALIZED_STRING_ID[shareType],
+            ...(opt_params?.['aria-label'] && { unlocalizedString: opt_params?.['aria-label'] })
           },
         ],
       },

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -117,13 +117,20 @@ function buildLinkShareItemTemplate(el) {
  */
 function buildProviderParams(opt_params) {
   const attrs = dict();
-
+  
   if (opt_params) {
     Object.keys(opt_params).forEach((field) => {
       if (field === 'provider') {
         return;
       }
-      attrs[`data-param-${field}`] = opt_params[field];
+
+      /**
+       * based on amp-social-share accepted attributes
+       * https://amp.dev/documentation/components/amp-social-share/#attributes
+       */
+      if (['data-target', 'data-share-endpoint', 'aria-label'].includes(field) || /^data-param-/.test(field)) {
+        attrs[field] = opt_params[field];
+      }
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -130,6 +130,8 @@ function buildProviderParams(opt_params) {
        */
       if (['data-target', 'data-share-endpoint', 'aria-label'].includes(field) || /^data-param-/.test(field)) {
         attrs[field] = opt_params[field];
+      } else {
+        attrs[`data-param-${field}`] = opt_params[field];
       }
     });
   }


### PR DESCRIPTION
Adjust the logic on amp-story-share.js that generates attributes to be used for `amp-social-share` since the existing logic doesn't quite generate the expected attributes as listed on the documentation
https://amp.dev/documentation/components/amp-social-share/#attributes