### PR TITLE
🐛 amp-tiktok: remove excess space from document

### DIFF
--- a/extensions/amp-tiktok/amp-tiktok.md
+++ b/extensions/amp-tiktok/amp-tiktok.md
@@ -96,7 +96,7 @@ Example with source url:
 
 ```html
 <amp-tiktok
-  width="325 "
+  width="325"
   height="575"
   data-src="https://www.tiktok.com/@scout2015/video/6948210747285441798"
 ></amp-tiktok>


### PR DESCRIPTION
Removed excess space in ```width```-attribute, that caused https://amp.dev/documentation/components/amp-tiktok/ to be invalid.

/cc @sebastianbenz @matthiasrohmer