### PR TITLE
✨ Sending targeting only when the Ad is refreshing

### DIFF
--- a/examples/refresh.amp.html
+++ b/examples/refresh.amp.html
@@ -12,7 +12,7 @@
     <style amp-custom>
       .artificialfold {
         height: 1000px;
-        width: 300px
+        width: 300px;
         background: #000;
       }
     </style>
@@ -21,6 +21,6 @@
     <h1>AMP Static Image DFP Reservation.</h1>
     <p>Tests a static image ad in an AMP page.</p>
     <div class="artificialfold"></div>
-    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>
-    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300></amp-ad>
+    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300 json='{"onRefresh":{"key1": "value1"}}'></amp-ad>
+    <amp-ad data-slot="/701/wpni.amp.opinions/blog/plum-line" height=250 layout=fixed type=doubleclick width=300 json='{"onRefresh":{"key1": "value1"}}'></amp-ad>
 </body></html>

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -680,6 +680,22 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       this.win,
       this.element.parentElement
     );
+
+    const targeting =
+      (this.jsonTargeting && this.jsonTargeting['targeting']) || null;
+
+    const onRefresh =
+      (this.isRefreshing &&
+        this.jsonTargeting &&
+        this.jsonTargeting['onRefresh']) ||
+      null;
+
+    const scp = serializeTargeting(
+      {...targeting, ...onRefresh},
+      (this.jsonTargeting && this.jsonTargeting['categoryExclusions']) || null,
+      null
+    );
+
     const {fwSignal, parentWidth, slotWidth} = this.flexibleAdSlotData_;
     // If slotWidth is -1, that means its width must be determined by its
     // parent container, and so should have the same value as parentWidth.
@@ -703,12 +719,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       'msz': msz,
       'psz': psz,
       'fws': fws,
-      'scp': serializeTargeting(
-        (this.jsonTargeting && this.jsonTargeting['targeting']) || null,
-        (this.jsonTargeting && this.jsonTargeting['categoryExclusions']) ||
-          null,
-        null
-      ),
+      'scp': scp,
       'spsa': this.isSinglePageStoryAd
         ? `${pageLayoutBox.width}x${pageLayoutBox.height}`
         : null,


### PR DESCRIPTION
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->

Through reports from Google Ad Manager, I want to be able to filter from Ads that had refresh. Today this is not possible.

**This is how it should work**
```
<amp-ad json='{"onRefresh":{"key1": "value1"}}'></amp-ad>
```

**When refreshing, this is how the request should be**
```
https://securepubads.g.doubleclick.net/gampad/ads?...&scp=key1=value1...
```
