### PR TITLE
🏗 Use a different process to pre-build AMP while running tests

### DIFF
--- a/build-system/common/utils.js
+++ b/build-system/common/utils.js
@@ -21,8 +21,7 @@ const globby = require('globby');
 const {clean} = require('../tasks/clean');
 const {cyan, green, red, yellow} = require('./colors');
 const {default: ignore} = require('ignore');
-const {doBuild} = require('../tasks/build');
-const {doDist} = require('../tasks/dist');
+const {execOrDie} = require('./exec');
 const {gitDiffNameOnlyMain} = require('./git');
 const {log, logLocalDev} = require('./logging');
 
@@ -38,9 +37,9 @@ const {log, logLocalDev} = require('./logging');
 async function buildRuntime(opt_compiled = false) {
   await clean();
   if (argv.compiled || opt_compiled === true) {
-    await doDist({fortesting: true});
+    execOrDie(`amp dist --fortesting`);
   } else {
-    await doBuild({fortesting: true});
+    execOrDie(`amp build --fortesting`);
   }
 }
 

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -48,20 +48,10 @@ async function runPreBuildSteps(options) {
  * @return {Promise<void>}
  */
 async function build() {
-  await doBuild();
-}
-
-/**
- * Performs an unminified build with the given extra args.
- *
- * @param {Object=} extraArgs
- * @return {Promise<void>}
- */
-async function doBuild(extraArgs = {}) {
   const handlerProcess = createCtrlcHandler('build');
   process.env.NODE_ENV = 'development';
   const options = {
-    fortesting: extraArgs.fortesting || argv.fortesting,
+    fortesting: argv.fortesting,
     minify: false,
     watch: argv.watch,
   };
@@ -86,7 +76,6 @@ async function doBuild(extraArgs = {}) {
 
 module.exports = {
   build,
-  doBuild,
   runPreBuildSteps,
 };
 

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -116,20 +116,10 @@ async function runPreDistSteps(options) {
  * @return {Promise<void>}
  */
 async function dist() {
-  await doDist();
-}
-
-/**
- * Performs a minified build with the given extra args.
- *
- * @param {Object=} extraArgs
- * @return {Promise<void>}
- */
-async function doDist(extraArgs = {}) {
   const handlerProcess = createCtrlcHandler('dist');
   process.env.NODE_ENV = 'production';
   const options = {
-    fortesting: extraArgs.fortesting || argv.fortesting,
+    fortesting: argv.fortesting,
     minify: true,
     watch: argv.watch,
   };
@@ -382,7 +372,6 @@ async function preBuildLoginDoneVersion(version) {
 
 module.exports = {
   dist,
-  doDist,
   runPreDistSteps,
 };
 

--- a/build-system/tasks/firebase.js
+++ b/build-system/tasks/firebase.js
@@ -16,9 +16,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const fs = require('fs-extra');
 const path = require('path');
-const {clean} = require('./clean');
-const {doBuild} = require('./build');
-const {doDist} = require('./dist');
+const {buildRuntime} = require('../common/utils');
 const {green} = require('../common/colors');
 const {log} = require('../common/logging');
 
@@ -61,12 +59,7 @@ async function copyAndReplaceUrls(src, dest) {
  */
 async function firebase() {
   if (!argv.nobuild) {
-    await clean();
-    if (argv.compiled) {
-      await doDist({fortesting: argv.fortesting});
-    } else {
-      await doBuild({fortesting: argv.fortesting});
-    }
+    await buildRuntime();
   }
   await fs.mkdirp('firebase');
   if (argv.file) {

--- a/build-system/tasks/performance/compile-scripts.js
+++ b/build-system/tasks/performance/compile-scripts.js
@@ -15,7 +15,7 @@
  */
 
 const argv = require('minimist')(process.argv.slice(2));
-const {doDist} = require('../dist');
+const {buildRuntime} = require('../../common/utils');
 const {EXPERIMENT, urlToCachePath} = require('./helpers');
 const {setExtensionsToBuildFromDocuments} = require('../extension-helpers');
 
@@ -29,7 +29,7 @@ async function compileScripts(urls) {
   if (!argv.nobuild) {
     const examples = urls.map((url) => urlToCachePath(url, EXPERIMENT));
     setExtensionsToBuildFromDocuments(examples);
-    await doDist();
+    await buildRuntime(/* opt_compiled */ true);
   }
 }
 


### PR DESCRIPTION
Previously, we used to pre-build the AMP runtime (minified or unminified) via an in-process function call to the entry point function of `amp dist` or `amp build`. This broke recently, most likely due to the interaction between nodejs module load, cache instantiation, and actual building of code.

This PR switches the pre-building step to invoke `amp dist|build` in a separate process instead of calling `doDist()|doBuild()`. This fixes the bugs around in-process building, and lets us simplify / consolidate all calls from testing tasks to the pre-build function `buildRuntime()`.

As a follow up, we could consider renaming the `--compiled` flag to something like `--minified` for better usability.