### PR TITLE
🏗  Remove label from PRs for release tagger

### DIFF
--- a/build-system/release-tagger/label-pull-requests.js
+++ b/build-system/release-tagger/label-pull-requests.js
@@ -21,6 +21,7 @@
  * 1. head tag (amp version)
  * 2. base tag (amp version)
  * 3. channel (beta|lts|stable)
+ * 4. rollback
  */
 
 const argv = require('minimist')(process.argv.slice(2));
@@ -29,6 +30,7 @@ const {
   getPullRequestsBetweenCommits,
   getRelease,
   labelPullRequests,
+  unlabelPullRequests,
 } = require('./utils');
 
 const labelConfig = {
@@ -42,9 +44,10 @@ const labelConfig = {
  * @param {string} head tag
  * @param {string} base tag
  * @param {string} channel (beta|stable|lts)
+ * @param {boolean} rollback
  * @return {Promise<Object>}
  */
-async function main(head, base, channel) {
+async function main(head, base, channel, rollback = false) {
   const [label, headRelease, baseRelease] = await Promise.all([
     await getLabel(labelConfig[channel]),
     await getRelease(head),
@@ -54,8 +57,13 @@ async function main(head, base, channel) {
     headRelease['target_commitish'],
     baseRelease['target_commitish']
   );
+
+  if (rollback) {
+    return await unlabelPullRequests(prs, label['node_id']);
+  }
+
   return await labelPullRequests(prs, label['node_id']);
 }
 
-main(argv.head, argv.base, argv.label);
+main(argv.head, argv.base, argv.label, argv.rollback);
 module.exports = {main};

--- a/build-system/release-tagger/test/label-pull-requests.test.js
+++ b/build-system/release-tagger/test/label-pull-requests.test.js
@@ -140,3 +140,122 @@ test('label', async (t) => {
   t.true(rest.isDone());
   t.true(graphql.isDone());
 });
+
+test('unlabel', async (t) => {
+  const rest = nock('https://api.github.com')
+    // https://docs.github.com/en/rest/reference/issues#get-a-label
+    .get(
+      '/repos/ampproject/amphtml/labels/PR%20Use%3A%20In%20Beta%20%2F%20Experimental'
+    )
+    .reply(200, {
+      'node_id': 1,
+    })
+    // https://docs.github.com/en/rest/reference/repos#get-a-release-by-tag-name
+    .get('/repos/ampproject/amphtml/releases/tags/2107280123000')
+    .reply(200, {
+      id: 2,
+      'target_commitish': '3abcdef',
+    })
+    // https://docs.github.com/en/rest/reference/repos#get-a-release-by-tag-name
+    .get('/repos/ampproject/amphtml/releases/tags/2107210123000')
+    .reply(200, {
+      id: 1,
+      'target_commitish': '1abcdef',
+    })
+    // https://docs.github.com/en/rest/reference/repos#compare-two-commits
+    .get('/repos/ampproject/amphtml/compare/1abcdef...3abcdef')
+    .reply(200, {
+      commits: [{sha: '1abcdef'}, {sha: '2abcdef'}, {sha: '3abcdef'}],
+    });
+
+  const graphql = nock('https://api.github.com/graphql')
+    .post(
+      '',
+      '{"query":"query {' +
+        'pr0: search(query:\\"repo:ampproject/amphtml sha:1abcdef\\", ' +
+        'type:ISSUE first:100){nodes { ... on PullRequest { id title number ' +
+        'url author { login } files(first:100) { nodes { path }} mergeCommit ' +
+        '{ commitUrl oid abbreviatedOid }}}} ' +
+        'pr1: search(query:\\"repo:ampproject/amphtml sha:2abcdef\\", ' +
+        'type:ISSUE first:100){nodes { ... on PullRequest { id title number ' +
+        'url author { login } files(first:100) { nodes { path }} mergeCommit ' +
+        '{ commitUrl oid abbreviatedOid }}}} ' +
+        'pr2: search(query:\\"repo:ampproject/amphtml sha:3abcdef\\", ' +
+        'type:ISSUE first:100){nodes { ... on PullRequest { id title number ' +
+        'url author { login } files(first:100) { nodes { path }} mergeCommit ' +
+        '{ commitUrl oid abbreviatedOid }}}}}"}'
+    )
+    .reply(200, {
+      data: {
+        pr0: {
+          nodes: [
+            {
+              id: 'MDEx01',
+              title: 'Bunch of changes',
+              number: 1,
+              url: 'https://github.com/ampproject/amphtml/pull/1',
+              author: {login: 'testauthor'},
+              mergeCommit: {
+                commitUrl:
+                  'https://github.com/ampproject/amphtml/commit/1abcdef',
+                oid: '1abcdef',
+                abbreviatedOid: '1abc',
+              },
+            },
+          ],
+        },
+        pr1: {
+          nodes: [
+            {
+              id: 'MDEx02',
+              title: '`README` updates',
+              number: 2,
+              url: 'https://github.com/ampproject/amphtml/pull/2',
+              author: {login: 'testauthor'},
+              mergeCommit: {
+                commitUrl:
+                  'https://github.com/ampproject/amphtml/commit/2abcdef',
+                oid: '2abcdef',
+                abbreviatedOid: '2abc',
+              },
+            },
+          ],
+        },
+        pr2: {
+          nodes: [
+            {
+              id: 'MDEx03',
+              title: 'Update packages',
+              number: 3,
+              url: 'https://github.com/ampproject/amphtml/pull/3',
+              author: {login: 'renovate-bot'},
+              mergeCommit: {
+                commitUrl:
+                  'https://github.com/ampproject/amphtml/commit/3abcdef',
+                oid: '3abcdef',
+                abbreviatedOid: '3abc',
+              },
+            },
+          ],
+        },
+      },
+    })
+    .post(
+      '',
+      '{"query":"mutation {' +
+        'pr0: removeLabelsFromLabelable(input:{labelIds:\\"1\\", ' +
+        'labelableId:\\"MDEx01\\", clientMutationId:\\"MDEx01\\"})' +
+        '{clientMutationId} ' +
+        'pr1: removeLabelsFromLabelable(input:{labelIds:\\"1\\", ' +
+        'labelableId:\\"MDEx02\\", clientMutationId:\\"MDEx02\\"})' +
+        '{clientMutationId} ' +
+        'pr2: removeLabelsFromLabelable(input:{labelIds:\\"1\\", ' +
+        'labelableId:\\"MDEx03\\", clientMutationId:\\"MDEx03\\"})' +
+        '{clientMutationId}}"}'
+    )
+    .reply(200, {data: {}});
+
+  await labelPullRequests('2107280123000', '2107210123000', 'beta', true);
+  t.true(rest.isDone());
+  t.true(graphql.isDone());
+});

--- a/build-system/release-tagger/utils.js
+++ b/build-system/release-tagger/utils.js
@@ -198,11 +198,31 @@ async function labelPullRequests(prs, labelId) {
   return await _runQueryInBatches('mutation', mutations);
 }
 
+/**
+ * Unlabel pull requests
+ * @param {Array<Object>} prs
+ * @param {string} labelId
+ * @return {Promise<Array<GraphQlQueryResponseData>>}
+ */
+async function unlabelPullRequests(prs, labelId) {
+  const mutations = [];
+  for (const [i, pr] of prs.entries()) {
+    mutations.push(
+      dedent`\
+      pr${i}: removeLabelsFromLabelable(input:{labelIds:"${labelId}", \
+      labelableId:"${pr.id}", clientMutationId:"${pr.id}"})\
+      {clientMutationId}`
+    );
+  }
+  return await _runQueryInBatches('mutation', mutations);
+}
+
 module.exports = {
   createRelease,
   getLabel,
   getPullRequestsBetweenCommits,
   getRelease,
   labelPullRequests,
+  unlabelPullRequests,
   updateRelease,
 };


### PR DESCRIPTION
Removes labels from PRs in the case of rollbacks.