### PR TITLE
🐛 [Amp story] Prevent pointer events on images

### DIFF
--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -369,7 +369,7 @@ amp-story-grid-layer[anchor*="right"] {
 /**
  * Prevents long-press image preview on iOS 15 that breaks pause UX.
  */
-amp-story amp-img img {
+ amp-story-grid-layer amp-img img {
   pointer-events: none !important;
 }
 

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -367,7 +367,7 @@ amp-story-grid-layer[anchor*="right"] {
 }
 
 /**
- * Prevents long-press image preview on iOS 15.
+ * Prevents long-press image preview on iOS 15 that breaks pause UX.
  */
 amp-story amp-img img {
   pointer-events: none !important;

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -367,6 +367,13 @@ amp-story-grid-layer[anchor*="right"] {
 }
 
 /**
+ * Prevents long-press image preview on iOS 15.
+ */
+amp-story amp-img img {
+  pointer-events: none !important;
+}
+
+/**
  * Prevents amp-video to layout until its element has been swapped by the media
  * pool. See #26718 for context.
  */


### PR DESCRIPTION
Context / Fixes #35381

iOS 15 expands images on long press. This breaks our long-press to pause UX. 
This PR prevents the image from being selectable by globally removing pointer events from images .
With this fix TalkBack is still able to select and read the `alt` text of images.

We have [this code](https://github.com/ampproject/amphtml/blob/11a2daaca49c45df1159ee0ea0c4187af30f22ab/extensions/amp-story/1.0/amp-story.js#L791-L799) to prevent `contextmenu` events. 
It does not help in this case since `contextmenu` does not fire. 
Events logged from `monitorEvents(window)`:
<img width="417" alt="Screen Shot 2021-09-02 at 1 40 56 PM" src="https://user-images.githubusercontent.com/3860311/131892209-8195f7ce-4bec-4094-a472-72d325280a8f.png">
