### PR TITLE
🏗📖 Remove AMP copyright from infrastructure source files

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # This script checks if a PR branch is using the most recent CircleCI config.
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 

--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # This script updates the .git cache and fetches the merge commit of a PR branch
 # with the main branch to make sure PRs are tested against all the latest
 # changes on CircleCI.

--- a/.circleci/get_pr_number.sh
+++ b/.circleci/get_pr_number.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # This script extracts the PR number (if there is one) for a CircleCI build.
 # Reference: https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
 

--- a/.circleci/initialize_repo.sh
+++ b/.circleci/initialize_repo.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # This script updates the .git cache and then establishes the merge commit at
 # the start of a CircleCI build so all stages use the same commit.
 

--- a/.circleci/install_microsoft_edge.sh
+++ b/.circleci/install_microsoft_edge.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # Script used by AMP's CI builds to install Microsoft Edge Beta on CircleCI.
 # Reference: https://www.microsoftedgeinsider.com/en-us/download?platform=linux-deb
 # TODO(rsimha): Switch from Beta to Stable once it's available.

--- a/.circleci/install_validator_dependencies.sh
+++ b/.circleci/install_validator_dependencies.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # Script used by AMP's CI builds to install AMP Validator dependencies on
 # CircleCI.
 

--- a/.circleci/maybe_gracefully_halt.sh
+++ b/.circleci/maybe_gracefully_halt.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # Script used by AMP's CI builds to gracefully halt unnecessary jobs, before
 # executing time-consuming steps such as checking out the code or installing
 # dependencies.

--- a/.circleci/restore_build_output.sh
+++ b/.circleci/restore_build_output.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # Script used by AMP's CI builds to restore any build outputs from previous jobs
 # in the workflow.
 

--- a/.github/workflows/install_dependencies.sh
+++ b/.github/workflows/install_dependencies.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2021 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # Script used by AMP's CI builds to install project dependencies on GH Actions.
 
 set -e

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,20 +1,4 @@
 /**
- * Copyright 2018 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the 'License');
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an 'AS-IS' BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/**
  * @fileoverview Global configuration file for various babel transforms.
  *
  * Notes: From https://babeljs.io/docs/en/plugins#plugin-ordering:

--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -1,18 +1,3 @@
-/**
- * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the 'License');
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an 'AS-IS' BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -1,18 +1,3 @@
-/**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the 'License');
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an 'AS-IS' BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));

--- a/build-system/common/default-pre-push
+++ b/build-system/common/default-pre-push
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-#
 # This file contains the default pre-push hook for AMPHTML. To enable it, run:
 #     "./build-system/common/enable-git-pre-push.sh"
 #

--- a/build-system/common/enable-git-pre-push.sh
+++ b/build-system/common/enable-git-pre-push.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 #
-# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-
 # This script adds a pre-push hook to .git/hooks/, which runs some basic tests
 # before running "git push".
 # To enable it, run this script: "./build-system/common/enable-git-pre-push.sh"

--- a/build-system/release-tagger/index.js
+++ b/build-system/release-tagger/index.js
@@ -1,20 +1,4 @@
 /**
- * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/**
  * @fileoverview
  * Entry file for ./github/workflows/release-tagger.yml
  * Parameters

--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -1,19 +1,3 @@
-/**
- * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific lan``guage governing permissions and
- * limitations under the License.
- */
-
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));

--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -221,7 +221,6 @@ async function makeExtensionFromTemplates(
   const namePascalCase = dashToPascalCase(name);
 
   const replacements = {
-    '__current_year__': `${new Date().getFullYear()}`,
     '__component_version__': version,
     '__component_version_snakecase__': version.replace(/\./g, '_'),
     '__component_name_hyphenated__': name,

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import {BaseElement} from './base-element';
 __css_import__;
 import {dict} from '#core/types/object';

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 __jss_import_component_css__;
 import {__component_name_pascalcase__} from './component';
 import {PreactBaseElement} from '#preact/base-element';

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import * as Preact from '#preact';
 import {ContainWrapper} from '#preact/component';
 import {

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /** @externs */
 
 /** @const */

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import * as Preact from '#preact';
 import {__component_name_pascalcase__} from '../component'
 import {withKnobs} from '@storybook/addon-knobs';

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-amp-__component_name_hyphenated__.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-amp-__component_name_hyphenated__.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import '../amp-__component_name_hyphenated__';
 import {htmlFor} from '#core/dom/static-template';
 import {toggleExperiment} from '#experiments';

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import * as Preact from '#preact';
 import {__component_name_pascalcase__} from '../component';
 import {mount} from 'enzyme';

--- a/build-system/tasks/make-extension/template/classic/examples/amp-__component_name_hyphenated__.html
+++ b/build-system/tasks/make-extension/template/classic/examples/amp-__component_name_hyphenated__.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!DOCTYPE html>
 <html ⚡ lang="en">
   <!-- prettier-ignore -->

--- a/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
+++ b/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 __css_import__;
 import {Layout, applyFillContent} from '#core/dom/layout';
 

--- a/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-amp-__component_name_hyphenated__.js
+++ b/build-system/tasks/make-extension/template/classic/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-amp-__component_name_hyphenated__.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import '../amp-__component_name_hyphenated__';
 import {htmlFor} from '#core/dom/static-template';
 

--- a/build-system/tasks/make-extension/template/css/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.css
+++ b/build-system/tasks/make-extension/template/css/extensions/amp-__component_name_hyphenated__/__component_version__/amp-__component_name_hyphenated__.css
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 amp-__component_name_hyphenated__ {
   /** Component styles */
 }

--- a/build-system/tasks/make-extension/template/jss/extensions/amp-__component_name_hyphenated__/__component_version__/component.jss.js
+++ b/build-system/tasks/make-extension/template/jss/extensions/amp-__component_name_hyphenated__/__component_version__/component.jss.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import {createUseStyles} from 'react-jss';
 
 // __do_not_submit__: Example class used for styling

--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.amp.js
@@ -1,19 +1,3 @@
-/**
- * Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 import * as Preact from '#preact';
 import {withAmp} from '@ampproject/storybook-addon';
 import {withKnobs} from '@storybook/addon-knobs';

--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/test/__validator__-amp-__component_name_hyphenated__.html
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__component_version__/test/__validator__-amp-__component_name_hyphenated__.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!DOCTYPE html>
 <html ⚡ lang="en">
   <!-- prettier-ignore -->

--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__validator__-amp-__component_name_hyphenated__.protoascii
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/__validator__-amp-__component_name_hyphenated__.protoascii
@@ -1,19 +1,3 @@
-#
-# Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS-IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the license.
-#
-
 tags: {  # amp-__component_name_hyphenated__
   html_format: AMP
   tag_name: "SCRIPT"

--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/amp-__component_name_hyphenated__.md
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/amp-__component_name_hyphenated__.md
@@ -15,22 +15,6 @@ teaser:
   * Remove this comment!
 -->
 
-<!--
-Copyright __current_year__ The AMP HTML Authors. All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS-IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
-
 # amp-__component_name_hyphenated__
 
 <!--

--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-config.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-config.js
@@ -1,20 +1,4 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/**
  * Removes an entry from files like tools/experiments/experiments-config.js,
  * whose id property is specified by --experimentId:
  *

--- a/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
+++ b/build-system/tasks/sweep-experiments/jscodeshift/remove-experiment-runtime.js
@@ -1,20 +1,4 @@
 /**
- * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/**
  * Replaces isExperimentOn() and toggleExperiment() calls when they match a name
  * specified by --isExperimentOnExperiment
  *

--- a/testing/helpers/index.js
+++ b/testing/helpers/index.js
@@ -1,20 +1,4 @@
 /**
- * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/**
  * A private encapsulation of the test env variable.
  */
 let env_;

--- a/testing/helpers/types.js
+++ b/testing/helpers/types.js
@@ -1,18 +1,3 @@
-/**
- * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS-IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 import {
   DOMRectDef,
   ElementHandle,


### PR DESCRIPTION
We're doing away with the AMP copyright in our source files. See https://github.com/ampproject/amphtml/pull/35717#issue-715220675.

This PR cleans up all infra source files.