### PR TITLE
🐛 [Amp story] Catch ScreenOrientation.lock promise

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -948,8 +948,18 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
+    const orientationWarning = (e) =>
+      dev().warn(TAG, 'Failed to lock screen orientation:', e.message);
+
+    // Returns a promise.
+    const lockOrientationPromise = screen.orientation?.lock;
+    if (lockOrientationPromise) {
+      lockOrientationPromise('portrait').catch(orientationWarning);
+      return;
+    }
+
+    // Will return boolean or undefined.
     const lockOrientation =
-      screen.orientation?.lock ||
       screen.lockOrientation ||
       screen.mozLockOrientation ||
       screen.msLockOrientation ||
@@ -958,7 +968,7 @@ export class AmpStory extends AMP.BaseElement {
     try {
       lockOrientation('portrait');
     } catch (e) {
-      dev().warn(TAG, 'Failed to lock screen orientation:', e.message);
+      orientationWarning(e.message);
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -968,7 +968,7 @@ export class AmpStory extends AMP.BaseElement {
     try {
       lockOrientation('portrait');
     } catch (e) {
-      orientationWarning(e.message);
+      orientationWarning(e);
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -958,7 +958,7 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    // Will return boolean or undefined.
+    // Returns boolean or undefined.
     const lockOrientation =
       screen.lockOrientation ||
       screen.mozLockOrientation ||


### PR DESCRIPTION
`screen.orientation?.lock` is returning an unhandled promise.
This PR chains the `.catch` directly to the promise.

Fixes #35659
