### PR TITLE
npm builds should not use `options.wrapper`

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -92,6 +92,7 @@ const ExtensionOptionDef = {};
  *   outfile: string,
  *   external?: Array<string>
  *   remap?: Record<string, string>
+ *   wrapper?: string,
  * }}
  */
 const ExtensionBinaryDef = {};
@@ -625,6 +626,7 @@ function buildNpmBinaries(extDir, options) {
         outfile: preact,
         external: ['preact', 'preact/dom', 'preact/compat', 'preact/hooks'],
         remap: {'preact/dom': 'preact'},
+        wrapper: '',
       });
     }
     if (react) {
@@ -638,6 +640,7 @@ function buildNpmBinaries(extDir, options) {
           'preact/hooks': 'react',
           'preact/dom': 'react-dom',
         },
+        wrapper: '',
       });
     }
     return buildBinaries(extDir, binaries, options);
@@ -655,7 +658,7 @@ function buildBinaries(extDir, binaries, options) {
   mkdirSync(`${extDir}/dist`);
 
   const promises = binaries.map((binary) => {
-    const {entryPoint, external, outfile, remap} = binary;
+    const {entryPoint, external, outfile, remap, wrapper} = binary;
     const {name} = pathParse(outfile);
     const esm = argv.esm || argv.sxg || false;
     return esbuildCompile(extDir + '/', entryPoint, `${extDir}/dist`, {
@@ -666,6 +669,7 @@ function buildBinaries(extDir, binaries, options) {
       outputFormat: esm ? 'esm' : 'cjs',
       externalDependencies: external,
       remapDependencies: remap,
+      wrapper: wrapper ?? options.wrapper,
     });
   });
   return Promise.all(promises);


### PR DESCRIPTION
The `wrapper` for bento components is defined for use with custom element builds, not preact/react builds. For npm binaries, the `"wrapper": "bento"` designation was being split up via this helper and written as a `bent` to the start of all npm build binaries:
https://github.com/ampproject/amphtml/blob/c43ba128ad9d11794a77ce79a7414b3feaf8d45e/build-system/tasks/helpers.js#L426-L439

Another option could be to guard for an invalid wrapper, which also fixes the issue (but may have more consequences given more code paths may be affected):
```diff
diff --git a/build-system/tasks/helpers.js b/build-system/tasks/helpers.js
index a92748b0ee..3cc029ab2a 100644
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -428,9 +428,13 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
    * @return {Object}
    */
   function splitWrapper() {
-    const wrapper = options.wrapper || wrappers.none;
     const sentinel = '<%= contents %>';
-    const start = wrapper.indexOf(sentinel);
+    let wrapper = options.wrapper || wrappers.none;
+    let start = wrapper.indexOf(sentinel);
+    if (start === -1) {
+      wrapper = wrappers.none;
+      start = wrapper.indexOf(sentinel);
+    }
     return {
       banner: {js: wrapper.slice(0, start)},
       footer: {js: wrapper.slice(start + sentinel.length)},
```

Fixes #35741