### PR TITLE
Remove extra wording from springAds readme doc

### DIFF
--- a/ads/vendors/springAds.md
+++ b/ads/vendors/springAds.md
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Spring AdTechnology AmpAd Integration
+# Spring AdTechnology
 
 ## Example
 


### PR DESCRIPTION
That text funnels to https://amp.dev/support/faq/platform-and-vendor-partners/ and makes it look weird