### PR TITLE
🐛 [Amp story] Toggle desktop attribute on tooltip overlay

### DIFF
--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -870,9 +870,12 @@ export class AmpStoryEmbeddedComponent {
     this.mutator_.mutateElement(
       dev().assertElement(this.focusedStateOverlay_),
       () => {
-        [UIType.DESKTOP_FULLBLEED, UIType.DESKTOP_PANELS].includes(uiState)
-          ? this.focusedStateOverlay_.setAttribute('desktop', '')
-          : this.focusedStateOverlay_.removeAttribute('desktop');
+        const isDesktop = [
+          UIType.DESKTOP_FULLBLEED,
+          UIType.DESKTOP_PANELS,
+          UIType.DESKTOP_ONE_PANEL,
+        ].includes(uiState);
+        this.focusedStateOverlay_.toggleAttribute('desktop', isDesktop);
       }
     );
   }


### PR DESCRIPTION
Hides the tooltip overlay arrows when a tweet is focused on desktop one panel UI mode.

<img width="608" alt="Screen Shot 2021-08-23 at 1 07 12 PM" src="https://user-images.githubusercontent.com/3860311/130488304-2cf74060-4b73-4b93-8613-853b7ba09298.png">

<img width="604" alt="Screen Shot 2021-08-23 at 1 07 59 PM" src="https://user-images.githubusercontent.com/3860311/130488306-77dd3461-d8ff-4f93-9617-19fe7fdaeaf6.png">
