### PR TITLE
`3p-frame`: Prefer `#core/mode` to `getMode`

### DIFF
--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -70,14 +70,6 @@ describes.realWin(
     let registryBackup;
     const whenFirstVisible = Promise.resolve();
 
-    function mockMode(options) {
-      env.sandbox
-        .stub(mode, 'isLocalDev')
-        .returns(!!options.localDev || !!options.test);
-      env.sandbox.stub(mode, 'isTest').returns(!!options.test);
-      env.sandbox.stub(mode, 'isProd').returns(!!options.isProd);
-    }
-
     beforeEach(() => {
       registryBackup = Object.create(null);
       Object.keys(adConfig).forEach((k) => {
@@ -336,7 +328,7 @@ describes.realWin(
 
     describe('preconnectCallback', () => {
       it('should add preconnect and prefetch to DOM header', () => {
-        mockMode({isProd: true});
+        env.sandbox.stub(mode, 'isProd').returns(true);
         ad3p.buildCallback();
         ad3p.preconnectCallback();
         return whenFirstVisible.then(() => {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-3p-impl.js
@@ -18,6 +18,7 @@ import '../../../amp-sticky-ad/1.0/amp-sticky-ad';
 import '../amp-ad';
 import * as adCid from '../../../../src/ad-cid';
 import * as consent from '../../../../src/consent';
+import * as mode from '#core/mode';
 import * as fakeTimers from '@sinonjs/fake-timers';
 import {AmpAd3PImpl} from '../amp-ad-3p-impl';
 import {AmpAdUIHandler} from '../amp-ad-ui';
@@ -69,8 +70,12 @@ describes.realWin(
     let registryBackup;
     const whenFirstVisible = Promise.resolve();
 
-    function mockMode(mode) {
-      env.sandbox.stub(win.parent, '__AMP_MODE').value(mode);
+    function mockMode(options) {
+      env.sandbox
+        .stub(mode, 'isLocalDev')
+        .returns(!!options.localDev || !!options.test);
+      env.sandbox.stub(mode, 'isTest').returns(!!options.test);
+      env.sandbox.stub(mode, 'isProd').returns(!!options.isProd);
     }
 
     beforeEach(() => {
@@ -331,7 +336,7 @@ describes.realWin(
 
     describe('preconnectCallback', () => {
       it('should add preconnect and prefetch to DOM header', () => {
-        mockMode({});
+        mockMode({isProd: true});
         ad3p.buildCallback();
         ad3p.preconnectCallback();
         return whenFirstVisible.then(() => {

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -202,13 +202,13 @@ export function addDataAndJsonAttributes_(element, attributes) {
  */
 export function getBootstrapUrl(type) {
   const extension = IS_ESM ? '.mjs' : '.js';
-  if (mode.isLocalDev()) {
-    const filename = mode.isMinified()
-      ? `./vendor/${type}`
-      : `./vendor/${type}.max`;
-    return filename + extension;
+  if (mode.isProd()) {
+    return `${urls.thirdParty}/${mode.version()}/vendor/${type}${extension}`;
   }
-  return `${urls.thirdParty}/${mode.version()}/vendor/${type}${extension}`;
+  const filename = mode.isMinified()
+    ? `./vendor/${type}`
+    : `./vendor/${type}.max`;
+  return filename + extension;
 }
 
 /**
@@ -268,7 +268,7 @@ export function resetBootstrapBaseUrlForTesting(win) {
  */
 export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
   const srcFileBasename = opt_srcFileBasename || 'frame';
-  if (mode.isLocalDev()) {
+  if (!mode.isProd()) {
     return getDevelopmentBootstrapBaseUrl(parentWindow, srcFileBasename);
   }
   // Ensure same sub-domain is used despite potentially different file.

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -202,7 +202,7 @@ export function addDataAndJsonAttributes_(element, attributes) {
  */
 export function getBootstrapUrl(type) {
   const extension = IS_ESM ? '.mjs' : '.js';
-  if (mode.isLocalDev() || mode.isTest()) {
+  if (mode.isLocalDev()) {
     const filename = mode.isMinified()
       ? `./vendor/${type}`
       : `./vendor/${type}.max`;
@@ -268,7 +268,7 @@ export function resetBootstrapBaseUrlForTesting(win) {
  */
 export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
   const srcFileBasename = opt_srcFileBasename || 'frame';
-  if (mode.isLocalDev() || mode.isTest()) {
+  if (mode.isLocalDev()) {
     return getDevelopmentBootstrapBaseUrl(parentWindow, srcFileBasename);
   }
   // Ensure same sub-domain is used despite potentially different file.

--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -23,7 +23,6 @@ import {tryParseJson} from '#core/types/object/json';
 import {urls} from './config';
 import {getContextMetadata} from './iframe-attributes';
 import {dev, devAssert, user, userAssert} from './log';
-import {getMode} from './mode';
 import {assertHttpsUrl, parseUrlDeprecated} from './url';
 
 /** @type {!Object<string,number>} Number of 3p frames on the for that type. */
@@ -203,7 +202,7 @@ export function addDataAndJsonAttributes_(element, attributes) {
  */
 export function getBootstrapUrl(type) {
   const extension = IS_ESM ? '.mjs' : '.js';
-  if (getMode().localDev || getMode().test) {
+  if (mode.isLocalDev() || mode.isTest()) {
     const filename = mode.isMinified()
       ? `./vendor/${type}`
       : `./vendor/${type}.max`;
@@ -269,7 +268,7 @@ export function resetBootstrapBaseUrlForTesting(win) {
  */
 export function getDefaultBootstrapBaseUrl(parentWindow, opt_srcFileBasename) {
   const srcFileBasename = opt_srcFileBasename || 'frame';
-  if (getMode().localDev || getMode().test) {
+  if (mode.isLocalDev() || mode.isTest()) {
     return getDevelopmentBootstrapBaseUrl(parentWindow, srcFileBasename);
   }
   // Ensure same sub-domain is used despite potentially different file.

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -45,8 +45,9 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
 
   function mockMode(options) {
     env.sandbox.stub(window.parent, '__AMP_MODE').value(options);
-    env.sandbox.stub(mode, 'isLocalDev').returns(!!options.localDev);
-    env.sandbox.stub(mode, 'isTest').returns(!!options.test);
+    env.sandbox
+      .stub(mode, 'isLocalDev')
+      .returns(!!options.localDev || !!options.test);
     env.sandbox.stub(mode, 'isProd').returns(!!options.isProd);
   }
 

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -47,7 +47,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
     env.sandbox.stub(window.parent, '__AMP_MODE').value(options);
     env.sandbox.stub(mode, 'isLocalDev').returns(!!options.localDev);
     env.sandbox.stub(mode, 'isTest').returns(!!options.test);
-    env.sandbox.stub(mode, 'isProd').returns(!options);
+    env.sandbox.stub(mode, 'isProd').returns(!!options.isProd);
   }
 
   describe
@@ -340,7 +340,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
       });
 
       it('should pick the right bootstrap unique url (prod)', () => {
-        mockMode({});
+        mockMode({isProd: true});
         const ampdoc = Services.ampdoc(window.document);
         expect(getBootstrapBaseUrl(window, ampdoc)).to.match(
           /^https:\/\/d-\d+\.ampproject\.net\/\$\internal\w+\$\/frame\.html$/
@@ -348,7 +348,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
       });
 
       it('should return a stable URL in getBootstrapBaseUrl', () => {
-        mockMode({});
+        mockMode({isProd: true});
         const ampdoc = Services.ampdoc(window.document);
         expect(getBootstrapBaseUrl(window, ampdoc)).to.equal(
           getBootstrapBaseUrl(window, ampdoc)
@@ -356,7 +356,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
       });
 
       it('should return a stable URL in getDefaultBootstrapBaseUrl', () => {
-        mockMode({});
+        mockMode({isProd: true});
         expect(getDefaultBootstrapBaseUrl(window)).to.equal(
           getDefaultBootstrapBaseUrl(window)
         );
@@ -371,7 +371,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
       });
 
       it('should return different values for different file names', () => {
-        mockMode({});
+        mockMode({isProd: true});
         let match =
           /^https:\/\/(d-\d+\.ampproject\.net)\/\$\internal\w+\$\/frame\.html$/.exec(
             getDefaultBootstrapBaseUrl(window)
@@ -418,7 +418,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
       });
 
       it('should prefetch bootstrap frame and JS', () => {
-        mockMode({});
+        mockMode({isProd: true});
         const ampdoc = Services.ampdoc(window.document);
         preloadBootstrap(window, 'avendor', ampdoc, preconnect);
         // Wait for visible promise.
@@ -479,7 +479,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
           .returns('http://acme.org/')
           .twice();
 
-        mockMode({});
+        mockMode({isProd: true});
         const link = document.createElement('link');
         link.setAttribute('rel', 'canonical');
         link.setAttribute('href', 'https://foo.bar/baz');

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -45,10 +45,6 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
 
   function mockMode(options) {
     env.sandbox.stub(window.parent, '__AMP_MODE').value(options);
-    env.sandbox
-      .stub(mode, 'isLocalDev')
-      .returns(!!options.localDev || !!options.test);
-    env.sandbox.stub(mode, 'isTest').returns(!!options.test);
     env.sandbox.stub(mode, 'isProd').returns(!!options.isProd);
   }
 

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -48,6 +48,7 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
     env.sandbox
       .stub(mode, 'isLocalDev')
       .returns(!!options.localDev || !!options.test);
+    env.sandbox.stub(mode, 'isTest').returns(!!options.test);
     env.sandbox.stub(mode, 'isProd').returns(!!options.isProd);
   }
 

--- a/test/unit/3p/test-3p-frame.js
+++ b/test/unit/3p/test-3p-frame.js
@@ -16,6 +16,7 @@
 
 import {deserializeMessage, serializeMessage} from '#core/3p-frame-messaging';
 import {DomFingerprint} from '#core/dom/fingerprint';
+import * as mode from '#core/mode';
 import {WindowInterface} from '#core/window/interface';
 
 import {toggleExperiment} from '#experiments';
@@ -42,8 +43,11 @@ describes.realWin('3p-frame', {amp: true}, (env) => {
     document = window.document;
   });
 
-  function mockMode(mode) {
-    env.sandbox.stub(window.parent, '__AMP_MODE').value(mode);
+  function mockMode(options) {
+    env.sandbox.stub(window.parent, '__AMP_MODE').value(options);
+    env.sandbox.stub(mode, 'isLocalDev').returns(!!options.localDev);
+    env.sandbox.stub(mode, 'isTest').returns(!!options.test);
+    env.sandbox.stub(mode, 'isProd').returns(!options);
   }
 
   describe


### PR DESCRIPTION
This change enables 3p iframe Bento components to reference the mode without having to be on an AMP document.