### PR TITLE
🐛 Fix child identifiers in amp-ad network=doubleclick SRA IUs.

### DIFF
--- a/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/sra-utils.js
@@ -82,7 +82,9 @@ export function combineInventoryUnits(impls) {
   const prevIusEncoded = [];
   impls.forEach((instance) => {
     const iu = devAssert(instance.element.getAttribute('data-slot'));
-    const componentNames = iu.split('/');
+    const componentNames = iu
+      .split('/')
+      .map((componentName) => componentName.replace(/,/g, ':'));
     const encodedNames = [];
     for (let i = 0; i < componentNames.length; i++) {
       if (componentNames[i] == '') {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-sra.js
@@ -132,13 +132,13 @@ describes.realWin('Doubleclick SRA', config, (env) => {
           element: {
             getAttribute: (name) => {
               expect(name).to.equal('data-slot');
-              return '/1234/foo.com/news/world/2018/06/17/article';
+              return '/1234,5678/foo.com/news/world/2018/06/17/article';
             },
           },
         });
       }
       expect(combineInventoryUnits(impls)).to.jsonEqual({
-        'iu_parts': '1234,foo.com,news,world,2018,06,17,article',
+        'iu_parts': '1234:5678,foo.com,news,world,2018,06,17,article',
         'enc_prev_ius': '0/1/2/3/4/5/6/7,0/1/2/3/4/5/6/7',
       });
     });


### PR DESCRIPTION
Some networks use a comma in a network code part to denote a child identifier. This comma however was kept when serialized, causing it to be treated as a separate network code. This change fixes it by converting it to a colon.