### PR TITLE
✨ Add act=lb for amp-ad sticky ads

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -390,6 +390,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         return fixture.addElement(elem).then(() =>
           googleAdUrl(impl, '', 0, [], []).then((url1) => {
@@ -411,6 +412,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         const getRect = () => {
           return {'width': 100, 'height': 200};
@@ -443,6 +445,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           [AMP_EXPERIMENT_ATTRIBUTE]: '111,222',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', 0, {}, ['789', '098']).then((url1) => {
@@ -464,6 +467,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         impl.win.AMP_CONFIG = {type: 'production'};
         impl.win.location.hash = 'foo,deid=123456,654321,bar';
@@ -486,6 +490,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         impl.win.gaGlobal = {cid: 'foo', hid: 'bar'};
         return fixture.addElement(elem).then(() => {
@@ -508,6 +513,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         const createElementStub = env.sandbox.stub(
           impl.win.document,
@@ -537,6 +543,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         const createElementStub = env.sandbox.stub(
           impl.win.document,
@@ -564,6 +571,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         impl.win.SVGElement = undefined;
         const createElementStub = env.sandbox.stub(
@@ -594,6 +602,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
           'height': '50',
         });
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         env.sandbox
           .stub(Services.viewerForDoc(impl.getAmpDoc()), 'getReferrerUrl')
@@ -623,6 +632,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
         doc.win = fixture.win;
         const elem = createElementWithAttributes(doc, 'amp-a4a', {});
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         return fixture.addElement(elem).then(() => {
           return googleAdUrl(impl, '', Date.now(), [], []).then((url) => {
@@ -639,6 +649,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
         doc.win = fixture.win;
         const elem = createElementWithAttributes(doc, 'amp-a4a', {});
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         Object.defineProperty(impl.win.navigator, 'userAgentData', {
           'value': {
@@ -673,6 +684,7 @@ describes.sandboxed('Google A4A utils', {}, (env) => {
         doc.win = fixture.win;
         const elem = createElementWithAttributes(doc, 'amp-a4a', {});
         const impl = new MockA4AImpl(elem);
+        impl.uiHandler = {isStickyAd: () => false};
         noopMethods(impl, fixture.ampdoc, env.sandbox);
         Object.defineProperty(impl.win.navigator, 'userAgentData', {
           'value': {

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -219,6 +219,12 @@ export function googleBlockParameters(a4a, opt_experimentIds) {
   const slotRect = getPageLayoutBoxBlocking(adElement);
   const iframeDepth = iframeNestingDepth(win);
   const enclosingContainers = getEnclosingContainerTypes(adElement);
+  if (
+    a4a.uiHandler.isStickyAd() &&
+    !enclosingContainers.includes(ValidAdContainerTypes['AMP-STICKY-AD'])
+  ) {
+    enclosingContainers.push(ValidAdContainerTypes['AMP-STICKY-AD']);
+  }
   let eids = adElement.getAttribute(EXPERIMENT_ATTRIBUTE);
   if (opt_experimentIds) {
     eids = mergeExperimentIds(opt_experimentIds, eids);

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -569,6 +569,7 @@ describes.realWin(
     describe('#getAdUrl', () => {
       beforeEach(() => {
         resetSharedState();
+        impl.uiHandler = {isStickyAd: () => false};
       });
 
       afterEach(() => {
@@ -783,6 +784,10 @@ describes.realWin(
         const impl1 = new AmpAdNetworkAdsenseImpl(elem1);
         const impl2 = new AmpAdNetworkAdsenseImpl(elem2);
         const impl3 = new AmpAdNetworkAdsenseImpl(elem3);
+
+        impl1.uiHandler = {isStickyAd: () => false};
+        impl2.uiHandler = {isStickyAd: () => false};
+        impl3.uiHandler = {isStickyAd: () => false};
         return impl1.getAdUrl().then((adUrl1) => {
           expect(adUrl1).to.match(/pv=2/);
           expect(adUrl1).to.not.match(/prev_fmts/);

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -660,6 +660,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         .returns(Promise.resolve('http://fake.example/?foo=bar'));
 
       const impl = new AmpAdNetworkDoubleclickImpl(element);
+      impl.uiHandler = {isStickyAd: () => false};
       const impl2 = new AmpAdNetworkDoubleclickImpl(element);
       impl.setPageviewStateToken('abc');
       impl2.setPageviewStateToken('def');
@@ -711,6 +712,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
     it('includes psts param when there are pageview tokens', () => {
       const impl = new AmpAdNetworkDoubleclickImpl(element);
       const impl2 = new AmpAdNetworkDoubleclickImpl(element);
+      impl.uiHandler = {isStickyAd: () => false};
       impl.setPageviewStateToken('abc');
       impl2.setPageviewStateToken('def');
       return impl.getAdUrl().then((url) => {
@@ -722,6 +724,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
     it('does not include psts param when there are no pageview tokens', () => {
       const impl = new AmpAdNetworkDoubleclickImpl(element);
       new AmpAdNetworkDoubleclickImpl(element);
+      impl.uiHandler = {isStickyAd: () => false};
       impl.setPageviewStateToken('abc');
       return impl.getAdUrl().then((url) => {
         expect(url).to.not.match(/(\?|&)psts=([^&]+%2C)*abc(%2C[^&]+)*(&|$)/);
@@ -739,6 +742,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
     it('handles tagForChildDirectedTreatment', () => {
       element.setAttribute('json', '{"tagForChildDirectedTreatment": 1}');
       new AmpAd(element).upgradeCallback();
+      impl.uiHandler = {isStickyAd: () => false};
       return impl.getAdUrl().then((url) => {
         expect(url).to.match(/&tfcd=1&/);
       });
@@ -746,24 +750,25 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
 
     describe('data-force-safeframe', () => {
       const fsfRegexp = /(\?|&)fsf=1(&|$)/;
-      it('handles default', () =>
-        expect(
-          new AmpAdNetworkDoubleclickImpl(element).getAdUrl()
-        ).to.eventually.not.match(fsfRegexp));
+      it('handles default', () => {
+        const impl = new AmpAdNetworkDoubleclickImpl(element);
+        impl.uiHandler = {isStickyAd: () => false};
+        return expect(impl.getAdUrl()).to.eventually.not.match(fsfRegexp);
+      });
 
       it('case insensitive attribute name', () => {
         element.setAttribute('data-FORCE-SafeFraMe', '1');
-        return expect(
-          new AmpAdNetworkDoubleclickImpl(element).getAdUrl()
-        ).to.eventually.match(fsfRegexp);
+        const impl = new AmpAdNetworkDoubleclickImpl(element);
+        impl.uiHandler = {isStickyAd: () => false};
+        return expect(impl.getAdUrl()).to.eventually.match(fsfRegexp);
       });
 
       ['tRuE', 'true', 'TRUE', '1'].forEach((val) => {
         it(`valid attribute: ${val}`, () => {
           element.setAttribute('data-force-safeframe', val);
-          return expect(
-            new AmpAdNetworkDoubleclickImpl(element).getAdUrl()
-          ).to.eventually.match(fsfRegexp);
+          const impl = new AmpAdNetworkDoubleclickImpl(element);
+          impl.uiHandler = {isStickyAd: () => false};
+          return expect(impl.getAdUrl()).to.eventually.match(fsfRegexp);
         });
       });
 
@@ -781,9 +786,9 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       ].forEach((val) => {
         it(`invalid attribute: ${val}`, () => {
           element.setAttribute('data-force-safeframe', val);
-          return expect(
-            new AmpAdNetworkDoubleclickImpl(element).getAdUrl()
-          ).to.eventually.not.match(fsfRegexp);
+          const impl = new AmpAdNetworkDoubleclickImpl(element);
+          impl.uiHandler = {isStickyAd: () => false};
+          return expect(impl.getAdUrl()).to.eventually.not.match(fsfRegexp);
         });
       });
     });
@@ -791,6 +796,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
     it('handles categoryExclusions without targeting', () => {
       element.setAttribute('json', '{"categoryExclusions": "sports"}');
       new AmpAd(element).upgradeCallback();
+      impl.uiHandler = {isStickyAd: () => false};
       return impl.getAdUrl().then((url) => {
         expect(url).to.match(/&scp=excl_cat%3Dsports&/);
       });
@@ -806,6 +812,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         }`
       );
       new AmpAd(element).upgradeCallback();
+      impl.uiHandler = {isStickyAd: () => false};
       return impl.getAdUrl().then((url) => {
         expect(url).to.match(/&scp=cid%3Damp-[\w-]+&/);
       });
@@ -821,6 +828,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         }`
       );
       new AmpAd(element).upgradeCallback();
+      impl.uiHandler = {isStickyAd: () => false};
       return impl.getAdUrl().then((url) => {
         expect(url).to.match(/&scp=arr%3Dcats%2Camp-[\w-]+&/);
       });
@@ -902,6 +910,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       delete env.win['ampAdGoogleIfiCounter'];
       new AmpAd(element).upgradeCallback();
       env.sandbox.stub(AmpA4A.prototype, 'tearDownSlot').callsFake(() => {});
+      impl.uiHandler = {isStickyAd: () => false};
       return impl.getAdUrl().then((url1) => {
         expect(url1).to.match(/ifi=1/);
         impl.tearDownSlot();
@@ -997,6 +1006,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
 
     it('should include npa=1 if unknown consent & explicit npa', () => {
       impl.element.setAttribute('data-npa-on-unknown-consent', 'true');
+      impl.uiHandler = {isStickyAd: () => false};
       return impl
         .getAdUrl({consentState: CONSENT_POLICY_STATE.UNKNOWN})
         .then((url) => {
@@ -1004,29 +1014,36 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         });
     });
 
-    it('should include npa=1 if insufficient consent', () =>
-      impl
+    it('should include npa=1 if insufficient consent', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl({consentState: CONSENT_POLICY_STATE.INSUFFICIENT})
         .then((url) => {
           expect(url).to.match(/(\?|&)npa=1(&|$)/);
-        }));
+        });
+    });
 
-    it('should not include npa, if sufficient consent', () =>
-      impl
+    it('should not include npa, if sufficient consent', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl({consentState: CONSENT_POLICY_STATE.SUFFICIENT})
         .then((url) => {
           expect(url).to.not.match(/(\?|&)npa=(&|$)/);
-        }));
+        });
+    });
 
-    it('should not include npa, if not required consent', () =>
-      impl
+    it('should not include npa, if not required consent', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl({consentState: CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED})
         .then((url) => {
           expect(url).to.not.match(/(\?|&)npa=(&|$)/);
-        }));
+        });
+    });
 
-    it('should save opt_serveNpaSignal', () =>
-      impl
+    it('should save opt_serveNpaSignal', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl(
           {consentState: CONSENT_POLICY_STATE.SUFFICIENT},
           undefined,
@@ -1034,10 +1051,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         )
         .then(() => {
           expect(impl.serveNpaSignal_).to.be.true;
-        }));
+        });
+    });
 
-    it('should include npa=1 if `serveNpaSignal` is found, regardless of consent', () =>
-      impl
+    it('should include npa=1 if `serveNpaSignal` is found, regardless of consent', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl(
           {consentState: CONSENT_POLICY_STATE.SUFFICIENT},
           undefined,
@@ -1045,10 +1064,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         )
         .then((url) => {
           expect(url).to.match(/(\?|&)npa=1(&|$)/);
-        }));
+        });
+    });
 
-    it('should include npa=1 if `serveNpaSignal` is false & insufficient consent', () =>
-      impl
+    it('should include npa=1 if `serveNpaSignal` is false & insufficient consent', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl(
           {consentState: CONSENT_POLICY_STATE.INSUFFICIENT},
           undefined,
@@ -1056,40 +1077,54 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         )
         .then((url) => {
           expect(url).to.match(/(\?|&)npa=1(&|$)/);
-        }));
+        });
+    });
 
-    it('should include gdpr_consent, if TC String is provided', () =>
-      impl.getAdUrl({consentString: 'tcstring'}).then((url) => {
+    it('should include gdpr_consent, if TC String is provided', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl.getAdUrl({consentString: 'tcstring'}).then((url) => {
         expect(url).to.match(/(\?|&)gdpr_consent=tcstring(&|$)/);
-      }));
+      });
+    });
 
-    it('should include gdpr=1, if gdprApplies is true', () =>
-      impl.getAdUrl({gdprApplies: true}).then((url) => {
+    it('should include gdpr=1, if gdprApplies is true', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl.getAdUrl({gdprApplies: true}).then((url) => {
         expect(url).to.match(/(\?|&)gdpr=1(&|$)/);
-      }));
+      });
+    });
 
-    it('should include gdpr=0, if gdprApplies is false', () =>
-      impl.getAdUrl({gdprApplies: false}).then((url) => {
+    it('should include gdpr=0, if gdprApplies is false', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl.getAdUrl({gdprApplies: false}).then((url) => {
         expect(url).to.match(/(\?|&)gdpr=0(&|$)/);
-      }));
+      });
+    });
 
-    it('should not include gdpr, if gdprApplies is missing', () =>
-      impl.getAdUrl({}).then((url) => {
+    it('should not include gdpr, if gdprApplies is missing', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl.getAdUrl({}).then((url) => {
         expect(url).to.not.match(/(\?|&)gdpr=(&|$)/);
-      }));
+      });
+    });
 
-    it('should include addtl_consent', () =>
-      impl.getAdUrl({additionalConsent: 'abc123'}).then((url) => {
+    it('should include addtl_consent', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl.getAdUrl({additionalConsent: 'abc123'}).then((url) => {
         expect(url).to.match(/(\?|&)addtl_consent=abc123(&|$)/);
-      }));
+      });
+    });
 
-    it('should not include addtl_consent, if additionalConsent is missing', () =>
-      impl.getAdUrl({}).then((url) => {
+    it('should not include addtl_consent, if additionalConsent is missing', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl.getAdUrl({}).then((url) => {
         expect(url).to.not.match(/(\?|&)addtl_consent=/);
-      }));
+      });
+    });
 
-    it('should include us_privacy, if consentStringType matches', () =>
-      impl
+    it('should include us_privacy, if consentStringType matches', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl({
           consentStringType: CONSENT_STRING_TYPE.US_PRIVACY_STRING,
           consentString: 'usPrivacyString',
@@ -1097,10 +1132,12 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         .then((url) => {
           expect(url).to.match(/(\?|&)us_privacy=usPrivacyString(&|$)/);
           expect(url).to.not.match(/(\?|&)gdpr_consent=/);
-        }));
+        });
+    });
 
-    it('should include gdpr_consent, if consentStringType is not US_PRIVACY_STRING', () =>
-      impl
+    it('should include gdpr_consent, if consentStringType is not US_PRIVACY_STRING', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl({
           consentStringType: CONSENT_STRING_TYPE.TCF_V2,
           consentString: 'gdprString',
@@ -1108,20 +1145,24 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
         .then((url) => {
           expect(url).to.match(/(\?|&)gdpr_consent=gdprString(&|$)/);
           expect(url).to.not.match(/(\?|&)us_privacy=/);
-        }));
+        });
+    });
 
-    it('should include gdpr_consent, if consentStringType is undefined', () =>
-      impl
+    it('should include gdpr_consent, if consentStringType is undefined', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return impl
         .getAdUrl({consentStringType: undefined, consentString: 'gdprString'})
         .then((url) => {
           expect(url).to.match(/(\?|&)gdpr_consent=gdprString(&|$)/);
           expect(url).to.not.match(/(\?|&)us_privacy=/);
-        }));
+        });
+    });
 
     it('should include msz/psz/fws if in holdback control', () => {
       env.sandbox
         .stub(impl, 'randomlySelectUnsetExperiments_')
         .returns({flexAdSlots: '21063173'});
+      impl.uiHandler = {isStickyAd: () => false};
       impl.setPageLevelExperiments();
       return impl.getAdUrl().then((url) => {
         expect(url).to.match(/(\?|&)msz=[0-9]+x-1(&|$)/);
@@ -1132,6 +1173,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
     });
 
     it('should include msz/psz by default', () => {
+      impl.uiHandler = {isStickyAd: () => false};
       return impl.getAdUrl().then((url) => {
         expect(url).to.match(/(\?|&)msz=[0-9]+x-1(&|$)/);
         expect(url).to.match(/(\?|&)psz=[0-9]+x-1(&|$)/);
@@ -1140,8 +1182,10 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
       });
     });
 
-    it('sets ptt parameter', () =>
-      expect(impl.getAdUrl()).to.eventually.match(/(\?|&)ptt=13(&|$)/));
+    it('sets ptt parameter', () => {
+      impl.uiHandler = {isStickyAd: () => false};
+      return expect(impl.getAdUrl()).to.eventually.match(/(\?|&)ptt=13(&|$)/);
+    });
   });
 
   describe('#getPageParameters', () => {
@@ -1354,6 +1398,7 @@ describes.realWin('amp-ad-network-doubleclick-impl', realWinConfig, (env) => {
 
       impl = new AmpAdNetworkDoubleclickImpl(element);
       impl.initialSize_ = {width: 200, height: 50};
+      impl.uiHandler = {isStickyAd: () => false};
 
       // Boilerplate stubbing
       env.sandbox


### PR DESCRIPTION
If the google ads is rendered within `<amp-ad sticky=bottom`, we still want it to carry sticky ads attributes. This google parameters function does not have a test right now, so I am deferring that.

@zombifier