### PR TITLE
♻️  Remove `attemptChangeHeight` method since it has AMP specific `overflow` feature

### DIFF
--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -369,22 +369,6 @@ export class PreactBaseElement extends BaseElement {
     }
   }
 
-  /** @override */
-  attemptChangeHeight(newHeight) {
-    return super.attemptChangeHeight(newHeight).catch((e) => {
-      // It's okay to disable this lint rule since we check that the restricted
-      // method exists.
-      // eslint-disable-next-line local/restrict-this-access
-      if (this.getOverflowElement && !this.getOverflowElement()) {
-        console./* OK */ warn(
-          '[overflow] element not found. Provide one to enable resizing to full contents.',
-          this.element
-        );
-      }
-      throw e;
-    });
-  }
-
   /**
    * @protected
    * @param {!JsonObject} props


### PR DESCRIPTION
`attemptChangeHeight` looks for overflow element, which is AMP specific. Removing this method so it calls the parent's i.e. BaseElement's `attemptChangeHeight` method.

Fixes #35760
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
