### PR TITLE
🐛 [Amp story page attachment] Propagate title attribute to draggable drawer header

### DIFF
--- a/examples/amp-story/attachment.html
+++ b/examples/amp-story/attachment.html
@@ -63,7 +63,7 @@
             <span data-text-background-color="#00A3DB">Default amp-story-page-attachment.</span></br></br>
           </p>
         </amp-story-grid-layer>
-        <amp-story-page-attachment data-title="Lorem ipsum" layout="nodisplay">
+        <amp-story-page-attachment title="Lorem ipsum" layout="nodisplay">
           <a href="https://google.com">Left link</a>
           <div style="text-align: center;"><a href="https://google.com">Center link</a></div>
           <div style="text-align: right;"><a href="https://google.com">Right link</a></div>

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -143,7 +143,9 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       closeButtonEl.setAttribute('aria-label', localizedCloseString);
     }
 
-    if (this.element.hasAttribute('data-title')) {
+    if (this.element.hasAttribute('title')) {
+      titleEl.textContent = this.element.getAttribute('title');
+    } else if (this.element.hasAttribute('data-title')) {
       titleEl.textContent = this.element.getAttribute('data-title');
     }
 

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -133,9 +133,6 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
           </button>`;
     const localizationService = getLocalizationService(devAssert(this.element));
 
-    const titleEl = htmlFor(this.element)`
-    <span class="i-amphtml-story-page-attachment-title"></span>`;
-
     if (localizationService) {
       const localizedCloseString = localizationService.getLocalizedString(
         LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
@@ -143,18 +140,21 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       closeButtonEl.setAttribute('aria-label', localizedCloseString);
     }
 
-    if (this.element.hasAttribute('title')) {
-      titleEl.textContent = this.element.getAttribute('title');
-    } else if (this.element.hasAttribute('data-title')) {
-      titleEl.textContent = this.element.getAttribute('data-title');
-    }
-
     const titleAndCloseWrapperEl = this.headerEl.appendChild(
       htmlFor(this.element)`
             <div class="i-amphtml-story-draggable-drawer-header-title-and-close"></div>`
     );
     titleAndCloseWrapperEl.appendChild(closeButtonEl);
-    titleAndCloseWrapperEl.appendChild(titleEl);
+
+    const titleText =
+      this.element.getAttribute('title') ||
+      this.element.getAttribute('data-title');
+    if (titleText) {
+      const titleEl = htmlFor(this.element)`
+        <span class="i-amphtml-story-page-attachment-title"></span>`;
+      titleEl.textContent = titleText;
+      titleAndCloseWrapperEl.appendChild(titleEl);
+    }
 
     const templateEl = this.element.querySelector(
       '.i-amphtml-story-draggable-drawer'


### PR DESCRIPTION
Adds `title` attribute to the draggable-drawer header if defined.
Will default to `data-title` if `title` is not defined.

This is communicated in our [docs](https://amp.dev/documentation/components/amp-story-page-attachment/#title-%28optional%29) and needs to be reflected in our code.