### PR TITLE
allow amp-geo server side rendering on cache

### DIFF
--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -25,7 +25,7 @@ import {isArray, isObject} from '#core/types';
 import {tryParseJson} from '#core/types/object/json';
 import {getHashParams} from '#core/types/string/url';
 
-import {isCanary} from '#experiments';
+import {isCanary, isExperimentOn} from '#experiments';
 
 import {Services} from '#service';
 
@@ -200,7 +200,7 @@ export class AmpGeo extends AMP.BaseElement {
         }
         this.mode_ = mode.GEO_OVERRIDE;
       }
-    } else if (preRenderMatch) {
+    } else if (preRenderMatch && isExperimentOn('amp-geo-ssr')) {
       // pre-rendered by a publisher case or cache case.
       this.mode_ = mode.GEO_PRERENDER;
       this.country_ = preRenderMatch[1];

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -170,7 +170,7 @@ export class AmpGeo extends AMP.BaseElement {
     // compatibility. We make sure that docElem exists at it can be undefined
     // in shadow mode.
     const preRenderMatch =
-      (docElem?.className.match(PRE_RENDER_REGEX)) ||
+      docElem?.className.match(PRE_RENDER_REGEX) ||
       bodyElem.className.match(PRE_RENDER_REGEX);
 
     // Trim the spaces off the patched country.

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -194,14 +194,8 @@ export class AmpGeo extends AMP.BaseElement {
         }
         this.mode_ = mode.GEO_OVERRIDE;
       }
-    } else if (
-      preRenderMatch &&
-      !Services.urlForDoc(this.element).isProxyOrigin(this.win.location)
-    ) {
-      // pre-rendered by a publisher case, if we're a cache we ignore that
-      // since there is no way the publisher could know the geo of the client.
-      // When caches start pre-rendering geo we'll need to add specifc code
-      // to handle that.
+    } else if (preRenderMatch) {
+      // pre-rendered by a publisher case or cache case.
       this.mode_ = mode.GEO_PRERENDER;
       this.country_ = preRenderMatch[1];
     } else if (trimmedGeoMatch[1]) {

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -20,7 +20,7 @@
  */
 
 import {Deferred} from '#core/data-structures/promise';
-import {isJsonScriptTag} from '#core/dom';
+import {isJsonScriptTag, iterateCursor} from '#core/dom';
 import {isArray, isObject} from '#core/types';
 import {tryParseJson} from '#core/types/object/json';
 import {getHashParams} from '#core/types/string/url';
@@ -438,12 +438,12 @@ export class AmpGeo extends AMP.BaseElement {
     const {classList: docElemClassList} = docElem;
     const classesToRemove = new Set();
 
-    docElemClassList.forEach((el) => {
+    iterateCursor(docElemClassList, (el) => {
       if (STRIP_RE.test(el)) {
         classesToRemove.add(el);
       }
     });
-    bodyClassList.forEach((el) => {
+    iterateCursor(bodyClassList, (el) => {
       if (STRIP_RE.test(el)) {
         classesToRemove.add(el);
       }

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -436,16 +436,16 @@ export class AmpGeo extends AMP.BaseElement {
     const {classList: htmlClassList} = body.parentElement;
     const classesToRemove = new Set();
 
-    for (let i = htmlClassList.length - 1; i > 0; i--) {
-      if (STRIP_RE.test(htmlClassList[i])) {
-        classesToRemove.add(htmlClassList[i]);
+    htmlClassList.forEach((el) => {
+      if (STRIP_RE.test(el)) {
+        classesToRemove.add(el);
       }
-    }
-    for (let i = bodyClassList.length - 1; i > 0; i--) {
-      if (STRIP_RE.test(bodyClassList[i])) {
-        classesToRemove.add(bodyClassList[i]);
+    });
+    bodyClassList.forEach((el) => {
+      if (STRIP_RE.test(el)) {
+        classesToRemove.add(el);
       }
-    }
+    });
     return classesToRemove;
   }
 

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -200,7 +200,7 @@ export class AmpGeo extends AMP.BaseElement {
         }
         this.mode_ = mode.GEO_OVERRIDE;
       }
-    } else if (preRenderMatch && isExperimentOn('amp-geo-ssr')) {
+    } else if (preRenderMatch && (!Services.urlForDoc(this.element).isProxyOrigin(this.win.location) || isExperimentOn('amp-geo-ssr'))) {
       // pre-rendered by a publisher case or cache case.
       this.mode_ = mode.GEO_PRERENDER;
       this.country_ = preRenderMatch[1];

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -170,7 +170,7 @@ export class AmpGeo extends AMP.BaseElement {
     // compatibility. We make sure that docElem exists at it can be undefined
     // in shadow mode.
     const preRenderMatch =
-      (docElem && docElem.className.match(PRE_RENDER_REGEX)) ||
+      (docElem?.className.match(PRE_RENDER_REGEX)) ||
       bodyElem.className.match(PRE_RENDER_REGEX);
 
     // Trim the spaces off the patched country.

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -530,11 +530,13 @@ describes.realWin(
 
     it('should allow hash to override pre-rendered geo in test', () => {
       setGeoOverrideHash('nz');
+      // NOTE: notide that we cause the the body and html element classes
+      // to go out of sync but we still clear `amp-iso-country-mx` AND
+      // `amp-geo-group-nafta`.
       doc.documentElement.classList.add(
-        'amp-iso-country-mx',
-        'amp-geo-group-nafta'
+        'amp-iso-country-mx'
       );
-      doc.body.classList.add('amp-iso-country-mx', 'amp-geo-group-nafta');
+      doc.body.classList.add('amp-geo-group-nafta');
       addConfigElement('script');
       geo.buildCallback();
 

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -533,9 +533,7 @@ describes.realWin(
       // NOTE: notide that we cause the the body and html element classes
       // to go out of sync but we still clear `amp-iso-country-mx` AND
       // `amp-geo-group-nafta`.
-      doc.documentElement.classList.add(
-        'amp-iso-country-mx'
-      );
+      doc.documentElement.classList.add('amp-iso-country-mx');
       doc.body.classList.add('amp-geo-group-nafta');
       addConfigElement('script');
       geo.buildCallback();

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -95,9 +95,15 @@ describes.realWin(
       geo.element.appendChild(child);
     }
 
-    function expectBodyHasClass(klasses, expected) {
+    function expectElementHasClass(target, klasses, expected) {
       for (const k in klasses) {
-        expect(doc.body.classList.contains(klasses[k])).to.equal(expected);
+        const klass = klasses[k];
+        expect(target.classList.contains(klass)).to.equal(
+          expected,
+          expected
+            ? `missing ${klass} class for ${target.tagName}`
+            : `should not have ${klass} class for ${target.tagName}`
+        );
       }
     }
 
@@ -116,30 +122,48 @@ describes.realWin(
       expect(userErrorStub).to.not.be.called;
     });
 
-    it('should add classes to body element for the geo', () => {
+    it('should add classes to html and body element for the geo', () => {
       addConfigElement('script');
 
       geo.buildCallback();
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('unknown');
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
           ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
           true
         );
-        expectBodyHasClass(['amp-iso-country-nz', 'amp-geo-group-anz'], false);
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          false
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          false
+        );
       });
     });
 
-    it('should remove amp-geo-pending class from body element', () => {
+    it('should remove amp-geo-pending class from html and body element', () => {
       addConfigElement('script');
+      doc.documentElement.classList.add('amp-geo-pending');
       doc.body.classList.add('amp-geo-pending');
 
-      expectBodyHasClass(['amp-geo-pending'], true);
+      expectElementHasClass(doc.body, ['amp-geo-pending'], true);
+      expectElementHasClass(doc.documentElement, ['amp-geo-pending'], true);
 
       geo.buildCallback();
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('unknown');
-        expectBodyHasClass(['amp-geo-pending'], false);
+        expectElementHasClass(doc.body, ['amp-geo-pending'], false);
+        expectElementHasClass(doc.documentElement, ['amp-geo-pending'], false);
       });
     });
 
@@ -180,8 +204,29 @@ describes.realWin(
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('nz');
-        expectBodyHasClass(['amp-iso-country-nz', 'amp-geo-group-anz'], true);
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          [
+            'amp-iso-country-unknown',
+            'amp-geo-group-nafta',
+            'amp-geo-no-group',
+            'amp-geo-group-eea',
+            'amp-geo-group-myGroup',
+          ],
+          false
+        );
+        expectElementHasClass(
+          doc.documentElement,
           [
             'amp-iso-country-unknown',
             'amp-geo-group-nafta',
@@ -201,7 +246,8 @@ describes.realWin(
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('us');
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
           [
             'amp-iso-country-us',
             'amp-geo-group-nafta',
@@ -210,7 +256,23 @@ describes.realWin(
           ],
           true
         );
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.documentElement,
+          [
+            'amp-iso-country-us',
+            'amp-geo-group-nafta',
+            'amp-geo-group-myGroup',
+            'amp-geo-group-uscaGroup',
+          ],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-unknown', 'amp-geo-no-group', 'amp-geo-group-eea'],
+          false
+        );
+        expectElementHasClass(
+          doc.documentElement,
           ['amp-iso-country-unknown', 'amp-geo-no-group', 'amp-geo-group-eea'],
           false
         );
@@ -224,11 +286,22 @@ describes.realWin(
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('fr');
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
           ['amp-iso-country-fr', 'amp-geo-group-eea', 'amp-geo-group-myGroup'],
           true
         );
-        expectBodyHasClass([, 'amp-geo-no-group'], false);
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-fr', 'amp-geo-group-eea', 'amp-geo-group-myGroup'],
+          true
+        );
+        expectElementHasClass(doc.body, [, 'amp-geo-no-group'], false);
+        expectElementHasClass(
+          doc.documentElement,
+          [, 'amp-geo-no-group'],
+          false
+        );
       });
     });
 
@@ -242,8 +315,18 @@ describes.realWin(
       geo.buildCallback();
 
       return Services.geoForDocOrNull(el).then(() => {
-        expectBodyHasClass(['amp-geo-group-uscaGroup'], true);
-        expectBodyHasClass(['amp-geo-group-invalid'], false);
+        expectElementHasClass(doc.body, ['amp-geo-group-uscaGroup'], true);
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-geo-group-uscaGroup'],
+          true
+        );
+        expectElementHasClass(doc.body, ['amp-geo-group-invalid'], false);
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-geo-group-invalid'],
+          false
+        );
       });
     });
 
@@ -254,8 +337,27 @@ describes.realWin(
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('za');
-        expectBodyHasClass(['amp-iso-country-za', 'amp-geo-no-group'], true);
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-za', 'amp-geo-no-group'],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-za', 'amp-geo-no-group'],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          [
+            'amp-iso-country-unknown',
+            'amp-geo-group-nafta',
+            'amp-geo-group-anz',
+          ],
+          false
+        );
+        expectElementHasClass(
+          doc.documentElement,
           [
             'amp-iso-country-unknown',
             'amp-geo-group-nafta',
@@ -323,8 +425,23 @@ describes.realWin(
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('nz');
-        expectBodyHasClass(['amp-iso-country-nz', 'amp-geo-group-anz'], true);
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
+          false
+        );
+        expectElementHasClass(
+          doc.documentElement,
           ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
           false
         );
@@ -342,8 +459,23 @@ describes.realWin(
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('nz');
-        expectBodyHasClass(['amp-iso-country-nz', 'amp-geo-group-anz'], true);
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
+          false
+        );
+        expectElementHasClass(
+          doc.documentElement,
           ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
           false
         );
@@ -354,15 +486,42 @@ describes.realWin(
      * pre-rendered geo is the the case where a publisher uses their own
      * infrastructure to add a country tag to the body.
      */
-    it('should respect pre-rendered geo tags', () => {
+    it('should respect pre-rendered geo tags in the body', () => {
       addConfigElement('script');
       doc.body.classList.add('amp-iso-country-nz', 'amp-geo-group-anz');
       geo.buildCallback();
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('nz');
-        expectBodyHasClass(['amp-iso-country-nz', 'amp-geo-group-anz'], true);
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.body[('amp-iso-country-unknown', 'amp-geo-group-nafta')],
+          false
+        );
+      });
+    });
+
+    it('should respect pre-rendered geo tags in the html element', () => {
+      addConfigElement('script');
+      doc.documentElement.classList.add(
+        'amp-iso-country-nz',
+        'amp-geo-group-anz'
+      );
+      geo.buildCallback();
+
+      return Services.geoForDocOrNull(el).then((geo) => {
+        expect(geo.ISOCountry).to.equal('nz');
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
           ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
           false
         );
@@ -371,14 +530,33 @@ describes.realWin(
 
     it('should allow hash to override pre-rendered geo in test', () => {
       setGeoOverrideHash('nz');
+      doc.documentElement.classList.add(
+        'amp-iso-country-mx',
+        'amp-geo-group-nafta'
+      );
       doc.body.classList.add('amp-iso-country-mx', 'amp-geo-group-nafta');
       addConfigElement('script');
       geo.buildCallback();
 
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('nz');
-        expectBodyHasClass(['amp-iso-country-nz', 'amp-geo-group-anz'], true);
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
+          false
+        );
+        expectElementHasClass(
+          doc.documentElement,
           ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
           false
         );
@@ -424,7 +602,8 @@ describes.realWin(
       geo.buildCallback();
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(geo.ISOCountry).to.equal('unknown');
-        expectBodyHasClass(['amp-geo-error'], true);
+        expectElementHasClass(doc.body, ['amp-geo-error'], true);
+        expectElementHasClass(doc.documentElement, ['amp-geo-error'], true);
       });
     });
 
@@ -456,7 +635,18 @@ describes.realWin(
       return Services.geoForDocOrNull(el).then((geo) => {
         expect(userErrorStub).to.not.be.called;
         expect(geo.ISOCountry).to.equal('us');
-        expectBodyHasClass(
+        expectElementHasClass(
+          doc.body,
+          [
+            'amp-iso-country-us',
+            'amp-geo-group-nafta',
+            'amp-geo-group-myGroup',
+            'amp-geo-group-uscaGroup',
+          ],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
           [
             'amp-iso-country-us',
             'amp-geo-group-nafta',

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -122,6 +122,26 @@ describes.realWin(
       expect(userErrorStub).to.not.be.called;
     });
 
+    it('should be able to handle `documentElement` being null (shadow mode instances)', () => {
+      env.sandbox.stub(ampdoc, 'getRootNode').returns({});
+      addConfigElement('script');
+
+      geo.buildCallback();
+      return Services.geoForDocOrNull(el).then((geo) => {
+        expect(geo.ISOCountry).to.equal('unknown');
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-unknown', 'amp-geo-group-nafta'],
+          true
+        );
+        expectElementHasClass(
+          doc.body,
+          ['amp-iso-country-nz', 'amp-geo-group-anz'],
+          false
+        );
+      });
+    });
+
     it('should add classes to html and body element for the geo', () => {
       addConfigElement('script');
 


### PR DESCRIPTION
The design of the amp-geo server side rendering of amp-geo related classes prioritizes the number of bytes that we can cache. This forces us to add the "prerender" hinting classes on the `html` element as the `body` element can be very far from the byte start of the document. (imagine for example a document with a fully used `style[amp-custom]` which has an allowed 75kb worth of data as of writing).

- render the amp-geo related classes (geolocation/groups) to the `html` element as well as the `body` element.
- prioritize `html` as the element to scan for `prerender` hinting classes
- fix off by 1 error in `clearPreRender`

I didn't make the change to us-ca as i wanted to do it in a separate PR for further discussion if there are any implications in doing so such as, would a publisher be relying on the behavior of it not getting rendered.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
