### PR TITLE
🐛 amp-mode-transformer: Only resolve development mode for esm builds

### DIFF
--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js
@@ -52,12 +52,12 @@ module.exports = function ({types: t}) {
         const {node} = path;
         const {object: obj, property} = node;
         const {callee} = obj;
-        const {INTERNAL_RUNTIME_VERSION: version} = this.opts;
+        const {INTERNAL_RUNTIME_VERSION: version, IS_ESM} = this.opts;
 
         if (callee && callee.name === 'getMode') {
           if (property.name === 'test' || property.name === 'localDev') {
             path.replaceWith(t.booleanLiteral(false));
-          } else if (property.name === 'development') {
+          } else if (property.name === 'development' && IS_ESM) {
             path.replaceWith(t.booleanLiteral(false));
           } else if (property.name === 'minified') {
             path.replaceWith(t.booleanLiteral(true));

--- a/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-amp-mode-transformer/test/fixtures/transform-assertions/nomodule/output.mjs
@@ -17,10 +17,10 @@ import { getMode } from '../../../../../../../src/mode';
 const test = false;
 const localDev = false;
 const minified = true;
-const development = false;
+const development = getMode().development;
 
 function foo() {
-  if (false == false) {
+  if (getMode().development == false) {
     return false;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/35655

`getMode().development` should correspond to whether or not the page has development params in the URL. I mistakenly disabled this for all builds in a previous PR (https://github.com/ampproject/amphtml/pull/35294).  It should only be disabled for `.mjs` builds for smaller bundle size.