### PR TITLE
🏗 Fix CircleCI config check so it works with `.git` caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ commands:
           name: 'Configure Development Environment'
           command: |
             ./.circleci/fetch_merge_commit.sh
-            ./.circleci/check_config.sh
             ./.circleci/restore_build_output.sh
             cat ./build-system/test-configs/hosts | sudo tee -a /etc/hosts
       - setup_node_environment
@@ -164,6 +163,9 @@ jobs:
       - run:
           name: 'Initialize Repository'
           command: ./.circleci/initialize_repo.sh
+      - run:
+          name: 'Check Config'
+          command: ./.circleci/check_config.sh
       - run:
           name: 'Initialize Workspace'
           command: cp .circleci/maybe_gracefully_halt.sh /tmp/workspace

--- a/.circleci/initialize_repo.sh
+++ b/.circleci/initialize_repo.sh
@@ -38,8 +38,8 @@ if [[ -z "${PR_NUMBER}" ]]; then
   exit 0
 fi
 
-echo "$(GREEN "Fetching all branches to update") $(CYAN ".git") $(GREEN "cache.")"
-git fetch
+echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
+git fetch origin main:main
 
 # GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for
 # every PR branch that can be cleanly merged to the main branch. For more


### PR DESCRIPTION
**Background:** With the introduction of `.git` caching on CircleCI, the repo initialization job often ends up with an outdated view of the `main` branch that is restored from the cache. This can cause our check for config freshness to incorrectly pass when it should fail. (The risk is that PRs will run an incomplete set of tests and go on to break `main` once merged.)

**PR Highlights:**
- Fix `initialize_repo.sh` to actually update `main`. (It was doing a fetch, but wasn't updating the local `main` branch.)
- Move the check to the `Initialize Repository` job so failures are detected at the very start, and logs are less confusing.

**Screenshots:** [link](https://app.circleci.com/pipelines/github/ampproject/amphtml/14704/workflows/e58b1336-9a74-4abb-89ab-e4eab438ac69)

![image](https://user-images.githubusercontent.com/26553114/129261028-cc8dc4a2-6c75-403c-b11a-2b9fa92bc97a.png)
![image](https://user-images.githubusercontent.com/26553114/129261179-4f11e04b-260f-408b-a157-66ddfb8cf52e.png)


