### PR TITLE
♻️ Remove rendundant `getAmpDoc()` from services

### DIFF
--- a/src/service/resource.js
+++ b/src/service/resource.js
@@ -503,7 +503,7 @@ export class Resource {
     // Calculate whether the element is currently is or in `position:fixed`.
     let isFixed = false;
     if (viewport.supportsPositionFixed() && this.isDisplayed()) {
-      const {win} = this.resources_.getAmpdoc();
+      const {win} = this.resources_.ampdoc;
       const {body} = win.document;
       for (let n = this.element; n && n != body; n = n./*OK*/ offsetParent) {
         if (n.isAlwaysFixed && n.isAlwaysFixed()) {

--- a/src/service/resources-impl.js
+++ b/src/service/resources-impl.js
@@ -282,11 +282,6 @@ export class ResourcesImpl {
   }
 
   /** @override */
-  getAmpdoc() {
-    return this.ampdoc;
-  }
-
-  /** @override */
   getResourceForElement(element) {
     return Resource.forElement(element);
   }

--- a/src/service/resources-interface.js
+++ b/src/service/resources-interface.js
@@ -38,7 +38,7 @@ export class ResourcesInterface {
   /**
    * @return {!./ampdoc-impl.AmpDoc}
    */
-  getAmpdoc() {}
+  get ampdoc() {}
 
   /**
    * Returns the {@link Resource} instance corresponding to the specified AMP

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -316,11 +316,6 @@ export class ViewerImpl {
   }
 
   /** @override */
-  getAmpDoc() {
-    return this.ampdoc;
-  }
-
-  /** @override */
   getParam(name) {
     return this.ampdoc.getParam(name);
   }

--- a/src/service/viewer-interface.js
+++ b/src/service/viewer-interface.js
@@ -11,7 +11,7 @@ export class ViewerInterface {
   /**
    * @return {!./ampdoc-impl.AmpDoc}
    */
-  getAmpDoc() {}
+  get ampdoc() {}
 
   /**
    * Returns the value of a viewer's startup parameter with the specified

--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -39,7 +39,7 @@ export class SsrTemplateHelper {
    * @return {boolean}
    */
   isEnabled() {
-    const ampdoc = this.viewer_.getAmpDoc();
+    const {ampdoc} = this.viewer_;
     if (ampdoc.isSingleDoc()) {
       const htmlElement = ampdoc.getRootNode().documentElement;
       if (htmlElement.hasAttribute('allow-viewer-render-template')) {


### PR DESCRIPTION
`.ampdoc` is already public in these services, so we don't need a getter.
