### PR TITLE
amp-analytics: Remove unused `getViewer` method

### DIFF
--- a/extensions/amp-analytics/0.1/analytics-root.js
+++ b/extensions/amp-analytics/0.1/analytics-root.js
@@ -93,14 +93,6 @@ export class AnalyticsRoot {
   getRoot() {}
 
   /**
-   * The viewer of analytics root
-   * @return {!../../../src/service/viewer-interface.ViewerInterface}
-   */
-  getViewer() {
-    return Services.viewerForDoc(this.ampdoc);
-  }
-
-  /**
    * The root element within the analytics root.
    *
    * @return {!Element}


### PR DESCRIPTION
`AnalyticsRoot.getViewer()` was introduced in #8805 and used as a helper in a method that has since been removed:
https://github.com/zhouyx/amphtml/blob/33a0d3c643947b9f9a9820b23b4bc62db0de962f/extensions/amp-analytics/0.1/events.js#L423-L441

The only comparable piece of code similar to the above is `createReportReadyPromiseForDocumentHidden_`, which now uses the ampdoc instead:
https://github.com/ampproject/amphtml/blob/38d96dac71275e901683097053ffe07690f40a3a/extensions/amp-analytics/0.1/events.js#L1674-L1694