### PR TITLE
eslint rule: no-deep-destructuring should handle ArrayPattern

### DIFF
--- a/build-system/babel-config/import-resolver.js
+++ b/build-system/babel-config/import-resolver.js
@@ -43,6 +43,7 @@ function readJsconfigPaths() {
     const aliasPaths = tsConfig.compilerOptions.paths;
 
     const stripSuffix = (s) => s.replace(/\/\*$/, '');
+    // eslint-disable-next-line local/no-deep-destructuring
     const aliases = Object.entries(aliasPaths).map(([alias, [dest]]) => [
       stripSuffix(alias),
       stripSuffix(dest),

--- a/build-system/eslint-rules/no-deep-destructuring.js
+++ b/build-system/eslint-rules/no-deep-destructuring.js
@@ -20,17 +20,29 @@
  *
  * Bad:
  *   const { x: { y } } = obj.prop;
+ *   const {x: [y]} = obj;
+ *   const [[x], y] = arr;
+ *   const [{x}] = arr;
  * Good:
  *   const { y } = obj.prop.x;
+ *   const [x, y] = arr;
+ *
  * @return {!Object}
  */
 module.exports = function (context) {
+  const isPatternOrProperty = (node) =>
+    node.type === 'Property' || node.type === 'ArrayPattern';
+
   return {
     ObjectPattern: function (node) {
-      if (node.parent.type !== 'Property') {
-        return;
+      if (isPatternOrProperty(node.parent)) {
+        context.report({node, message: 'No deep destructuring allowed.'});
       }
-      context.report({node, message: 'No deep object destructuring allowed.'});
+    },
+    ArrayPattern: function (node) {
+      if (isPatternOrProperty(node.parent)) {
+        context.report({node, message: 'No deep destructuring allowed.'});
+      }
     },
   };
 };

--- a/build-system/release-tagger/create-release.js
+++ b/build-system/release-tagger/create-release.js
@@ -170,6 +170,7 @@ function _createBody(head, base, prs) {
  
      ${Object.entries(bento)
        .map(
+         // eslint-disable-next-line local/no-deep-destructuring
          ([major, {packages, unchanged}]) => dedent`\
          <h2>npm packages @ ${getSemver(major, head)}</h2>
          ${Object.entries(packages)

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -318,6 +318,7 @@ async function populateOrgCdn_(flavorType, rtvPrefixes, tempDir, outputDir) {
   if (flavorType == 'base') {
     rtvCopyingPromises.push(
       ...Object.entries(experimentsConfig)
+        // eslint-disable-next-line local/no-deep-destructuring
         .filter(([, {environment}]) => environment == 'INABOX')
         .map(
           ([experimentFlavor]) =>

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -98,8 +98,8 @@ function ProxyIframeEmbedWithRef(
     return countGenerators[type]();
   }, [type]);
 
-  // eslint-disable-next-line local/no-deep-destructuring
-  const [{name, src}, setNameAndSrc] = useState({name: nameProp, src: srcProp});
+  const [nameAndSrc, setNameAndSrc] = useState({name: nameProp, src: srcProp});
+  const {name, src} = nameAndSrc;
   useLayoutEffect(() => {
     const win = contentRef.current?.ownerDocument?.defaultView;
     const src =

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -98,6 +98,7 @@ function ProxyIframeEmbedWithRef(
     return countGenerators[type]();
   }, [type]);
 
+  // eslint-disable-next-line local/no-deep-destructuring
   const [{name, src}, setNameAndSrc] = useState({name: nameProp, src: srcProp});
   useLayoutEffect(() => {
     const win = contentRef.current?.ownerDocument?.defaultView;


### PR DESCRIPTION
**summary** 
Partial for https://github.com/ampproject/amphtml/issues/35694

Explicitly bans these kinds of patterns:
```js
const [[x], y] = arr;
```
```js
const [{x}] = arr
```