### PR TITLE
resources: cleanup amp-img r1 experiment

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -1,11 +1,5 @@
 {
   "experimentA": {},
-  "experimentB": {
-    "name": "amp-img in the deferred mount mode",
-    "environment": "AMP",
-    "issue": "https://github.com/ampproject/amphtml/issues/31915",
-    "expiration_date_utc": "2021-06-30",
-    "define_experiment_constant": "R1_IMG_DEFERRED_BUILD"
-  },
+  "experimentB": {},
   "experimentC": {}
 }

--- a/build-system/global-configs/experiments-const.json
+++ b/build-system/global-configs/experiments-const.json
@@ -1,6 +1,5 @@
 {
   "INI_LOAD_INOB": true,
   "NO_SIGNING_RTV": true,
-  "R1_IMG_DEFERRED_BUILD": false,
   "WITHIN_VIEWPORT_INOB": false
 }

--- a/src/builtins/amp-img/amp-img.js
+++ b/src/builtins/amp-img/amp-img.js
@@ -52,7 +52,7 @@ export const ATTRIBUTES_TO_PROPAGATE = [
 export class AmpImg extends BaseElement {
   /** @override @nocollapse */
   static R1() {
-    return R1_IMG_DEFERRED_BUILD;
+    return false;
   }
 
   /** @override @nocollapse */
@@ -243,7 +243,7 @@ export class AmpImg extends BaseElement {
    * @private
    */
   maybeGenerateSizes_(sync) {
-    if (R1_IMG_DEFERRED_BUILD) {
+    if (AmpImg.R1()) {
       // The `getLayoutSize()` is not available for a R1 element. Skip this
       // codepath. Also: is this feature at all useful? E.g. it doesn't even
       // execute in the `i-amphtml-ssr` mode.

--- a/test/integration/test-visibility-states.js
+++ b/test/integration/test-visibility-states.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import {AmpImg} from '#builtins/amp-img/amp-img';
+
 import {VisibilityState} from '#core/constants/visibility-state';
 import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
 import {getVendorJsPropertyName} from '#core/dom/style';
@@ -90,7 +92,7 @@ t.run('Viewer Visibility State', {}, () => {
           shouldPass = true;
           resources.schedulePass();
         }).then(() => {
-          if (R1_IMG_DEFERRED_BUILD) {
+          if (AmpImg.R1()) {
             return new Promise((resolve) => setTimeout(resolve, 20));
           }
         });
@@ -133,7 +135,7 @@ t.run('Viewer Visibility State', {}, () => {
             img.setAttribute('height', 100);
             img.setAttribute('layout', 'fixed');
             // TODO(#31915): Cleanup when R1_IMG_DEFERRED_BUILD is complete.
-            if (!R1_IMG_DEFERRED_BUILD) {
+            if (!AmpImg.R1()) {
               win.document.body.appendChild(img);
             }
 
@@ -143,16 +145,16 @@ t.run('Viewer Visibility State', {}, () => {
             prerenderAllowed = env.sandbox.stub(img, 'prerenderAllowed');
             prerenderAllowed.returns(false);
 
-            if (R1_IMG_DEFERRED_BUILD) {
+            if (AmpImg.R1()) {
               win.document.body.appendChild(img);
             }
             return img.getImpl(false);
           })
           .then((impl) => {
-            layoutCallback = R1_IMG_DEFERRED_BUILD
+            layoutCallback = AmpImg.R1()
               ? env.sandbox.stub(impl, 'mountCallback')
               : env.sandbox.stub(impl, 'layoutCallback');
-            unlayoutCallback = R1_IMG_DEFERRED_BUILD
+            unlayoutCallback = AmpImg.R1()
               ? env.sandbox.stub(impl, 'unmountCallback')
               : env.sandbox.stub(impl, 'unlayoutCallback');
             pauseCallback = env.sandbox.stub(impl, 'pauseCallback');
@@ -265,7 +267,7 @@ t.run('Viewer Visibility State', {}, () => {
             });
             changeVisibility('hidden');
             return waitForNextPass().then(() => {
-              if (R1_IMG_DEFERRED_BUILD) {
+              if (AmpImg.R1()) {
                 expect(layoutCallback).to.have.been.called;
               } else {
                 expect(layoutCallback).not.to.have.been.called;
@@ -444,7 +446,7 @@ t.run('Viewer Visibility State', {}, () => {
           });
           changeVisibility('hidden');
           return waitForNextPass().then(() => {
-            if (R1_IMG_DEFERRED_BUILD) {
+            if (AmpImg.R1()) {
               expect(layoutCallback).to.have.been.called;
             } else {
               expect(layoutCallback).not.to.have.been.called;


### PR DESCRIPTION
**summary**
Cleans up the R1_DEFERRED_IMG experiment. The results weren't particularly useful.