### PR TITLE
🐛 [Amp story] Desktop one panel play button

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -307,7 +307,8 @@
   display: block !important;
 }
 
-[desktop] .i-amphtml-paused-display {
+[desktop] .i-amphtml-paused-display, 
+.i-amphtml-story-desktop-one-panel .i-amphtml-paused-display {
   display: block !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -307,7 +307,7 @@
   display: block !important;
 }
 
-[desktop] .i-amphtml-paused-display, 
+[desktop] .i-amphtml-paused-display,
 .i-amphtml-story-desktop-one-panel .i-amphtml-paused-display {
   display: block !important;
 }


### PR DESCRIPTION
Displays the pause/play controls when in desktop panel mode.

Fixes #35640