### PR TITLE
🐛 Use `/register` for Storybook addons

### DIFF
--- a/build-system/tasks/storybook/amp-env/main.js
+++ b/build-system/tasks/storybook/amp-env/main.js
@@ -11,8 +11,8 @@ module.exports = {
     // since it only checks the structure of the outer iframe element.
     // Enable this once we find a way to inspect the iframe document's tree.
     // '@storybook/addon-a11y',
-    '@storybook/addon-viewport',
-    '@storybook/addon-knobs',
+    '@storybook/addon-viewport/register',
+    '@storybook/addon-knobs/register',
     '@ampproject/storybook-addon',
   ],
   managerWebpack: (config) => {


### PR DESCRIPTION
Preact environment had been updated to this syntax, but the AMP environment had not.
