### PR TITLE
Rename `FitText` Component as `BentoFitText`

### DIFF
--- a/extensions/amp-fit-text/1.0/base-element.js
+++ b/extensions/amp-fit-text/1.0/base-element.js
@@ -15,13 +15,13 @@
  */
 
 import {CSS} from './component.jss';
-import {FitText} from './component';
+import {BentoFitText} from './component';
 import {PreactBaseElement} from '#preact/base-element';
 
 export class BaseElement extends PreactBaseElement {}
 
 /** @override */
-BaseElement['Component'] = FitText;
+BaseElement['Component'] = BentoFitText;
 
 /** @override */
 BaseElement['props'] = {

--- a/extensions/amp-fit-text/1.0/component.js
+++ b/extensions/amp-fit-text/1.0/component.js
@@ -22,10 +22,10 @@ import {toWin} from '#core/window';
 import {useCallback, useLayoutEffect, useRef} from '#preact';
 
 /**
- * @param {!FitTextProps} props
+ * @param {!BentoFitTextDef.Props} props
  * @return {PreactDef.Renderable}
  */
-export function FitText({
+export function BentoFitText({
   children,
   maxFontSize = 72,
   minFontSize = 6,

--- a/extensions/amp-fit-text/1.0/component.type.js
+++ b/extensions/amp-fit-text/1.0/component.type.js
@@ -16,6 +16,9 @@
 
 /** @externs */
 
+/** @const */
+var BentoFitTextDef = {};
+
 /**
  * @typedef {{
  *   minFontSize: (number|undefined),
@@ -23,4 +26,4 @@
  *   children: (?PreactDef.Renderable|undefined),
  * }}
  */
-var FitTextProps;
+BentoFitTextDef.Props;

--- a/extensions/amp-fit-text/1.0/storybook/Basic.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.js
@@ -15,12 +15,12 @@
  */
 
 import * as Preact from '#preact';
-import {FitText} from '../component';
+import {BentoFitText} from '../component';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
 
 export default {
-  title: 'FitText',
-  component: FitText,
+  title: 'BentoFitText',
+  component: BentoFitText,
   decorators: [withKnobs],
 };
 
@@ -30,14 +30,14 @@ export const _default = () => {
   const width = number('width', 300);
   const height = number('height', 200);
   return (
-    <FitText
+    <BentoFitText
       minFontSize={minFontSize}
       maxFontSize={maxFontSize}
       style={{border: '1px solid black', width, height}}
     >
       Lorem <i>ips</i>um dolor sit amet, has nisl nihil convenire et, vim at
       aeque inermis reprehendunt.
-    </FitText>
+    </BentoFitText>
   );
 };
 
@@ -47,14 +47,14 @@ export const scaleUpOverflowEllipsis = () => {
   const width = number('width', 300);
   const height = number('height', 200);
   return (
-    <FitText
+    <BentoFitText
       minFontSize={minFontSize}
       maxFontSize={maxFontSize}
       style={{border: '1px solid black', width, height}}
     >
       Lorem <i>ips</i>um dolor sit amet, has nisl nihil convenire et, vim at
       aeque inermis reprehendunt.
-    </FitText>
+    </BentoFitText>
   );
 };
 
@@ -64,7 +64,7 @@ export const scaleDown = () => {
   const width = number('width', 300);
   const height = number('height', 200);
   return (
-    <FitText
+    <BentoFitText
       minFontSize={minFontSize}
       maxFontSize={maxFontSize}
       style={{border: '1px solid black', width, height}}
@@ -75,7 +75,7 @@ export const scaleDown = () => {
       apeirian et. Omnium legendos tractatos cu mea. Vix in stet dolorem
       accusamus. Iisque rationibus consetetur in cum, quo unum nulla legere ut.
       Simul numquam saperet no sit.
-    </FitText>
+    </BentoFitText>
   );
 };
 
@@ -85,13 +85,13 @@ export const scaleDownMore = () => {
   const width = number('width', 108);
   const height = number('height', 78);
   return (
-    <FitText
+    <BentoFitText
       minFontSize={minFontSize}
       maxFontSize={maxFontSize}
       style={{border: '1px solid black', width, height}}
     >
       Superlongword text
-    </FitText>
+    </BentoFitText>
   );
 };
 
@@ -102,12 +102,12 @@ export const configureContent = () => {
   const width = number('width', 400);
   const height = number('height', 400);
   return (
-    <FitText
+    <BentoFitText
       minFontSize={minFontSize}
       maxFontSize={maxFontSize}
       style={{border: '1px solid black', width, height}}
     >
       {content}
-    </FitText>
+    </BentoFitText>
   );
 };

--- a/extensions/amp-fit-text/1.0/test/test-component.js
+++ b/extensions/amp-fit-text/1.0/test/test-component.js
@@ -15,13 +15,13 @@
  */
 
 import * as Preact from '#preact';
-import {FitText, calculateFontSize, setOverflowStyle} from '../component';
+import {BentoFitText, calculateFontSize, setOverflowStyle} from '../component';
 import {computedStyle} from '#core/dom/style';
 import {mount} from 'enzyme';
 import {useStyles} from '../component.jss';
 import {waitFor} from '#testing/test-helper';
 
-describes.realWin('FitText preact component v1.0', {}, (env) => {
+describes.realWin('BentoFitText preact component v1.0', {}, (env) => {
   let win;
 
   const styles = useStyles();
@@ -41,9 +41,9 @@ describes.realWin('FitText preact component v1.0', {}, (env) => {
   it('renders', async () => {
     const ref = Preact.createRef();
     const wrapper = mount(
-      <FitText ref={ref} style={{width: '300px', height: '100px'}}>
+      <BentoFitText ref={ref} style={{width: '300px', height: '100px'}}>
         Hello World
-      </FitText>,
+      </BentoFitText>,
       {attachTo: win.document.body}
     );
 
@@ -59,9 +59,13 @@ describes.realWin('FitText preact component v1.0', {}, (env) => {
   it('should respect minFontSize', async () => {
     const ref = Preact.createRef();
     const wrapper = mount(
-      <FitText ref={ref} style={{width: '1px', height: '1px'}} minFontSize="24">
+      <BentoFitText
+        ref={ref}
+        style={{width: '1px', height: '1px'}}
+        minFontSize="24"
+      >
         Hello World
-      </FitText>,
+      </BentoFitText>,
       {attachTo: win.document.body}
     );
 
@@ -77,13 +81,13 @@ describes.realWin('FitText preact component v1.0', {}, (env) => {
   it('should respect maxFontSize', async () => {
     const ref = Preact.createRef();
     const wrapper = mount(
-      <FitText
+      <BentoFitText
         ref={ref}
         style={{width: '300px', height: '100px'}}
         maxFontSize="48"
       >
         Hello World
-      </FitText>,
+      </BentoFitText>,
       {attachTo: win.document.body}
     );
 
@@ -97,7 +101,7 @@ describes.realWin('FitText preact component v1.0', {}, (env) => {
   });
 });
 
-describes.realWin('FitText calculateFontSize', {}, (env) => {
+describes.realWin('BentoFitText calculateFontSize', {}, (env) => {
   let win, doc;
   let element;
 
@@ -154,7 +158,7 @@ describes.realWin('FitText calculateFontSize', {}, (env) => {
   });
 });
 
-describes.realWin('FitText setOverflowStyle', {}, (env) => {
+describes.realWin('BentoFitText setOverflowStyle', {}, (env) => {
   let win, doc;
   let measurer;
 


### PR DESCRIPTION
This change updates the name of the released Preact/React components on npm from `FitText` to `BentoFitText`.