### PR TITLE
✅ Remove a couple unnecessary `async`s from `amp-bind` e2e test

### DIFF
--- a/test/e2e/test-amp-bind-brightcove.js
+++ b/test/e2e/test-amp-bind-brightcove.js
@@ -19,10 +19,10 @@ describes.endtoend(
   {
     fixture: 'amp-bind/bind-brightcove.html',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 


### PR DESCRIPTION
This appears to be causing the test case to return control early and continue running in the background, resulting in concatenated test suite names during `amp e2e`... and maybe bogus test failures?

![image](https://user-images.githubusercontent.com/26553114/129401941-7a778d31-1ffe-45fe-8b9c-ac0a49720a71.png)
