### PR TITLE
🏗 Matrixify `amp build | dist` checks on GH actions

### DIFF
--- a/.github/workflows/cross-platform-builds.yml
+++ b/.github/workflows/cross-platform-builds.yml
@@ -1,22 +1,22 @@
 name: Cross-Platform Builds
+
 on:
   push:
     branches:
       - main
 
 jobs:
-  build:
+  compile:
     if: github.repository == 'ampproject/amphtml'
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
+        platform: [ubuntu, macos, windows]
+        flavor: [Build, Dist]
+    runs-on: ${{ matrix.platform }}-latest
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh
-      - name: Build
-        run: node build-system/pr-check/cross-platform-builds.js
+      - name: ${{ matrix.flavor }}
+        run: node build-system/pr-check/cross-platform-builds.js --flavor=${{ matrix.flavor }}

--- a/build-system/pr-check/cross-platform-builds.js
+++ b/build-system/pr-check/cross-platform-builds.js
@@ -19,6 +19,7 @@
  * @fileoverview Script that builds every commit on Linux, macOS, and Windows.
  */
 
+const {flavor} = require('minimist')(process.argv.slice(2));
 const {runCiJob} = require('./ci-job');
 const {timedExecOrDie} = require('./utils');
 
@@ -28,8 +29,7 @@ const jobName = 'cross-platform-builds.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp build');
-  timedExecOrDie('amp dist');
+  timedExecOrDie(flavor == 'Build' ? 'amp build' : 'amp dist');
 }
 
 runCiJob(jobName, pushBuildWorkflow, () => {});


### PR DESCRIPTION
This should speed up our post-merge cross-platform build verification workflow a little and make errors (e.g. https://github.com/ampproject/amphtml/pull/35630#issuecomment-899945493) easier to spot. Does not affect PR checks in any way.
 
**Example:** https://github.com/ampproject/amphtml/actions/runs/1144580544

**Screenshot:**

![image](https://user-images.githubusercontent.com/26553114/129970446-4bbd4588-1358-42c7-9d4c-321a8ad1ef1f.png)

Follow up to #35713