### PR TITLE
🏗 Refresh git cache only for non-main branches

### DIFF
--- a/.circleci/fetch_merge_commit.sh
+++ b/.circleci/fetch_merge_commit.sh
@@ -25,11 +25,15 @@ GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
-git fetch origin main:main
-
-echo "$(GREEN "Fetching other branches to update") $(CYAN ".git") $(GREEN "cache.")"
-git fetch
+# Update the .git cache for non-main branches.
+if [[ "$CIRCLE_BRANCH" == "main" ]]; then
+  echo "$(GREEN "No need to update the") $(CYAN ".git") $(GREEN "cache because this is the") $(CYAN "main") $(GREEN "branch.")"
+else
+  echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
+  git fetch origin main:main
+  echo "$(GREEN "Fetching other branches to update") $(CYAN ".git") $(GREEN "cache.")"
+  git fetch
+fi
 
 # Try to determine the PR number.
 ./.circleci/get_pr_number.sh

--- a/.circleci/initialize_repo.sh
+++ b/.circleci/initialize_repo.sh
@@ -24,11 +24,15 @@ GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
-git fetch origin main:main
-
-echo "$(GREEN "Fetching other branches to update") $(CYAN ".git") $(GREEN "cache.")"
-git fetch
+# Update the .git cache for non-main branches.
+if [[ "$CIRCLE_BRANCH" == "main" ]]; then
+  echo "$(GREEN "No need to update the") $(CYAN ".git") $(GREEN "cache because this is the") $(CYAN "main") $(GREEN "branch.")"
+else
+  echo "$(GREEN "Fetching") $(CYAN "main") $(GREEN "branch to update") $(CYAN ".git") $(GREEN "cache.")"
+  git fetch origin main:main
+  echo "$(GREEN "Fetching other branches to update") $(CYAN ".git") $(GREEN "cache.")"
+  git fetch
+fi
 
 # Ensure the CircleCI workspace directory exists.
 mkdir -p /tmp/workspace


### PR DESCRIPTION
Turns out we can't refresh the `main` branch during push builds because it's already refreshed and checked out.

![image](https://user-images.githubusercontent.com/26553114/130128843-e812fe61-d270-4b57-9fd0-8bc5aaa88d73.png)

This PR does the refresh step only for non-main branches.

Follow up to #35742.