### PR TITLE
Make `compiler.js` runnable within a node.js environment

### DIFF
--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -1,21 +1,12 @@
 import {CSS} from '../../../build/amp-fit-text-0.1.css';
-import {
-  applyFillContent,
-  getLengthNumeral,
-  isLayoutSizeDefined,
-} from '#core/dom/layout';
+import {getLengthNumeral, isLayoutSizeDefined} from '#core/dom/layout';
 import {px, setImportantStyles, setStyle, setStyles} from '#core/dom/style';
-import {realChildNodes} from '#core/dom/query';
 import {throttle} from '#core/types/function';
-import {copyChildren, removeChildren} from '#core/dom';
+import {buildDom, mirrorNode} from './build-dom';
 
 const TAG = 'amp-fit-text';
 const LINE_HEIGHT_EM_ = 1.15; // WARNING: when updating this ensure you also update the css values for line-height.
 const RESIZE_THROTTLE_MS = 100;
-const MEASURER_CLASS = 'i-amphtml-fit-text-measurer';
-const CONTENT_CLASS = 'i-amphtml-fit-text-content';
-const CONTENT_WRAPPER_CLASS = 'i-amphtml-fit-text-content-wrapper';
-
 export class AmpFitText extends AMP.BaseElement {
   /** @override @nocollapse */
   static prerenderAllowed() {
@@ -202,47 +193,6 @@ export function updateOverflow_(content, measurer, maxHeight, fontSize) {
     lineClamp: overflown ? numberOfLines : '',
     maxHeight: overflown ? px(lineHeight * numberOfLines) : '',
   });
-}
-
-/**
- * @see amphtml/compiler/types.js for full description
- *
- * @param {!Element} element
- * @return {{content: !Element, contentWrapper: !Element, measurer: !Element}}
- */
-export function buildDom(element) {
-  const doc = element.ownerDocument;
-  const content = doc.createElement('div');
-  applyFillContent(content);
-  content.classList.add(CONTENT_CLASS);
-
-  const contentWrapper = doc.createElement('div');
-  contentWrapper.classList.add(CONTENT_WRAPPER_CLASS);
-  content.appendChild(contentWrapper);
-
-  const measurer = doc.createElement('div');
-  measurer.classList.add(MEASURER_CLASS);
-
-  realChildNodes(element).forEach((node) => contentWrapper.appendChild(node));
-  mirrorNode(contentWrapper, measurer);
-  element.appendChild(content);
-  element.appendChild(measurer);
-
-  return {content, contentWrapper, measurer};
-}
-
-/**
- * Make a destination node a clone of the source.
- *
- * @param {!Node} from
- * @param {!Node} to
- */
-function mirrorNode(from, to) {
-  // First clear out the destination node.
-  removeChildren(to);
-
-  // Then copy all the source's child nodes into destination node.
-  copyChildren(from, to);
 }
 
 AMP.extension(TAG, '0.1', (AMP) => {

--- a/extensions/amp-fit-text/0.1/build-dom.js
+++ b/extensions/amp-fit-text/0.1/build-dom.js
@@ -1,0 +1,48 @@
+import {copyChildren, removeChildren} from '#core/dom';
+import {applyFillContent} from '#core/dom/layout';
+import {realChildNodes} from '#core/dom/query';
+
+const MEASURER_CLASS = 'i-amphtml-fit-text-measurer';
+const CONTENT_CLASS = 'i-amphtml-fit-text-content';
+const CONTENT_WRAPPER_CLASS = 'i-amphtml-fit-text-content-wrapper';
+
+/**
+ * @see amphtml/compiler/types.js for full description
+ *
+ * @param {!Element} element
+ * @return {{content: !Element, contentWrapper: !Element, measurer: !Element}}
+ */
+export function buildDom(element) {
+  const doc = element.ownerDocument;
+  const content = doc.createElement('div');
+  applyFillContent(content);
+  content.classList.add(CONTENT_CLASS);
+
+  const contentWrapper = doc.createElement('div');
+  contentWrapper.classList.add(CONTENT_WRAPPER_CLASS);
+  content.appendChild(contentWrapper);
+
+  const measurer = doc.createElement('div');
+  measurer.classList.add(MEASURER_CLASS);
+
+  realChildNodes(element).forEach((node) => contentWrapper.appendChild(node));
+  mirrorNode(contentWrapper, measurer);
+  element.appendChild(content);
+  element.appendChild(measurer);
+
+  return {content, contentWrapper, measurer};
+}
+
+/**
+ * Make a destination node a clone of the source.
+ *
+ * @param {!Node} from
+ * @param {!Node} to
+ */
+export function mirrorNode(from, to) {
+  // First clear out the destination node.
+  removeChildren(to);
+
+  // Then copy all the source's child nodes into destination node.
+  copyChildren(from, to);
+}

--- a/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
@@ -1,10 +1,6 @@
 import {createElementWithAttributes} from '#core/dom';
-import {
-  AmpFitText,
-  buildDom,
-  calculateFontSize_,
-  updateOverflow_,
-} from '../amp-fit-text';
+import {AmpFitText, calculateFontSize_, updateOverflow_} from '../amp-fit-text';
+import {buildDom} from '../build-dom';
 
 describes.realWin(
   'amp-fit-text component',

--- a/src/builtins/amp-layout/amp-layout.js
+++ b/src/builtins/amp-layout/amp-layout.js
@@ -1,10 +1,10 @@
-import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
-import {realChildNodes} from '#core/dom/query';
+import {Layout, isLayoutSizeDefined} from '#core/dom/layout';
 
 import {registerElement} from '#service/custom-element-registry';
 
+import {buildDom} from './build-dom';
+
 import {BaseElement} from '../../base-element';
-import {getEffectiveLayout} from '../../static-layout';
 
 export class AmpLayout extends BaseElement {
   /** @override @nocollapse */
@@ -21,26 +21,6 @@ export class AmpLayout extends BaseElement {
   buildCallback() {
     buildDom(this.element);
   }
-}
-
-/**
- * @see amphtml/compiler/types.js for full description
- *
- * @param {!Element} element
- */
-export function buildDom(element) {
-  const layout = getEffectiveLayout(element);
-  if (layout == Layout.CONTAINER) {
-    return;
-  }
-
-  const doc = element.ownerDocument;
-  const container = doc.createElement('div');
-  applyFillContent(container);
-  realChildNodes(element).forEach((child) => {
-    container.appendChild(child);
-  });
-  element.appendChild(container);
 }
 
 /**

--- a/src/builtins/amp-layout/build-dom.js
+++ b/src/builtins/amp-layout/build-dom.js
@@ -1,0 +1,24 @@
+import {Layout, applyFillContent} from '#core/dom/layout';
+import {realChildNodes} from '#core/dom/query';
+
+import {getEffectiveLayout} from '../../static-layout';
+
+/**
+ * @see amphtml/compiler/types.js for full description
+ *
+ * @param {!Element} element
+ */
+export function buildDom(element) {
+  const layout = getEffectiveLayout(element);
+  if (layout == Layout.CONTAINER) {
+    return;
+  }
+
+  const doc = element.ownerDocument;
+  const container = doc.createElement('div');
+  applyFillContent(container);
+  realChildNodes(element).forEach((child) => {
+    container.appendChild(child);
+  });
+  element.appendChild(container);
+}

--- a/src/compiler/builders.js
+++ b/src/compiler/builders.js
@@ -1,6 +1,6 @@
-import {buildDom as ampLayoutClassic} from '#builtins/amp-layout/amp-layout';
+import {buildDom as ampLayoutClassic} from '#builtins/amp-layout/build-dom';
 
-import {buildDom as ampFitTextClassic} from '../../extensions/amp-fit-text/0.1/amp-fit-text';
+import {buildDom as ampFitTextClassic} from '../../extensions/amp-fit-text/0.1/build-dom';
 
 const builderMap = {
   'v0': {

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1,3 +1,4 @@
+import './polyfills';
 import * as compiler from '@ampproject/bento-compiler';
 
 import {getBuilders} from './builders';

--- a/src/compiler/polyfills.js
+++ b/src/compiler/polyfills.js
@@ -1,0 +1,2 @@
+// compiler.js is meant to be run in server environments which do not have `self`.
+globalThis['self'] = globalThis;

--- a/src/compiler/shame.extern.js
+++ b/src/compiler/shame.extern.js
@@ -12,12 +12,12 @@
 /**
  * @type {!./types.BuildDomDef}
  */
-var buildDom$$module$src$builtins$amp_layout$amp_layout;
+var buildDom$$module$src$builtins$amp_layout$build_dom;
 
 /**
  * @type {!./types.BuildDomDef}
  */
-var buildDom$$module$extensions$amp_fit_text$0_1$amp_fit_text;
+var buildDom$$module$extensions$amp_fit_text$0_1$build_dom;
 
 /** @type {{renderAst: function(!./types.TreeProtoDef, Object<string, !./types.BuildDomDef>): !./types.TreeProtoDef}} */
 var module$$ampproject$bento_compiler;

--- a/test/unit/builtins/test-amp-layout.js
+++ b/test/unit/builtins/test-amp-layout.js
@@ -1,4 +1,5 @@
-import {AmpLayout, buildDom} from '#builtins/amp-layout/amp-layout';
+import {AmpLayout} from '#builtins/amp-layout/amp-layout';
+import {buildDom} from '#builtins/amp-layout/build-dom';
 
 import {createElementWithAttributes} from '#core/dom';
 import {Layout} from '#core/dom/layout';


### PR DESCRIPTION
**summary**
Make compiler.js bundle runnable
- Extracts buildDoms to their own file to reduce import-based side-effects.
- Creates a `self` polyfill

If the code is still not runnable in V8 directly, this will at least get us partway.

**testing done**
1. `npx amp dist --noextensions`
2. Enter the node repl via `node`
3. `require('./dist/compiler.js')` should not throw