### PR TITLE
check-build-system: fix two types

### DIFF
--- a/build-system/server/app-index/settings.js
+++ b/build-system/server/app-index/settings.js
@@ -94,7 +94,6 @@ const HtmlEnvelopeSelector = ({htmlEnvelopePrefix}) =>
 const JsModeSelector = ({jsMode}) =>
   PanelSelector({
     key: jsModeStateKey,
-    name: 'mode',
     children: jsModes.map(({description, value}) =>
       PanelSelectorBlock({
         id: `serve-mode-${value}`,

--- a/build-system/tasks/e2e/expect.js
+++ b/build-system/tasks/e2e/expect.js
@@ -216,7 +216,9 @@ function overwriteAlwaysUseSuper(utils) {
         }
       };
 
-      const resultPromise = waitForValue(valueSatisfiesExpectation);
+      const resultPromise = /** @type {*}*/ (waitForValue)(
+        valueSatisfiesExpectation
+      );
       flag(that, 'object', resultPromise);
       return resultPromise;
     };


### PR DESCRIPTION
**summary**

Typescript just published a new version of `4.3.2` with a breaking change.

![Screen Shot 2021-08-26 at 5 47 25 PM](https://user-images.githubusercontent.com/4656974/131040668-dc820fb3-1a62-4f66-a9e6-58a9f0bebbe3.png)


**new error**
![Screen Shot 2021-08-26 at 5 37 42 PM](https://user-images.githubusercontent.com/4656974/131040912-02b5d0ac-fb38-4148-a557-35fa2fcd2f8c.png)

cc @rileyajones 