### PR TITLE
Update sourcemap helper according to @jridgewell feedback.

### DIFF
--- a/build-system/compile/helpers.js
+++ b/build-system/compile/helpers.js
@@ -13,7 +13,7 @@ const {VERSION: internalRuntimeVersion} = require('./internal-version');
  * @param {Object} options
  * @return {string}
  */
-function getSourceMapBase(options) {
+function getSourceRoot(options) {
   if (argv.sourcemap_url) {
     return String(argv.sourcemap_url)
       .replace(/\{version\}/g, internalRuntimeVersion)
@@ -49,12 +49,14 @@ function updatePaths(sourcemaps) {
  */
 async function writeSourcemaps(sourcemapsFile, options) {
   const sourcemaps = await fs.readJson(sourcemapsFile);
+
   updatePaths(sourcemaps);
-  const extra = {
-    sourceRoot: getSourceMapBase(options),
-    includeContent: !!argv.full_sourcemaps,
-  };
-  await fs.writeJSON(sourcemapsFile, {...sourcemaps, ...extra});
+  if (!argv.full_sourcemaps) {
+    delete sourcemaps.sourcesContent;
+  }
+  sourcemaps.sourceRoot = getSourceRoot(options);
+
+  await fs.writeJSON(sourcemapsFile, sourcemaps);
 }
 
 module.exports = {


### PR DESCRIPTION
Addresses https://github.com/ampproject/amphtml/pull/35675#discussion_r693232730. Likely not causing any issues since `sourcesContent` isn't included in the first place unless `--full_sourcemaps` is present. A less defensive version of this PR would be to remove the logic entirely.

https://github.com/ampproject/amphtml/blob/c43ba128ad9d11794a77ce79a7414b3feaf8d45e/build-system/compile/compile.js#L260