### PR TITLE
✨ Add action `toggleCheckboxState`

### DIFF
--- a/docs/spec/amp-actions-and-events.md
+++ b/docs/spec/amp-actions-and-events.md
@@ -391,6 +391,10 @@ event.response</pre></td>
     <td>Toggles class of the target element. <code>force</code> is optional, and if defined, it ensures that class would only be added but not removed if set to <code>true</code>, and only removed but not added if set to <code>false</code>.</td>
   </tr>
   <tr>
+    <td><code>toggleCheckboxState(state=BOOLEAN)</code></td>
+    <td>Toggles state of the target checkbox element. <code>state</code> is optional, and if defined, it ensures that the resulting state would be as defined.</td>
+  </tr>
+  <tr>
     <td><code>scrollTo(duration=INTEGER, position=STRING)</code></td>
     <td>Scrolls an element into view with a smooth animation.<br>
     <code>duration</code> is optional. Specifies the length of the animation in milliseconds. If unspecified, an amount relative to scroll difference

--- a/docs/spec/amp-email-actions-and-events.md
+++ b/docs/spec/amp-email-actions-and-events.md
@@ -362,6 +362,10 @@ event.response</pre></td>
     <td>Toggles class of the target element. <code>force</code> is optional, and if defined, it ensures that class would only be added but not removed if set to <code>true</code>, and only removed but not added if set to <code>false</code>.</td>
   </tr>
   <tr>
+    <td><code>toggleCheckboxState(state=BOOLEAN)</code></td>
+    <td>Toggles state of the target checkbox element. <code>state</code> is optional, and if defined, it ensures that the resulting state would be as defined.</td>
+  </tr>
+  <tr>
     <td><code>focus</code></td>
     <td>Makes the target element gain focus. To lose focus, <code>focus</code>
     on another element (usually parent element). We strongly advise against

--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -99,6 +99,9 @@
   <button on="tap:normal-element2.toggleClass('class' = 'red-text')">Toggle Class</button>
   <button on="tap:normal-element2.toggleClass('class' = 'red-text', 'force' = true)">Toggle Class (force = true)</button>
   <button on="tap:normal-element2.toggleClass('class' = 'red-text', 'force' = false)">Toggle Class (force = false)</button>
+  <button on="tap:normal-element2.toggleCheckboxState()">Toggle Checkbox State</button>
+  <button on="tap:normal-element2.toggleCheckboxState('force' = true)">Set Checkbox State to true</button>
+  <button on="tap:normal-element2.toggleCheckboxState('force' = false)">Set Checkbox State to false</button>
   <button on="tap:normal-element3.scrollTo">ScrollTo</button>
   <button on="tap:normal-element3.scrollTo('position' = 'bottom')">ScrollTo Bottom</button>
   <button on="tap:normal-element3.scrollTo('position' = 'center')">ScrollTo Center</button>

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -116,10 +116,11 @@ export class ScrollComponent {
    * @protected
    */
   toggleCheckboxState(condition) {
+    const input = devAssert(this.root_);
     if (condition) {
-      checked = true;
+      input.checked = true;
     } else {
-      checked = false;
+      input.checked = false;
     }
   }
 

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -110,6 +110,20 @@ export class ScrollComponent {
   }
 
   /**
+   * Action toggleCheckboxState.
+   * @param {string} className
+   * @param {boolean} condition
+   * @protected
+   */
+  toggleCheckboxState(condition) {
+    if (condition) {
+      checked = true;
+    } else {
+      checked = false;
+    }
+  }
+
+  /**
    * @param {Object} updates
    * @return {boolean} true if changed
    * @protected

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -95,7 +95,7 @@ export class ScrollComponent {
   }
 
   /**
-   *
+   * Action toggleClass.
    * @param {string} className
    * @param {boolean} condition
    * @protected

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -65,6 +65,7 @@ const DEFAULT_EMAIL_ALLOWLIST = [
   {tagOrTarget: '*', method: 'focus'},
   {tagOrTarget: '*', method: 'hide'},
   {tagOrTarget: '*', method: 'show'},
+  {tagOrTarget: '*', method: 'toggleCheckboxState'},
   {tagOrTarget: '*', method: 'toggleClass'},
   {tagOrTarget: '*', method: 'toggleVisibility'},
 ];

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -455,15 +455,19 @@ export class StandardActions {
     );
 
     this.mutator_.mutateElement(target, () => {
-      if (args['force'] !== undefined) {
+      if (args['state'] !== undefined) {
         // must be boolean, won't do type conversion
         const shouldForce = user().assertBoolean(
-          args['force'],
-          "Optional argument 'force' must be a boolean."
+          args['state'],
+          "Optional argument 'state' must be a boolean."
         );
-        target.checked = checkboxState (shouldForce);
-      } else {
         target.checked = checkboxState;
+      } else {
+        if (target.checked = true) {
+          target.checked = false;
+        } else {
+          target.checked = true;
+        }
       }
     });
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -459,7 +459,7 @@ export class StandardActions {
         );
         target.checked = shouldForce;
       } else {
-        if (target.checked = true) {
+        if (target.checked === true) {
           target.checked = false;
         } else {
           target.checked = true;

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -111,6 +111,11 @@ export class StandardActions {
       'toggleClass',
       this.handleToggleClass_.bind(this)
     );
+
+    actionService.addGlobalMethodHandler(
+      'toggleCheckboxState',
+      this.handleToggleCheckboxState_.bind(this)
+    );
   }
 
   /**
@@ -428,6 +433,37 @@ export class StandardActions {
         target.classList.toggle(className, shouldForce);
       } else {
         target.classList.toggle(className);
+      }
+    });
+
+    return null;
+  }
+}
+
+  /**
+   * Handles "toggleCheckboxState" action.
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @return {?Promise}
+   * @private Visible to tests only.
+   */
+  handleToggleCheckboxState_(invocation) {
+    const target = dev().assertElement(invocation.node);
+    const {args} = invocation;
+    const checkboxState = user().assertString(
+      args['state'],
+      "Argument 'state' must be a boolean."
+    );
+
+    this.mutator_.mutateElement(target, () => {
+      if (args['force'] !== undefined) {
+        // must be boolean, won't do type conversion
+        const shouldForce = user().assertBoolean(
+          args['force'],
+          "Optional argument 'force' must be a boolean."
+        );
+        target.checked = checkboxState (shouldForce);
+      } else {
+        target.checked = checkboxState;
       }
     });
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -449,19 +449,15 @@ export class StandardActions {
   handleToggleCheckboxState_(invocation) {
     const target = dev().assertElement(invocation.node);
     const {args} = invocation;
-    const checkboxState = user().assertString(
-      args['state'],
-      "Argument 'state' must be a boolean."
-    );
 
     this.mutator_.mutateElement(target, () => {
-      if (args['state'] !== undefined) {
+      if (args['force'] !== undefined) {
         // must be boolean, won't do type conversion
         const shouldForce = user().assertBoolean(
-          args['state'],
-          "Optional argument 'state' must be a boolean."
+          args['force'],
+          "Optional argument 'force' must be a boolean."
         );
-        target.checked = checkboxState;
+        target.checked = shouldForce;
       } else {
         if (target.checked = true) {
           target.checked = false;

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -1807,6 +1807,12 @@ describes.realWin(
         expect(spy).to.be.calledWithExactly(i);
       });
 
+      it('should supply default actions allowlist', () => {
+        const i = getActionInvocation(target, 'toggleCheckboxState', 'AMP');
+        action.invoke_(i);
+        expect(spy).to.be.calledWithExactly(i);
+      });
+
       it('should not allow non-default actions', () => {
         const i = getActionInvocation(target, 'print', 'AMP');
         env.sandbox.stub(action, 'error_');

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -558,7 +558,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
   describe('"toggleCheckboxState" action', () => {
 
     it('should set checked state to false when state is true', () => {
-      const element = createElement('input');
+      const element = createElement();
       element.type = 'checkbox';
       element.checked = true;
       const invocation = {
@@ -570,7 +570,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
     });
 
     it('should set checked state to true when state is false', () => {
-      const element = createElement('input');
+      const element = createElement();
       element.type = 'checkbox';
       element.checked = false;
       const invocation = {
@@ -582,7 +582,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
     });
 
     it('should set checked state to true when force=true', () => {
-      const element = createElement('input');
+      const element = createElement();
       element.type = 'checkbox';
       const invocation = {
         node: element,
@@ -596,7 +596,7 @@ describes.sandboxed('StandardActions', {}, (env) => {
     });
 
     it('should set checked state to false when force=false', () => {
-      const element = createElement('input');
+      const element = createElement();
       element.type = 'checkbox';
       const invocation = {
         node: element,

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -87,6 +87,21 @@ describes.sandboxed('StandardActions', {}, (env) => {
     expect(element.classList.contains(className)).to.false;
   }
 
+  function expectCheckboxToHaveStateTrue(element) {
+    expectElementMutatedAsync(element);
+    expect(element.checked).to.true;
+  }
+
+  function expectCheckboxToHaveStateFalse(element) {
+    expectElementMutatedAsync(element);
+    expect(element.checked).to.false;
+  }
+
+  function expectCheckboxToHaveState(element, state) {
+    expectElementMutatedAsync(element);
+    expect(element.checked).to.state;
+  }
+
   function expectAmpElementToHaveBeenHidden(element) {
     expectElementMutatedAsync(element);
     expect(element.collapse).to.be.calledOnce;
@@ -537,6 +552,61 @@ describes.sandboxed('StandardActions', {}, (env) => {
       };
       standardActions.handleToggleClass_(invocation);
       expectElementToDropClass(element, dummyClass);
+    });
+  });
+
+  describe('"toggleCheckboxState" action', () => {
+
+    it('should set checked state to false when state is true', () => {
+      const element = createElement('input');
+      element.type = 'checkbox';
+      element.checked = true;
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+      };
+      standardActions.handleToggleCheckboxState_(invocation);
+      expectCheckboxToHaveStateFalse(element);
+    });
+
+    it('should set checked state to true when state is false', () => {
+      const element = createElement('input');
+      element.type = 'checkbox';
+      element.checked = false;
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+      };
+      standardActions.handleToggleCheckboxState_(invocation);
+      expectCheckboxToHaveStateTrue(element);
+    });
+
+    it('should set checked state to true when force=true', () => {
+      const element = createElement('input');
+      element.type = 'checkbox';
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'force': true,
+        },
+      };
+      standardActions.handleToggleCheckboxState_(invocation);
+      expectCheckboxToHaveState(element, true);
+    });
+
+    it('should set checked state to false when force=false', () => {
+      const element = createElement('input');
+      element.type = 'checkbox';
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'force': false,
+        },
+      };
+      standardActions.handleToggleCheckboxState_(invocation);
+      expectCheckboxToHaveState(element, false);
     });
   });
 


### PR DESCRIPTION
Using hidden adjacent sibling checkboxes as toggles for CSS is an AMP (and general) best practice, as it avoids the use of JS if the elements where these checkboxes are toggled from are not link text in the same time, since else HTML prevents default action of following the link. So we can use `<label for="id">` everywhere except when the inner HTML is also the inner HTML of an anchor element. So when it is, we must use the JS `.checked` method. 

This doesn’t seem to have its AMP action equivalent yet.

The new `toggleCheckboxState()` action is already going to be used. Until its release, AMP pages will have functionality limited to what is available in browsers without JavaScript, consistently with AMP-WP unwrapping the `<noscript>` elements, and because turning off JS deactivates AMPHTML’s `toggleClass()` action and requires reverting to checkbox toggles. As these must be adjacent siblings, wrapping them in `<noscript>` is impossible, and ineffective anyway on AMP pages.
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
