### PR TITLE
Allow private click measurement attributes

### DIFF
--- a/validator/js/engine/validator_test.js
+++ b/validator/js/engine/validator_test.js
@@ -1769,7 +1769,7 @@ describe('ValidatorRulesMakeSense', () => {
            // it's sufficiently wrapped in private context inside the validator
            // that I don't see a way to call it.  For now just gold the current
            // index.
-           expect(tagSpec.attrLists[0]).toEqual(16);
+           expect(tagSpec.attrLists[0]).toEqual(17);
          });
     }
 

--- a/validator/testdata/feature_tests/a_private_click_measurement.html
+++ b/validator/testdata/feature_tests/a_private_click_measurement.html
@@ -1,0 +1,33 @@
+<!--
+  Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS-IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the license.
+-->
+<!--
+  Test Description:
+  Tests attributes related to Private Click Measurement.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <!-- Valid -->
+  <a href="/lemur.png" attributiondestination attributionexpiry attributionreportto attributionsourceeventid attributionsourceid conversiondestination impressiondata impressionexpiry reportingorigin>Lemurs</a>
+</body>
+</html>

--- a/validator/testdata/feature_tests/a_private_click_measurement.out
+++ b/validator/testdata/feature_tests/a_private_click_measurement.out
@@ -1,0 +1,34 @@
+PASS
+|  <!--
+|    Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+|
+|    Licensed under the Apache License, Version 2.0 (the "License");
+|    you may not use this file except in compliance with the License.
+|    You may obtain a copy of the License at
+|
+|        http://www.apache.org/licenses/LICENSE-2.0
+|
+|    Unless required by applicable law or agreed to in writing, software
+|    distributed under the License is distributed on an "AS-IS" BASIS,
+|    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+|    See the License for the specific language governing permissions and
+|    limitations under the license.
+|  -->
+|  <!--
+|    Test Description:
+|    Tests attributes related to Private Click Measurement.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|  </head>
+|  <body>
+|    <!-- Valid -->
+|    <a href="/lemur.png" attributiondestination attributionexpiry attributionreportto attributionsourceeventid attributionsourceid conversiondestination impressiondata impressionexpiry reportingorigin>Lemurs</a>
+|  </body>
+|  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1413,6 +1413,11 @@ tags: {
     implicit: true
   }
   attrs: {
+    name: "show-tooltip"
+    value: "auto"
+    value: "true"
+  }
+  attrs: {
     name: "tabindex"
     implicit: true
   }
@@ -1427,13 +1432,9 @@ tags: {
     value_casei: "text/html"
     value_casei: "application/rss+xml"
   }
-  attrs: {
-    name: "show-tooltip"
-    value: "auto"
-    value: "true"
-  }
   attr_lists: "click-attributions"
   attr_lists: "name-attr"
+  attr_lists: "private-click-measurement-attributes"
   # <amp-bind>
   attrs: { name: "[href]" }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#links"
@@ -1490,6 +1491,20 @@ tags: {
     name: "type"
     value_casei: "text/html"
   }
+}
+# Private Click Measurement attributes for anchor tags.
+# See https://github.com/ampproject/amphtml/issues/35067
+attr_lists {
+  name: "private-click-measurement-attributes"
+  attrs: { name: "attributiondestination" }
+  attrs: { name: "attributionexpiry" }
+  attrs: { name: "attributionreportto" }
+  attrs: { name: "attributionsourceeventid" }
+  attrs: { name: "attributionsourceid" }
+  attrs: { name: "conversiondestination" }
+  attrs: { name: "impressiondata" }
+  attrs: { name: "impressionexpiry" }
+  attrs: { name: "reportingorigin" }
 }
 
 # 4.5.2 The em element


### PR DESCRIPTION
Fixes #35067 by allowing the following attributes on `a` tags for AMP Websites and AMP Ads only:

```
attributiondestination
attributionexpiry
attributionreportto
attributionsourceeventid
attributionsourceid
conversiondestination
impressiondata
impressionexpiry
reportingorigin
```