### PR TITLE
🐛 [Amp story page outlink] Default outlink color and warning

### DIFF
--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -4,6 +4,7 @@
 import {AttachmentTheme} from './amp-story-page-attachment';
 import {LocalizedStringId} from '#service/localization/strings';
 import {computedStyle, setImportantStyles} from '#core/dom/style';
+import {dev} from '../../../src/log';
 import {getLocalizationService} from './amp-story-localization-service';
 import {
   getRGBFromCssColorValue,
@@ -221,13 +222,21 @@ const renderInlineUi = (pageEl, attachmentEl) => {
  * @param {!Element} openAttachmentEl
  */
 export const setCustomThemeStyles = (attachmentEl, openAttachmentEl) => {
-  const accentColor = attachmentEl.getAttribute('cta-accent-color');
+  if (!attachmentEl.hasAttribute('cta-accent-color')) {
+    dev().warn(
+      'AMP-STORY-PAGE-OUTLINK',
+      'No cta-accent-color attribute found.'
+    );
+  }
+
+  const accentColor =
+    attachmentEl.getAttribute('cta-accent-color') || '#000000';
 
   // Calculating contrast color (black or white) needed for outlink CTA UI.
   let contrastColor = null;
   if (accentColor) {
     setImportantStyles(attachmentEl, {
-      'background-color': attachmentEl.getAttribute('cta-accent-color'),
+      'background-color': accentColor,
     });
 
     const win = toWin(attachmentEl.ownerDocument.defaultView);

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -234,19 +234,17 @@ export const setCustomThemeStyles = (attachmentEl, openAttachmentEl) => {
 
   // Calculating contrast color (black or white) needed for outlink CTA UI.
   let contrastColor = null;
-  if (accentColor) {
-    setImportantStyles(attachmentEl, {
-      'background-color': accentColor,
-    });
+  setImportantStyles(attachmentEl, {
+    'background-color': accentColor,
+  });
 
-    const win = toWin(attachmentEl.ownerDocument.defaultView);
-    const styles = computedStyle(win, attachmentEl);
-    const rgb = getRGBFromCssColorValue(styles['background-color']);
-    contrastColor = getTextColorForRGB(rgb);
-    setImportantStyles(attachmentEl, {
-      'background-color': '',
-    });
-  }
+  const win = toWin(attachmentEl.ownerDocument.defaultView);
+  const styles = computedStyle(win, attachmentEl);
+  const rgb = getRGBFromCssColorValue(styles['background-color']);
+  contrastColor = getTextColorForRGB(rgb);
+  setImportantStyles(attachmentEl, {
+    'background-color': '',
+  });
   if (
     attachmentEl.getAttribute('cta-accent-element') ===
     CtaAccentElement.BACKGROUND


### PR DESCRIPTION
Prevents display issues if `cta-accent-color` is not defined.
Throws a warning to notify user to define the `cta-accent-color` attribute.

Fixes #34983 