### PR TITLE
✨ Action `toggleState()`

### DIFF
--- a/docs/spec/amp-actions-and-events.md
+++ b/docs/spec/amp-actions-and-events.md
@@ -375,6 +375,10 @@ event.response</pre></td>
     <td>Toggles class of the target element. <code>force</code> is optional, and if defined, it ensures that class would only be added but not removed if set to <code>true</code>, and only removed but not added if set to <code>false</code>.</td>
   </tr>
   <tr>
+    <td><code>toggleState(force=BOOLEAN)</code></td>
+    <td>Toggles state of the target element. <code>force</code> is optional, and if defined, it ensures that the resulting state would be identical to the value of <code>force</code>.</td>
+  </tr>
+  <tr>
     <td><code>scrollTo(duration=INTEGER, position=STRING)</code></td>
     <td>Scrolls an element into view with a smooth animation.<br>
     <code>duration</code> is optional. Specifies the length of the animation in milliseconds. If unspecified, an amount relative to scroll difference

--- a/docs/spec/amp-email-actions-and-events.md
+++ b/docs/spec/amp-email-actions-and-events.md
@@ -346,6 +346,10 @@ event.response</pre></td>
     <td>Toggles class of the target element. <code>force</code> is optional, and if defined, it ensures that class would only be added but not removed if set to <code>true</code>, and only removed but not added if set to <code>false</code>.</td>
   </tr>
   <tr>
+    <td><code>toggleState(force=BOOLEAN)</code></td>
+    <td>Toggles state of the target element. <code>force</code> is optional, and if defined, it ensures that the resulting state would be identical to the value of <code>force</code>.</td>
+  </tr>
+  <tr>
     <td><code>focus</code></td>
     <td>Makes the target element gain focus. To lose focus, <code>focus</code>
     on another element (usually parent element). We strongly advise against

--- a/examples/standard-actions.amp.html
+++ b/examples/standard-actions.amp.html
@@ -99,6 +99,9 @@
   <button on="tap:normal-element2.toggleClass('class' = 'red-text')">Toggle Class</button>
   <button on="tap:normal-element2.toggleClass('class' = 'red-text', 'force' = true)">Toggle Class (force = true)</button>
   <button on="tap:normal-element2.toggleClass('class' = 'red-text', 'force' = false)">Toggle Class (force = false)</button>
+  <button on="tap:normal-element2.toggleState()">Toggle State</button>
+  <button on="tap:normal-element2.toggleState('force' = true)">Toggle State (force = true)</button>
+  <button on="tap:normal-element2.toggleState('force' = false)">Toggle State (force = false)</button>
   <button on="tap:normal-element3.scrollTo">ScrollTo</button>
   <button on="tap:normal-element3.scrollTo('position' = 'bottom')">ScrollTo Bottom</button>
   <button on="tap:normal-element3.scrollTo('position' = 'center')">ScrollTo Center</button>

--- a/extensions/amp-access-scroll/0.1/scroll-component.js
+++ b/extensions/amp-access-scroll/0.1/scroll-component.js
@@ -93,6 +93,20 @@ export class ScrollComponent {
   }
 
   /**
+   * Action toggleState.
+   * @param {boolean} condition
+   * @protected
+   */
+  toggleState(condition) {
+    const input = devAssert(this.root_);
+    if (condition) {
+      input.checked = true;
+    } else {
+      input.checked = false;
+    }
+  }
+
+  /**
    * @param {Object} updates
    * @return {boolean} true if changed
    * @protected

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -50,6 +50,7 @@ const DEFAULT_EMAIL_ALLOWLIST = [
   {tagOrTarget: '*', method: 'hide'},
   {tagOrTarget: '*', method: 'show'},
   {tagOrTarget: '*', method: 'toggleClass'},
+  {tagOrTarget: '*', method: 'toggleState'},
   {tagOrTarget: '*', method: 'toggleVisibility'},
 ];
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -95,6 +95,11 @@ export class StandardActions {
       'toggleClass',
       this.handleToggleClass_.bind(this)
     );
+
+    actionService.addGlobalMethodHandler(
+      'toggleState',
+      this.handletoggleState_.bind(this)
+    );
   }
 
   /**
@@ -412,6 +417,36 @@ export class StandardActions {
         target.classList.toggle(className, shouldForce);
       } else {
         target.classList.toggle(className);
+      }
+    });
+
+    return null;
+  }
+
+  /**
+   * Handles "toggleState" action.
+   * @param {!./action-impl.ActionInvocation} invocation
+   * @return {?Promise}
+   * @private Visible to tests only.
+   */
+  handletoggleState_(invocation) {
+    const target = dev().assertElement(invocation.node);
+    const {args} = invocation;
+
+    this.mutator_.mutateElement(target, () => {
+      if (args['force'] !== undefined) {
+        // must be boolean, won't do type conversion
+        const shouldForce = user().assertBoolean(
+          args['force'],
+          "Optional argument 'force' must be a boolean."
+        );
+        target.checked = shouldForce;
+      } else {
+        if (target.checked === true) {
+          target.checked = false;
+        } else {
+          target.checked = true;
+        }
       }
     });
 

--- a/test/unit/test-action.js
+++ b/test/unit/test-action.js
@@ -1791,6 +1791,12 @@ describes.realWin(
         expect(spy).to.be.calledWithExactly(i);
       });
 
+      it('should supply default actions allowlist', () => {
+        const i = getActionInvocation(target, 'toggleState', 'AMP');
+        action.invoke_(i);
+        expect(spy).to.be.calledWithExactly(i);
+      });
+
       it('should not allow non-default actions', () => {
         const i = getActionInvocation(target, 'print', 'AMP');
         env.sandbox.stub(action, 'error_');

--- a/test/unit/test-standard-actions.js
+++ b/test/unit/test-standard-actions.js
@@ -71,6 +71,21 @@ describes.sandboxed('StandardActions', {}, (env) => {
     expect(element.classList.contains(className)).to.false;
   }
 
+  function expectCheckboxToHaveStateTrue(element) {
+    expectElementMutatedAsync(element);
+    expect(element.checked).to.true;
+  }
+
+  function expectCheckboxToHaveStateFalse(element) {
+    expectElementMutatedAsync(element);
+    expect(element.checked).to.false;
+  }
+
+  function expectCheckboxToHaveState(element, state) {
+    expectElementMutatedAsync(element);
+    expect(element.checked).to.state;
+  }
+
   function expectAmpElementToHaveBeenHidden(element) {
     expectElementMutatedAsync(element);
     expect(element.collapse).to.be.calledOnce;
@@ -521,6 +536,61 @@ describes.sandboxed('StandardActions', {}, (env) => {
       };
       standardActions.handleToggleClass_(invocation);
       expectElementToDropClass(element, dummyClass);
+    });
+  });
+
+  describe('"toggleState" action', () => {
+
+    it('should set checked state to false when state is true', () => {
+      const element = createElement();
+      element.type = 'checkbox';
+      element.checked = true;
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+      };
+      standardActions.handletoggleState_(invocation);
+      expectCheckboxToHaveStateFalse(element);
+    });
+
+    it('should set checked state to true when state is false', () => {
+      const element = createElement();
+      element.type = 'checkbox';
+      element.checked = false;
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+      };
+      standardActions.handletoggleState_(invocation);
+      expectCheckboxToHaveStateTrue(element);
+    });
+
+    it('should set checked state to true when force=true', () => {
+      const element = createElement();
+      element.type = 'checkbox';
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'force': true,
+        },
+      };
+      standardActions.handletoggleState_(invocation);
+      expectCheckboxToHaveState(element, true);
+    });
+
+    it('should set checked state to false when force=false', () => {
+      const element = createElement();
+      element.type = 'checkbox';
+      const invocation = {
+        node: element,
+        satisfiesTrust: () => true,
+        args: {
+          'force': false,
+        },
+      };
+      standardActions.handletoggleState_(invocation);
+      expectCheckboxToHaveState(element, false);
     });
   });
 


### PR DESCRIPTION
An action required to toggle checkboxes used as CSS toggles when using labels would prevent default actions.

Although the logical counterpart of `toggleClass()`, it hasn’t been considered yet because adjacent sibling checkboxes haven’t become mainstream yet, although they are part of best practice, both on AMP and non-AMP websites.

Closes #35794

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
