### PR TITLE
♻️ Remove use of `.find`

### DIFF
--- a/extensions/amp-date-display/format.js
+++ b/extensions/amp-date-display/format.js
@@ -19,8 +19,11 @@ export function getTimeZoneName(date, locale, options, format = 'long') {
     timeZone: options?.timeZone,
     timeZoneName: format,
   });
-  return (
-    formatter.formatToParts(date).find(({type}) => type === 'timeZoneName')
-      ?.value || ''
-  );
+  const parts = formatter.formatToParts?.(date) || [];
+  for (let i = 0; i < parts.length; i++) {
+    if (parts[i].type === 'timeZoneName') {
+      return parts[i].value;
+    }
+  }
+  return '';
 }

--- a/extensions/amp-date-display/format.js
+++ b/extensions/amp-date-display/format.js
@@ -20,9 +20,9 @@ export function getTimeZoneName(date, locale, options, format = 'long') {
     timeZoneName: format,
   });
   const parts = formatter.formatToParts?.(date) || [];
-  for (let i = 0; i < parts.length; i++) {
-    if (parts[i].type === 'timeZoneName') {
-      return parts[i].value;
+  for (const part of parts) {
+    if (part.type === 'timeZoneName') {
+      return part.value;
     }
   }
   return '';


### PR DESCRIPTION
- Fixes compatibility in very old browsers that don't support `.find()`
- Fixes https://github.com/ampproject/error-reporting/issues/103