### PR TITLE
esbuild for dist: fix 3 discovered issues

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -870,7 +870,7 @@ function shouldUseClosure() {
   // the release process automatically. Since this experiment is actually on the build system
   // itself instead of runtime, it is never run through babel (where the replacements usually happen).
   // Therefore we must compute this one by hand.
-  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION';
+  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION' && false;
 }
 
 module.exports = {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -870,7 +870,7 @@ function shouldUseClosure() {
   // the release process automatically. Since this experiment is actually on the build system
   // itself instead of runtime, it is never run through babel (where the replacements usually happen).
   // Therefore we must compute this one by hand.
-  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION' && false;
+  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION';
 }
 
 module.exports = {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -182,6 +182,21 @@ async function compileAllJs(options) {
 }
 
 /**
+ * Returns the compiled file to prepend within an extension bundle, empty string if nothing.
+ * @param {string} srcFilename Name of the JS source file
+ * @return {Promise<string>}
+ */
+async function getCompiledFile(srcFilename) {
+  const bundleFiles = EXTENSION_BUNDLE_MAP[srcFilename];
+  if (!bundleFiles) {
+    return '';
+  }
+  return (
+    await Promise.all(bundleFiles.map((file) => fs.readFile(file, 'utf8')))
+  ).join(MODULE_SEPARATOR);
+}
+
+/**
  * Allows pending inside the compile wrapper to the already minified JS file.
  * @param {string} srcFilename Name of the JS source file
  * @param {string} destFilePath File path to the minified JS file
@@ -355,26 +370,13 @@ function handleBundleError(err, continueOnError, destFilename) {
 /**
  * Performs the final steps after a JS file is bundled and optionally minified
  * with esbuild and babel.
- * @param {string} srcFilename
  * @param {string} destDir
  * @param {string} destFilename
  * @param {?Object} options
  * @param {number} startTime
  * @return {Promise<void>}
  */
-async function finishBundle(
-  srcFilename,
-  destDir,
-  destFilename,
-  options,
-  startTime
-) {
-  combineWithCompiledFile(
-    srcFilename,
-    path.join(destDir, destFilename),
-    options
-  );
-
+async function finishBundle(destDir, destFilename, options, startTime) {
   const logPrefix = options.minify ? 'Minified' : 'Compiled';
   let {latestName} = options;
   if (latestName) {
@@ -443,6 +445,8 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     };
   }
   const {banner, footer} = splitWrapper();
+  const compiledFile = await getCompiledFile(srcFilename);
+  banner.js += compiledFile;
 
   const babelPlugin = getEsbuildBabelPlugin(
     options.minify ? 'minified' : 'unminified',
@@ -495,8 +499,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
       fs.outputFile(`${destFile}.map`, map),
     ]);
 
-    // TODO: finishBundle should operate in-mem instead of reading/writing from FS.
-    await finishBundle(srcFilename, destDir, destFilename, options, startTime);
+    await finishBundle(destDir, destFilename, options, startTime);
   }
 
   /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -583,12 +583,13 @@ async function minify(code, map, {mangle} = {mangle: false}) {
   // - Should not convert computed properties into regular property definition
   if (mangle) {
     // eslint-disable-next-line google-camelcase/google-camelcase
-    terserOptions.mangle.properties = {keep_quoted: true, regex: '_$'};
+    terserOptions.mangle.properties = {keep_quoted: 'strict', regex: '_$'};
     terserOptions.nameCache = nameCache;
 
-    // Disables converting computed properties ({['hello']: 5}) into regular prop ({ hello: 5}).
-    // This was an assumption baked into closure.
+    // TODO: uncomment once terser bugs related to these are fixed
+    // https://github.com/terser/terser/pull/1058
     terserOptions.compress.computed_props = false; // eslint-disable-line google-camelcase/google-camelcase
+    terserOptions.compress.properties = false;
   }
 
   const minified = await terser.minify(code, terserOptions);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -182,21 +182,6 @@ async function compileAllJs(options) {
 }
 
 /**
- * Returns the compiled file to prepend within an extension bundle, empty string if nothing.
- * @param {string} srcFilename Name of the JS source file
- * @return {Promise<string>}
- */
-async function getCompiledFile(srcFilename) {
-  const bundleFiles = EXTENSION_BUNDLE_MAP[srcFilename];
-  if (!bundleFiles) {
-    return '';
-  }
-  return (
-    await Promise.all(bundleFiles.map((file) => fs.readFile(file, 'utf8')))
-  ).join(MODULE_SEPARATOR);
-}
-
-/**
  * Allows pending inside the compile wrapper to the already minified JS file.
  * @param {string} srcFilename Name of the JS source file
  * @param {string} destFilePath File path to the minified JS file
@@ -370,13 +355,26 @@ function handleBundleError(err, continueOnError, destFilename) {
 /**
  * Performs the final steps after a JS file is bundled and optionally minified
  * with esbuild and babel.
+ * @param {string} srcFilename
  * @param {string} destDir
  * @param {string} destFilename
  * @param {?Object} options
  * @param {number} startTime
  * @return {Promise<void>}
  */
-async function finishBundle(destDir, destFilename, options, startTime) {
+async function finishBundle(
+  srcFilename,
+  destDir,
+  destFilename,
+  options,
+  startTime
+) {
+  combineWithCompiledFile(
+    srcFilename,
+    path.join(destDir, destFilename),
+    options
+  );
+
   const logPrefix = options.minify ? 'Minified' : 'Compiled';
   let {latestName} = options;
   if (latestName) {
@@ -445,8 +443,6 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     };
   }
   const {banner, footer} = splitWrapper();
-  const compiledFile = await getCompiledFile(srcFilename);
-  banner.js += compiledFile;
 
   const babelPlugin = getEsbuildBabelPlugin(
     options.minify ? 'minified' : 'unminified',
@@ -499,7 +495,8 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
       fs.outputFile(`${destFile}.map`, map),
     ]);
 
-    await finishBundle(destDir, destFilename, options, startTime);
+    // TODO: finishBundle should operate in-mem instead of reading/writing from FS.
+    await finishBundle(srcFilename, destDir, destFilename, options, startTime);
   }
 
   /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -182,6 +182,23 @@ async function compileAllJs(options) {
 }
 
 /**
+ * Returns compiled file to prepend within wrapper and empty string if none.
+ *
+ * @param {string} srcFilename
+ * @return {Promise<string>}
+ */
+async function getCompiledFile(srcFilename) {
+  const bundleFiles = EXTENSION_BUNDLE_MAP[srcFilename];
+  if (!bundleFiles) {
+    return '';
+  }
+  const filesContents = await Promise.all(
+    bundleFiles.map((file) => fs.readFile(file, 'utf8'))
+  );
+  return filesContents.join('\n');
+}
+
+/**
  * Allows pending inside the compile wrapper to the already minified JS file.
  * @param {string} srcFilename Name of the JS source file
  * @param {string} destFilePath File path to the minified JS file
@@ -355,26 +372,13 @@ function handleBundleError(err, continueOnError, destFilename) {
 /**
  * Performs the final steps after a JS file is bundled and optionally minified
  * with esbuild and babel.
- * @param {string} srcFilename
  * @param {string} destDir
  * @param {string} destFilename
  * @param {?Object} options
  * @param {number} startTime
  * @return {Promise<void>}
  */
-async function finishBundle(
-  srcFilename,
-  destDir,
-  destFilename,
-  options,
-  startTime
-) {
-  combineWithCompiledFile(
-    srcFilename,
-    path.join(destDir, destFilename),
-    options
-  );
-
+async function finishBundle(destDir, destFilename, options, startTime) {
   const logPrefix = options.minify ? 'Minified' : 'Compiled';
   let {latestName} = options;
   if (latestName) {
@@ -443,6 +447,8 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     };
   }
   const {banner, footer} = splitWrapper();
+  const compiledFile = await getCompiledFile(srcFilename);
+  banner.js += compiledFile;
 
   const babelPlugin = getEsbuildBabelPlugin(
     options.minify ? 'minified' : 'unminified',
@@ -486,7 +492,9 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     let map = result.outputFiles.find(({path}) => path.endsWith('.map')).text;
 
     if (options.minify) {
-      ({code, map} = await minify(code, map, {mangle: options.mangle}));
+      ({code, map} = await minify(code, map, {
+        mangle: !compiledFile && options.mangle,
+      }));
       map = await massageSourcemaps(map, options);
     }
 
@@ -496,7 +504,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     ]);
 
     // TODO: finishBundle should operate in-mem instead of reading/writing from FS.
-    await finishBundle(srcFilename, destDir, destFilename, options, startTime);
+    await finishBundle(destDir, destFilename, options, startTime);
   }
 
   /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -592,13 +592,7 @@ async function minify(code, map, {mangle} = {mangle: false}) {
   }
 
   const minified = await terser.minify(code, terserOptions);
-  if (!minified.code) {
-    throw new Error(
-      `Minification resulted in an empty bundle. This should never happen.`
-    );
-  }
-
-  return {code: minified.code, map: minified.map};
+  return {code: minified.code ?? '', map: minified.map};
 }
 
 /**


### PR DESCRIPTION
**summary**
1. Removes the check that minification results in an empty bundle as this is expected in a single case (`amp-shadow-polyfill`)
2. Updates `terserOptions` during mangling according to recently discovered bugs.
3. Creates a new `combinedWithCompiledFile` codepath for esbuild flow. It is much simpler albeit less efficient since it forces us to disable mangling. Note that the final combined binaries are still smaller than what Closure was outputting (w/ one exception)