### PR TITLE
🏗 Refresh git branches before potentially early-exiting during repo setup

### DIFF
--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the license.
 
-# This script fetches the merge commit of a PR branch with the main branch to
-# make sure PRs are tested against all the latest changes on CircleCI.
+# This script updates the .git cache and fetches the merge commit of a PR branch
+# with the main branch to make sure PRs are tested against all the latest
+# changes on CircleCI.
 
 set -e
 err=0

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -24,6 +24,12 @@ GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
+echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
+git fetch origin main:main
+
+echo "$(GREEN "Fetching other branches to update") $(CYAN ".git") $(GREEN "cache.")"
+git fetch
+
 # Try to determine the PR number.
 ./.circleci/get_pr_number.sh
 if [[ -f "${BASH_ENV}" ]]; then
@@ -40,9 +46,6 @@ fi
 if [[ ! -f /tmp/restored-workspace/.CIRCLECI_MERGE_COMMIT ]]; then
   exit 0
 fi
-
-echo "$(GREEN "Fetching all branches to update") $(CYAN ".git") $(GREEN "cache.")"
-git fetch
 
 # Extract the merge commit for this workflow and make it visible to other steps.
 CIRCLECI_MERGE_COMMIT="$(cat /tmp/restored-workspace/.CIRCLECI_MERGE_COMMIT)"

--- a/.circleci/initialize_repo.sh
+++ b/.circleci/initialize_repo.sh
@@ -24,6 +24,12 @@ GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
+echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
+git fetch origin main:main
+
+echo "$(GREEN "Fetching other branches to update") $(CYAN ".git") $(GREEN "cache.")"
+git fetch
+
 # Ensure the CircleCI workspace directory exists.
 mkdir -p /tmp/workspace
 
@@ -37,9 +43,6 @@ fi
 if [[ -z "${PR_NUMBER}" ]]; then
   exit 0
 fi
-
-echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
-git fetch origin main:main
 
 # GitHub provides refs/pull/<PR_NUMBER>/merge, an up-to-date merge branch for
 # every PR branch that can be cleanly merged to the main branch. For more

--- a/.circleci/initialize_repo.sh
+++ b/.circleci/initialize_repo.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the license.
 
-# This script establishes the merge commit at the start of a CircleCI build so
-# all stages use the same commit.
+# This script updates the .git cache and then establishes the merge commit at
+# the start of a CircleCI build so all stages use the same commit.
 
 set -e
 err=0


### PR DESCRIPTION
**Highlights:**

This PR solves the corner case where if a PR originates directly from a branch on the main `ampproject/amphtml` repo, and if that branch gradually goes out of date, we still do a full refresh of the current view of `main`, `origin/main`, and other repo branches _before_ running CI checks.

Note that on git repos, we need to fetch the `main` and `origin/main` branches in a separate step because it also needs to update the _local_ `main` branch on the VM. (Hence the two step `git fetch`.)

With these precautions, we should no longer see PRs that edit only a few files, but are [tested as if](https://app.circleci.com/pipelines/github/ampproject/amphtml/15096/workflows/9abab3f1-0458-492b-8dec-00a1fdcca93c/jobs/259490?invite=true#step-113-10) they edit a whole lot more files.

**Verification:**

Confirmed this works by creating a PR from an outdated branch on the main `ampproject/amphtml` repo. The logs show that we are refreshing all branches in the `.git` cache and then correctly showing that only two files changed.

<img width="1675" alt="Screen Shot 2021-08-19 at 2 24 54 PM" src="https://user-images.githubusercontent.com/26553114/130123905-753856e0-ad03-4d9f-96cb-07468a0096b3.png">

Follow up to #35646.