### PR TITLE
🚮 Remove getIntersectionElementLayoutBox from amp-iframe

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -1033,7 +1033,6 @@ const forbiddenTermsSrcInclusive = {
       'extensions/amp-ad/0.1/amp-ad-3p-impl.js',
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js',
-      'extensions/amp-iframe/0.1/amp-iframe.js',
     ],
   },
   "require\\('fancy-log'\\)": {

--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -12,7 +12,7 @@ import {PauseHelper} from '#core/dom/video/pause-helper';
 import {Services} from '#service';
 import {base64EncodeFromBytes} from '#core/types/string/base64';
 import {createCustomEvent, getData, listen} from '../../../src/event-helper';
-import {devAssert, user, userAssert} from '../../../src/log';
+import {user, userAssert} from '../../../src/log';
 import {dict} from '#core/types/object';
 import {endsWith} from '#core/types/string';
 import {getConsentDataToForward} from '../../../src/consent';
@@ -23,7 +23,6 @@ import {
 } from '../../../src/iframe-helper';
 import {isAdPositionAllowed} from '../../../src/ad-helper';
 import {isExperimentOn} from '#experiments';
-import {moveLayoutRect} from '#core/dom/layout/rect';
 import {parseJson} from '#core/types/object/json';
 import {propagateAttributes} from '#core/dom/propagate-attributes';
 import {removeElement} from '#core/dom';
@@ -73,12 +72,6 @@ export class AmpIframe extends AMP.BaseElement {
 
     /** @private {boolean} */
     this.isDisallowedAsAd_ = false;
-
-    /**
-     * The (relative) layout box of the ad iframe to the amp-ad tag.
-     * @private {?../../../src/layout-rect.LayoutRectDef}
-     */
-    this.iframeLayoutBox_ = null;
 
     /** @private  {?HTMLIFrameElement} */
     this.iframe_ = null;
@@ -299,10 +292,6 @@ export class AmpIframe extends AMP.BaseElement {
 
   /** @override */
   onLayoutMeasure() {
-    // We remeasured this tag, lets also remeasure the iframe. Should be
-    // free now and it might have changed.
-    this.measureIframeLayoutBox_();
-
     const {element} = this;
 
     this.isAdLike_ = isAdLike(element);
@@ -318,37 +307,6 @@ export class AmpIframe extends AMP.BaseElement {
   looksLikeTrackingIframe_() {
     // It may be tempting to inline this method, but it's referenced in tests.
     return looksLikeTrackingIframe(this.element);
-  }
-
-  /**
-   * Measure the layout box of the iframe if we rendered it already.
-   * @private
-   */
-  measureIframeLayoutBox_() {
-    if (this.iframe_) {
-      const iframeBox = this.getViewport().getLayoutRect(this.iframe_);
-      const box = this.getLayoutBox();
-      // Cache the iframe's relative position to the amp-iframe. This is
-      // necessary for fixed-position containers which "move" with the
-      // viewport.
-      this.iframeLayoutBox_ = moveLayoutRect(iframeBox, -box.left, -box.top);
-    }
-  }
-
-  /** @override */
-  getIntersectionElementLayoutBox() {
-    if (!this.iframe_) {
-      return super.getIntersectionElementLayoutBox();
-    }
-    const box = this.getLayoutBox();
-    if (!this.iframeLayoutBox_) {
-      this.measureIframeLayoutBox_();
-    }
-
-    const iframe = /** @type {!../../../src/layout-rect.LayoutRectDef} */ (
-      devAssert(this.iframeLayoutBox_)
-    );
-    return moveLayoutRect(iframe, box.left, box.top);
   }
 
   /** @override */

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -889,39 +889,6 @@ describes.realWin(
       yield ampIframe.signals().whenSignal(CommonSignals.LOAD_START);
     });
 
-    it('should not cache intersection box', async () => {
-      const ampIframe = createAmpIframe(env, {
-        src: iframeSrc,
-        sandbox: 'allow-scripts allow-same-origin',
-        width: 300,
-        height: 250,
-      });
-      await waitForAmpIframeLayoutPromise(doc, ampIframe);
-      const impl = await ampIframe.getImpl(false);
-      const stub = env.sandbox.stub(impl, 'getLayoutBox');
-      const box = {
-        top: 100,
-        bottom: 200,
-        left: 0,
-        right: 100,
-        width: 100,
-        height: 100,
-      };
-      stub.returns(box);
-
-      impl.onLayoutMeasure();
-      const intersection = impl.getIntersectionElementLayoutBox();
-      // Simulate a fixed position element "moving" 100px by scrolling down
-      // the page.
-      box.top += 100;
-      box.bottom += 100;
-      const newIntersection = impl.getIntersectionElementLayoutBox();
-      expect(newIntersection).not.to.deep.equal(intersection);
-      expect(newIntersection.top).to.equal(intersection.top + 100);
-      expect(newIntersection.width).to.equal(300);
-      expect(newIntersection.height).to.equal(250);
-    });
-
     it('should propagate `src` when container attribute is mutated', async () => {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,


### PR DESCRIPTION
**summary**
`getIntersectionElementLayoutBox` is used in two places:
1. As part of `Ads` code (amp-a4a, amp-ad-3p-impl, amp-ad-network-adsense, amp-ad-network-doubleclick)
2. In the implementation of `base-element.getIntersectionChangeEntry`. This in turn is only called by the same Ads files as (1), but with the addition of `name-frame-renderer.js` which is also part of a4a.

Unless there is a codepath where Ads utilizes `<amp-iframe>` under the hood, it should be safe to remove this measurement API.


**note**: I did find a suspicious codepath around checking to see if the iframe is `adLike` or a tracking pixel, but it did not seem to use the measured iframe value. They both depend on `CE.getLayoutSize` (which depends on resources system size)