### PR TITLE
🏗 Alias `amp-*.js` binaries as `bento-*.js`

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -721,7 +721,6 @@ async function buildExtensionJs(extDir, name, version, latestVersion, options) {
   const aliasBundle = extensionAliasBundles[name];
   const isAliased = aliasBundle && aliasBundle.version == version;
 
-  /** @type {([string, string] | null)[]} */
   const aliases = [
     isAliased ? [name, aliasBundle.aliasedVersion] : null,
     // TODO(alanorozco): We'd like to provide bento-foo.js binaries that only

--- a/examples/bento/api.html
+++ b/examples/bento/api.html
@@ -8,8 +8,7 @@
       content="width=device-width,minimum-scale=1,initial-scale=1"
     />
     <script src="https://cdn.ampproject.org/custom-elements-polyfill.js"></script>
-    <!-- TODO(alanorozco): Once available, change src to bento-video.js -->
-    <script async src="https://cdn.ampproject.org/v0/amp-video-1.0.js"></script>
+    <script async src="https://cdn.ampproject.org/v0/bento-video-1.0.js"></script>
   </head>
   <body>
     <bento-video

--- a/examples/bento/no-v0.html
+++ b/examples/bento/no-v0.html
@@ -29,10 +29,9 @@
       }
     </style>
     <script src="https://cdn.ampproject.org/custom-elements-polyfill.js"></script>
-    <!-- TODO(alanorozco): Once available, change src to bento-timeago.js -->
     <script
       async
-      src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"
+      src="https://cdn.ampproject.org/v0/bento-timeago-1.0.js"
     ></script>
   </head>
   <body>

--- a/extensions/amp-base-carousel/1.0/README.md
+++ b/extensions/amp-base-carousel/1.0/README.md
@@ -58,8 +58,7 @@ import '@ampproject/bento-base-carousel';
       position: relative;
     }
   </style>
-  <!-- TODO(wg-bento): Once available, change src to bento-base-carousel.js -->
-  <script async src="https://cdn.ampproject.org/v0/amp-base-carousel-1.0.js"></script>
+  <script async src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.js"></script>
   <style>
     bento-base-carousel, bento-base-carousel > div {
       aspect-ratio: 4/1;

--- a/test/fixtures/e2e/bento/minimal.html
+++ b/test/fixtures/e2e/bento/minimal.html
@@ -8,10 +8,9 @@
       content="width=device-width,minimum-scale=1,initial-scale=1"
     />
     <script src="https://cdn.ampproject.org/custom-elements-polyfill.js"></script>
-    <!-- TODO(alanorozco): Once available, change src to bento-timeago.js -->
     <script
       async
-      src="https://cdn.ampproject.org/v0/amp-timeago-1.0.js"
+      src="https://cdn.ampproject.org/v0/bento-timeago-1.0.js"
     ></script>
   </head>
   <body>


### PR DESCRIPTION
`amp-*.js` binaries for Bento-compatible extensions provide an `<amp-*>` element that can be used **with** `v0.js`, and a `<bento-*>` element that can be used **without** `v0.js`.

We'd like that Bento elements are used from `bento-*.js` in Bento mode.

Eventually, this binary will only provide the Bento element, while `amp-*.js` provides only an AMP element. In the meantime, we alias the multiple-compatibility binary so that `bento-*.js` can be used as soon as possible. This unblocks release since we'll be able to include the scripts in Bento mode using the correct URL.
