### PR TITLE
🏗 Ensure every babel invocation has a name

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -45,7 +45,6 @@ module.exports = function (api) {
     const configFunctionName = babelTransforms.get(callerName);
     return require('./build-system/babel-config')[configFunctionName]();
   } else {
-    console.trace(callerName);
     log(
       yellow('WARNING:'),
       'Unrecognized Babel caller',

--- a/babel.config.js
+++ b/babel.config.js
@@ -25,6 +25,8 @@ const babelTransforms = new Map([
   ['minified', 'getMinifiedConfig'],
   ['jss', 'getJssConfig'],
   ['@babel/eslint-parser', 'getEslintConfig'],
+  ['is-enum-value', 'getEmptyConfig'],
+  ['import-resolver', 'getEmptyConfig'],
 ]);
 
 /**
@@ -43,6 +45,7 @@ module.exports = function (api) {
     const configFunctionName = babelTransforms.get(callerName);
     return require('./build-system/babel-config')[configFunctionName]();
   } else {
+    console.trace(callerName);
     log(
       yellow('WARNING:'),
       'Unrecognized Babel caller',

--- a/build-system/babel-config/import-resolver.js
+++ b/build-system/babel-config/import-resolver.js
@@ -46,8 +46,13 @@ function readJsconfigPaths() {
  */
 function getImportResolver() {
   return {
-    'root': ['.'],
-    'alias': readJsconfigPaths(),
+    root: ['.'],
+    alias: readJsconfigPaths(),
+    babelOptions: {
+      caller: {
+        name: 'import-resolver',
+      },
+    },
   };
 }
 

--- a/build-system/babel-plugins/babel-plugin-transform-inline-isenumvalue/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-inline-isenumvalue/index.js
@@ -49,7 +49,7 @@ module.exports = function (babel) {
       const {imported} = importDeclaration.node.specifiers.find(
         ({local}) => local.name === path.node.name
       );
-      traverse(parseSync(code), {
+      traverse(parseSync(code, {caller: {name: 'is-enum-value'}}), {
         Program(path) {
           path.stop(); // prevent a full walk
 


### PR DESCRIPTION
I'm tired of seeing `Unrecognized Babel caller` in my logs.