### PR TITLE
📖 Remove AMP Copyright notice from non-validator HTML files

### DIFF
--- a/examples/ad-lightbox.amp.html
+++ b/examples/ad-lightbox.amp.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2017 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/examples/amp-date-countdown.amp.html
+++ b/examples/amp-date-countdown.amp.html
@@ -1,15 +1,3 @@
-<!--
-  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/examples/amp-next-page.amp.html
+++ b/examples/amp-next-page.amp.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2017 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/examples/amp-smartlinks.html
+++ b/examples/amp-smartlinks.html
@@ -1,16 +1,4 @@
 <!--
-	Copyright 2019 The AMP HTML Authors. All Rights Reserved.
-	Licensed under the Apache License, Version 2.0 (the "License");
-	you may not use this file except in compliance with the License.
-	You may obtain a copy of the License at
-			http://www.apache.org/licenses/LICENSE-2.0
-	Unless required by applicable law or agreed to in writing, software
-	distributed under the License is distributed on an "AS-IS" BASIS,
-	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-	See the License for the specific language governing permissions and
-	limitations under the license.
--->
-<!--
 	Test Description:
 	Valid amp-smartlinks tag
 -->

--- a/examples/amp-story/interactive_quizzes.html
+++ b/examples/amp-story/interactive_quizzes.html
@@ -1,19 +1,3 @@
-<!--
-  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
-
 <!doctype html>
 <html ⚡ lang="en">
   <head>

--- a/examples/amp-story/interactive_size.html
+++ b/examples/amp-story/interactive_size.html
@@ -1,19 +1,3 @@
-<!--
-  Copyright 2020 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
-
 <!doctype html>
 <html ⚡ lang="en">
   <head>

--- a/examples/viqeo.amp.html
+++ b/examples/viqeo.amp.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2018 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!DOCTYPE html>
 <html ⚡ lang="en">
   <head>

--- a/test/fixtures/e2e/amp-base-carousel/captions.amp.html
+++ b/test/fixtures/e2e/amp-base-carousel/captions.amp.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/test/fixtures/served/ampdoc-with-messaging.html
+++ b/test/fixtures/served/ampdoc-with-messaging.html
@@ -1,16 +1,4 @@
 <!--
-  Copyright 2016 The AMP HTML Authors. All Rights Reserved.
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
-<!--
   Test Description:
   Tests amp-viewer-integration.
 -->

--- a/test/manual/amp-analytics/analytics-shadow.html
+++ b/test/manual/amp-analytics/analytics-shadow.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/test/manual/amp-flying-carpet-media.amp.html
+++ b/test/manual/amp-flying-carpet-media.amp.html
@@ -1,4 +1,3 @@
-
 <html amp lang="en">
 <head>
     <meta charset="utf-8">

--- a/test/manual/amp-lightbox-gallery.amp.html
+++ b/test/manual/amp-lightbox-gallery.amp.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/test/manual/amp-list/infinite-scroll-2.amp.html
+++ b/test/manual/amp-list/infinite-scroll-2.amp.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 
 <!---

--- a/test/manual/amp-sidebar-focus.amp.html
+++ b/test/manual/amp-sidebar-focus.amp.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html amp lang="en">
 <head>

--- a/test/manual/autofocus-on-show.html
+++ b/test/manual/autofocus-on-show.html
@@ -1,18 +1,3 @@
-<!--
-  Copyright 2019 The AMP HTML Authors. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS-IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the license.
--->
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/test/manual/video-caching.amp.html
+++ b/test/manual/video-caching.amp.html
@@ -1,4 +1,3 @@
-
 <!doctype html>
 <html amp lang="en">
   <head>


### PR DESCRIPTION
We're doing away with the AMP copyright in our source files. See https://github.com/ampproject/amphtml/pull/35717#issue-715220675.

This PR cleans up all non-validator HTML files (there are only a handful remaining). It also removes blank lines left behind from a previous cleanup.