### PR TITLE
Add wg-caching as owners of validator-*.out.cpponly

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,7 +13,7 @@
       ],
     },
     {
-      pattern: '**/validator-*.{protoascii,html,out}',
+      pattern: '**/validator-*.{protoascii,html,out,out.cpponly}',
       owners: [{name: 'ampproject/wg-caching', required: true}],
     },
     {


### PR DESCRIPTION
Add wg-caching as owners for `validator-*.out.cpponly`files.

Example where just these files aren't owned by wg-caching:
https://github.com/ampproject/amphtml/pull/35748/checks?check_run_id=3376047276