### PR TITLE
📖 Update amp-twitter documentation

### DIFF
--- a/extensions/amp-twitter/0.1/amp-twitter.md
+++ b/extensions/amp-twitter/0.1/amp-twitter.md
@@ -11,7 +11,7 @@ teaser:
 
 ## Behavior
 
-The `amp-twitter` component allows you to embed a Tweet or Moment for the specified Twitter ID.
+The `amp-twitter` component allows you to embed a Tweet or Moment.
 
 Here's an example of a basic embedded Tweet:
 

--- a/extensions/amp-twitter/1.0/README.md
+++ b/extensions/amp-twitter/1.0/README.md
@@ -12,7 +12,7 @@ bento: true
 
 ## Behavior
 
-The Bento Twitter component allows you to embed a Tweet or Moment for the specified Twitter ID. Use it as a web component [`<bento-twitter>`](#web-component), or a Preact/React functional component [`<BentoTwitter>`](#preact/react-Component).
+The Bento Twitter component allows you to embed a Tweet or Moment. Use it as a web component [`<bento-twitter>`](#web-component), or a Preact/React functional component [`<BentoTwitter>`](#preact/react-Component).
 
 ### Web Component
 

--- a/extensions/amp-twitter/amp-twitter.md
+++ b/extensions/amp-twitter/amp-twitter.md
@@ -12,7 +12,7 @@ bento: true
 
 ## Behavior
 
-The `amp-twitter` component allows you to embed a Tweet or Moment for the specified Twitter ID.
+The `amp-twitter` component allows you to embed a Tweet or Moment.
 
 Here's an example of a basic embedded Tweet:
 


### PR DESCRIPTION
Remove unnecessary bit about a "twitter ID" which is (1) not a thing and (2) not even required (you can use `data-tweetid`, `data-momentid`, or a `data-timeline-` attr.