### PR TITLE
🏗 Pin CircleCI's Chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ commands:
     steps:
       - browser-tools/install-chrome:
           replace-existing: true
+          chrome-version: 93.0.4577.63
       - browser-tools/install-chromedriver
   install_firefox:
     steps:


### PR DESCRIPTION
This is to prevent new stable releases of Chrome from causing test failures. Eg, the Chrome 93 release caused several tests failures that made `main` red until the tests were skipped. This delayed a cherry-pick we're working on, since the new release (on on top of old code) also picked up Chrome 93.

This should be updated regularly, hopefully with a chance to test Chrome releases during the Beta period so we can proactively fix issues.