### PR TITLE
Disable esbuild experiment

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -7,11 +7,5 @@
     "expiration_date_utc": "2021-06-30",
     "define_experiment_constant": "R1_IMG_DEFERRED_BUILD"
   },
-  "experimentC": {
-    "name": "EsbuildCompilation",
-    "environment": "AMP",
-    "issue": "https://github.com/ampproject/amphtml/issues/35264",
-    "expiration_date_utc": "2021-10-30",
-    "define_experiment_constant": "ESBUILD_COMPILATION"
-  }
+  "experimentC": {}
 }


### PR DESCRIPTION
**summary**
Have some items to iron out before reenabling:

1. [x] Disabling `compress.properties` and `computed_props` when mangle is enabled. As well as setting `keep_quotes=`.
2. [x] Ensuring `combineWithCompiledFile` still works for both the DCE'd case (amp-shadow) and the wrapper cases (amp-inputmast, amp-date-picker)