### PR TITLE
🐛 [Amp story] Null check on screen.orientation

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -965,7 +965,7 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     const lockOrientation =
-      screen.orientation.lock ||
+      screen.orientation?.lock ||
       screen.lockOrientation ||
       screen.mozLockOrientation ||
       screen.msLockOrientation ||


### PR DESCRIPTION
On iPads, `orientation` is not defined. 
An error is being thrown when trying to access the `screen.orientation.lock` property.

This PR checks if `orientation` exists before accessing `lock`.

Related to the work in #35478

<img width="972" alt="Screen Shot 2021-08-12 at 11 17 58 AM" src="https://user-images.githubusercontent.com/3860311/129222878-25e492cd-5ead-4b88-a1c4-49bcb4522c06.png">