### PR TITLE
 ♻️  ads-initialIntersection: clean up failed experiment

### DIFF
--- a/extensions/amp-a4a/0.1/name-frame-renderer.js
+++ b/extensions/amp-a4a/0.1/name-frame-renderer.js
@@ -1,13 +1,7 @@
 import {createElementWithAttributes} from '#core/dom';
-import {
-  intersectionEntryToJson,
-  measureIntersection,
-} from '#core/dom/layout/intersection';
+import {intersectionEntryToJson} from '#core/dom/layout/intersection';
 import {dict} from '#core/types/object';
 import {utf8Decode} from '#core/types/string/bytes';
-
-import {getExperimentBranch} from '#experiments';
-import {ADS_INITIAL_INTERSECTION_EXP} from '#experiments/ads-initial-intersection-exp';
 
 import {Renderer} from './amp-ad-type-defs';
 
@@ -46,39 +40,30 @@ export class NameFrameRenderer extends Renderer {
     );
     contextMetadata['creative'] = creative;
 
-    const asyncIntersection =
-      getExperimentBranch(
-        element.ownerDocument.defaultView,
-        ADS_INITIAL_INTERSECTION_EXP.id
-      ) === ADS_INITIAL_INTERSECTION_EXP.experiment;
-    const intersectionPromise = asyncIntersection
-      ? measureIntersection(element)
-      : Promise.resolve(element.getIntersectionChangeEntry());
-    return intersectionPromise.then((intersection) => {
-      contextMetadata['_context']['initialIntersection'] =
-        intersectionEntryToJson(intersection);
-      const attributes = dict({
-        'src': srcPath,
-        'name': JSON.stringify(contextMetadata),
-        'height': context.size.height,
-        'width': context.size.width,
-        'frameborder': '0',
-        'allowfullscreen': '',
-        'allowtransparency': '',
-        'scrolling': 'no',
-        'marginwidth': '0',
-        'marginheight': '0',
-      });
-      if (crossDomainData.sentinel) {
-        attributes['data-amp-3p-sentinel'] = crossDomainData.sentinel;
-      }
-      const iframe = createElementWithAttributes(
-        /** @type {!Document} */ (element.ownerDocument),
-        'iframe',
-        /** @type {!JsonObject} */ (attributes)
-      );
-      // TODO(glevitzky): Ensure that applyFillContent or equivalent is called.
-      element.appendChild(iframe);
+    const intersection = element.getIntersectionChangeEntry();
+    contextMetadata['_context']['initialIntersection'] =
+      intersectionEntryToJson(intersection);
+    const attributes = dict({
+      'src': srcPath,
+      'name': JSON.stringify(contextMetadata),
+      'height': context.size.height,
+      'width': context.size.width,
+      'frameborder': '0',
+      'allowfullscreen': '',
+      'allowtransparency': '',
+      'scrolling': 'no',
+      'marginwidth': '0',
+      'marginheight': '0',
     });
+    if (crossDomainData.sentinel) {
+      attributes['data-amp-3p-sentinel'] = crossDomainData.sentinel;
+    }
+    const iframe = createElementWithAttributes(
+      /** @type {!Document} */ (element.ownerDocument),
+      'iframe',
+      /** @type {!JsonObject} */ (attributes)
+    );
+    // TODO(glevitzky): Ensure that applyFillContent or equivalent is called.
+    element.appendChild(iframe);
   }
 }

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -42,7 +42,6 @@ import {
   getExperimentBranch,
   randomlySelectUnsetExperiments,
 } from '#experiments';
-import {ADS_INITIAL_INTERSECTION_EXP} from '#experiments/ads-initial-intersection-exp';
 import {StoryAdAutoAdvance} from '#experiments/story-ad-auto-advance';
 import {StoryAdPlacements} from '#experiments/story-ad-placements';
 import {StoryAdSegmentExp} from '#experiments/story-ad-progress-segment';
@@ -224,16 +223,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    */
   divertExperiments() {
     const experimentInfoList =
-      /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
-        {
-          experimentId: ADS_INITIAL_INTERSECTION_EXP.id,
-          isTrafficEligible: () => true,
-          branches: [
-            ADS_INITIAL_INTERSECTION_EXP.control,
-            ADS_INITIAL_INTERSECTION_EXP.experiment,
-          ],
-        },
-      ]);
+      /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([]);
     const setExps = randomlySelectUnsetExperiments(
       this.win,
       experimentInfoList

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -67,7 +67,6 @@ import {
   isExperimentOn,
   randomlySelectUnsetExperiments,
 } from '#experiments';
-import {ADS_INITIAL_INTERSECTION_EXP} from '#experiments/ads-initial-intersection-exp';
 import {StoryAdAutoAdvance} from '#experiments/story-ad-auto-advance';
 import {StoryAdPlacements} from '#experiments/story-ad-placements';
 import {StoryAdSegmentExp} from '#experiments/story-ad-progress-segment';
@@ -465,14 +464,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
           experimentId: ZINDEX_EXP,
           isTrafficEligible: () => true,
           branches: Object.values(ZINDEX_EXP_BRANCHES),
-        },
-        {
-          experimentId: ADS_INITIAL_INTERSECTION_EXP.id,
-          isTrafficEligible: () => true,
-          branches: [
-            ADS_INITIAL_INTERSECTION_EXP.control,
-            ADS_INITIAL_INTERSECTION_EXP.experiment,
-          ],
         },
         {
           experimentId: IDLE_CWV_EXP,

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -2,7 +2,6 @@ import {
   ADSENSE_MCRSPV_TAG,
   getMatchedContentResponsiveHeightAndUpdatePubParams,
 } from '#ads/google/utils';
-import {ADS_INITIAL_INTERSECTION_EXP} from '#experiments/ads-initial-intersection-exp';
 import {AmpAdUIHandler} from './amp-ad-ui';
 import {AmpAdXOriginIframeHandler} from './amp-ad-xorigin-iframe-handler';
 import {
@@ -32,12 +31,8 @@ import {
   getConsentPolicySharedData,
   getConsentPolicyState,
 } from '../../../src/consent';
-import {getExperimentBranch} from '#experiments';
 import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
-import {
-  intersectionEntryToJson,
-  measureIntersection,
-} from '#core/dom/layout/intersection';
+import {intersectionEntryToJson} from '#core/dom/layout/intersection';
 import {moveLayoutRect} from '#core/dom/layout/rect';
 import {
   observeWithSharedInOb,
@@ -134,9 +129,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
      * @private {boolean}
      */
     this.isFullWidthRequested_ = false;
-
-    /** @private {Promise<!IntersectionObserverEntry>} */
-    this.initialIntersectionPromise_ = null;
   }
 
   /** @override */
@@ -203,13 +195,6 @@ export class AmpAd3PImpl extends AMP.BaseElement {
     if (this.isFullWidthRequested_) {
       return this.attemptFullWidthSizeChange_();
     }
-
-    const asyncIntersection =
-      getExperimentBranch(this.win, ADS_INITIAL_INTERSECTION_EXP.id) ===
-      ADS_INITIAL_INTERSECTION_EXP.experiment;
-    this.initialIntersectionPromise_ = asyncIntersection
-      ? measureIntersection(this.element)
-      : Promise.resolve(this.element.getIntersectionChangeEntry());
   }
 
   /**
@@ -409,20 +394,19 @@ export class AmpAd3PImpl extends AMP.BaseElement {
         // here, though, allows us to measure the impact of ad throttling via
         // incrementLoadingAds().
 
-        return this.initialIntersectionPromise_.then((intersection) => {
-          const iframe = getIframe(
-            toWin(this.element.ownerDocument.defaultView),
-            this.element,
-            this.type_,
-            opt_context,
-            {
-              initialIntersection: intersectionEntryToJson(intersection),
-            }
-          );
-          iframe.title = this.element.title || 'Advertisement';
-          this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(this);
-          return this.xOriginIframeHandler_.init(iframe);
-        });
+        const intersection = this.element.getIntersectionChangeEntry();
+        const iframe = getIframe(
+          toWin(this.element.ownerDocument.defaultView),
+          this.element,
+          this.type_,
+          opt_context,
+          {
+            initialIntersection: intersectionEntryToJson(intersection),
+          }
+        );
+        iframe.title = this.element.title || 'Advertisement';
+        this.xOriginIframeHandler_ = new AmpAdXOriginIframeHandler(this);
+        return this.xOriginIframeHandler_.init(iframe);
       })
       .then(() => {
         observeWithSharedInOb(this.element, (inViewport) =>

--- a/src/experiments/ads-initial-intersection-exp.js
+++ b/src/experiments/ads-initial-intersection-exp.js
@@ -1,6 +1,0 @@
-/** @const */
-export const ADS_INITIAL_INTERSECTION_EXP = {
-  id: 'ads-initialIntersection',
-  control: '31060065',
-  experiment: '31060066',
-};

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -78,18 +78,7 @@ describes.sandboxed('amp-ad 3P', {}, () => {
         });
         const {initialIntersection} = context;
         expect(initialIntersection.rootBounds).to.deep.equal(
-          layoutRectLtwh(
-            0,
-            0,
-            Math.min(
-              iframe.ownerDocument.body.clientWidth,
-              iframe.ownerDocument.defaultView.innerWidth
-            ),
-            Math.min(
-              iframe.ownerDocument.body.clientHeight,
-              iframe.ownerDocument.defaultView.innerHeight
-            )
-          )
+          layoutRectLtwh(0, 0, 500, IFRAME_HEIGHT)
         );
 
         expect(initialIntersection.boundingClientRect).to.deep.equal(

--- a/test/integration/test-amp-ad-3p.js
+++ b/test/integration/test-amp-ad-3p.js
@@ -1,8 +1,5 @@
 import {layoutRectLtwh} from '#core/dom/layout/rect';
 
-import {forceExperimentBranch} from '#experiments';
-import {ADS_INITIAL_INTERSECTION_EXP} from '#experiments/ads-initial-intersection-exp';
-
 import {Services} from '#service';
 import {installPlatformService} from '#service/platform-impl';
 
@@ -26,11 +23,6 @@ describes.sandboxed('amp-ad 3P', {}, () => {
     return createFixture().then((f) => {
       fixture = f;
       installPlatformService(fixture.win);
-      forceExperimentBranch(
-        fixture.win,
-        ADS_INITIAL_INTERSECTION_EXP.id,
-        ADS_INITIAL_INTERSECTION_EXP.experiment
-      );
     });
   });
 


### PR DESCRIPTION
**summary**
Reviving a very old effort. I had tried to move measurements of ad iframe `initialIntersection` param to async, but the experiments showed a negative enough impact to ad performance that I didn't feel comfortable pushing through. Instead now opting to move this codepath to ads-specific code. First step is removing the experiment.

Partial for https://github.com/ampproject/amphtml/pull/34133