### PR TITLE
🐛[Amp story] Add position scope to attachment-content wrapper

### DIFF
--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.css
@@ -53,6 +53,7 @@
 }
 
 .i-amphtml-story-draggable-drawer-content {
+  position: relative !important;  
   opacity: 1 !important;
   transition: opacity 0.3s cubic-bezier(0.0, 0.0, 0.2, 1) !important;
   background: var(--i-amphtml-draggable-drawer-background-color) !important;


### PR DESCRIPTION
This scopes positioning of all child elements `attachment-content`.
Fixes #35764