### PR TITLE
Allow `i-amphtml-sizer[slot="i-amphtml-svc"]` on transformed documents.

### DIFF
--- a/validator/testdata/transformed_feature_tests/amp-img.html
+++ b/validator/testdata/transformed_feature_tests/amp-img.html
@@ -65,5 +65,47 @@
     <i-amphtml-sizer style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
     <img class=i-amphtml-blurry-placeholder placeholder src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http%3A//www.w3.org/2000/svg' xmlns%3Axlink='http%3A//www.w3.org/1999/xlink' viewBox='0 0 9 7'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='.5'%3E%3C/feGaussianBlur%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1'%3E%3C/feFuncA%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Cimage filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' xlink%3Ahref='data%3Aimage/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAYAAADam2dgAAAA4klEQVR4ARXBO04CURSA4f/OnHkpA4TRWGhFMg3oFlyCjTuwYRsULMEtuAgTGzUhttpZkagREwhEhwvjvI7x+8z0aqAHXYj3wA/gfpZz82yZXCakPYf8u0LspmGbGTxXaUfK21fJ7atltGiRHvn4cYOYXIl8RRSkVj5+Sv5JXvD7qWQrg2QW3BqWlDzOtuycGhSe3nOSdkmaeIjdKXfzjMNQGA1asF9wMXQ4G1Z0ogqxipuZYNyVkH4YsVg7FGuh73qcnAvecczqwSBL49AJI6a1QSolLJTexnB6bRC/4WUe8AdyJ1gLZ2JPFwAAAABJRU5ErkJggg=='%3E%3C/image%3E%3C/svg%3E">
   </amp-img>
+
+  <!-- Valid: amp-img[layout=intrinsic] > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+    <i-amphtml-sizer slot="i-amphtml-svc" class="i-amphtml-sizer">
+      <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+    </i-amphtml-sizer>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+  </amp-img>
+
+  <!-- Valid: amp-img[layout=responsive] > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <i-amphtml-sizer slot="i-amphtml-svc" style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+    <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img[layout=intrinsic] > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+    <i-amphtml-sizer slot="asd" class="i-amphtml-sizer">
+      <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+    </i-amphtml-sizer>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img[layout=responsive] > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <i-amphtml-sizer slot="asd" style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+    <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img[layout=intrinsic] > i-amphtml-sizer[slot] -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+    <i-amphtml-sizer slot class="i-amphtml-sizer">
+      <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+    </i-amphtml-sizer>
+    <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+  </amp-img>
+
+  <!-- Invalid: amp-img[layout=responsive] > i-amphtml-sizer[slot] -->
+  <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+    <i-amphtml-sizer slot style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+    <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+  </amp-img>
 </body>
 </html>

--- a/validator/testdata/transformed_feature_tests/amp-img.out
+++ b/validator/testdata/transformed_feature_tests/amp-img.out
@@ -72,5 +72,55 @@ transformed_feature_tests/amp-img.html:60:4 The mandatory attribute 'class' is m
 |      <i-amphtml-sizer style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
 |      <img class=i-amphtml-blurry-placeholder placeholder src="data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http%3A//www.w3.org/2000/svg' xmlns%3Axlink='http%3A//www.w3.org/1999/xlink' viewBox='0 0 9 7'%3E%3Cfilter id='b' color-interpolation-filters='sRGB'%3E%3CfeGaussianBlur stdDeviation='.5'%3E%3C/feGaussianBlur%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1'%3E%3C/feFuncA%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Cimage filter='url(%23b)' x='0' y='0' height='100%25' width='100%25' xlink%3Ahref='data%3Aimage/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAHCAYAAADam2dgAAAA4klEQVR4ARXBO04CURSA4f/OnHkpA4TRWGhFMg3oFlyCjTuwYRsULMEtuAgTGzUhttpZkagREwhEhwvjvI7x+8z0aqAHXYj3wA/gfpZz82yZXCakPYf8u0LspmGbGTxXaUfK21fJ7atltGiRHvn4cYOYXIl8RRSkVj5+Sv5JXvD7qWQrg2QW3BqWlDzOtuycGhSe3nOSdkmaeIjdKXfzjMNQGA1asF9wMXQ4G1Z0ogqxipuZYNyVkH4YsVg7FGuh73qcnAvecczqwSBL49AJI6a1QSolLJTexnB6bRC/4WUe8AdyJ1gLZ2JPFwAAAABJRU5ErkJggg=='%3E%3C/image%3E%3C/svg%3E">
 |    </amp-img>
+|
+|    <!-- Valid: amp-img[layout=intrinsic] > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+|      <i-amphtml-sizer slot="i-amphtml-svc" class="i-amphtml-sizer">
+|        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+|      </i-amphtml-sizer>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+|    </amp-img>
+|
+|    <!-- Valid: amp-img[layout=responsive] > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <i-amphtml-sizer slot="i-amphtml-svc" style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+|      <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img[layout=intrinsic] > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+|      <i-amphtml-sizer slot="asd" class="i-amphtml-sizer">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:85:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value 'asd'.
+|        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+|      </i-amphtml-sizer>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img[layout=responsive] > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <i-amphtml-sizer slot="asd" style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:93:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value 'asd'.
+|      <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img[layout=intrinsic] > i-amphtml-sizer[slot] -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="intrinsic" width="900" height="600" i-amphtml-layout="intrinsic" i-amphtml-ssr>
+|      <i-amphtml-sizer slot class="i-amphtml-sizer">
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:99:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value ''.
+|        <img alt aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;600&quot; width=&quot;900&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>">
+|      </i-amphtml-sizer>
+|      <img src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+|    </amp-img>
+|
+|    <!-- Invalid: amp-img[layout=responsive] > i-amphtml-sizer[slot] -->
+|    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="responsive" width="900" height="600" i-amphtml-ssr>
+|      <i-amphtml-sizer slot style=display:block;padding-top:58.6667%;></i-amphtml-sizer>
+>>     ^~~~~~~~~
+transformed_feature_tests/amp-img.html:107:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value ''.
+|      <img loading="lazy" src="/img/canoe_900x600.jpg" alt="An image about canoeing" class="i-amphtml-fill-content i-amphtml-replaced-content" decoding="async">
+|    </amp-img>
 |  </body>
 |  </html>

--- a/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.html
+++ b/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.html
@@ -56,5 +56,18 @@
      <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
      <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
    </amp-image-slider>
+
+  <!-- Valid: amp-image-slider > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+  <amp-image-slider width="300" height="200" layout="responsive" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+    <i-amphtml-sizer slot="i-amphtml-svc" style="display:block;padding-top:66.6667%;"></i-amphtml-sizer>
+    <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+  </amp-image-slider>
+
+  <!-- Valid: amp-video-iframe > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+  <amp-video-iframe id="myVideo" src="/amp-video-iframe-videojs.html" width="720" height="405" layout="responsive" autoplay="" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+    <i-amphtml-sizer slot="i-amphtml-svc" style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+  </amp-video-iframe>
 </body>
 </html>

--- a/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.html
+++ b/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.html
@@ -69,5 +69,32 @@
     <i-amphtml-sizer slot="i-amphtml-svc" style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
     <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
   </amp-video-iframe>
+
+  <!-- Invalid: amp-image-slider > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+  <amp-image-slider width="300" height="200" layout="responsive" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+    <i-amphtml-sizer slot="foo" style="display:block;padding-top:66.6667%;"></i-amphtml-sizer>
+    <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+  </amp-image-slider>
+
+  <!-- Invalid: amp-video-iframe > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+  <amp-video-iframe id="myVideo" src="/amp-video-iframe-videojs.html" width="720" height="405" layout="responsive" autoplay="" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+    <i-amphtml-sizer slot="foo" style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+  </amp-video-iframe>
+
+
+  <!-- Invalid: amp-image-slider > i-amphtml-sizer[slot] -->
+  <amp-image-slider width="300" height="200" layout="responsive" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+    <i-amphtml-sizer slot style="display:block;padding-top:66.6667%;"></i-amphtml-sizer>
+    <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+    <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+  </amp-image-slider>
+
+  <!-- Invalid: amp-video-iframe > i-amphtml-sizer[slot] -->
+  <amp-video-iframe id="myVideo" src="/amp-video-iframe-videojs.html" width="720" height="405" layout="responsive" autoplay="" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+    <i-amphtml-sizer slot style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+    <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+  </amp-video-iframe>
 </body>
 </html>

--- a/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.out
+++ b/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.out
@@ -1,4 +1,4 @@
-PASS
+FAIL
 |  <!--
 |    Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 |
@@ -68,6 +68,41 @@ PASS
 |    <!-- Valid: amp-video-iframe > i-amphtml-sizer[slot="i-amphtml-svc"] -->
 |    <amp-video-iframe id="myVideo" src="/amp-video-iframe-videojs.html" width="720" height="405" layout="responsive" autoplay="" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
 |      <i-amphtml-sizer slot="i-amphtml-svc" style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+|      <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|    </amp-video-iframe>
+|
+|    <!-- Invalid: amp-image-slider > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+|    <amp-image-slider width="300" height="200" layout="responsive" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+|      <i-amphtml-sizer slot="foo" style="display:block;padding-top:66.6667%;"></i-amphtml-sizer>
+>>     ^~~~~~~~~
+transformed_feature_tests/i_amphtml_sizer_child.html:75:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value 'foo'.
+|      <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|      <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|    </amp-image-slider>
+|
+|    <!-- Invalid: amp-video-iframe > i-amphtml-sizer[slot!="i-amphtml-svc"] -->
+|    <amp-video-iframe id="myVideo" src="/amp-video-iframe-videojs.html" width="720" height="405" layout="responsive" autoplay="" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+|      <i-amphtml-sizer slot="foo" style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+>>     ^~~~~~~~~
+transformed_feature_tests/i_amphtml_sizer_child.html:82:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value 'foo'.
+|      <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|    </amp-video-iframe>
+|
+|
+|    <!-- Invalid: amp-image-slider > i-amphtml-sizer[slot] -->
+|    <amp-image-slider width="300" height="200" layout="responsive" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+|      <i-amphtml-sizer slot style="display:block;padding-top:66.6667%;"></i-amphtml-sizer>
+>>     ^~~~~~~~~
+transformed_feature_tests/i_amphtml_sizer_child.html:89:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value ''.
+|      <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|      <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|    </amp-image-slider>
+|
+|    <!-- Invalid: amp-video-iframe > i-amphtml-sizer[slot] -->
+|    <amp-video-iframe id="myVideo" src="/amp-video-iframe-videojs.html" width="720" height="405" layout="responsive" autoplay="" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+|      <i-amphtml-sizer slot style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+>>     ^~~~~~~~~
+transformed_feature_tests/i_amphtml_sizer_child.html:96:4 The attribute 'slot' in tag 'i-amphtml-sizer' is set to the invalid value ''.
 |      <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
 |    </amp-video-iframe>
 |  </body>

--- a/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.out
+++ b/validator/testdata/transformed_feature_tests/i_amphtml_sizer_child.out
@@ -57,5 +57,18 @@ PASS
 |       <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
 |       <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
 |     </amp-image-slider>
+|
+|    <!-- Valid: amp-image-slider > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+|    <amp-image-slider width="300" height="200" layout="responsive" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+|      <i-amphtml-sizer slot="i-amphtml-svc" style="display:block;padding-top:66.6667%;"></i-amphtml-sizer>
+|      <amp-img src="/img/canoe_900x600_blur.jpg" alt="A blurry image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|      <amp-img src="/img/canoe_900x600.jpg" alt="An image about canoeing" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|    </amp-image-slider>
+|
+|    <!-- Valid: amp-video-iframe > i-amphtml-sizer[slot="i-amphtml-svc"] -->
+|    <amp-video-iframe id="myVideo" src="/amp-video-iframe-videojs.html" width="720" height="405" layout="responsive" autoplay="" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive">
+|      <i-amphtml-sizer slot="i-amphtml-svc" style="display:block;padding-top:56.2500%;"></i-amphtml-sizer>
+|      <amp-img placeholder="" src="/img/amp-video-iframe-sample-placeholder.jpg" layout="fill" class="i-amphtml-layout-fill i-amphtml-layout-size-defined" i-amphtml-layout="fill"></amp-img>
+|    </amp-video-iframe>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -3778,6 +3778,10 @@ tags: {
     name: "i-amphtml-disable-ar"
     value: ""
   }
+  attrs: {
+    name: "slot"
+    value: "i-amphtml-svc"
+  }
 }
 
 tags: {
@@ -3795,6 +3799,10 @@ tags: {
   attrs: {
     name: "i-amphtml-disable-ar"
     value: ""
+  }
+  attrs: {
+    name: "slot"
+    value: "i-amphtml-svc"
   }
 }
 


### PR DESCRIPTION
This PR is the first step for resolving #35485, after which we will update cache and optimizer transforms to apply `slot="i-amphtml-svc"` to `i-amphtml-sizer` elements to be consistent with https://github.com/ampproject/amphtml/blob/07771ad684334ee96894f70a8ea7f839c738a8a3/src/static-layout.js#L163