### PR TITLE
build-system: merge localDev and fortesting

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -11,8 +11,6 @@ const {getReplacePlugin} = require('./helpers');
  * @return {!Object}
  */
 function getMinifiedConfig() {
-  const isProd = BUILD_CONSTANTS.IS_PROD;
-
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',
     {
@@ -54,7 +52,7 @@ function getMinifiedConfig() {
     //? './build-system/babel-plugins/babel-plugin-transform-function-declarations'
     //: null,
     './build-system/babel-plugins/babel-plugin-transform-json-configuration',
-    isProd && [
+    BUILD_CONSTANTS.IS_PROD && [
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
       BUILD_CONSTANTS,
     ],

--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -11,7 +11,7 @@ const {getReplacePlugin} = require('./helpers');
  * @return {!Object}
  */
 function getMinifiedConfig() {
-  const isProd = argv._.includes('dist') && !argv.fortesting;
+  const isProd = BUILD_CONSTANTS.IS_PROD;
 
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -12,7 +12,7 @@ const {getReplacePlugin} = require('./helpers');
  */
 function getPreClosureConfig() {
   const isCheckTypes = argv._.includes('check-types');
-  const isProd = argv._.includes('dist') && !argv.fortesting;
+  const isProd = BUILD_CONSTANTS.IS_PROD;
 
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',

--- a/build-system/compile/build-constants.js
+++ b/build-system/compile/build-constants.js
@@ -19,7 +19,13 @@ const isMinified = argv._.includes('dist') || !!argv.minified;
  * TODO: move constant replacement to bundlers once either https://github.com/google/closure-compiler/issues/1601
  *       is resolved, or we switch to using a different bundler.
  *
- * @type {Object<string, boolean|string>}
+ * @type {{
+ *   IS_PROD: boolean,
+ *   IS_MINIFIED: boolean,
+ *   INTERNAL_RUNTIME_VERSION: string,
+ *   IS_ESM: boolean,
+ *   IS_SXG: boolean,
+ * }}
  */
 const BUILD_CONSTANTS = {
   IS_PROD: isProd,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -14,7 +14,6 @@ const {
   VERSION: internalRuntimeVersion,
 } = require('../compile/internal-version');
 const {applyConfig, removeConfig} = require('./prepend-global');
-const {BUILD_CONSTANTS} = require('../compile/build-constants');
 const {closureCompile} = require('../compile/compile');
 const {cyan, green, red} = require('../common/colors');
 const {getEsbuildBabelPlugin} = require('../common/esbuild-babel');
@@ -738,13 +737,11 @@ async function applyAmpConfig(targetFile) {
   const baseConfigFile =
     'build-system/global-configs/' + config + '-config.json';
 
-  const isTest = !BUILD_CONSTANTS.IS_PROD;
   await removeConfig(targetFile);
   await applyConfig(
     config,
     targetFile,
     baseConfigFile,
-    isTest,
     /* opt_localBranch */ true
   );
 }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -23,6 +23,7 @@ const {jsBundles} = require('../compile/bundles.config');
 const {log, logLocalDev} = require('../common/logging');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {watch} = require('chokidar');
+const isProd = argv._.includes('dist') && !argv.fortesting;
 
 /** @type {Remapping.default} */
 const remapping = /** @type {*} */ (Remapping);
@@ -323,11 +324,7 @@ async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
 
   const target = path.basename(minifiedName, path.extname(minifiedName));
   if (!argv.noconfig && MINIFIED_TARGETS.includes(target)) {
-    await applyAmpConfig(
-      maybeToEsmName(`${destDir}/${minifiedName}`),
-      /* localDev */ options.fortesting,
-      /* fortesting */ options.fortesting
-    );
+    await applyAmpConfig(maybeToEsmName(`${destDir}/${minifiedName}`));
   }
 }
 
@@ -398,11 +395,7 @@ async function finishBundle(
   const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;
   const target = path.basename(destFilename, path.extname(destFilename));
   if (targets.includes(target)) {
-    await applyAmpConfig(
-      path.join(destDir, destFilename),
-      /* localDev */ true,
-      /* fortesting */ options.fortesting
-    );
+    await applyAmpConfig(path.join(destDir, destFilename));
   }
 }
 
@@ -738,11 +731,9 @@ async function maybePrintCoverageMessage(covPath = '') {
  * various runtime files.
  *
  * @param {string} targetFile File to which the config is to be written.
- * @param {boolean} localDev Whether or not to enable local development.
- * @param {boolean} fortesting Whether or not to enable testing mode.
  * @return {!Promise}
  */
-async function applyAmpConfig(targetFile, localDev, fortesting) {
+async function applyAmpConfig(targetFile) {
   const config = argv.config === 'canary' ? 'canary' : 'prod';
   const baseConfigFile =
     'build-system/global-configs/' + config + '-config.json';
@@ -752,10 +743,9 @@ async function applyAmpConfig(targetFile, localDev, fortesting) {
     config,
     targetFile,
     baseConfigFile,
-    /* opt_localDev */ localDev,
+    /* isTest */ !isProd,
     /* opt_localBranch */ true,
-    /* opt_branch */ undefined,
-    /* opt_fortesting */ fortesting
+    /* opt_branch */ undefined
   );
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -14,6 +14,7 @@ const {
   VERSION: internalRuntimeVersion,
 } = require('../compile/internal-version');
 const {applyConfig, removeConfig} = require('./prepend-global');
+const {BUILD_CONSTANTS} = require('../compile/build-constants');
 const {closureCompile} = require('../compile/compile');
 const {cyan, green, red} = require('../common/colors');
 const {getEsbuildBabelPlugin} = require('../common/esbuild-babel');
@@ -23,7 +24,6 @@ const {jsBundles} = require('../compile/bundles.config');
 const {log, logLocalDev} = require('../common/logging');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {watch} = require('chokidar');
-const isProd = argv._.includes('dist') && !argv.fortesting;
 
 /** @type {Remapping.default} */
 const remapping = /** @type {*} */ (Remapping);
@@ -738,14 +738,14 @@ async function applyAmpConfig(targetFile) {
   const baseConfigFile =
     'build-system/global-configs/' + config + '-config.json';
 
+  const isTest = !BUILD_CONSTANTS.IS_PROD;
   await removeConfig(targetFile);
   await applyConfig(
     config,
     targetFile,
     baseConfigFile,
-    /* isTest */ !isProd,
-    /* opt_localBranch */ true,
-    /* opt_branch */ undefined
+    isTest,
+    /* opt_localBranch */ true
   );
 }
 

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -145,8 +145,7 @@ async function applyConfig(
     }
   }
   if (opt_fortesting) {
-    configJson = enableLocalDev_(target, configJson);
-    configJson = {test: true, ...configJson};
+    configJson = enableTest_(target, configJson);
   }
   if (opt_derandomize) {
     configJson = derandomize_(target, configJson);
@@ -171,8 +170,8 @@ async function applyConfig(
  * @param {!JSON} configJson The json object in which to enable local dev
  * @return {!JSON}
  */
-function enableLocalDev_(target, configJson) {
-  let LOCAL_DEV_AMP_CONFIG = {localDev: true};
+function enableTest_(target, configJson) {
+  let LOCAL_DEV_AMP_CONFIG = {test: true};
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
     const TESTING_HOST_FULL_URL = TESTING_HOST.match(/^https?:\/\//)

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -171,7 +171,7 @@ async function applyConfig(
  * @return {!JSON}
  */
 function enableTest_(target, configJson) {
-  let LOCAL_DEV_AMP_CONFIG = {test: true};
+  let TEST_AMP_CONFIG = {test: true};
   const TESTING_HOST = process.env.AMP_TESTING_HOST;
   if (typeof TESTING_HOST == 'string') {
     const TESTING_HOST_FULL_URL = TESTING_HOST.match(/^https?:\/\//)
@@ -179,7 +179,7 @@ function enableTest_(target, configJson) {
       : 'http://' + TESTING_HOST;
     const TESTING_HOST_NO_PROTOCOL = TESTING_HOST.replace(/^https?:\/\//, '');
 
-    LOCAL_DEV_AMP_CONFIG = Object.assign(LOCAL_DEV_AMP_CONFIG, {
+    TEST_AMP_CONFIG = Object.assign(TEST_AMP_CONFIG, {
       thirdPartyUrl: TESTING_HOST_FULL_URL,
       thirdPartyFrameHost: TESTING_HOST_NO_PROTOCOL,
       thirdPartyFrameRegex: TESTING_HOST_NO_PROTOCOL,
@@ -193,7 +193,7 @@ function enableTest_(target, configJson) {
       cyan(target)
     );
   }
-  return Object.assign(LOCAL_DEV_AMP_CONFIG, configJson);
+  return Object.assign(TEST_AMP_CONFIG, configJson);
 }
 
 /**

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -100,10 +100,9 @@ function valueOrDefault(value, defaultValue) {
  * @param {string} config Prod or canary
  * @param {string} target File containing the AMP runtime (amp.js or v0.js)
  * @param {string} filename File containing the (prod or canary) config
- * @param {boolean=} opt_localDev Whether to enable local development
+ * @param {boolean=} opt_fortesting Whether for testing.
  * @param {boolean=} opt_localBranch Whether to use the local branch version
  * @param {string=} opt_branch If not the local branch, which branch to use
- * @param {boolean=} opt_fortesting Whether to force getMode().test to be true
  * @param {boolean=} opt_derandomize Whether to remove experiment randomization
  * @return {!Promise<void>}
  */
@@ -111,10 +110,9 @@ async function applyConfig(
   config,
   target,
   filename,
-  opt_localDev,
+  opt_fortesting,
   opt_localBranch,
   opt_branch,
-  opt_fortesting,
   opt_derandomize
 ) {
   const configString = await fetchConfigFromBranch_(
@@ -146,10 +144,8 @@ async function applyConfig(
       );
     }
   }
-  if (opt_localDev) {
-    configJson = enableLocalDev_(target, configJson);
-  }
   if (opt_fortesting) {
+    configJson = enableLocalDev_(target, configJson);
     configJson = {test: true, ...configJson};
   }
   if (opt_derandomize) {
@@ -164,7 +160,6 @@ async function applyConfig(
   const details =
     '(' +
     cyan(config) +
-    (opt_localDev ? ', ' + cyan('localDev') : '') +
     (opt_fortesting ? ', ' + cyan('test') : '') +
     (opt_derandomize ? ', ' + cyan('derandomized') : '') +
     ')';
@@ -264,6 +259,7 @@ async function prependGlobal() {
       'build-system/global-configs/prod-config.json'
     );
   }
+  const fortesting = !argv._.includes('dist') || argv.fortesting;
   await Promise.all([...targets.map(removeConfig)]);
   await Promise.all([
     ...targets.map((target) =>
@@ -271,10 +267,9 @@ async function prependGlobal() {
         config,
         target,
         filename,
-        argv.local_dev,
+        fortesting,
         argv.local_branch,
         argv.branch,
-        argv.fortesting,
         argv.derandomize
       )
     ),

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -144,12 +144,15 @@ const forbiddenTermsGlobal = {
     message:
       'Do not use build constants directly. Instead, use the helpers in `#core/mode`.',
     allowlist: [
-      'src/core/mode/version.js',
+      'build-system/babel-config/minified-config.js',
+      'build-system/babel-config/pre-closure-config.js',
+      'build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js',
+      'build-system/compile/build-constants.js',
+      'build-system/tasks/helpers.js',
+      'src/core/mode/esm.js',
       'src/core/mode/minified.js',
       'src/core/mode/prod.js',
-      'src/core/mode/esm.js',
-      'build-system/compile/build-constants.js',
-      'build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js',
+      'src/core/mode/version.js',
     ],
   },
   '\\.prefetch\\(': {

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -144,11 +144,11 @@ const forbiddenTermsGlobal = {
     message:
       'Do not use build constants directly. Instead, use the helpers in `#core/mode`.',
     allowlist: [
+      'build-system/tasks/prepend-global/index.js',
       'build-system/babel-config/minified-config.js',
       'build-system/babel-config/pre-closure-config.js',
       'build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js',
       'build-system/compile/build-constants.js',
-      'build-system/tasks/helpers.js',
       'src/core/mode/esm.js',
       'src/core/mode/minified.js',
       'src/core/mode/prod.js',


### PR DESCRIPTION
**summary**
- Implements the `build-system` side of https://github.com/ampproject/amphtml/issues/35674.
- Improves typing of `BUILD_CONSTANTS` as a bonus


This is a followup to our implementation of this on the `src` side: https://github.com/ampproject/amphtml/pull/35823