### PR TITLE
♻️ Bento Selector: Simplify logic

### DIFF
--- a/extensions/amp-selector/1.0/base-element.js
+++ b/extensions/amp-selector/1.0/base-element.js
@@ -97,7 +97,7 @@ function getOptions(element, mu) {
         option,
         disabled,
         index,
-        onFocus: () => tryFocus(child),
+        focus: () => tryFocus(child),
         role: child.getAttribute('role') || 'option',
         shimDomElement: child,
         // TODO(wg-bento): This implementation causes infinite loops on DOM mutation.

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -272,6 +272,7 @@ export {Selector};
  */
 export function Option({
   as: Comp = 'div',
+  'class': className = '',
   disabled = false,
   index,
   onClick: customOnClick,
@@ -361,26 +362,29 @@ export function Option({
   );
 
   const isSelected = /** @type {!Array} */ (selected).includes(option);
-  const optionProps = {
-    ...rest,
-    className: objstr({
-      [classes.option]: true,
-      [classes.selected]: isSelected && !selectorMultiple,
-      [classes.multiselected]: isSelected && selectorMultiple,
-      [classes.disabled]: disabled || selectorDisabled,
-    }),
-    disabled,
-    'aria-disabled': String(disabled),
-    onClick,
-    onFocus: () => (focusRef.current.active = option),
-    onKeyDown,
-    option,
-    ref,
-    role,
-    selected: isSelected,
-    'aria-selected': String(isSelected),
-    tabIndex:
-      tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0,
-  };
-  return <Comp {...optionProps} />;
+  return (
+    <Comp
+      {...rest}
+      aria-disabled={String(disabled)}
+      aria-selected={String(isSelected)}
+      class={objstr({
+        [className]: !!className,
+        [classes.option]: true,
+        [classes.selected]: isSelected && !selectorMultiple,
+        [classes.multiselected]: isSelected && selectorMultiple,
+        [classes.disabled]: disabled || selectorDisabled,
+      })}
+      disabled={disabled}
+      onClick={onClick}
+      onFocus={() => (focusRef.current.active = option)}
+      onKeyDown={onKeyDown}
+      ref={ref}
+      role={role}
+      selected={isSelected}
+      tabIndex={
+        tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0
+      }
+      value={option}
+    />
+  );
 }

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -50,7 +50,6 @@ function SelectorWithRef(
     multiple,
     name,
     onChange,
-    onKeyDown: customOnKeyDown,
     role = 'listbox',
     tabIndex,
     children,
@@ -209,9 +208,6 @@ function SelectorWithRef(
 
   const onKeyDown = useCallback(
     (e) => {
-      if (customOnKeyDown) {
-        customOnKeyDown(e);
-      }
       const {key} = e;
       let dir;
       switch (key) {
@@ -234,7 +230,7 @@ function SelectorWithRef(
         }
       }
     },
-    [customOnKeyDown, keyboardSelectMode, focusBy, selectBy]
+    [keyboardSelectMode, focusBy, selectBy]
   );
 
   return (
@@ -274,10 +270,8 @@ export function Option({
   as: Comp = 'div',
   'class': className = '',
   disabled = false,
+  focus: customFocus,
   index,
-  onClick: customOnClick,
-  onFocus: customOnFocus,
-  onKeyDown: customOnKeyDown,
   option,
   role = 'option',
   tabIndex,
@@ -295,17 +289,12 @@ export function Option({
     selected,
   } = useContext(SelectorContext);
 
-  const focus = useCallback(
-    (e) => {
-      if (customOnFocus) {
-        customOnFocus(e);
-      }
-      if (ref.current) {
-        tryFocus(ref.current);
-      }
-    },
-    [customOnFocus]
-  );
+  const focus = useCallback(() => {
+    customFocus?.();
+    if (ref.current) {
+      tryFocus(ref.current);
+    }
+  }, [customFocus]);
 
   // Element should be "registered" before it is visible.
   useLayoutEffect(() => {
@@ -339,26 +328,17 @@ export function Option({
     selectOption(option);
   }, [disabled, option, selectOption, selectorDisabled]);
 
-  const onClick = useCallback(
-    (e) => {
-      trySelect();
-      if (customOnClick) {
-        customOnClick(e);
-      }
-    },
-    [customOnClick, trySelect]
-  );
+  const onClick = useCallback(() => {
+    trySelect();
+  }, [trySelect]);
 
   const onKeyDown = useCallback(
     (e) => {
       if (e.key === Keys.ENTER || e.key === Keys.SPACE) {
         trySelect();
       }
-      if (customOnKeyDown) {
-        customOnKeyDown(e);
-      }
     },
-    [customOnKeyDown, trySelect]
+    [trySelect]
   );
 
   const isSelected = /** @type {!Array} */ (selected).includes(option);


### PR DESCRIPTION
- Pass everything from `optionProps` directly in the JSX 
- Remove extraneous `customOnClick`-type handlers. Because we take `as`, authors with custom event logic can interpolate on their own rather if relevant than us including code trying to call a handler that may not be given:
  ```jsx
  function reportClick(e) {
    console.log('Option interacted:', e);
  }

  // Before
  function CustomOption() {
    return <Option as="option" onClick={reportClick} />;
  }
  return <CustomOption />;

  // After
  function CustomOption({onClick}) {
    return (<option onClick={(e) => {
       onClick?.(e);
       reportClick(e);
    }}/>);
  }
  return <Option as={CustomOption} />;
  ```
- `Option` component renames `onFocus` prop to `focus` (it was misnamed as something that happens _on_ focus, as opposed to something called happens _to_ focus).