### PR TITLE
ie deprecation/bugfix: remove isIe check

### DIFF
--- a/src/amp.js
+++ b/src/amp.js
@@ -135,13 +135,6 @@ startupChunk(self.document, function initial() {
     /* opt_isRuntimeCss */ true,
     /* opt_ext */ 'amp-runtime'
   );
-  // TODO(kbax) Remove this IE deprecation warning on 26 August 2021.
-  if (Services.platformFor(self).isIe() && self.console) {
-    (console.info || console.log).call(
-      console,
-      'IE Support is being deprecated, in September 2021 IE will no longer be supported. See https://github.com/ampproject/amphtml/issues/34453 for more details.'
-    );
-  }
 });
 
 // Output a message to the console and add an attribute to the <html>


### PR DESCRIPTION
**summary**
Loading any page on `main` will yield an error claiming `isIe` is not defined:
```
TypeError: Services.platformFor(...).isIe is not a function
```

This was introduced in https://github.com/ampproject/amphtml/pull/35317.