### PR TITLE
🏗 Move nightly branch cut job from CircleCI to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,6 @@ executors:
     docker:
       - image: cimg/base:stable
     resource_class: small
-  node-docker-small:
-    docker:
-      - image: cimg/node:lts-browsers
-    resource_class: small
   node-docker-medium:
     docker:
       - image: cimg/node:lts-browsers
@@ -431,13 +427,6 @@ jobs:
           command: node build-system/pr-check/experiment-e2e-tests.js --experiment=experiment<< parameters.exp >>
       - store_test_output
       - teardown_vm
-  cut_nightly:
-    executor:
-      name: node-docker-small
-    steps:
-      - run:
-          name: '⭐ Cut Nightly Branch ⭐'
-          command: node --unhandled-rejections=strict build-system/release-workflows/cut-nightly.js
 
 workflows:
   version: 2
@@ -579,18 +568,3 @@ workflows:
       #     <<: *push_builds_only
       #     requires:
       #       - 'Nomodule Build (Test)'
-
-  'Nightly':
-    triggers:
-      - schedule:
-          # 1 a.m. PST / 12 a.m. PDT, Tuesdays through Saturdays.
-          cron: '0 8 * * 2-6'
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - initialize_repository:
-          name: 'Initialize Repository'
-      - cut_nightly:
-          name: 'Cut Nightly Branch'

--- a/.github/workflows/cut-nightly.yml
+++ b/.github/workflows/cut-nightly.yml
@@ -1,0 +1,30 @@
+# Cuts a new nightly branch on a schedule.
+
+name: Cut Nightly Branch
+
+on:
+  schedule:
+    # 1 a.m. PST / 12 a.m. PDT, Tuesdays through Saturdays.
+    - cron: '0 8 * * 2-6'
+
+jobs:
+  sweep-experiments:
+    if: github.repository == 'ampproject/amphtml'
+    name: Cut Nightly Branch
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Set Up Node
+        uses: actions/setup-node@v2.4.0
+
+      - name: Set Up Environment
+        run: sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: ⭐ Cut Nightly Branch ⭐
+        run: node --unhandled-rejections=strict build-system/release-workflows/cut-nightly.js


### PR DESCRIPTION
This allows us to better control the permissions model wrt GitHub API tokens (replaces #35878)