### PR TITLE
remove notice from validator/js/... files

### DIFF
--- a/validator/js/chromeextension/README.md
+++ b/validator/js/chromeextension/README.md
@@ -1,19 +1,3 @@
-<!---
-Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
 # AMP Validator Chrome Extension
 
 This is the source code to the publicly available [AMP Validator](https://chrome.google.com/webstore/detail/amp-validator/nmoffdblmcmgeicmolmhobpoocbbmknc) Chrome extension.

--- a/validator/js/chromeextension/background.html
+++ b/validator/js/chromeextension/background.html
@@ -1,18 +1,3 @@
-<!---
-Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <!doctype html>
 <html>
   <head>

--- a/validator/js/chromeextension/background.js
+++ b/validator/js/chromeextension/background.js
@@ -1,19 +1,3 @@
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 const globals = {};
 globals.ampCacheBgcolor = '#ffffff';
 globals.ampCacheIconPrefix = 'amp-link';

--- a/validator/js/chromeextension/build_extension.sh
+++ b/validator/js/chromeextension/build_extension.sh
@@ -1,19 +1,5 @@
 #!/bin/bash -ex
 #
-# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-#
 # A script to install dependencies and then build the extension.
 
 echo 'Installing web components'

--- a/validator/js/chromeextension/content_script.js
+++ b/validator/js/chromeextension/content_script.js
@@ -1,19 +1,3 @@
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 const globals = {};
 globals.amphtmlRegex = new RegExp('(^\\s*)amphtml(\\s*$)');
 globals.ampCaches = [

--- a/validator/js/chromeextension/package_extension.sh
+++ b/validator/js/chromeextension/package_extension.sh
@@ -1,19 +1,5 @@
 #!/bin/bash -ex
 #
-# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-#
 # A script to package only the necessary files of the extension.
 
 echo "Building chrome extension"

--- a/validator/js/chromeextension/polymer-extension-toolbar.html
+++ b/validator/js/chromeextension/polymer-extension-toolbar.html
@@ -1,18 +1,3 @@
-<!---
-Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <link href="polymer.html" rel="import">
 <dom-module id="extension-toolbar">
   <style scope="extension-toolbar">

--- a/validator/js/chromeextension/polymer.html
+++ b/validator/js/chromeextension/polymer.html
@@ -1,18 +1,3 @@
-<!---
-Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <!DOCTYPE html>
 <meta charset="utf-8">
 <link rel="import" href="bower_components/iron-pages/iron-pages.html">

--- a/validator/js/chromeextension/popup-validator-not-present.html
+++ b/validator/js/chromeextension/popup-validator-not-present.html
@@ -1,18 +1,3 @@
-<!---
-Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <!doctype html>
 <html>
   <head>

--- a/validator/js/chromeextension/popup-validator.html
+++ b/validator/js/chromeextension/popup-validator.html
@@ -1,18 +1,3 @@
-<!---
-Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <!doctype html>
 <html>
   <head>

--- a/validator/js/engine/amp4ads-parse-css.js
+++ b/validator/js/engine/amp4ads-parse-css.js
@@ -1,20 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 goog.module('amp.validator.validateAmp4AdsCss');
 
 const parse_css = goog.require('parse_css');

--- a/validator/js/engine/amp4ads-parse-css_test.js
+++ b/validator/js/engine/amp4ads-parse-css_test.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('parse_css.Amp4AdsParseCssTest');
 
 const json_testutil = goog.require('json_testutil');

--- a/validator/js/engine/definitions.js
+++ b/validator/js/engine/definitions.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.provide('amp.validator.VALIDATE_CSS');
 
 /** @define {boolean} */

--- a/validator/js/engine/htmlparser-interface.js
+++ b/validator/js/engine/htmlparser-interface.js
@@ -1,20 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 goog.module('amp.htmlparser.interface');
 
 /**

--- a/validator/js/engine/htmlparser.js
+++ b/validator/js/engine/htmlparser.js
@@ -1,19 +1,4 @@
 /**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- *
  * Credits:
  *   Copyright 2006-2008, The Google Caja project, licensed under the
  *   Apache License (http://code.google.com/p/google-caja/).

--- a/validator/js/engine/htmlparser_test.js
+++ b/validator/js/engine/htmlparser_test.js
@@ -1,19 +1,4 @@
 /**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- *
  * Credits:
  *   Copyright 2006-2008, The Google Caja project, licensed under the
  *   Apache License (http://code.google.com/p/google-caja/).

--- a/validator/js/engine/json-testutil.js
+++ b/validator/js/engine/json-testutil.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('json_testutil');
 const asserts = goog.require('goog.asserts');
 

--- a/validator/js/engine/keyframes-parse-css.js
+++ b/validator/js/engine/keyframes-parse-css.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('amp.validator.keyframesParseCss');
 
 const parse_css = goog.require('parse_css');

--- a/validator/js/engine/keyframes-parse-css_test.js
+++ b/validator/js/engine/keyframes-parse-css_test.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2017 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('parse_css.KeyframesParseCssTest');
 
 const json_testutil = goog.require('json_testutil');

--- a/validator/js/engine/parse-css.js
+++ b/validator/js/engine/parse-css.js
@@ -1,19 +1,4 @@
 /**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- *
  * Credits:
  *   This original version of this file was derived from
  *   https://github.com/tabatkins/parse-css by Tab Atkins,

--- a/validator/js/engine/parse-css_test.js
+++ b/validator/js/engine/parse-css_test.js
@@ -1,19 +1,4 @@
 /**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- *
  * Credits:
  *   This original version of this file was derived from
  *   https://github.com/tabatkins/parse-css by Tab Atkins,

--- a/validator/js/engine/parse-srcset.js
+++ b/validator/js/engine/parse-srcset.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 goog.module('parse_srcset');
 const Set = goog.require('goog.structs.Set');
 const {ValidationError} = goog.require('amp.validator.protogenerated');

--- a/validator/js/engine/parse-srcset_test.js
+++ b/validator/js/engine/parse-srcset_test.js
@@ -1,19 +1,4 @@
 /**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- *
  *  Credits:
  *    Original version of this file was derived from
  *    https://github.com/ampproject/amphtml/blob/main/test/unit/test-srcset.js

--- a/validator/js/engine/parse-url.js
+++ b/validator/js/engine/parse-url.js
@@ -1,20 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 goog.module('parse_url');
 const googString = goog.require('goog.string');
 

--- a/validator/js/engine/parse-url_test.js
+++ b/validator/js/engine/parse-url_test.js
@@ -1,19 +1,3 @@
-/**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('parse_url.ParseURLTest');
 
 const parse_url = goog.require('parse_url');

--- a/validator/js/engine/tokenize-css.js
+++ b/validator/js/engine/tokenize-css.js
@@ -1,19 +1,4 @@
 /**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- *
  * Credits:
  *   This original version of this file was derived from
  *   https://github.com/tabatkins/parse-css by Tab Atkins,

--- a/validator/js/engine/validator-in-browser.js
+++ b/validator/js/engine/validator-in-browser.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('amp.validator.validatorInBrowser');
 
 const GoogPromise = goog.require('goog.Promise');

--- a/validator/js/engine/validator.js
+++ b/validator/js/engine/validator.js
@@ -1,19 +1,3 @@
-/**
- * @license DEDUPE_ON_MINIFY
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('amp.validator');
 const VALIDATE_CSS = goog.require('amp.validator.VALIDATE_CSS');
 const amp4ads = goog.require('amp.validator.validateAmp4AdsCss');

--- a/validator/js/engine/validator_test.js
+++ b/validator/js/engine/validator_test.js
@@ -1,19 +1,3 @@
-/**
- * @license
- * Copyright 2015 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 goog.module('amp.validator.ValidatorTest');
 
 const asserts = goog.require('goog.asserts');

--- a/validator/js/gulpjs/index.js
+++ b/validator/js/gulpjs/index.js
@@ -1,20 +1,3 @@
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 'use strict';
 
 const amphtmlValidator = require('amphtml-validator');

--- a/validator/js/gulpjs/sample/gulpfile.js
+++ b/validator/js/gulpjs/sample/gulpfile.js
@@ -1,20 +1,3 @@
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 const gulp = require('gulp');
 const gulpAmpHtmlValidator = require('gulp-amphtml-validator');
 

--- a/validator/js/gulpjs/test/validate.js
+++ b/validator/js/gulpjs/test/validate.js
@@ -1,20 +1,3 @@
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 'use strict';
 
 const assert = require('assert');

--- a/validator/js/nodejs/cli.js
+++ b/validator/js/nodejs/cli.js
@@ -1,20 +1,4 @@
 #!/usr/bin/env node
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 
 'use strict';
 

--- a/validator/js/nodejs/index.js
+++ b/validator/js/nodejs/index.js
@@ -1,20 +1,3 @@
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 'use strict';
 
 const colors = require('colors/safe');

--- a/validator/js/nodejs/index_test.js
+++ b/validator/js/nodejs/index_test.js
@@ -1,20 +1,4 @@
 #!/usr/bin/env node
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
 
 'use strict';
 

--- a/validator/js/webui/@polymer/amphtml-editor/amphtml-editor.html
+++ b/validator/js/webui/@polymer/amphtml-editor/amphtml-editor.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!-- An editor control using CodeMirror. This fires 'amphtml-editor-changes'
      events which are not parameterized, and allows clients to get / set
      the editor value, add line widgets (inline displays of errors) and move

--- a/validator/js/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
+++ b/validator/js/webui/@polymer/ampproject-toolbar/ampproject-toolbar.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!-- Toolbar displayed at the top of the page. This doesn't do much but has a
      lot of styling, so we isolate it to keep the source for other parts of
      the page easier to read. -->

--- a/validator/js/webui/@polymer/webui-errorlist/webui-errorlist.html
+++ b/validator/js/webui/@polymer/webui-errorlist/webui-errorlist.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!-- A custom element for the error list below the editor window. The errors
      are kept as an array of validation errors, and selection changes will
      fire an event ('error-selected') with the appropriate error. -->

--- a/validator/js/webui/@polymer/webui-mainpage/webui-mainpage.html
+++ b/validator/js/webui/@polymer/webui-mainpage/webui-mainpage.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!-- The main contents of the page, which instantiates the
      custom elements defined in the other files. -->
 <link rel="import" href="../polymer/polymer.html">

--- a/validator/js/webui/@polymer/webui-statusbar/webui-statusbar.html
+++ b/validator/js/webui/@polymer/webui-statusbar/webui-statusbar.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!-- Very simple status bar displaying PASS / FAIL
      below the editor window. -->
 <link rel="import" href="../paper-material/paper-material.html">

--- a/validator/js/webui/@polymer/webui-urlform/webui-urlform.html
+++ b/validator/js/webui/@polymer/webui-urlform/webui-urlform.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!-- Form for entering a URL above the main editor window. -->
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../paper-button/paper-button.html">

--- a/validator/js/webui/README.md
+++ b/validator/js/webui/README.md
@@ -1,19 +1,3 @@
-<!---
-Copyright 2015 The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
 # Validator Web UI
 
 If you'd like to use the web UI, simply visit [validator.amp.dev](https://validator.amp.dev/).

--- a/validator/js/webui/build.py
+++ b/validator/js/webui/build.py
@@ -1,19 +1,4 @@
 #!/usr/bin/env python
-#
-# Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-#
 """A build script which (thus far) works on Ubuntu 14."""
 
 # TODO(powdercloud): Make a gulp file or similar for this. For now

--- a/validator/js/webui/index.html
+++ b/validator/js/webui/index.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!doctype html>
 <head>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">

--- a/validator/js/webui/main/serve.go
+++ b/validator/js/webui/main/serve.go
@@ -1,19 +1,3 @@
-/**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 // To use this:
 // (1) Install the App Engine SDK for Go from
 //     https://cloud.google.com/appengine/downloads#Google_App_Engine_SDK_for_Go

--- a/validator/js/webui/serve-standalone.go
+++ b/validator/js/webui/serve-standalone.go
@@ -1,18 +1,3 @@
-/**
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package main
 
 import (

--- a/validator/js/webui/webui.js
+++ b/validator/js/webui/webui.js
@@ -1,20 +1,3 @@
-/**
- * @license
- * Copyright 2016 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the license.
- */
-
 const DOC_INPUT_ATTR = 'doc';
 
 // Extracts a dictionary of parameters from window.location.hash.


### PR DESCRIPTION
This is a first pass at removing notice from validator files. This covers files in `validator/js/`.

See #35717
```
Per conversations with OpenJS and Google, we have permission to remove the notice at the top of each AMPHTML source file.
```