### PR TITLE
🐛 Bento Carousel: Fix unrecognized attributes

### DIFF
--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -335,7 +335,7 @@ function BaseCarouselWithRef(
           by={-advanceCount}
           disabled={disableForDir(-1)}
           outsetArrows={outsetArrows}
-          rtl={rtl}
+          rtl={rtl.toString()}
         />
       )}
       <Scroller
@@ -375,7 +375,7 @@ function BaseCarouselWithRef(
           as={arrowNextAs}
           disabled={disableForDir(1)}
           outsetArrows={outsetArrows}
-          rtl={rtl}
+          rtl={rtl.toString()}
         />
       )}
     </ContainWrapper>

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -371,7 +371,9 @@ function renderSlides(
             ? classes.centerAlign
             : classes.startAlign
         } ${_thumbnails ? classes.thumbnails : ''} `}
-        group={lightboxGroup}
+        // lightboxGroup is a string when defined, and `false` otherwise. In the case
+        // of the latter, we do not want to pass group={false} into the DOM.
+        group={lightboxGroup || undefined}
         part="slide"
         style={{
           flex: mixedLength ? '0 0 auto' : `0 0 ${100 / visibleCount}%`,

--- a/extensions/amp-base-carousel/1.0/test/test-component.js
+++ b/extensions/amp-base-carousel/1.0/test/test-component.js
@@ -31,6 +31,9 @@ describes.sandboxed('BaseCarousel preact component', {}, () => {
       </BaseCarousel>
     );
     expect(wrapper.find('Arrow')).to.have.lengthOf(2);
+    expect(wrapper.find('Arrow').first().prop('rtl')).to.equal('false');
+    expect(wrapper.find('Arrow').last().prop('rtl')).to.equal('false');
+    expect(wrapper.find('Scroller').prop('group')).to.be.undefined;
 
     const slides = wrapper.find('[data-slide]');
     expect(slides).to.have.lengthOf(3);


### PR DESCRIPTION
This PR modifies `rtl` to return a string, and `group` to be `undefined` when irrelevant (as opposed to `false`). This fixes the following issues described in #35553:
```
* Warning: Received `false` for a non-boolean attribute `rtl`. If you want to write it to the DOM, pass a string instead: `rtl="false"` or `rtl={value.toString()}`. If you used to conditionally omit it with `rtl={condition && value}`, pass `rtl={condition ? value : undefined}` instead.
* Warning: Received `false` for a non-boolean attribute `group`. If you want to write it to the DOM, pass a string instead: `group="false"` or `group={value.toString()}`. If you used to conditionally omit it with `group={condition && value}`, pass `group={condition ? value : undefined}` instead.
```