### PR TITLE
history-impl: fix local dev server handling of history

### DIFF
--- a/build-system/server/shadow-viewer.js
+++ b/build-system/server/shadow-viewer.js
@@ -135,6 +135,11 @@ const renderShadowViewer = ({baseHref, src}) =>
       <head>
         <base href="${baseHref}" />
         <title>Shadow Viewer</title>
+        // TODO(35889): determine why this is necessary for AMP_SHADOW test of
+        amp-lightbox.
+        <script>
+          window.__AMP_TEST_IFRAME = true;
+        </script>
         <script>
           ${SCRIPT};
         </script>

--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -5,7 +5,6 @@ import {getHistoryState} from '#core/window/history';
 import {Services} from '#service';
 
 import {dev, devAssert} from '../log';
-import {getMode} from '../mode';
 import {
   getService,
   registerServiceBuilder,
@@ -1115,11 +1114,7 @@ export class HistoryBindingVirtual_ {
 function createHistory(ampdoc) {
   const viewer = Services.viewerForDoc(ampdoc);
   let binding;
-  if (
-    viewer.isOvertakeHistory() ||
-    getMode(ampdoc.win).test ||
-    ampdoc.win.__AMP_TEST_IFRAME
-  ) {
+  if (viewer.isOvertakeHistory() || ampdoc.win.__AMP_TEST_IFRAME) {
     binding = new HistoryBindingVirtual_(ampdoc.win, viewer);
   } else {
     // Only one global "natural" binding is allowed since it works with the

--- a/test/unit/core/window/test-history.js
+++ b/test/unit/core/window/test-history.js
@@ -327,7 +327,6 @@ describes.sandboxed('Window - History', {}, (env) => {
     });
 
     it('should create natural binding and make it singleton', () => {
-      win.AMP_CONFIG = {test: false};
       const history = Services.historyForDoc(ampdoc);
       expect(history.binding_).to.be.instanceOf(HistoryBindingNatural_);
       expect(win.__AMP_SERVICES.history.obj).to.equal(history);
@@ -348,6 +347,9 @@ describes.sandboxed('Window - History', {}, (env) => {
   });
 
   describe('HistoryBindingNatural', () => {
+    // TODO: Fix tests s.t. they are isolated from both each other and other test files.
+    delete window.history.state['AMP.History'];
+
     let clock;
     let onStateUpdated;
     let history;
@@ -1013,6 +1015,7 @@ describes.fakeWin(
     });
   }
 );
+
 describes.fakeWin('Window - History - Get and update fragment', {}, (env) => {
   let history;
   let viewer;


### PR DESCRIPTION
**summary**
https://github.com/ampproject/amphtml/pull/35823 introduced a bug in history for local dev servers - opting them to always create a virtual history. This PR removes the check for `.test` since `__AMP_TEST_IFRAME` allows us to differentiate between unit tests and dev server.