### PR TITLE
✅ Remove unnessary `async` annotations from E2E tests

### DIFF
--- a/extensions/amp-accordion/1.0/test-e2e/test-amp-accordion.js
+++ b/extensions/amp-accordion/1.0/test-e2e/test-amp-accordion.js
@@ -22,7 +22,7 @@ describes.endtoend(
     experiments: ['bento-accordion'],
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     let header1;

--- a/extensions/amp-accordion/1.0/test-e2e/test-single-expand.js
+++ b/extensions/amp-accordion/1.0/test-e2e/test-single-expand.js
@@ -22,10 +22,10 @@ describes.endtoend(
     experiments: ['bento-accordion'],
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-analytics/0.1/test-e2e/test-browser-event.js
+++ b/extensions/amp-analytics/0.1/test-e2e/test-browser-event.js
@@ -24,7 +24,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-analytics/0.1/test-e2e/test-iframe-transport.js
+++ b/extensions/amp-analytics/0.1/test-e2e/test-iframe-transport.js
@@ -23,7 +23,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-animation/0.1/test-e2e/test-amp-animation.js
+++ b/extensions/amp-animation/0.1/test-e2e/test-amp-animation.js
@@ -24,7 +24,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-auto-lightbox/0.1/test-e2e/test-amp-auto-lightbox.js
+++ b/extensions/amp-auto-lightbox/0.1/test-e2e/test-amp-auto-lightbox.js
@@ -22,10 +22,10 @@ describes.endtoend(
     environments: ['single'],
     browsers: ['chrome'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-advance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-advance.js
@@ -28,7 +28,7 @@ describes.endtoend(
     environments: ['single'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     let controller;
     let nextArrow;
     let prevArrow;

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-in-lightbox.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-in-lightbox.js
@@ -22,12 +22,12 @@ describes.endtoend(
     fixture: 'amp-base-carousel/arrows-in-lightbox.amp.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
     let nextArrow;
     let prevArrow;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-arrows-non-looping.js
@@ -31,7 +31,7 @@ describes.endtoend(
     //TODO(spaharmi): fails on shadow demo
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
     let prevArrow;
     let nextArrow;

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-autoadvance.js
@@ -27,14 +27,14 @@ describes.endtoend(
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     function rect(el) {
       return controller.getElementRect(el);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-carousel.js
@@ -36,7 +36,7 @@ describes.endtoend(
     //TODO(spaharmi): fails on shadow demo
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     /** The total number of slides in the carousel */
     const SLIDE_COUNT = 7;
     let controller;

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-default-attributes.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-default-attributes.js
@@ -31,7 +31,7 @@ describes.endtoend(
     let scrollContainer;
     let loop;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-goToSlide.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-goToSlide.js
@@ -22,12 +22,12 @@ describes.endtoend(
     fixture: 'amp-base-carousel/arrows-in-lightbox.amp.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
     let slides;
     let prevArrow;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-grouping.js
@@ -27,7 +27,7 @@ describes.endtoend(
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     const slideWidth = pageWidth / 2;
     let controller;
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -47,7 +47,7 @@ describes.endtoend(
 
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-initial-slide.js
@@ -27,10 +27,10 @@ describes.endtoend(
     environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths-no-snap.js
@@ -29,7 +29,7 @@ describes.endtoend(
     //TODO(spaharmi): fails on viewer and shadow demo
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     function prop(el, name) {
@@ -41,7 +41,7 @@ describes.endtoend(
       await expect(prop(spacers[1], 'offsetWidth')).to.equal(width);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
@@ -27,7 +27,7 @@ describes.endtoend(
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     function prop(el, name) {
@@ -39,7 +39,7 @@ describes.endtoend(
       await expect(prop(spacers[1], 'offsetWidth')).to.equal(width);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-mixed-lengths.js
@@ -69,20 +69,17 @@ describes.endtoend(
           await assertSpacerWidth(1, slideTwoWidth);
         });
 
-      //TODO(sparhami): fails on shadow demo
-      it.configure()
-        .skipShadowDemo()
-        // TODO(#35241): flaky test disabled in #35176
-        .skip('should snap on the center point', async () => {
-          const el = await getScrollingElement(controller);
-          const slides = await getSlides(controller);
-          const scrollAmount = 1 + slideOneWidth / 2;
+      // TODO(#35241): flaky test disabled in #35176
+      it.skip('should snap on the center point', async () => {
+        const el = await getScrollingElement(controller);
+        const slides = await getSlides(controller);
+        const scrollAmount = 1 + slideOneWidth / 2;
 
-          await controller.scrollBy(el, {left: scrollAmount});
-          await expect(controller.getElementRect(slides[1])).to.include({
-            x: (pageWidth - slideTwoWidth) / 2,
-          });
+        await controller.scrollBy(el, {left: scrollAmount});
+        await expect(controller.getElementRect(slides[1])).to.include({
+          x: (pageWidth - slideTwoWidth) / 2,
         });
+      });
     });
   }
 );

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-non-looping.js
@@ -27,7 +27,7 @@ describes.endtoend(
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     /** The total number of slides in the carousel */
     const SLIDE_COUNT = 4;
     let controller;
@@ -36,7 +36,7 @@ describes.endtoend(
       return controller.getElementProperty(el, name);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-responsive.js
@@ -29,14 +29,14 @@ describes.endtoend(
     //TODO(spaharmi): fails on shadow demo
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     function prop(el, name) {
       return controller.getElementProperty(el, name);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-rtl.js
@@ -30,11 +30,11 @@ describes.endtoend(
     // TODO(sparhami) Make other environments work too
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     /** The total number of slides in the carousel */
     const SLIDE_COUNT = 7;
     let controller;
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-snap-property.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-snap-property.js
@@ -26,7 +26,7 @@ describes.endtoend(
   async function (env) {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/0.1/test-e2e/test-vertical.js
@@ -27,7 +27,7 @@ describes.endtoend(
     experiments: ['amp-base-carousel', 'layers'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     /** The total number of slides in the carousel */
     const SLIDE_COUNT = 7;
     let controller;
@@ -40,7 +40,7 @@ describes.endtoend(
       return controller.getElementRect(el);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-advance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-advance.js
@@ -35,7 +35,7 @@ describes.endtoend(
     environments: ['single'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     let controller;
     let nextArrow;
     let prevArrow;

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-arrows-non-looping.js
@@ -36,7 +36,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     const styles = useStyles();
     let controller;
     let prevArrow;

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-autoadvance.js
@@ -29,7 +29,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
     const styles = useStyles();
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-component.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-component.js
@@ -32,7 +32,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     /** The total number of slides in the carousel */
     const SLIDE_COUNT = 7;
     let controller;

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-grouping.js
@@ -33,7 +33,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller, btnPrev, btnNext;
 
     const styles = useStyles();

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths-no-snap.js
@@ -29,7 +29,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
     const styles = useStyles();
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-mixed-lengths.js
@@ -29,7 +29,7 @@ describes.endtoend(
     environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     let controller;
     const styles = useStyles();
 

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-non-looping.js
@@ -29,7 +29,7 @@ describes.endtoend(
     environments: ['single', 'viewer-demo'],
     initialRect: {width: pageWidth, height: pageHeight},
   },
-  async (env) => {
+  (env) => {
     /** The total number of slides in the carousel */
     const SLIDE_COUNT = 4;
     const styles = useStyles();

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-responsive.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-responsive.js
@@ -29,7 +29,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     const styles = useStyles();
     let controller;
     let carousel;

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-rtl.js
@@ -30,7 +30,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     const styles = useStyles();
 
     /** The total number of slides in the carousel */

--- a/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
+++ b/extensions/amp-base-carousel/1.0/test-e2e/test-vertical.js
@@ -29,7 +29,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     /** The total number of slides in the carousel */
     const SLIDE_COUNT = 7;
     let controller;

--- a/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -44,7 +44,7 @@ describes.endtoend(
 
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
@@ -43,7 +43,7 @@ describes.endtoend(
       }, opt_selector);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-carousel/0.2/test/test-e2e/test-arrows-in-lightbox.js
+++ b/extensions/amp-carousel/0.2/test/test-e2e/test-arrows-in-lightbox.js
@@ -20,7 +20,7 @@ describes.endtoend(
     fixture: 'amp-carousel/0.2/amp-lightbox-carousel-selector.amp.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
     let nextArrow;
     let prevArrow;
@@ -37,7 +37,7 @@ describes.endtoend(
       );
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-carousel/0.2/test/test-e2e/test-repsonsive-slides.js
+++ b/extensions/amp-carousel/0.2/test/test-e2e/test-repsonsive-slides.js
@@ -30,7 +30,7 @@ describes.endtoend(
       return controller.getElementRect(el);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-date-countdown/1.0/test-e2e/test-amp-date-countdown.js
+++ b/extensions/amp-date-countdown/1.0/test-e2e/test-amp-date-countdown.js
@@ -22,10 +22,10 @@ describes.endtoend(
     experiments: ['bento-date-countdown'],
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-date-picker/0.1/test-e2e/test-blocked-dates.js
+++ b/extensions/amp-date-picker/0.1/test-e2e/test-blocked-dates.js
@@ -22,10 +22,10 @@ describes.endtoend(
     fixture: 'amp-date-picker/blocked-dates.html',
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-fit-text/0.1/test-e2e/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/test-e2e/test-amp-fit-text.js
@@ -23,7 +23,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-form/0.1/test-e2e/test-custom-validation-reporting.js
+++ b/extensions/amp-form/0.1/test-e2e/test-custom-validation-reporting.js
@@ -25,7 +25,7 @@ describes.endtoend(
     fixture: 'amp-form/custom-validation-reporting.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
     let fullnameInput;
     let submitButton;

--- a/extensions/amp-form/0.1/test-e2e/test-ssr.js
+++ b/extensions/amp-form/0.1/test-e2e/test-ssr.js
@@ -20,10 +20,10 @@ describes.endtoend(
     fixture: 'amp-form/amp-form.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 
@@ -53,10 +53,10 @@ describes.endtoend(
     fixture: 'amp-form/amp-form.html',
     environments: ['viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-lightbox-gallery/0.1/test-e2e/test-carousel-0.2-declared.js
+++ b/extensions/amp-lightbox-gallery/0.1/test-e2e/test-carousel-0.2-declared.js
@@ -24,7 +24,7 @@ describes.endtoend(
     initialRect: {width: pageWidth, height: pageHeight},
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     function css(handle, name) {
@@ -35,7 +35,7 @@ describes.endtoend(
       return controller.getElementProperty(el, name);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-lightbox-gallery/0.1/test-e2e/test-open-close.js
+++ b/extensions/amp-lightbox-gallery/0.1/test-e2e/test-open-close.js
@@ -25,7 +25,7 @@ describes.endtoend(
     // TODO(sparhami) Get this working in other environments.
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     function css(handle, name) {
@@ -36,7 +36,7 @@ describes.endtoend(
       return controller.getElementProperty(el, name);
     }
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-lightbox/1.0/test-e2e/test-custom-close-button.js
+++ b/extensions/amp-lightbox/1.0/test-e2e/test-custom-close-button.js
@@ -27,7 +27,7 @@ describes.endtoend(
       },
     },
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-lightbox/test-e2e/test-amp-lightbox-autocomplete.js
+++ b/extensions/amp-lightbox/test-e2e/test-amp-lightbox-autocomplete.js
@@ -21,7 +21,7 @@ describes.endtoend(
     fixture: 'amp-lightbox/amp-lightbox-autocomplete.html',
     environments: 'ampdoc-preset',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-lightbox/test-e2e/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/test-e2e/test-amp-lightbox.js
@@ -31,7 +31,7 @@ describes.endtoend(
       },
     },
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-list/0.1/test-e2e/test-function-src.js
+++ b/extensions/amp-list/0.1/test-e2e/test-function-src.js
@@ -20,10 +20,10 @@ describes.endtoend(
     fixture: 'amp-list/amp-list-function-src.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 
@@ -44,10 +44,10 @@ describes.endtoend(
     fixture: 'amp-list/amp-list-function-load-more.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-auto.js
@@ -29,7 +29,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
+++ b/extensions/amp-list/0.1/test-e2e/test-load-more-manual.js
@@ -25,10 +25,10 @@ describes.endtoend(
     // TODO(cathyxz, cvializ): figure out why 'viewer-demo' only shows 'FALLBACK'
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-list/0.1/test-e2e/test-ssr.js
+++ b/extensions/amp-list/0.1/test-e2e/test-ssr.js
@@ -20,10 +20,10 @@ describes.endtoend(
     fixture: 'amp-list/amp-list.html',
     environments: ['viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 
@@ -52,10 +52,10 @@ describes.endtoend(
     fixture: 'amp-list/amp-list.html',
     environments: ['single'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-script/0.1/test-e2e/test-amp-script.js
+++ b/extensions/amp-script/0.1/test-e2e/test-amp-script.js
@@ -22,10 +22,10 @@ describes.endtoend(
     environments: ['single'],
     browsers: ['chrome', 'safari'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-selector/test-e2e/test-amp-selector-tabs.js
+++ b/extensions/amp-selector/test-e2e/test-amp-selector-tabs.js
@@ -29,7 +29,7 @@ describes.endtoend(
       },
     },
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar-toolbar.js
+++ b/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar-toolbar.js
@@ -20,7 +20,7 @@ describes.endtoend(
     fixture: 'amp-sidebar/amp-sidebar-toolbar.html',
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.1/test-e2e/test-amp-sidebar.js
@@ -23,7 +23,7 @@ describes.endtoend(
     fixture: 'amp-sidebar/amp-sidebar.html',
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-sidebar/0.2/test-e2e/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/test-e2e/test-amp-sidebar.js
@@ -22,7 +22,7 @@ describes.endtoend(
     fixture: 'amp-sidebar/amp-sidebar.html',
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-sidebar/1.0/test-e2e/test-amp-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test-e2e/test-amp-sidebar.js
@@ -24,7 +24,7 @@ describes.endtoend(
     experiments: ['bento-sidebar'],
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-social-share/1.0/test-e2e/test-amp-social-share.js
+++ b/extensions/amp-social-share/1.0/test-e2e/test-amp-social-share.js
@@ -24,7 +24,7 @@ describes.endtoend(
     experiments: ['bento-social-share'],
     environments: ['single', 'viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     let controller;
 
     beforeEach(() => {

--- a/extensions/amp-story/1.0/test-e2e/test-amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/test-e2e/test-amp-story-share-menu.js
@@ -24,7 +24,7 @@ describes.endtoend(
     environments: ['single'],
     deviceName: 'iPhone X',
   },
-  async (env) => {
+  (env) => {
     /** @type {SeleniumWebDriverController} */
     let controller;
 

--- a/extensions/amp-video/0.1/test-e2e/test-amp-video-analytics.js
+++ b/extensions/amp-video/0.1/test-e2e/test-amp-video-analytics.js
@@ -23,7 +23,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/extensions/amp-video/0.1/test-e2e/test-amp-video.js
+++ b/extensions/amp-video/0.1/test-e2e/test-amp-video.js
@@ -23,7 +23,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-adchoices.js
+++ b/test/e2e/test-adchoices.js
@@ -23,7 +23,7 @@ describes.endtoend(
   (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-bind-email.js
+++ b/test/e2e/test-amp-bind-email.js
@@ -19,10 +19,10 @@ describes.endtoend(
   {
     fixture: 'amp-bind/bind-amp4email.html',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-bind-form.js
+++ b/test/e2e/test-amp-bind-form.js
@@ -19,10 +19,10 @@ describes.endtoend(
   {
     fixture: 'amp-bind/bind-form.html',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-bind-iframe.js
+++ b/test/e2e/test-amp-bind-iframe.js
@@ -19,10 +19,10 @@ describes.endtoend(
   {
     fixture: 'amp-bind/bind-iframe.html',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-bind-live-list.js
+++ b/test/e2e/test-amp-bind-live-list.js
@@ -19,10 +19,10 @@ describes.endtoend(
   {
     fixture: 'amp-bind/bind-live-list.html',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-bind-state.js
+++ b/test/e2e/test-amp-bind-state.js
@@ -20,10 +20,10 @@ describes.endtoend(
     fixture: 'amp-bind/bind-basic.html',
     environments: 'ampdoc-amp4ads-preset',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-bind-video.js
+++ b/test/e2e/test-amp-bind-video.js
@@ -20,10 +20,10 @@ describes.endtoend(
     fixture: 'amp-bind/bind-video.html',
     environments: 'ampdoc-amp4ads-preset',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-bind-youtube.js
+++ b/test/e2e/test-amp-bind-youtube.js
@@ -19,10 +19,10 @@ describes.endtoend(
   {
     fixture: 'amp-bind/bind-youtube.html',
   },
-  async (env) => {
+  (env) => {
     let controller;
 
-    beforeEach(async () => {
+    beforeEach(() => {
       controller = env.controller;
     });
 

--- a/test/e2e/test-amp-email.js
+++ b/test/e2e/test-amp-email.js
@@ -20,7 +20,7 @@ describes.endtoend(
     fixture: 'amp4email/viewport-size-race.html',
     environments: ['email-demo'],
   },
-  async (env) => {
+  (env) => {
     it('Should call amp-img layoutCallback', async () => {
       const {controller} = env;
       const imgEl = await controller.findElement('img');
@@ -35,7 +35,7 @@ describes.endtoend(
     fixture: 'amp4email/element-size-race.html',
     environments: ['email-demo'],
   },
-  async (env) => {
+  (env) => {
     it('Should call amp-list layoutCallback', async () => {
       const {controller} = env;
       const ampListChild = await controller.findElement('.fruit');

--- a/test/e2e/test-document-height.js
+++ b/test/e2e/test-document-height.js
@@ -20,7 +20,7 @@ describes.endtoend(
     fixture: 'amp-carousel/0.1/document-height.html',
     environments: ['viewer-demo'],
   },
-  async (env) => {
+  (env) => {
     it('should send documentHeight once amp has completed init', async () => {
       const messages = env.receivedMessages;
       const documentHeightMessages = messages.filter(


### PR DESCRIPTION
There are two problems with our E2E tests:

- About half of them are immediately returning control and running in the background because the underlying `describes` block doesn't actually `await` the `async (env) => {...}` test suite body. There's no reason for a test suite to be `async`.
https://github.com/ampproject/amphtml/blob/f43cfa041f531834ebc43579e1d8f821d011628c/build-system/tasks/e2e/describes-e2e.js#L512-L514
- In addition, several `beforeEach()` blocks are unnecessarily marked `async` when they're entirely synchronous. E.g.:
https://github.com/ampproject/amphtml/blob/a824298a21e2e9c5f4a76718021d8a736216a5d4/extensions/amp-analytics/0.1/test-e2e/test-browser-event.js#L27-L29

This PR cleans up both patterns in the E2E tests. Let's see what the CI results are. Once this lands, we can try to figure out a way to prevent future misuse of `async` in tests.