### PR TITLE
🏗 Fix unminified build on Windows

### DIFF
--- a/build-system/tasks/compile-jison.js
+++ b/build-system/tasks/compile-jison.js
@@ -43,16 +43,16 @@ const imports = new Map([
  * @return {!Promise}
  */
 async function compileJison(searchDir = jisonPath) {
-  fs.mkdirSync('build/parsers', {recursive: true});
-
-  const promises = globby.sync(searchDir).map((jisonFile) => {
-    const jsFile = path.basename(jisonFile, '.jison');
-    const extension = jsFile.replace('-expr-impl', '');
-    const parser = extension + 'Parser';
-    const newFilePath = `build/parsers/${jsFile}.js`;
-    return compileExpr(jisonFile, parser, newFilePath);
-  });
-  return Promise.all(promises);
+  const jisonFiles = globby.sync(searchDir);
+  await Promise.all(
+    jisonFiles.map((jisonFile) => {
+      const jsFile = path.basename(jisonFile, '.jison');
+      const extension = jsFile.replace('-expr-impl', '');
+      const parser = extension + 'Parser';
+      const newFilePath = `build/parsers/${jsFile}.js`;
+      return compileExpr(jisonFile, parser, newFilePath);
+    })
+  );
 }
 
 /**
@@ -84,7 +84,7 @@ async function compileExpr(jisonFilePath, parserName, newFilePath) {
       // adversely affect lexer performance.
       // See https://github.com/ampproject/amphtml/pull/18574#discussion_r223506153.
       .replace(/[ \t]*_token_stack:[ \t]*/, '') + '\n';
-  return fs.writeFile(newFilePath, out);
+  await fs.outputFile(newFilePath, out);
 }
 
 module.exports = {

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -490,7 +490,7 @@ async function buildExtension(
     }
   }
 
-  await compileJison(path.join(extDir, '**', '*.jison'));
+  await compileJison(`${extDir}/**/*.jison`);
   if (name === 'amp-bind') {
     await doBuildJs(jsBundles, 'ww.max.js', options);
   }


### PR DESCRIPTION
**PR Highlights:**
- Fix `amp build` on Windows (the path being passed to `compileJison()` was incorrectly formatted on Windows)
- **Bonus:** Speed up `compileJison()` by eliminating ~200 parallel + synchronous + unnecessary `mkdirSync` operations

**Passing logs:** [here](https://github.com/ampproject/amphtml/runs/3355857514?check_suite_focus=true)

Addresses https://github.com/ampproject/amphtml/pull/35630#issuecomment-899945493