### PR TITLE
Remove amp-unresolved when extension downloads in R1

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -387,8 +387,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       this.upgradeDelayMs_ = win.Date.now() - upgradeStartTime;
       this.upgradeState_ = UpgradeState.UPGRADED;
       this.setReadyStateInternal(ReadyState.BUILDING);
-      this.classList.remove('amp-unresolved');
-      this.classList.remove('i-amphtml-unresolved');
+      this.classList.remove('amp-unresolved', 'i-amphtml-unresolved');
       this.assertLayout_();
       this.dispatchCustomEventForTesting(AmpEvents.ATTACHED);
       if (!this.R1()) {
@@ -529,8 +528,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         () => {
           this.built_ = true;
           this.classList.add('i-amphtml-built');
-          this.classList.remove('i-amphtml-notbuilt');
-          this.classList.remove('amp-notbuilt');
+          this.classList.remove('i-amphtml-notbuilt', 'amp-notbuilt');
           this.signals_.signal(CommonSignals.BUILT);
 
           if (this.R1()) {
@@ -1137,9 +1135,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       this.isConnected_ = true;
 
       if (!this.everAttached) {
-        this.classList.add('i-amphtml-element');
-        this.classList.add('i-amphtml-notbuilt');
-        this.classList.add('amp-notbuilt');
+        this.classList.add('i-amphtml-element', 'i-amphtml-notbuilt', 'amp-notbuilt');
       }
 
       if (!this.ampdoc_) {
@@ -1184,8 +1180,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           this.upgradeOrSchedule_();
         }
         if (!this.isUpgraded()) {
-          this.classList.add('amp-unresolved');
-          this.classList.add('i-amphtml-unresolved');
+          this.classList.add('amp-unresolved', 'i-amphtml-unresolved');
           this.dispatchCustomEventForTesting(AmpEvents.STUBBED);
         }
       }
@@ -1227,6 +1222,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       // Schedule build and mount.
       const scheduler = getSchedulerForDoc(this.getAmpDoc());
       scheduler.schedule(this);
+      this.classList.remove('amp-unresolved', 'i-amphtml-unresolved');
 
       if (this.buildingPromise_) {
         // Already built or building: just needs to be mounted.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1135,7 +1135,11 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
       this.isConnected_ = true;
 
       if (!this.everAttached) {
-        this.classList.add('i-amphtml-element', 'i-amphtml-notbuilt', 'amp-notbuilt');
+        this.classList.add(
+          'i-amphtml-element',
+          'i-amphtml-notbuilt',
+          'amp-notbuilt'
+        );
       }
 
       if (!this.ampdoc_) {

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -216,6 +216,7 @@ export function extensionScriptsInNode(head) {
       script.getAttribute('custom-element') ||
       script.getAttribute('custom-template');
     const urlParts = parseExtensionUrl(script.src);
+    // TODO: register error handler
     if (extensionId && urlParts) {
       scripts.push({extensionId, extensionVersion: urlParts.extensionVersion});
     }

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -72,6 +72,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
   describe('upgrade', () => {
     it('should not create impl immediately when attached', () => {
       const element = new ElementClass();
+      const removeSpy = env.sandbox.spy(element.classList, 'remove');
 
       builderMock.expects('schedule').withExactArgs(element).once();
 
@@ -88,6 +89,7 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(element.readyState).to.equal('building');
       expect(element.isBuilt()).to.be.false;
       expect(element.getBuildPriority()).equal(LayoutPriority.CONTENT);
+      expect(removeSpy).to.have.been.calledWith('amp-unresolved', 'i-amphtml-unresolved');
     });
 
     it('should not upgrade immediately when attached', () => {

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -89,7 +89,10 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       expect(element.readyState).to.equal('building');
       expect(element.isBuilt()).to.be.false;
       expect(element.getBuildPriority()).equal(LayoutPriority.CONTENT);
-      expect(removeSpy).to.have.been.calledWith('amp-unresolved', 'i-amphtml-unresolved');
+      expect(removeSpy).to.have.been.calledWith(
+        'amp-unresolved',
+        'i-amphtml-unresolved'
+      );
     });
 
     it('should not upgrade immediately when attached', () => {


### PR DESCRIPTION
This fixes a bug caused by easylist's hiding of any element with a `.amp-unresolved` class.

Since the initial releases of AMP, we've added an `.amp-unresolved` class to our custom elements to allow publishers to style elements while the element's JS file is downloading. As soon as it was downloaded, we immediately upgraded the element and removed the `.amp-unresolved` class. Essentially "downloaded" and "upgraded" meant the same thing.

Now, easylist blocks certain JS files from being downloaded. This left large empty blocks on the page, because the element can never be upgraded to actually run. They took advantage of the `.amp-unresolved` class to hide the element from the page. Now the blocked elements are hidden from page when the JS is blocked.

This actually has a nasty side-effect that _every_ AMP element on the page initially starts as `display: none`, and becomes displayable after the JS file downloads. **THIS IS BAD** because it causes issues with Cumulative Layout Shift as the elements magically pop into view when the JS downloads. A core goal for AMP is that CLS should be essentially 0.

Now, we need to discuss the new R1 element system. We noticed in the old R0 system that upgrading every element on the page can take a while and cause noticeable slowdowns when scrolling. So R1 uses a "deferred upgrade" pattern, where we delay upgrading the element until it's close to viewport. Now, "downloaded" and "upgraded" mean two different things, with upgraded being deferred needed. Remember, `.amp-unresolved` isn't removed until an element is upgraded.

To implement the deferred upgrade, we register the element with an `IntersectionObserver` and wait until the element is near viewport. The problem is, because every element starts as `display: none` due to easylist's hiding, the `IntersectionObserver` never fires and we never upgrade the element and we never remove `.amp-unresolved`. **THIS IS EVEN WORSE** because now every element is permanently hidden.

To temporarily solve this, we'll remove the `.amp-unresolved` when the JS is downloaded. This still isn't ideal because it'll still cause elements to magically pop into view and CLS, but it's better than never rendering any element.

- - -

Steps to reproduce the bug:
1.  Install an adblocker using easylist, eg [uBlock Origin](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm)
2. Go to https://www-nytimes-com.cdn.ampproject.org/experiments.html
   1. Click the "Advanced" dropdown
   2. Insert `112108192119000`
   3. Click opt-in
   4. (This makes it so you're using the new R1 system in the AMP Runtime)
3. Go to https://www-nytimes-com.cdn.ampproject.org/c/s/www.nytimes.com/live/2021/08/04/world/covid-delta-variant-vaccine.amp.html
   1. **Notice there are no images displayed on the page**
   2. Disabled uBlock Origin and refresh
   3. **Notice there are images on the page**