### PR TITLE
Change amp-sticky-ad-to-amp-ad name to avoid trigging the old experim…

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -22,5 +22,5 @@
   "story-load-inactive-outside-viewport": 1,
   "story-disable-animations-first-page": 0.5,
   "amp-story-page-attachment-ui-v2": 1,
-  "amp-sticky-ad-to-amp-ad": 0
+  "amp-sticky-ad-to-amp-ad-v2": 0
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -19,5 +19,5 @@
   "story-load-first-page-only": 0.5,
   "story-load-inactive-outside-viewport": 1,
   "amp-story-page-attachment-ui-v2": 1,
-  "amp-sticky-ad-to-amp-ad": 0
+  "amp-sticky-ad-to-amp-ad-v2": 0
 }

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -104,7 +104,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /** @override */
   upgradeCallback() {
-    if (!isExperimentOn(this.win, 'amp-sticky-ad-to-amp-ad')) {
+    if (!isExperimentOn(this.win, 'amp-sticky-ad-to-amp-ad-v2')) {
       return null;
     }
 
@@ -119,7 +119,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
     const adType = (ad.getAttribute('type') || '').toLowerCase();
     if (adType == 'doubleclick' || adType == 'adsense') {
-      addExperimentIdToElement(enableConversion ? '31061856' : '31061855', ad);
+      addExperimentIdToElement(enableConversion ? '31062372' : '31062371', ad);
     }
 
     if (!enableConversion) {


### PR DESCRIPTION
We wish to start this experiment again, but since the old one shares the same name, it would be safer to rename the experiment and experiment id.