### PR TITLE
Revert "Improve AMP_CONFIG handling during build"

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -8,7 +8,6 @@ const {checkForUnknownDeps} = require('./check-for-unknown-deps');
 const {CLOSURE_SRC_GLOBS} = require('./sources');
 const {cpus} = require('os');
 const {cyan, green} = require('../common/colors');
-const {getAmpConfigForFile} = require('../tasks/prepend-global');
 const {log, logLocalDev} = require('../common/logging');
 const {postClosureBabel} = require('./post-closure-babel');
 const {preClosureBabel} = require('./pre-closure-babel');
@@ -186,9 +185,9 @@ function getSrcs(entryModuleFilenames, options) {
  *
  * @param {string} outputFilename
  * @param {!OptionsDef} options
- * @return {!Promise<!Object>}
+ * @return {!Object}
  */
-async function generateCompilerOptions(outputFilename, options) {
+function generateCompilerOptions(outputFilename, options) {
   // Determine externs
   let externs = options.externs || [];
   if (!options.noAddDeps) {
@@ -221,11 +220,10 @@ async function generateCompilerOptions(outputFilename, options) {
   if (argv.pseudo_names) {
     define.push('PSEUDO_NAMES=true');
   }
-  const ampConfig = await getAmpConfigForFile(outputFilename, options);
   let wrapper = options.wrapper
     ? options.wrapper.replace('<%= contents %>', '%output%')
     : `(function(){%output%})();`;
-  wrapper = `${ampConfig}${wrapper}\n\n//# sourceMappingURL=${outputFilename}.map`;
+  wrapper = `${wrapper}\n\n//# sourceMappingURL=${outputFilename}.map`;
 
   /**
    * TODO(#28387) write a type for this.
@@ -402,10 +400,7 @@ async function compile(
   }
   const destFile = `${outputDir}/${outputFilename}`;
   const sourcemapFile = `${destFile}.map`;
-  const compilerOptions = await generateCompilerOptions(
-    outputFilename,
-    options
-  );
+  const compilerOptions = generateCompilerOptions(outputFilename, options);
   const srcs = options.noAddDeps
     ? entryModuleFilenames.concat(options.extraGlobs || [])
     : getSrcs(entryModuleFilenames, options);

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -5,7 +5,7 @@
  */
 
 const argv = require('minimist')(process.argv.slice(2));
-const {MINIFIED_TARGETS} = require('../tasks/prepend-global');
+const {MINIFIED_TARGETS} = require('../tasks/helpers');
 const {runCiJob} = require('./ci-job');
 const {skipDependentJobs, timedExecOrDie} = require('./utils');
 const {Targets, buildTargetsInclude} = require('./build-targets');

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -10,7 +10,7 @@ const {
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
-const {MINIFIED_TARGETS} = require('../tasks/prepend-global');
+const {MINIFIED_TARGETS} = require('../tasks/helpers');
 const {runCiJob} = require('./ci-job');
 const {Targets, buildTargetsInclude} = require('./build-targets');
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -13,9 +13,9 @@ const wrappers = require('../compile/compile-wrappers');
 const {
   VERSION: internalRuntimeVersion,
 } = require('../compile/internal-version');
+const {applyConfig, removeConfig} = require('./prepend-global');
 const {closureCompile} = require('../compile/compile');
 const {cyan, green, red} = require('../common/colors');
-const {getAmpConfigForFile} = require('./prepend-global');
 const {getEsbuildBabelPlugin} = require('../common/esbuild-babel');
 const {getSourceRoot} = require('../compile/helpers');
 const {isCiBuild} = require('../common/ci');
@@ -51,6 +51,16 @@ const EXTENSION_BUNDLE_MAP = {
     'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js',
   ],
 };
+
+/**
+ * List of unminified targets to which AMP_CONFIG should be written
+ */
+const UNMINIFIED_TARGETS = ['alp.max', 'amp-inabox', 'amp-shadow', 'amp'];
+
+/**
+ * List of minified targets to which AMP_CONFIG should be written
+ */
+const MINIFIED_TARGETS = ['alp', 'amp4ads-v0', 'shadow-v0', 'v0'];
 
 /**
  * Used while building the 3p frame
@@ -310,6 +320,15 @@ async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
     name += ` → ${maybeToEsmName(options.latestName)}`;
   }
   endBuildStep('Minified', name, timeInfo.startTime);
+
+  const target = path.basename(minifiedName, path.extname(minifiedName));
+  if (!argv.noconfig && MINIFIED_TARGETS.includes(target)) {
+    await applyAmpConfig(
+      maybeToEsmName(`${destDir}/${minifiedName}`),
+      /* localDev */ options.fortesting,
+      /* fortesting */ options.fortesting
+    );
+  }
 }
 
 /**
@@ -375,6 +394,16 @@ async function finishBundle(
         : destFilename;
     endBuildStep(logPrefix, loggingName, startTime);
   }
+
+  const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;
+  const target = path.basename(destFilename, path.extname(destFilename));
+  if (targets.includes(target)) {
+    await applyAmpConfig(
+      path.join(destDir, destFilename),
+      /* localDev */ true,
+      /* fortesting */ options.fortesting
+    );
+  }
 }
 
 /**
@@ -405,7 +434,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
    * @return {Object}
    */
   function splitWrapper() {
-    const wrapper = options.wrapper ?? wrappers.none;
+    const wrapper = options.wrapper || wrappers.none;
     const sentinel = '<%= contents %>';
     const start = wrapper.indexOf(sentinel);
     return {
@@ -414,10 +443,6 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     };
   }
   const {banner, footer} = splitWrapper();
-  const config = await getAmpConfigForFile(srcFilename, options);
-  if (config) {
-    banner.js = config + banner.js;
-  }
 
   const babelPlugin = getEsbuildBabelPlugin(
     options.minify ? 'minified' : 'unminified',
@@ -470,6 +495,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
       fs.outputFile(`${destFile}.map`, map),
     ]);
 
+    // TODO: finishBundle should operate in-mem instead of reading/writing from FS.
     await finishBundle(srcFilename, destDir, destFilename, options, startTime);
   }
 
@@ -545,6 +571,8 @@ async function minify(code, map, {mangle} = {mangle: false}) {
       beautify: !!argv.pretty_print,
       // eslint-disable-next-line google-camelcase/google-camelcase
       keep_quoted_props: true,
+      // // TODO: only add preamble for mainBundles?
+      preamble: ';',
     },
     sourceMap: {content: map},
     module: !!argv.esm,
@@ -705,6 +733,33 @@ async function maybePrintCoverageMessage(covPath = '') {
 }
 
 /**
+ * Writes AMP_CONFIG to a runtime file. Optionally enables localDev mode and
+ * fortesting mode. Called by "amp build" and "amp dist" while building
+ * various runtime files.
+ *
+ * @param {string} targetFile File to which the config is to be written.
+ * @param {boolean} localDev Whether or not to enable local development.
+ * @param {boolean} fortesting Whether or not to enable testing mode.
+ * @return {!Promise}
+ */
+async function applyAmpConfig(targetFile, localDev, fortesting) {
+  const config = argv.config === 'canary' ? 'canary' : 'prod';
+  const baseConfigFile =
+    'build-system/global-configs/' + config + '-config.json';
+
+  await removeConfig(targetFile);
+  await applyConfig(
+    config,
+    targetFile,
+    baseConfigFile,
+    /* opt_localDev */ localDev,
+    /* opt_localBranch */ true,
+    /* opt_branch */ undefined,
+    /* opt_fortesting */ fortesting
+  );
+}
+
+/**
  * Copies frame.html to output folder, replaces js references to minified
  * copies, and generates symlink to it.
  *
@@ -816,6 +871,8 @@ function shouldUseClosure() {
 }
 
 module.exports = {
+  MINIFIED_TARGETS,
+  applyAmpConfig,
   bootstrapThirdPartyFrames,
   compileAllJs,
   compileCoreRuntime,

--- a/build-system/tasks/prepend-global/prepend-global.test.js
+++ b/build-system/tasks/prepend-global/prepend-global.test.js
@@ -3,6 +3,16 @@
 const m = require('.');
 const test = require('ava');
 
+test('sync - prepends global config', (t) => {
+  t.plan(1);
+  const res = m.prependConfig('{"hello":"world"}', 'var x = 1 + 1;');
+  t.is(
+    res,
+    'self.AMP_CONFIG||(self.AMP_CONFIG={"hello":"world"});' +
+      '/*AMP_CONFIG*/var x = 1 + 1;'
+  );
+});
+
 test('sync - valueOrDefault', (t) => {
   t.plan(2);
   let res = m.valueOrDefault(true, 'hello');

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -40,7 +40,7 @@ const tar = require('tar');
 const {cyan, green} = require('../../common/colors');
 const {execOrDie} = require('../../common/exec');
 const {log} = require('../../common/logging');
-const {MINIFIED_TARGETS} = require('../prepend-global');
+const {MINIFIED_TARGETS} = require('../helpers');
 const {VERSION} = require('../../compile/internal-version');
 
 // Flavor config for the base flavor type.

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -637,6 +637,7 @@ const forbiddenTermsGlobal = {
       'build-system/tasks/build.js',
       'build-system/tasks/default-task.js',
       'build-system/tasks/dist.js',
+      'build-system/tasks/helpers.js',
       'src/config.js',
       'src/core/window/window.extern.js',
       'src/experiments/index.js',


### PR DESCRIPTION
Reverts ampproject/amphtml#35773.

When updating how `AMP_CONFIG` is handled, I hadn't properly taken dev workflows into account (`localDev:true`).
During `esbuildCompile`, localDev should always be true (at least it historically was).
Reverting for now.