### PR TITLE
🐛 Toggle placeholders/fallbacks properly on Bento components

### DIFF
--- a/docs/building-a-bento-amp-extension.md
+++ b/docs/building-a-bento-amp-extension.md
@@ -25,6 +25,7 @@ Read this document to learn how to create a new Bento AMP component.
     -   [Actions and events](#actions-and-events)
     -   [PreactBaseElement callbacks](#preactbaseelement-callbacks)
     -   [Element and Component classes](#element-and-component-classes)
+    -   [Loading state](#loading-state)
     -   [Element styling](#element-styling)
     -   [Layouts supported in your element](#layouts-supported-in-your-element)
     -   [Register element with AMP](#register-element-with-amp)
@@ -324,6 +325,27 @@ You must document your element's actions and events in its own reference documen
 -   **Usage**: If your extension 'props' definition is not sufficient, or when registering AMP actions and events.
 -   **Example Usage**: `amp-base-carousel`, `amp-lightbox`
 
+#### handleOnLoading
+
+-   **Default**: Optional.
+-   **Override**: Sometimes
+-   **Usage**: Method to override to customize the display of the Placeholder/Fallback/Loader
+-   **Example Usage**: `amp-render`
+
+#### handleOnLoad
+
+-   **Default**: Optional.
+-   **Override**: Sometimes
+-   **Usage**: Method to override to customize the display of the Placeholder/Fallback/Loader
+-   **Example Usage**: `amp-render`, `amp-iframe`
+
+#### handleOnError
+
+-   **Default**: Optional.
+-   **Override**: Sometimes
+-   **Usage**: Method to override to customize the display of the Placeholder/Fallback/Loader
+-   **Example Usage**: `amp-render`
+
 #### mutationObserverCallback
 
 -   **Default**: Optional.
@@ -418,6 +440,22 @@ export function MyElement({propName1, propName2, ...rest}) {
   );
 }
 ```
+
+### Loading state
+
+For components that may load asynchronously, be sure to support `onLoading`, `onLoad`, and `onError` callbacks as props on your Preact component to allow components to fail gracefully.
+
+By default, `PreactBaseElement` provides callbacks which do the following from the AMP layer:
+
+-   `onLoading` toggles on a loader
+-   `onLoad` toggles off any loaders, placeholders, or fallbacks
+-   `onError` toggles on the fallpack (or, if unavailable, the placeholder)
+
+Your Preact component **must** invoke the `onLoad()` callback once your component has loaded. This is especially important for components that display content dynamically, for example through an iframe or after fetching remote data, because they may take time to load which would affect perceived performance.
+
+Your Preact component _should_ invoke the `onLoading()` and `onError()` callbacks so document authors in any environment can implement graceful behavior when appropriate.
+
+Your AMP extension may customize this behavior by overriding the `handleOnLoading()` / `handleOnLoad()` / `handleOnError()` methods in your AMP extension's class.
 
 ### Element styling
 

--- a/docs/building-a-bento-iframe-component.md
+++ b/docs/building-a-bento-iframe-component.md
@@ -21,6 +21,7 @@
     -   [Use `ProxyIframeEmbed` directly](#use-proxyiframeembed-directly)
         -   [Resizing components in AMP](#resizing-components-in-amp)
         -   [Passing or overriding props](#passing-or-overriding-props)
+    -   [Placeholders](#placeholders)
 -   [Completing your extension](#completing-your-extension)
 -   [Example Pull Requests](#example-pull-requests)
 
@@ -305,6 +306,12 @@ function FantasticEmbedInternalWithRef(
 > **If you need to pass `style` or `ref` to the underlying iframe, these are exceptional in that they are propagated to the outer `ContainWrapper` which parents the `iframe` element. You should use `iframeStyle` or `iframeRef` accordingly to pass inline styles and refs.**
 
 You may similarly choose to pass or override properties at the higher level, passed from `FantasticEmbed` into the `ProxyIframeEmbed` we instantiate. For a list of these properties [see `component.type.js`](../src/preact/component/component.type.js)
+
+### Placeholders
+
+All Bento components implemented using iframes should utilize placeholders to mitigate the risk of poor perceived performance. Placeholders, Fallbacks, and Loaders can be toggled on/off using the hooks provided to the Preact Component. See [here](https://github.com/ampproject/amphtml/blob/main/docs/building-a-bento-amp-extension.md#placeholders) for detailed instructions on how to toggle placeholders/fallbacks/loaders.
+
+It is encouraged to create a Storybook story that specifically demonstrates utilization of placeholders and fallbacks.
 
 ## Completing your extension
 

--- a/docs/building-a-bento-video-player.md
+++ b/docs/building-a-bento-video-player.md
@@ -23,6 +23,7 @@
         -   [`origin`](#origin)
         -   [Playback methods with `makeMethodMessage`](#playback-methods-with-makemethodmessage)
         -   [Handling events with `onMessage`](#handling-events-with-onmessage)
+        -   [Placeholders](#placeholders)
     -   [Use `VideoWrapper` directly](#use-videowrapper-directly)
         -   [Specifying `component`](#specifying-component)
         -   [Passing or overriding props](#passing-or-overriding-props)
@@ -347,6 +348,12 @@ function FantasticPlayerWithRef(
 ```
 
 Your iframe's interface to post messages is likely different, but your component should always dispatch [`HTMLMediaElement` events](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement#events) upstream.
+
+#### Placeholders
+
+All Bento components implemented using iframes should utilize placeholders to mitigate the risk of poor perceived performance. Placeholders, Fallbacks, and Loaders can be toggled on/off using the hooks provided to the Preact Component. See [here](https://github.com/ampproject/amphtml/blob/main/docs/building-a-bento-amp-extension.md#placeholders) for detailed instructions on how to toggle placeholders/fallbacks/loaders.
+
+It is encouraged to create a Storybook story that specifically demonstrates utilization of placeholders and fallbacks.
 
 ### Use `VideoWrapper` directly
 

--- a/extensions/amp-brightcove/1.0/component.js
+++ b/extensions/amp-brightcove/1.0/component.js
@@ -5,6 +5,7 @@ import {VideoIframe} from '../../amp-video/1.0/video-iframe';
 import {mutedOrUnmutedEvent} from '../../../src/iframe-video';
 import {dispatchCustomEvent} from '#core/dom';
 import {BRIGHTCOVE_EVENTS, getBrightcoveIframeSrc} from '../brightcove-api';
+import {useValueRef} from '#preact/component';
 
 /** @const {string} */
 const DEFAULT = 'default';
@@ -37,10 +38,12 @@ export function BrightcoveWithRef(props, ref) {
     videoId,
     onPlayingState,
     urlParams,
+    onLoad,
     ...rest
   } = props;
 
   const playerStateRef = useRef({});
+  const onLoadRef = useValueRef(onLoad);
   const [muted, setMuted] = useState(mutedProp);
   const src = useMemo(
     () =>
@@ -62,6 +65,7 @@ export function BrightcoveWithRef(props, ref) {
       switch (eventType) {
         case 'ready':
           dispatchCustomEvent(currentTarget, 'canplay');
+          onLoadRef.current?.();
           break;
         case 'playing':
           onPlayingState?.(true);
@@ -96,7 +100,7 @@ export function BrightcoveWithRef(props, ref) {
         dispatchCustomEvent(currentTarget, mutedOrUnmutedEvent(isMuted));
       }
     },
-    [muted, onPlayingState]
+    [muted, onPlayingState, onLoadRef]
   );
 
   // Check for valid props

--- a/extensions/amp-brightcove/1.0/component.type.js
+++ b/extensions/amp-brightcove/1.0/component.type.js
@@ -9,6 +9,7 @@ var BrightcoveDef = {};
  *   autoplay: (boolean|undefined),
  *   embed: (string|undefined),
  *   muted: (boolean|undefined),
+ *   onLoad: (function():undefined|undefined),
  *   player: (string|undefined),
  *   playlistId: (string|undefined),
  *   videoId: (string|undefined),

--- a/extensions/amp-brightcove/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-brightcove/1.0/storybook/Basic.amp.js
@@ -1,6 +1,6 @@
 import * as Preact from '#preact';
 import {withAmp} from '@ampproject/storybook-addon';
-import {withKnobs} from '@storybook/addon-knobs';
+import {text, withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'amp-brightcove-1_0',
@@ -24,6 +24,35 @@ export const Default = () => {
       width="480"
       height="270"
     ></amp-brightcove>
+  );
+};
+
+export const WithPlaceholderAndFallback = () => {
+  const videoid = text('videoid', 'ref:amp-docs-sample');
+  const playerid = text('playerid', 'SyIOV8yWM');
+  const account = text('account', '1290862519001');
+  const height = text('height', '270');
+  const width = text('width', '480');
+
+  return (
+    <amp-brightcove
+      id="myPlayer"
+      data-referrer="EXTERNAL_REFERRER"
+      data-account={account}
+      data-video-id={videoid}
+      data-player-id={playerid}
+      layout="responsive"
+      width={width}
+      height={height}
+    >
+      <div placeholder style="background:red">
+        Placeholder. Loading content...
+      </div>
+
+      <div fallback style="background:blue">
+        Fallback. Could not load content...
+      </div>
+    </amp-brightcove>
   );
 };
 

--- a/extensions/amp-embedly-card/1.0/component.js
+++ b/extensions/amp-embedly-card/1.0/component.js
@@ -3,6 +3,7 @@ import {MessageType, deserializeMessage} from '#core/3p-frame-messaging';
 import * as Preact from '#preact';
 import {useCallback, useContext, useState} from '#preact';
 import {forwardRef} from '#preact/compat';
+import {useValueRef} from '#preact/component';
 import {ProxyIframeEmbed} from '#preact/component/3p-frame';
 
 import {EmbedlyContext} from './embedly-context';
@@ -22,10 +23,11 @@ const FULL_HEIGHT = '100%';
  * @return {PreactDef.Renderable}
  */
 export function EmbedlyCardWithRef(
-  {requestResize, style, title, url, ...rest},
+  {onLoad, requestResize, style, title, url, ...rest},
   ref
 ) {
   const [height, setHeight] = useState(null);
+  const onLoadRef = useValueRef(onLoad);
   const messageHandler = useCallback(
     (event) => {
       const data = deserializeMessage(event.data);
@@ -37,9 +39,11 @@ export function EmbedlyCardWithRef(
         } else {
           setHeight(height);
         }
+
+        onLoadRef.current?.();
       }
     },
-    [requestResize]
+    [requestResize, onLoadRef]
   );
 
   const {apiKey} = useContext(EmbedlyContext);

--- a/extensions/amp-embedly-card/1.0/component.type.js
+++ b/extensions/amp-embedly-card/1.0/component.type.js
@@ -5,6 +5,7 @@ var EmbedlyCardDef = {};
 
 /**
  * @typedef {{
+ *   onLoad: (function():undefined|undefined),
  *   requestResize: (function(number):*|undefined),
  *   title: (string|undefined),
  *   url: (string),

--- a/extensions/amp-embedly-card/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-embedly-card/1.0/storybook/Basic.amp.js
@@ -42,3 +42,26 @@ export const WithAPIKey = () => {
     </>
   );
 };
+
+export const WithPlaceholderAndFallback = () => {
+  const apiKey = text('Embedly API Key', 'valid-api-key');
+  return (
+    <>
+      <amp-embedly-key layout="nodisplay" value={apiKey}></amp-embedly-key>
+      <amp-embedly-card
+        data-url="https://www.youtube.com/watch?v=lBTCB7yLs8Y"
+        layout="responsive"
+        width="300"
+        height="200"
+      >
+        <div placeholder style="background:red">
+          Placeholder. Loading content...
+        </div>
+
+        <div fallback style="background:blue">
+          Fallback. Could not load content...
+        </div>
+      </amp-embedly-card>
+    </>
+  );
+};

--- a/extensions/amp-facebook/1.0/amp-facebook.js
+++ b/extensions/amp-facebook/1.0/amp-facebook.js
@@ -40,7 +40,6 @@ class AmpFacebook extends BaseElement {
   /** @override */
   init() {
     return dict({
-      'onReady': () => this.togglePlaceholder(false),
       'requestResize': (height) => this.attemptChangeHeight(height),
     });
   }

--- a/extensions/amp-facebook/1.0/component.js
+++ b/extensions/amp-facebook/1.0/component.js
@@ -30,7 +30,7 @@ function FacebookWithRef(
     layout,
     locale: localeProp,
     numPosts,
-    onReady,
+    onLoad,
     orderBy,
     refLabel,
     requestResize,
@@ -51,7 +51,7 @@ function FacebookWithRef(
     (event) => {
       const data = tryParseJson(event.data) ?? deserializeMessage(event.data);
       if (data['action'] == 'ready') {
-        onReady?.();
+        onLoad?.();
       }
       if (data['type'] == MessageType.EMBED_SIZE) {
         const height = data['height'];
@@ -63,7 +63,7 @@ function FacebookWithRef(
         }
       }
     },
-    [requestResize, onReady]
+    [requestResize, onLoad]
   );
 
   const [locale, setLocale] = useState(localeProp);

--- a/extensions/amp-facebook/1.0/component.js
+++ b/extensions/amp-facebook/1.0/component.js
@@ -5,6 +5,7 @@ import {MessageType, deserializeMessage} from '#core/3p-frame-messaging';
 import {forwardRef} from '#preact/compat';
 import {tryParseJson} from '#core/types/object/json';
 import {useCallback, useLayoutEffect, useMemo, useState} from '#preact';
+import {useValueRef} from '#preact/component';
 
 /** @const {string} */
 const TYPE = 'facebook';
@@ -47,11 +48,12 @@ function FacebookWithRef(
   ref
 ) {
   const [height, setHeight] = useState(null);
+  const onLoadRef = useValueRef(onLoad);
   const messageHandler = useCallback(
     (event) => {
       const data = tryParseJson(event.data) ?? deserializeMessage(event.data);
       if (data['action'] == 'ready') {
-        onLoad?.();
+        onLoadRef.current?.();
       }
       if (data['type'] == MessageType.EMBED_SIZE) {
         const height = data['height'];
@@ -63,7 +65,7 @@ function FacebookWithRef(
         }
       }
     },
-    [requestResize, onLoad]
+    [requestResize, onLoadRef]
   );
 
   const [locale, setLocale] = useState(localeProp);

--- a/extensions/amp-facebook/1.0/component.type.js
+++ b/extensions/amp-facebook/1.0/component.type.js
@@ -15,6 +15,7 @@ var FacebookDef = {};
  *   locale: (string|undefined),
  *   layout: (string|undefined),
  *   numPosts: (number|undefined),
+ *   onLoad: (function():undefined|undefined),
  *   orderBy: (string|undefined),
  *   onReadyState: (function(string, *=)|undefined),
  *   refLabel: (string|undefined),

--- a/extensions/amp-facebook/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-facebook/1.0/storybook/Basic.amp.js
@@ -48,7 +48,13 @@ export const Default = () => {
       height="200"
       layout="responsive"
     >
-      <div placeholder>Loading...</div>
+      <div placeholder style="background:red">
+        Placeholder. Loading content...
+      </div>
+
+      <div fallback style="background:blue">
+        Fallback. Could not load content...
+      </div>
     </amp-facebook>
   );
 };

--- a/extensions/amp-iframe/1.0/amp-iframe.js
+++ b/extensions/amp-iframe/1.0/amp-iframe.js
@@ -27,7 +27,7 @@ class AmpIframe extends BaseElement {
    * element and hides it if it does. Also checks the position of the iframe on the
    * document.
    */
-  handleOnLoad_() {
+  handleOnLoad() {
     if (this.getPlaceholder()) {
       this.togglePlaceholder(false);
       return;
@@ -81,9 +81,6 @@ class AmpIframe extends BaseElement {
   /** @override */
   init() {
     return dict({
-      'onLoad': () => {
-        this.handleOnLoad_();
-      },
       'requestResize': (height, width) => {
         return this.updateSize_(height, width);
       },

--- a/extensions/amp-iframe/1.0/amp-iframe.js
+++ b/extensions/amp-iframe/1.0/amp-iframe.js
@@ -26,6 +26,7 @@ class AmpIframe extends BaseElement {
    * Callback for onload event of iframe. Checks if the component has a placeholder
    * element and hides it if it does. Also checks the position of the iframe on the
    * document.
+   * @override
    */
   handleOnLoad() {
     if (this.getPlaceholder()) {

--- a/extensions/amp-iframe/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-iframe/1.0/storybook/Basic.amp.js
@@ -1,6 +1,6 @@
 import * as Preact from '#preact';
 import {withAmp} from '@ampproject/storybook-addon';
-import {withKnobs} from '@storybook/addon-knobs';
+import {text, withKnobs} from '@storybook/addon-knobs';
 
 export default {
   title: 'amp-iframe-1_0',
@@ -25,9 +25,11 @@ export const WithSrc = () => {
 WithSrc.storyName = 'amp-iframe with src attribute';
 
 export const WithPlaceholder = () => {
+  const src = text('src', `https://www.wikipedia.org/`);
   return (
-    <amp-iframe width="800" height="600" src="https://www.wikipedia.org/">
-      <h1>Placeholder</h1>
+    <amp-iframe width="800" height="600" src={src}>
+      <h1 placeholder>Placeholder</h1>
+      <h1 fallback>Fallback</h1>
     </amp-iframe>
   );
 };

--- a/extensions/amp-instagram/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/0.1/storybook/Basic.amp.js
@@ -29,3 +29,29 @@ export const _default = () => {
     ></amp-instagram>
   );
 };
+
+export const WithPlaceholder = () => {
+  const width = number('width', 500);
+  const height = number('height', 600);
+  const shortcode = text('shortcode', 'B8QaZW4AQY_');
+  const captioned = boolean('captioned');
+  const layout = text('layout', 'fixed');
+
+  return (
+    <amp-instagram
+      data-shortcode={shortcode}
+      data-captioned={captioned}
+      width={width}
+      height={height}
+      layout={layout}
+    >
+      <div placeholder style="background:red">
+        Placeholder. Loading content...
+      </div>
+
+      <div fallback style="background:blue">
+        Fallback. Could not load content...
+      </div>
+    </amp-instagram>
+  );
+};

--- a/extensions/amp-instagram/1.0/component.js
+++ b/extensions/amp-instagram/1.0/component.js
@@ -4,6 +4,7 @@ import {parseJson} from '#core/types/object/json';
 import * as Preact from '#preact';
 import {useCallback, useState} from '#preact';
 import {forwardRef} from '#preact/compat';
+import {useValueRef} from '#preact/component';
 import {IframeEmbed} from '#preact/component/iframe';
 
 import {getData} from '../../../src/event-helper';
@@ -18,11 +19,12 @@ const MATCHES_MESSAGING_ORIGIN = (origin) =>
  * @return {PreactDef.Renderable}
  */
 function InstagramWithRef(
-  {captioned, requestResize, shortcode, title = 'Instagram', ...rest},
+  {captioned, onLoad, requestResize, shortcode, title = 'Instagram', ...rest},
   ref
 ) {
   const [heightStyle, setHeightStyle] = useState(NO_HEIGHT_STYLE);
   const [opacity, setOpacity] = useState(0);
+  const onLoadRef = useValueRef(onLoad);
 
   const messageHandler = useCallback(
     (event) => {
@@ -34,9 +36,11 @@ function InstagramWithRef(
         }
         setHeightStyle(dict({'height': height}));
         setOpacity(1);
+
+        onLoadRef.current?.();
       }
     },
-    [requestResize]
+    [requestResize, onLoadRef]
   );
 
   return (

--- a/extensions/amp-instagram/1.0/component.type.js
+++ b/extensions/amp-instagram/1.0/component.type.js
@@ -11,6 +11,7 @@ var InstagramDef = {};
  *   requestResize: (function(number):*|undefined),
  *   loading: (string|undefined),
  *   onReadyState: (function(string, *=)|undefined),
+ *   onLoad: (function():undefined|undefined),
  * }}
  */
 InstagramDef.Props;

--- a/extensions/amp-instagram/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-instagram/1.0/storybook/Basic.amp.js
@@ -69,3 +69,29 @@ export const InsideDetails = () => {
     </details>
   );
 };
+
+export const WithPlaceholderAndFallback = () => {
+  const width = number('width', 500);
+  const height = number('height', 600);
+  const shortcode = text('shortcode', 'B8QaZW4AQY_');
+  const captioned = boolean('captioned');
+  const layout = text('layout', 'fixed');
+
+  return (
+    <amp-instagram
+      data-shortcode={shortcode}
+      data-captioned={captioned}
+      width={width}
+      height={height}
+      layout={layout}
+    >
+      <div placeholder style="background:red">
+        Placeholder. Loading content...
+      </div>
+
+      <div fallback style="background:blue">
+        Fallback. Could not load content...
+      </div>
+    </amp-instagram>
+  );
+};

--- a/extensions/amp-render/1.0/amp-render.js
+++ b/extensions/amp-render/1.0/amp-render.js
@@ -275,58 +275,46 @@ export class AmpRender extends BaseElement {
         ? this.element.getAttribute('aria-live')
         : 'polite',
       'getJson': this.getFetchJsonFn(),
-      'onLoading': () => {
-        this.toggleLoading(true);
-      },
-      'onReady': () => {
-        this.toggleLoading(false);
-        if (this.element.getAttribute('layout') !== Layout.CONTAINER) {
-          this.togglePlaceholder(false);
-          return;
-        }
+    });
+  }
 
-        let componentHeight, contentHeight;
-        // TODO(dmanek): Look into using measureIntersection instead
-        this.measureMutateElement(
-          () => {
-            componentHeight = computedStyle(
-              this.getAmpDoc().win,
-              this.element
-            ).getPropertyValue('height');
-            contentHeight = this.element.querySelector(
-              '[i-amphtml-rendered]'
-            )./*OK*/ scrollHeight;
-          },
-          () => {
-            setStyles(this.element, {
-              'overflow': 'hidden',
-              'height': componentHeight,
-            });
-          }
-        ).then(() => {
-          return this.attemptChangeHeight(contentHeight)
-            .then(() => {
-              this.togglePlaceholder(false);
-              setStyles(this.element, {
-                'overflow': '',
-              });
-            })
-            .catch(() => {
-              this.togglePlaceholder(false);
-            });
+  /** @override */
+  handleOnLoad() {
+    this.toggleLoading(false);
+    if (this.element.getAttribute('layout') !== Layout.CONTAINER) {
+      this.togglePlaceholder(false);
+      return;
+    }
+
+    let componentHeight, contentHeight;
+    // TODO(dmanek): Look into using measureIntersection instead
+    this.measureMutateElement(
+      () => {
+        componentHeight = computedStyle(
+          this.getAmpDoc().win,
+          this.element
+        ).getPropertyValue('height');
+        contentHeight = this.element.querySelector(
+          '[i-amphtml-rendered]'
+        )./*OK*/ scrollHeight;
+      },
+      () => {
+        setStyles(this.element, {
+          'overflow': 'hidden',
+          'height': componentHeight,
         });
-      },
-      'onError': () => {
-        this.toggleLoading(false);
-        // If the content fails to load and there's a fallback element, display the fallback.
-        // Otherwise, continue displaying the placeholder.
-        if (this.getFallback()) {
+      }
+    ).then(() => {
+      return this.attemptChangeHeight(contentHeight)
+        .then(() => {
           this.togglePlaceholder(false);
-          this.toggleFallback(true);
-        } else {
-          this.togglePlaceholder(true);
-        }
-      },
+          setStyles(this.element, {
+            'overflow': '',
+          });
+        })
+        .catch(() => {
+          this.togglePlaceholder(false);
+        });
     });
   }
 

--- a/extensions/amp-render/1.0/component.js
+++ b/extensions/amp-render/1.0/component.js
@@ -30,7 +30,7 @@ export function RenderWithRef(
     render = DEFAULT_RENDER,
     ariaLiveValue = 'polite',
     onLoading,
-    onReady,
+    onLoad,
     onRefresh,
     onError,
     ...rest
@@ -68,12 +68,12 @@ export function RenderWithRef(
     getJson(src, /* shouldRefresh */ true)
       .then((data) => {
         setData(data);
-        onReady?.();
+        onLoad?.();
       })
       .catch((e) => {
         onError?.(e);
       });
-  }, [getJson, src, onReady, onRefresh, onError]);
+  }, [getJson, src, onLoad, onRefresh, onError]);
 
   useImperativeHandle(
     ref,
@@ -93,9 +93,9 @@ export function RenderWithRef(
       if (!node?.firstElementChild || !rendered) {
         return;
       }
-      onReady?.();
+      onLoad?.();
     },
-    [rendered, onReady]
+    [rendered, onLoad]
   );
 
   return (

--- a/extensions/amp-render/1.0/component.js
+++ b/extensions/amp-render/1.0/component.js
@@ -1,5 +1,5 @@
 import * as Preact from '#preact';
-import {Wrapper, useRenderer} from '#preact/component';
+import {Wrapper, useRenderer, useValueRef} from '#preact/component';
 import {forwardRef} from '#preact/compat';
 import {useCallback, useEffect, useImperativeHandle, useState} from '#preact';
 import {useResourcesNotify} from '#preact/utils';
@@ -40,6 +40,8 @@ export function RenderWithRef(
   useResourcesNotify();
 
   const [data, setData] = useState({});
+  const onLoadRef = useValueRef(onLoad);
+  const onErrorRef = useValueRef(onError);
 
   useEffect(() => {
     // TODO(dmanek): Add additional validation for src
@@ -56,24 +58,24 @@ export function RenderWithRef(
         }
       })
       .catch((e) => {
-        onError?.(e);
+        onErrorRef.current?.(e);
       });
     return () => {
       cancelled = true;
     };
-  }, [getJson, src, onError, onLoading]);
+  }, [getJson, src, onErrorRef, onLoading]);
 
   const refresh = useCallback(() => {
     onRefresh?.();
     getJson(src, /* shouldRefresh */ true)
       .then((data) => {
         setData(data);
-        onLoad?.();
+        onLoadRef.current?.();
       })
       .catch((e) => {
-        onError?.(e);
+        onErrorRef.current?.(e);
       });
-  }, [getJson, src, onLoad, onRefresh, onError]);
+  }, [getJson, src, onLoadRef, onRefresh, onErrorRef]);
 
   useImperativeHandle(
     ref,
@@ -93,9 +95,9 @@ export function RenderWithRef(
       if (!node?.firstElementChild || !rendered) {
         return;
       }
-      onLoad?.();
+      onLoadRef.current?.();
     },
-    [rendered, onLoad]
+    [rendered, onLoadRef]
   );
 
   return (

--- a/extensions/amp-render/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-render/1.0/storybook/Basic.amp.js
@@ -51,6 +51,12 @@ export const WithRemoteSrc = () => {
 
   return (
     <amp-render src={srcUrl} width="300" height="400" layout="fixed">
+      <div placeholder style="background:red">
+        placeholder
+      </div>
+      <div fallback style="background:blue">
+        fallback
+      </div>
       <template type="amp-mustache">{`Hi {{name}}!`}</template>
     </amp-render>
   );

--- a/extensions/amp-soundcloud/1.0/component.js
+++ b/extensions/amp-soundcloud/1.0/component.js
@@ -1,8 +1,16 @@
 import {dict} from '#core/types/object';
+import {parseJson} from '#core/types/object/json';
 
 import * as Preact from '#preact';
-import {useEffect, useRef} from '#preact';
+import {useCallback, useEffect, useRef} from '#preact';
+import {useValueRef} from '#preact/component';
 import {IframeEmbed} from '#preact/component/iframe';
+
+import {getData} from '../../../src/event-helper';
+
+const MATCHES_MESSAGING_ORIGIN = (origin) => {
+  return origin === 'https://w.soundcloud.com';
+};
 
 /**
  * @param {!SoundcloudDef.Props} props
@@ -10,6 +18,7 @@ import {IframeEmbed} from '#preact/component/iframe';
  */
 export function Soundcloud({
   color,
+  onLoad,
   playlistId,
   secretToken,
   trackId,
@@ -18,6 +27,7 @@ export function Soundcloud({
 }) {
   // Property and Reference Variables
   const iframeRef = useRef(null);
+  const onLoadRef = useValueRef(onLoad);
 
   useEffect(() => {
     /** Unmount Procedure */
@@ -32,6 +42,16 @@ export function Soundcloud({
       iframeRef.current = null;
     };
   }, []);
+
+  const messageHandler = useCallback(
+    (event) => {
+      const data = parseJson(getData(event));
+      if (data.method === 'ready') {
+        onLoadRef.current?.();
+      }
+    },
+    [onLoadRef]
+  );
 
   // Checking for valid props
   if (!checkProps(trackId, playlistId)) {
@@ -73,6 +93,8 @@ export function Soundcloud({
       scrolling="no"
       src={iframeSrc}
       title={'Soundcloud Widget - ' + mediaId}
+      messageHandler={messageHandler}
+      matchesMessagingOrigin={MATCHES_MESSAGING_ORIGIN}
       {...rest}
     />
   );

--- a/extensions/amp-soundcloud/1.0/component.type.js
+++ b/extensions/amp-soundcloud/1.0/component.type.js
@@ -10,6 +10,7 @@ var SoundcloudDef = {};
  *   secretToken: (string|undefined),
  *   trackId: (string|undefined),
  *   visual: boolean,
+ *   onLoad: (function():undefined|undefined),
  * }}
  */
 SoundcloudDef.Props;

--- a/extensions/amp-soundcloud/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-soundcloud/1.0/storybook/Basic.amp.js
@@ -121,3 +121,34 @@ export const ResponsiveLayout = () => {
     />
   );
 };
+
+export const WithPlaceholderAndFallback = () => {
+  // Knobs
+  const componentColor = color('Color', 'RGBA(255, 85, 0, 1)');
+  const height = text('Height', '180');
+  const trackid = text('Track ID', '864765493');
+  const visual = boolean('Visual', true);
+
+  // Convert RGBA to HEX (without Alpha Channel)
+  const hex = rgba2hex(componentColor);
+
+  // Render Preact Component
+  return (
+    <amp-soundcloud
+      data-color={hex}
+      data-trackid={trackid}
+      data-visual={visual}
+      height={height}
+      layout="fixed-height"
+      width="auto"
+    >
+      <div placeholder style="background:red">
+        Placeholder. Loading content...
+      </div>
+
+      <div fallback style="background:blue">
+        Fallback. Could not load content...
+      </div>
+    </amp-soundcloud>
+  );
+};

--- a/extensions/amp-twitter/1.0/amp-twitter.js
+++ b/extensions/amp-twitter/1.0/amp-twitter.js
@@ -58,8 +58,6 @@ class AmpTwitter extends BaseElement {
   /** @override */
   init() {
     return dict({
-      'onLoad': () => this.togglePlaceholder(false),
-      'onError': () => this.togglePlaceholder(true),
       'requestResize': (height) => this.attemptChangeHeight(height),
     });
   }

--- a/extensions/amp-twitter/1.0/component.js
+++ b/extensions/amp-twitter/1.0/component.js
@@ -3,6 +3,7 @@ import {ProxyIframeEmbed} from '#preact/component/3p-frame';
 import {MessageType, deserializeMessage} from '#core/3p-frame-messaging';
 import {forwardRef} from '#preact/compat';
 import {useCallback, useMemo, useState} from '#preact';
+import {useValueRef} from '#preact/component';
 
 /** @const {string} */
 const TYPE = 'twitter';
@@ -36,6 +37,9 @@ function TwitterWithRef(
   ref
 ) {
   const [height, setHeight] = useState(null);
+  const onLoadRef = useValueRef(onLoad);
+  const onErrorRef = useValueRef(onError);
+
   const messageHandler = useCallback(
     (event) => {
       const data = deserializeMessage(event.data);
@@ -48,12 +52,12 @@ function TwitterWithRef(
           setHeight(height);
         }
 
-        onLoad?.();
+        onLoadRef.current?.();
       } else if (data['type'] === MessageType.NO_CONTENT) {
-        onError?.();
+        onErrorRef.current?.();
       }
     },
-    [requestResize, onLoad, onError]
+    [requestResize, onLoadRef, onErrorRef]
   );
   const options = useMemo(
     () => ({

--- a/extensions/amp-twitter/1.0/component.type.js
+++ b/extensions/amp-twitter/1.0/component.type.js
@@ -9,6 +9,7 @@ var TwitterDef = {};
  *   onReadyState: (function(string, *=)|undefined),
  *   requestResize: (function(number):*|undefined),
  *   title: (string|undefined),
+ *   onLoad: (function():undefined|undefined),
  * }}
  */
 TwitterDef.Props;

--- a/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-video-iframe/1.0/storybook/Basic.amp.js
@@ -12,7 +12,7 @@ export default {
   },
 };
 
-const AmpVideoIframeWithKnobs = ({i, ...rest}) => {
+const AmpVideoIframeWithKnobs = ({i, withPlaceholder, ...rest}) => {
   const group = i ? `Player ${i + 1}` : undefined;
 
   const width = text('width', '640px', group);
@@ -39,6 +39,17 @@ const AmpVideoIframeWithKnobs = ({i, ...rest}) => {
     'https://amp.dev/static/samples/files/amp-video-iframe-videojs.html'
   );
 
+  const placeholderAndFallback = withPlaceholder ? (
+    <>
+      <div placeholder style="background:red">
+        placeholder
+      </div>
+      <div fallback style="background:blue">
+        fallback
+      </div>
+    </>
+  ) : null;
+
   return (
     <amp-video-iframe
       {...rest}
@@ -57,7 +68,9 @@ const AmpVideoIframeWithKnobs = ({i, ...rest}) => {
       width={width}
       height={height}
       src={src}
-    ></amp-video-iframe>
+    >
+      {placeholderAndFallback}
+    </amp-video-iframe>
   );
 };
 
@@ -119,5 +132,28 @@ export const Actions = () => {
         <ActionButton on="tap:player.fullscreen">Fullscreen</ActionButton>
       </div>
     </div>
+  );
+};
+
+export const WithPlaceholderAndFallback = () => {
+  const amount = number('Amount', 1, {}, 'Page');
+  const spacerHeight = text('Space', '80vh', 'Page');
+  const spaceAbove = boolean('Space above', false, 'Page');
+  const spaceBelow = boolean('Space below', false, 'Page');
+
+  const players = [];
+  for (let i = 0; i < amount; i++) {
+    players.push(<AmpVideoIframeWithKnobs key={i} i={i} placeholder={true} />);
+    if (i < amount - 1) {
+      players.push(<Spacer height={spacerHeight} />);
+    }
+  }
+
+  return (
+    <>
+      {spaceAbove && <Spacer height={spacerHeight} />}
+      {players}
+      {spaceBelow && <Spacer height={spacerHeight} />}
+    </>
   );
 };

--- a/extensions/amp-vimeo/1.0/component.js
+++ b/extensions/amp-vimeo/1.0/component.js
@@ -3,6 +3,7 @@ import {dispatchCustomEvent} from '#core/dom';
 import * as Preact from '#preact';
 import {useCallback, useMemo, useRef} from '#preact';
 import {forwardRef} from '#preact/compat';
+import {useValueRef} from '#preact/component';
 
 import {
   objOrParseJson,
@@ -49,7 +50,7 @@ function makeMethodMessage(method) {
  * @template T
  */
 export function VimeoWithRef(
-  {autoplay = false, doNotTrack = false, videoid, ...rest},
+  {autoplay = false, doNotTrack = false, onLoad, videoid, ...rest},
   ref
 ) {
   const origin = useMemo(getVimeoOriginRegExp, []);
@@ -59,6 +60,8 @@ export function VimeoWithRef(
   );
 
   const readyIframeRef = useRef(null);
+  const onLoadRef = useValueRef(onLoad);
+
   const onReadyMessage = useCallback((iframe) => {
     if (readyIframeRef.current === iframe) {
       return;
@@ -82,10 +85,11 @@ export function VimeoWithRef(
       }
       if (VIMEO_EVENTS[event]) {
         dispatchEvent(currentTarget, VIMEO_EVENTS[event]);
+        onLoadRef.current?.();
         return;
       }
     },
-    [onReadyMessage]
+    [onReadyMessage, onLoadRef]
   );
 
   const onIframeLoad = useCallback((e) => {

--- a/extensions/amp-vimeo/1.0/component.type.js
+++ b/extensions/amp-vimeo/1.0/component.type.js
@@ -8,6 +8,7 @@ var VimeoDef = {};
  *   videoid: string,
  *   autoplay: (boolean|undefined),
  *   doNotTrack: (boolean|undefined),
+ *   onLoad: (function():undefined|undefined),
  * }}
  */
 VimeoDef.Props;

--- a/extensions/amp-vimeo/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-vimeo/1.0/storybook/Basic.amp.js
@@ -32,6 +32,31 @@ export const Default = ({id}) => {
   );
 };
 
+export const WithPlaceholderAndFallback = ({id}) => {
+  const videoid = text('videoid', '27246366');
+  const autoplay = boolean('autoplay', true);
+  const doNotTrack = boolean('do-not-track', false);
+  return (
+    <amp-vimeo
+      id={id}
+      width="16"
+      height="9"
+      layout="responsive"
+      autoplay={autoplay}
+      data-videoid={videoid}
+      do-not-track={doNotTrack}
+    >
+      <div placeholder style="background:red">
+        Placeholder. Loading content...
+      </div>
+
+      <div fallback style="background:blue">
+        Fallback. Could not load content...
+      </div>
+    </amp-vimeo>
+  );
+};
+
 export const Actions = () => {
   const id = 'my-vimeo';
   return (

--- a/extensions/amp-wordpress-embed/1.0/component.js
+++ b/extensions/amp-wordpress-embed/1.0/component.js
@@ -2,6 +2,7 @@ import {dict} from '#core/types/object';
 
 import * as Preact from '#preact';
 import {forwardRef} from '#preact/compat';
+import {useValueRef} from '#preact/component';
 import {IframeEmbed} from '#preact/component/iframe';
 
 import {getData} from '../../../src/event-helper';
@@ -17,13 +18,14 @@ const NO_HEIGHT_STYLE = dict();
  * @return {PreactDef.Renderable}
  */
 function WordPressEmbedWithRef(
-  {requestResize, title = 'WordPressEmbed', url, ...rest},
+  {onLoad, requestResize, title = 'WordPressEmbed', url, ...rest},
   ref
 ) {
   const [heightStyle, setHeightStyle] = useState(NO_HEIGHT_STYLE);
   const [opacity, setOpacity] = useState(0);
   const contentRef = useRef(null);
   const [win, setWin] = useState(null);
+  const onLoadRef = useValueRef(onLoad);
 
   const iframeURL = useMemo(() => {
     return addParamToUrl(url, 'embed', 'true');
@@ -52,6 +54,8 @@ function WordPressEmbedWithRef(
             setHeightStyle(dict({'height': height}));
             setOpacity(1);
           }
+
+          onLoadRef.current?.();
           break;
         case 'link':
           // Only follow a link message for the currently-active iframe if the link is for the same origin.
@@ -62,7 +66,7 @@ function WordPressEmbedWithRef(
           break;
       }
     },
-    [requestResize, matchesMessagingOrigin, win]
+    [requestResize, matchesMessagingOrigin, win, onLoadRef]
   );
 
   useEffect(() => {

--- a/extensions/amp-wordpress-embed/1.0/component.type.js
+++ b/extensions/amp-wordpress-embed/1.0/component.type.js
@@ -10,6 +10,7 @@ var WordPressEmbedDef = {};
  *   requestResize: (function(number):*|undefined),
  *   loading: (string|undefined),
  *   onReadyState: (function(string, *=)|undefined),
+ *   onLoad: (function():undefined|undefined),
  * }}
  */
 WordPressEmbedDef.Props;

--- a/extensions/amp-wordpress-embed/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-wordpress-embed/1.0/storybook/Basic.amp.js
@@ -37,6 +37,36 @@ export const BasicEmbedExample = () => {
   );
 };
 
+export const WithPlaceholderAndFallback = () => {
+  const url = text(
+    'url',
+    'https://wordpress.org/news/2021/06/gutenberg-highlights'
+  );
+  const width = number('width', 500);
+  const height = number('height', 200);
+  const layout = text('layout', 'fixed');
+
+  return (
+    <>
+      <amp-wordpress-embed
+        data-url={url}
+        width={width}
+        height={height}
+        layout={layout}
+      >
+        <div placeholder style="background:red">
+          Placeholder. Loading content...
+        </div>
+
+        <div fallback style="background:blue">
+          Fallback. Could not load content...
+        </div>
+      </amp-wordpress-embed>
+      <p>text below</p>
+    </>
+  );
+};
+
 BasicEmbedExample.story = {
   name: 'Basic example',
 };

--- a/extensions/amp-youtube/1.0/component.js
+++ b/extensions/amp-youtube/1.0/component.js
@@ -67,7 +67,16 @@ function createDefaultInfo() {
  * @template T
  */
 function YoutubeWithRef(
-  {autoplay, loop, videoid, liveChannelid, params = {}, credentials, ...rest},
+  {
+    autoplay,
+    loop,
+    videoid,
+    liveChannelid,
+    onLoad,
+    params = {},
+    credentials,
+    ...rest
+  },
   ref
 ) {
   const datasourceExists =
@@ -128,6 +137,7 @@ function YoutubeWithRef(
 
     if (event == 'initialDelivery') {
       dispatchVideoEvent(currentTarget, VideoEvents.LOADEDMETADATA);
+      onLoad?.();
       return;
     }
 

--- a/extensions/amp-youtube/1.0/component.type.js
+++ b/extensions/amp-youtube/1.0/component.type.js
@@ -4,6 +4,7 @@
  * @typedef {{
  *   autoplay: boolean,
  *   loop: boolean,
+ *   onLoad: (function():undefined|undefined),
  *   videoid: (string|undefined),
  *   liveChannelid: (string|undefined),
  *   params: Object,

--- a/extensions/amp-youtube/1.0/storybook/Basic.amp.js
+++ b/extensions/amp-youtube/1.0/storybook/Basic.amp.js
@@ -90,4 +90,34 @@ export const InsideDetails = () => {
   );
 };
 
+export const WithPlaceholder = ({id}) => {
+  const videoid = text('videoid', 'IAvf-rkzNck');
+  const layout = text('layout', 'responsive');
+  const autoplay = boolean('autoplay', false);
+  const loop = boolean('loop', false);
+  const width = number('width', 300);
+  const height = number('height', 200);
+  const credentials = text('credentials', 'include');
+  return (
+    <amp-youtube
+      id={id}
+      width={width}
+      height={height}
+      data-videoid={videoid}
+      layout={layout}
+      autoplay={autoplay}
+      loop={loop}
+      credentials={credentials}
+    >
+      <div placeholder style="background:red">
+        Placeholder. Loading content...
+      </div>
+
+      <div fallback style="background:blue">
+        Fallback. Could not load content...
+      </div>
+    </amp-youtube>
+  );
+};
+
 Default.storyName = 'Default';

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -150,6 +150,15 @@ export class PreactBaseElement extends BaseElement {
       'onPlayingState': (isPlaying) => {
         this.updateIsPlaying_(isPlaying);
       },
+      'onLoading': () => {
+        this.handleOnLoading();
+      },
+      'onLoad': () => {
+        this.handleOnLoad();
+      },
+      'onError': () => {
+        this.handleOnError();
+      },
     });
 
     /** @private {!AmpContextDef.ContextType} */
@@ -508,6 +517,43 @@ export class PreactBaseElement extends BaseElement {
     if (this.resetLoading_) {
       this.resetLoading_ = false;
       this.mutateProps({'loading': Loading.AUTO});
+    }
+  }
+
+  /**
+   * Default handler for onLoad event
+   * Displays loader. Override to customize.
+   * @protected
+   */
+  handleOnLoad() {
+    this.toggleLoading?.(false);
+    this.toggleFallback?.(false);
+    this.togglePlaceholder?.(false);
+  }
+
+  /**
+   * Default handler for onLoading event
+   * Reveals loader. Override to customize.
+   * @protected
+   */
+  handleOnLoading() {
+    this.toggleLoading?.(true);
+  }
+
+  /**
+   * Default handler for onError event
+   * Displays Fallback / Placeholder. Override to customize.
+   * @protected
+   */
+  handleOnError() {
+    this.toggleLoading?.(false);
+    // If the content fails to load and there's a fallback element, display the fallback.
+    // Otherwise, continue displaying the placeholder.
+    if (this.getFallback?.()) {
+      this.toggleFallback?.(true);
+      this.togglePlaceholder?.(false);
+    } else {
+      this.togglePlaceholder?.(true);
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,14 +31,6 @@
       "#third_party/*": ["./third_party/*"]
     }
   },
-  "include": [
-    "src",
-    "3p",
-    "ads",
-    "extensions",
-    "test",
-    "testing",
-    "third_party"
-  ],
+  "include": ["src", "3p", "ads", "extensions", "test", "testing"],
   "exclude": ["build", "dist", "dist.*", "node_modules"]
 }


### PR DESCRIPTION
Standardizes logic for handling Placeholders/Fallbacks. 

- exposes `onLoading`, `onLoad`, `onError` callbacks as props to Preact components
  - `onLoading`: shows loader
  - `onLoad`: hides loader and placeholder/fallback
  - `onError`: shows fallback if available, otherwise shows placeholder
- customize behavior by overriding `handleOnLoading`, `handleOnLoad`, and `handleOnError` in AMP class

All bento components with dynamic content (displayed through iframe, rendered dynamically based on remote data, etc.) must call onLoad() when the content is loaded to hide any placeholders. 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
