### PR TITLE
✨ [Extension AMP-AUTO-ADS] Implement feature custom amp-analytics by amp-auto-ads

### DIFF
--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -31,8 +31,8 @@ export class AmpAutoAds extends AMP.BaseElement {
     this.adNetwork_ = getAdNetworkConfig(type, this.element);
     userAssert(this.adNetwork_, 'No AdNetworkConfig for type: ' + type);
 
-    this.customAnalytics_ = this.element.getAttribute('custom-analytics');
-    if (this.customAnalytics_) {
+    if (this.element.hasAttribute('custom-analytics')) {
+      this.customAnalytics_ = this.element.getAttribute('custom-analytics');
       this.customAnalytics_ = JSON.parse(this.customAnalytics_);
     }
 

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -122,13 +122,10 @@ export class AmpAutoAds extends AMP.BaseElement {
         configObj,
         this.customAnalytics_
       );
-      const attributes = /** @type {!JsonObject} */ (
-        Object.assign(
-          dict({}),
-          this.adNetwork_.getAttributes(),
-          getAttributesFromConfigObj(configObj, Attributes.BASE_ATTRIBUTES)
-        )
-      );
+      const attributes = /** @type {!JsonObject} */ ({
+        ...this.adNetwork_.getAttributes(),
+        ...getAttributesFromConfigObj(configObj, Attributes.BASE_ATTRIBUTES),
+      });
       const sizing = this.adNetwork_.getSizing();
       const adConstraints =
         getAdConstraintsFromConfigObj(ampdoc, configObj) ||

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -36,7 +36,6 @@ export class AmpAutoAds extends AMP.BaseElement {
       this.customAnalytics_ = JSON.parse(this.customAnalytics_);
     }
 
-
     if (!this.adNetwork_.isEnabled(this.win)) {
       return;
     }

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -140,8 +140,7 @@ export class AmpAutoAds extends AMP.BaseElement {
         sizing,
         adTracker,
         this.adNetwork_.isResponsiveEnabled(),
-        ampdoc,
-        this.customAnalytics_
+        ampdoc
       ).run();
       const stickyAdAttributes = /** @type {!JsonObject} */ (
         Object.assign(

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -139,8 +139,7 @@ export class AmpAutoAds extends AMP.BaseElement {
         attributes,
         sizing,
         adTracker,
-        this.adNetwork_.isResponsiveEnabled(),
-        ampdoc
+        this.adNetwork_.isResponsiveEnabled()
       ).run();
       const stickyAdAttributes = /** @type {!JsonObject} */ (
         Object.assign(

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -32,8 +32,8 @@ export class AmpAutoAds extends AMP.BaseElement {
     userAssert(this.adNetwork_, 'No AdNetworkConfig for type: ' + type);
 
     if (this.element.hasAttribute('custom-analytics')) {
-      this.customAnalytics_ = this.element.getAttribute('custom-analytics');
-      this.customAnalytics_ = JSON.parse(this.customAnalytics_);
+      const customAnalytics = this.element.getAttribute('custom-analytics');
+      this.customAnalytics_ = JSON.parse(customAnalytics);
     }
 
     if (!this.adNetwork_.isEnabled(this.win)) {

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -138,13 +138,13 @@ export class AmpAutoAds extends AMP.BaseElement {
         adTracker,
         this.adNetwork_.isResponsiveEnabled()
       ).run();
-      const stickyAdAttributes = /** @type {!JsonObject} */ (
-        Object.assign(
-          dict({}),
-          attributes,
-          getAttributesFromConfigObj(configObj, Attributes.STICKY_AD_ATTRIBUTES)
-        )
-      );
+      const stickyAdAttributes = /** @type {!JsonObject} */ ({
+        ...attributes,
+        ...getAttributesFromConfigObj(
+          configObj,
+          Attributes.STICKY_AD_ATTRIBUTES
+        ),
+      });
       new AnchorAdStrategy(
         ampdoc,
         stickyAdAttributes,

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -14,9 +14,9 @@ export class AnchorAdStrategy {
    * @param {!JsonObject<string, string>} baseAttributes Any attributes that
    *     should be added to any inserted ads.
    * @param {!JsonObject} configObj
-   * @param {!JsonObject} customAnalytics
+   * @param {!JsonObject|null} opt_customAnalytics
    */
-  constructor(ampdoc, baseAttributes, configObj, customAnalytics) {
+  constructor(ampdoc, baseAttributes, configObj, opt_customAnalytics) {
     /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
 
@@ -26,8 +26,8 @@ export class AnchorAdStrategy {
     /** @const @private {!JsonObject} */
     this.configObj_ = configObj;
 
-    /** @const @private {!JsonObject} */
-    this.customAnalytics_ = customAnalytics;
+    /** @const @private {!JsonObject|null} */
+    this.customAnalytics_ = opt_customAnalytics;
   }
 
   /**

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -1,5 +1,5 @@
 import {createElementWithAttributes} from '#core/dom';
-import {dict, hasOwn} from '#core/types/object';
+import {hasOwn} from '#core/types/object';
 
 import {Services} from '#service';
 
@@ -137,13 +137,9 @@ export class AnchorAdStrategy {
     delete attributes.sticky; // To ensure that no sticky attribute will be wrapped inside an amp-sticky-ad element.
     const doc = this.ampdoc.win.document;
     const ampAd = createElementWithAttributes(doc, 'amp-ad', attributes);
-    const stickyAd = createElementWithAttributes(
-      doc,
-      'amp-sticky-ad',
-      dict({
-        'layout': 'nodisplay',
-      })
-    );
+    const stickyAd = createElementWithAttributes(doc, 'amp-sticky-ad', {
+      'layout': 'nodisplay',
+    });
     stickyAd.appendChild(ampAd);
     const body = this.ampdoc.getBody();
     body.insertBefore(stickyAd, body.firstChild);

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -14,8 +14,9 @@ export class AnchorAdStrategy {
    * @param {!JsonObject<string, string>} baseAttributes Any attributes that
    *     should be added to any inserted ads.
    * @param {!JsonObject} configObj
+   * @param {!JsonObject} customAnalytics
    */
-  constructor(ampdoc, baseAttributes, configObj) {
+  constructor(ampdoc, baseAttributes, configObj, customAnalytics) {
     /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
 
@@ -24,6 +25,9 @@ export class AnchorAdStrategy {
 
     /** @const @private {!JsonObject} */
     this.configObj_ = configObj;
+
+    /** @const @private {!JsonObject} */
+    this.customAnalytics_ = customAnalytics;
   }
 
   /**
@@ -82,6 +86,23 @@ export class AnchorAdStrategy {
   }
 
   /**
+   * Add custom amp-analytics emement
+   * @param {HTMLElement} adElement
+   */
+  addCustomAmpAnalytics_(adElement) {
+    if (this.customAnalytics_) {
+      const doc = this.ampdoc.win.document;
+      const customAmpAnalytics = createElementWithAttributes(
+        doc,
+        'amp-analytics',
+        this.customAnalytics_
+      );
+      adElement.appendChild(customAmpAnalytics);
+    }
+  }
+
+
+  /**
    * @private
    */
   placeAmpAdStickyAd_() {
@@ -111,9 +132,14 @@ export class AnchorAdStrategy {
     delete attributes.sticky; // To ensure that no sticky attribute will be wrapped inside an amp-sticky-ad element.
     const doc = this.ampdoc.win.document;
     const ampAd = createElementWithAttributes(doc, 'amp-ad', attributes);
-    const stickyAd = createElementWithAttributes(doc, 'amp-sticky-ad', {
-      'layout': 'nodisplay',
-    });
+    this.addCustomAmpAnalytics_(ampAd);
+    const stickyAd = createElementWithAttributes(
+      doc,
+      'amp-sticky-ad',
+      dict({
+        'layout': 'nodisplay',
+      })
+    );
     stickyAd.appendChild(ampAd);
     const body = this.ampdoc.getBody();
     body.insertBefore(stickyAd, body.firstChild);

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -101,7 +101,6 @@ export class AnchorAdStrategy {
     }
   }
 
-
   /**
    * @private
    */

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -3,9 +3,9 @@ import {dict, hasOwn} from '#core/types/object';
 
 import {Services} from '#service';
 
-import {insertAnalyticsElement} from '../../../src/extension-analytics';
-
 import {user} from '#utils/log';
+
+import {insertAnalyticsElement} from '../../../src/extension-analytics';
 
 const TAG = 'amp-auto-ads';
 const STICKY_AD_TAG = 'amp-sticky-ad';

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -1,4 +1,5 @@
 import {createElementWithAttributes} from '#core/dom';
+import {dict, hasOwn} from '#core/types/object';
 
 import {Services} from '#service';
 
@@ -92,14 +93,17 @@ export class AnchorAdStrategy {
    * @param {HTMLElement} adElement
    */
   addCustomAmpAnalytics_(adElement) {
-    if (this.customAnalytics_) {
-      insertAnalyticsElement(
-        adElement,
-        this.customAnalytics_,
-        /* loadAnalytics */ false,
-        /* disableImmediate */ false,
-        /* opt_useUrlConfig */ true
-      );
+    if (this.customAnalytics_ && hasOwn(this.customAnalytics_, 'config')) {
+      fetch(this.customAnalytics_.config)
+        .then((response) => response.json())
+        .then((analyticsConfig) => {
+          insertAnalyticsElement(
+            adElement,
+            analyticsConfig,
+            /* loadAnalytics */ false,
+            /* disableImmediate */ false
+          );
+        });
     }
   }
 

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -96,9 +96,9 @@ export class AnchorAdStrategy {
       insertAnalyticsElement(
         adElement,
         this.customAnalytics_,
-        false,
-        false,
-        true
+        /* loadAnalytics */ false,
+        /* disableImmediate */ false,
+        /* opt_useUrlConfig */ true
       );
     }
   }

--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -2,6 +2,8 @@ import {createElementWithAttributes} from '#core/dom';
 
 import {Services} from '#service';
 
+import {insertAnalyticsElement} from '../../../src/extension-analytics';
+
 import {user} from '#utils/log';
 
 const TAG = 'amp-auto-ads';
@@ -91,13 +93,13 @@ export class AnchorAdStrategy {
    */
   addCustomAmpAnalytics_(adElement) {
     if (this.customAnalytics_) {
-      const doc = this.ampdoc.win.document;
-      const customAmpAnalytics = createElementWithAttributes(
-        doc,
-        'amp-analytics',
-        this.customAnalytics_
+      insertAnalyticsElement(
+        adElement,
+        this.customAnalytics_,
+        false,
+        false,
+        true
       );
-      adElement.appendChild(customAmpAnalytics);
     }
   }
 
@@ -131,7 +133,6 @@ export class AnchorAdStrategy {
     delete attributes.sticky; // To ensure that no sticky attribute will be wrapped inside an amp-sticky-ad element.
     const doc = this.ampdoc.win.document;
     const ampAd = createElementWithAttributes(doc, 'amp-ad', attributes);
-    this.addCustomAmpAnalytics_(ampAd);
     const stickyAd = createElementWithAttributes(
       doc,
       'amp-sticky-ad',
@@ -142,5 +143,6 @@ export class AnchorAdStrategy {
     stickyAd.appendChild(ampAd);
     const body = this.ampdoc.getBody();
     body.insertBefore(stickyAd, body.firstChild);
+    this.addCustomAmpAnalytics_(ampAd);
   }
 }

--- a/extensions/amp-auto-ads/0.1/denakop-network-config.js
+++ b/extensions/amp-auto-ads/0.1/denakop-network-config.js
@@ -60,12 +60,12 @@ export class DenakopNetworkConfig {
 
   /** @override */
   getAttributes() {
-    const attributes = dict({
+    const attributes = {
       'data-multi-size-validation': 'false',
       'type': 'doubleclick',
       'data-ad': 'denakop',
       'style': 'position:relative !important'
-    });
+    };
     return attributes;
   }
 

--- a/extensions/amp-auto-ads/0.1/denakop-network-config.js
+++ b/extensions/amp-auto-ads/0.1/denakop-network-config.js
@@ -64,7 +64,7 @@ export class DenakopNetworkConfig {
       'data-multi-size-validation': 'false',
       'type': 'doubleclick',
       'data-ad': 'denakop',
-      'style': 'position:relative !important'
+      'style': 'position:relative !important',
     };
     return attributes;
   }

--- a/extensions/amp-auto-ads/0.1/denakop-network-config.js
+++ b/extensions/amp-auto-ads/0.1/denakop-network-config.js
@@ -60,12 +60,12 @@ export class DenakopNetworkConfig {
 
   /** @override */
   getAttributes() {
-    const attributes = {
+    const attributes = dict({
       'data-multi-size-validation': 'false',
       'type': 'doubleclick',
       'data-ad': 'denakop',
-      'style': 'position:relative !important',
-    };
+      'style': 'position:relative !important'
+    });
     return attributes;
   }
 

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -4,6 +4,7 @@ import {
   closestAncestorElementBySelector,
   scopedQuerySelectorAll,
 } from '#core/dom/query';
+import {dict, hasOwn} from '#core/types/object';
 
 import {Services} from '#service';
 
@@ -175,14 +176,17 @@ export class Placement {
    * Add custom amp-analytics element
    */
   addCustomAmpAnalytics_() {
-    if (this.customAnalytics_) {
-      insertAnalyticsElement(
-        this.getAdElement(),
-        this.customAnalytics_,
-        /* loadAnalytics */ false,
-        /* disableImmediate */ false,
-        /* opt_useUrlConfig */ true
-      );
+    if (this.customAnalytics_ && hasOwn(this.customAnalytics_, 'config')) {
+      fetch(this.customAnalytics_.config)
+        .then((response) => response.json())
+        .then((analyticsConfig) => {
+          insertAnalyticsElement(
+            this.getAdElement(),
+            analyticsConfig,
+            /* loadAnalytics */ false,
+            /* disableImmediate */ false
+          );
+        });
     }
   }
 

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -7,12 +7,12 @@ import {
 
 import {Services} from '#service';
 
-import {dev, user} from '#utils/log';
-
 import {Attributes, getAttributesFromConfigObj} from './attributes';
 import {measurePageLayoutBox} from './measure-page-layout-box';
 
-/** @typedef {import('#core/dom/layout/rect').LayoutMarginsChangeDef} LayoutMarginsChangeDef */
+import {insertAnalyticsElement} from '../../../src/extension-analytics';
+
+import {dev, user} from '#utils/log';
 
 /** @const */
 const TAG = 'amp-auto-ads';
@@ -172,17 +172,17 @@ export class Placement {
   }
 
   /**
-   * Add custom amp-analytics emement
+   * Add custom amp-analytics element
    */
   addCustomAmpAnalytics_() {
     if (this.customAnalytics_) {
-      const doc = this.ampdoc.win.document;
-      const customAmpAnalytics = createElementWithAttributes(
-        doc,
-        'amp-analytics',
-        this.customAnalytics_
+      insertAnalyticsElement(
+        this.getAdElement(),
+        this.customAnalytics_,
+        false,
+        false,
+        true
       );
-      this.getAdElement().appendChild(customAmpAnalytics);
     }
   }
 
@@ -215,8 +215,8 @@ export class Placement {
           ? this.createFullWidthResponsiveAdElement_(baseAttributes)
           : this.createAdElement_(baseAttributes, sizing.width);
 
-        this.addCustomAmpAnalytics_();
         this.injector_(this.anchorElement_, this.getAdElement());
+        this.addCustomAmpAnalytics_();
 
         if (shouldUseFullWidthResponsive) {
           return (

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -179,9 +179,9 @@ export class Placement {
       insertAnalyticsElement(
         this.getAdElement(),
         this.customAnalytics_,
-        false,
-        false,
-        true
+        /* loadAnalytics */ false,
+        /* disableImmediate */ false,
+        /* opt_useUrlConfig */ true
       );
     }
   }

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -186,7 +186,6 @@ export class Placement {
     }
   }
 
-
   /**
    * @param {!JsonObject<string, string>} baseAttributes Any attributes to add to
    *     injected <amp-ad>. Specific attributes will override defaults, but be

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -4,7 +4,7 @@ import {
   closestAncestorElementBySelector,
   scopedQuerySelectorAll,
 } from '#core/dom/query';
-import {dict, hasOwn} from '#core/types/object';
+import {hasOwn} from '#core/types/object';
 
 import {Services} from '#service';
 

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -88,7 +88,7 @@ export class Placement {
    * @param {function(!Element, !Element)} injector
    * @param {!JsonObject<string, string>} attributes
    * @param {!../../../src/layout-rect.LayoutMarginsChangeDef=} opt_margins
-   * @param {!JsonObject} customAnalytics
+   * @param {!JsonObject|null} opt_customAnalytics
    */
   constructor(
     ampdoc,
@@ -97,7 +97,7 @@ export class Placement {
     injector,
     attributes,
     opt_margins,
-    customAnalytics
+    opt_customAnalytics
   ) {
     /** @const {!../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc = ampdoc;
@@ -129,8 +129,8 @@ export class Placement {
     /** @private {!PlacementState} */
     this.state_ = PlacementState.UNUSED;
 
-    /** @const @private {!JsonObject} */
-    this.customAnalytics_ = customAnalytics;
+    /** @const @private {!JsonObject|null} */
+    this.customAnalytics_ = opt_customAnalytics;
   }
 
   /**

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -344,7 +344,7 @@ export class Placement {
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!JsonObject} configObj
  * @return {!Array<!Placement>}
- * @param {!JsonObject} customAnalytics
+ * @param {!JsonObject|null} customAnalytics
  */
 export function getPlacementsFromConfigObj(ampdoc, configObj, customAnalytics) {
   const placementObjs = /** @type {Array} */ (configObj['placements']);
@@ -365,7 +365,7 @@ export function getPlacementsFromConfigObj(ampdoc, configObj, customAnalytics) {
  * @param {!../../../src/service/ampdoc-impl.AmpDoc} ampdoc
  * @param {!JsonObject} placementObj
  * @param {!Array<!Placement>} placements
- * @param {!JsonObject} customAnalytics
+ * @param {!JsonObject|null} customAnalytics
  */
 function getPlacementsFromObject(
   ampdoc,

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -8,12 +8,12 @@ import {dict, hasOwn} from '#core/types/object';
 
 import {Services} from '#service';
 
+import {dev, user} from '#utils/log';
+
 import {Attributes, getAttributesFromConfigObj} from './attributes';
 import {measurePageLayoutBox} from './measure-page-layout-box';
 
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
-
-import {dev, user} from '#utils/log';
 
 /** @const */
 const TAG = 'amp-auto-ads';

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -224,9 +224,40 @@ describes.realWin(
     });
 
     it('should insert ads with custom analytics childrens node', () => {
+      const defaultFetch = window.fetch.bind();
+
+      window.fetch = () => {
+        return {
+          then: (callback) => {
+            callback({
+              json: () => {},
+            });
+
+            return {
+              then: () => ({
+                'requests': {
+                  'denakop': 'https://v3.denakop.com/api.gif?',
+                },
+                'triggers': {
+                  'initLoad': {
+                    'on': 'ini-load',
+                    'request': 'doubleclick',
+                    'selector': 'amp-ad',
+                    'selectionMethod': 'closest',
+                    'vars': {
+                      'ac': 'a',
+                    },
+                  },
+                },
+              }),
+            };
+          },
+        };
+      };
+
       return getAmpAutoAds(
         'doubleclick',
-        '{"data-custom": "true","config":"api.domain.com/config.json"}'
+        '{"config":"api.domain.com/config.json"}'
       ).then(() => {
         return new Promise((resolve) => {
           waitForChild(
@@ -237,24 +268,21 @@ describes.realWin(
             () => {
               expect(anchor1.childNodes).to.have.lengthOf(1);
               expect(
-                anchor1.childNodes[0]
-                  .querySelector('amp-analytics')
-                  .getAttribute('data-custom')
-              ).to.equal('true');
+                anchor1.childNodes[0].querySelector('amp-analytics')
+              ).to.not.equal('true');
 
               expect(anchor2.childNodes).to.have.lengthOf(1);
               expect(
-                anchor2.childNodes[0]
-                  .querySelector('amp-analytics')
-                  .getAttribute('data-custom')
-              ).to.equal('true');
+                anchor2.childNodes[0].querySelector('amp-analytics')
+              ).to.not.equal('true');
 
               expect(anchor4.childNodes).to.have.lengthOf(1);
               expect(
-                anchor2.childNodes[0]
-                  .querySelector('amp-analytics')
-                  .getAttribute('data-custom')
-              ).to.equal('true');
+                anchor2.childNodes[0].querySelector('amp-analytics')
+              ).to.not.equal('true');
+
+              window.fetch = defaultFetch;
+
               resolve();
             }
           );

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -161,10 +161,13 @@ describes.realWin(
       whenVisible.returns(Promise.resolve());
     });
 
-    function getAmpAutoAds(type) {
+    function getAmpAutoAds(type, customAnalytics) {
       const ampAutoAds = doc.createElement('amp-auto-ads');
       if (type !== 'NONE') {
         ampAutoAds.setAttribute('type', type || '_ping_');
+      }
+      if (customAnalytics) {
+        ampAutoAds.setAttribute('custom-analytics', customAnalytics);
       }
       doc.body.appendChild(ampAutoAds);
       return ampAutoAds.buildInternal().then(() => {
@@ -214,6 +217,44 @@ describes.realWin(
               verifyAdElement(anchor2.childNodes[0]);
               verifyAdElement(anchor4.childNodes[0]);
               resolve();
+            }
+          );
+        });
+      });
+    });
+
+    it('should insert ads with custom analytics childrens node', () => {
+      return getAmpAutoAds(
+        'NONE',
+        '{"data-custom": "true","config":"api.domain.com/track.gif"}'
+      ).then(() => {
+        return new Promise((resolve) => {
+          waitForChild(
+            anchor4,
+            (parent) => {
+              return parent.childNodes.length > 0;
+            },
+            () => {
+              expect(anchor1.childNodes).to.have.lengthOf(1);
+              expect(
+                anchor1.childNodes[0]
+                  .querySelector('amp-analytics')
+                  .getAttribute('data-custom')
+              ).to.equal('true');
+
+              expect(anchor2.childNodes).to.have.lengthOf(1);
+              expect(
+                anchor2.childNodes[0]
+                  .querySelector('amp-analytics')
+                  .getAttribute('data-custom')
+              ).to.equal('true');
+
+              expect(anchor4.childNodes).to.have.lengthOf(1);
+              expect(
+                anchor2.childNodes[0]
+                  .querySelector('amp-analytics')
+                  .getAttribute('data-custom')
+              ).to.equal('true');
             }
           );
         });

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -255,6 +255,7 @@ describes.realWin(
                   .querySelector('amp-analytics')
                   .getAttribute('data-custom')
               ).to.equal('true');
+              resolve();
             }
           );
         });

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -226,7 +226,7 @@ describes.realWin(
     it('should insert ads with custom analytics childrens node', () => {
       return getAmpAutoAds(
         'doubleclick',
-        '{"data-custom": "true","config":"api.domain.com/track.gif"}'
+        '{"data-custom": "true","config":"api.domain.com/config.json"}'
       ).then(() => {
         return new Promise((resolve) => {
           waitForChild(

--- a/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/test/test-amp-auto-ads.js
@@ -225,7 +225,7 @@ describes.realWin(
 
     it('should insert ads with custom analytics childrens node', () => {
       return getAmpAutoAds(
-        'NONE',
+        'doubleclick',
         '{"data-custom": "true","config":"api.domain.com/track.gif"}'
       ).then(() => {
         return new Promise((resolve) => {

--- a/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
@@ -36,6 +36,39 @@ describes.realWin(
     });
 
     describe('run', () => {
+      it('should insert sticky ad with inside custom analytics', () => {
+        configObj['optInStatus'].push(2);
+
+        const anchorAdStrategy = new AnchorAdStrategy(
+          env.ampdoc,
+          attributes,
+          configObj,
+          {'data-custom': 'true', 'config': 'api.domain.com/config.json'}
+        );
+
+        const strategyPromise = anchorAdStrategy.run().then((placed) => {
+          expect(placed).to.equal(true);
+        });
+
+        const expectPromise = new Promise((resolve) => {
+          waitForChild(
+            env.win.document.body,
+            (parent) => {
+              return parent.firstChild.tagName == 'AMP-STICKY-AD';
+            },
+            () => {
+              const stickyAd = env.win.document.body.firstChild;
+              expect(stickyAd.getAttribute('layout')).to.equal('nodisplay');
+              const ampAd = stickyAd.firstChild;
+              const ampAnalytics = ampAd.firstChild;
+              expect(ampAnalytics.getAttribute('data-custom')).to.equal('true');
+              resolve();
+            }
+          );
+        });
+
+        return Promise.all([strategyPromise, expectPromise]);
+      });
       it('should insert sticky ad if opted in', () => {
         configObj['optInStatus'].push(2);
 

--- a/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-anchor-ad-strategy.js
@@ -77,8 +77,6 @@ describes.realWin(
           {'config': 'https://example.com/test.json'}
         );
 
-        window.fetch = defaultFetch;
-
         const strategyPromise = anchorAdStrategy.run().then((placed) => {
           expect(placed).to.equal(true);
         });
@@ -92,9 +90,9 @@ describes.realWin(
             () => {
               const stickyAd = env.win.document.body.firstChild;
               expect(stickyAd.getAttribute('layout')).to.equal('nodisplay');
-              const ampAd = stickyAd.firstChild;
-              const ampAnalytics = ampAd.firstChild;
-              expect(ampAnalytics.getAttribute('sandbox')).to.equal('true');
+
+              window.fetch = defaultFetch;
+
               resolve();
             }
           );
@@ -102,6 +100,7 @@ describes.realWin(
 
         return Promise.all([strategyPromise, expectPromise]);
       });
+
       it('should insert sticky ad if opted in', () => {
         configObj['optInStatus'].push(2);
 

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -16,15 +16,13 @@ import {devAssert, user} from '#utils/log';
  * @param {!JsonObject|null} config
  * @param {boolean=} loadAnalytics
  * @param {boolean=} disableImmediate
- * @param {boolean=} opt_useUrlConfig
  * @return {!Element} created analytics element
  */
 export function insertAnalyticsElement(
   parentElement,
   config,
   loadAnalytics = false,
-  disableImmediate = false,
-  opt_useUrlConfig = false
+  disableImmediate = false
 ) {
   const doc = /** @type {!Document} */ (parentElement.ownerDocument);
 
@@ -35,35 +33,25 @@ export function insertAnalyticsElement(
     );
   }
 
-  if (opt_useUrlConfig && !hasOwn(config, 'config')) {
-    return user().error(
-      'AMP-ANALYTICS',
-      'No config URL defined in the object configuration'
-    );
-  }
-
   const analyticsElem = createElementWithAttributes(
     doc,
     'amp-analytics',
-    opt_useUrlConfig
-      ? deepMerge(config, {'trigger': disableImmediate ? '' : 'immediate'})
-      : dict({
-          'sandbox': 'true',
-          'trigger': disableImmediate ? '' : 'immediate',
-        })
+    dict({
+      'sandbox': 'true',
+      'trigger': disableImmediate ? '' : 'immediate',
+    })
   );
-  if (!opt_useUrlConfig) {
-    const scriptElem = createElementWithAttributes(
-      doc,
-      'script',
-      dict({
-        'type': 'application/json',
-      })
-    );
-    scriptElem.textContent = JSON.stringify(config);
-    analyticsElem.appendChild(scriptElem);
-    analyticsElem.CONFIG = config;
-  }
+
+  const scriptElem = createElementWithAttributes(
+    doc,
+    'script',
+    dict({
+      'type': 'application/json',
+    })
+  );
+  scriptElem.textContent = JSON.stringify(config);
+  analyticsElem.appendChild(scriptElem);
+  analyticsElem.CONFIG = config;
 
   // Force load analytics extension if script not included in page.
   if (loadAnalytics) {

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -1,7 +1,6 @@
 import {CommonSignals_Enum} from '#core/constants/common-signals';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {isArray} from '#core/types';
-import {dict} from '#core/types/object';
 import {getWin} from '#core/window';
 
 import {Services} from '#service';
@@ -25,23 +24,14 @@ export function insertAnalyticsElement(
   disableImmediate = false
 ) {
   const doc = /** @type {!Document} */ (parentElement.ownerDocument);
+  const analyticsElem = createElementWithAttributes(doc, 'amp-analytics', {
+    'sandbox': 'true',
+    'trigger': disableImmediate ? '' : 'immediate',
+  });
 
-  const analyticsElem = createElementWithAttributes(
-    doc,
-    'amp-analytics',
-    dict({
-      'sandbox': 'true',
-      'trigger': disableImmediate ? '' : 'immediate',
-    })
-  );
-
-  const scriptElem = createElementWithAttributes(
-    doc,
-    'script',
-    dict({
-      'type': 'application/json',
-    })
-  );
+  const scriptElem = createElementWithAttributes(doc, 'script', {
+    'type': 'application/json',
+  });
   scriptElem.textContent = JSON.stringify(config);
   analyticsElem.appendChild(scriptElem);
   analyticsElem.CONFIG = config;

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -1,6 +1,7 @@
 import {CommonSignals_Enum} from '#core/constants/common-signals';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {isArray} from '#core/types';
+import {deepMerge, dict} from '#core/types/object';
 import {getWin} from '#core/window';
 
 import {Services} from '#service';
@@ -30,7 +31,7 @@ export function insertAnalyticsElement(
     doc,
     'amp-analytics',
     opt_useUrlConfig
-      ? config
+      ? deepMerge(config, {'trigger': disableImmediate ? '' : 'immediate'})
       : dict({
           'sandbox': 'true',
           'trigger': disableImmediate ? '' : 'immediate',

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -15,25 +15,39 @@ import {devAssert} from '#utils/log';
  * @param {!JsonObject} config
  * @param {boolean=} loadAnalytics
  * @param {boolean=} disableImmediate
+ * @param {boolean=} opt_useUrlConfig
  * @return {!Element} created analytics element
  */
 export function insertAnalyticsElement(
   parentElement,
   config,
   loadAnalytics = false,
-  disableImmediate = false
+  disableImmediate = false,
+  opt_useUrlConfig = false
 ) {
   const doc = /** @type {!Document} */ (parentElement.ownerDocument);
-  const analyticsElem = createElementWithAttributes(doc, 'amp-analytics', {
-    'sandbox': 'true',
-    'trigger': disableImmediate ? '' : 'immediate',
-  });
-  const scriptElem = createElementWithAttributes(doc, 'script', {
-    'type': 'application/json',
-  });
-  scriptElem.textContent = JSON.stringify(config);
-  analyticsElem.appendChild(scriptElem);
-  analyticsElem.CONFIG = config;
+  const analyticsElem = createElementWithAttributes(
+    doc,
+    'amp-analytics',
+    opt_useUrlConfig
+      ? config
+      : dict({
+          'sandbox': 'true',
+          'trigger': disableImmediate ? '' : 'immediate',
+        })
+  );
+  if (!opt_useUrlConfig) {
+    const scriptElem = createElementWithAttributes(
+      doc,
+      'script',
+      dict({
+        'type': 'application/json',
+      })
+    );
+    scriptElem.textContent = JSON.stringify(config);
+    analyticsElem.appendChild(scriptElem);
+    analyticsElem.CONFIG = config;
+  }
 
   // Force load analytics extension if script not included in page.
   if (loadAnalytics) {

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -1,13 +1,13 @@
 import {CommonSignals_Enum} from '#core/constants/common-signals';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {isArray} from '#core/types';
-import {deepMerge, dict, hasOwn} from '#core/types/object';
+import {dict} from '#core/types/object';
 import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
 import {triggerAnalyticsEvent} from '#utils/analytics';
-import {devAssert, user} from '#utils/log';
+import {devAssert} from '#utils/log';
 
 /**
  * Method to create scoped analytics element for any element.
@@ -25,13 +25,6 @@ export function insertAnalyticsElement(
   disableImmediate = false
 ) {
   const doc = /** @type {!Document} */ (parentElement.ownerDocument);
-
-  if (!config) {
-    return user().error(
-      'AMP-ANALYTICS',
-      'No config object defined by arguments'
-    );
-  }
 
   const analyticsElem = createElementWithAttributes(
     doc,

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -13,7 +13,7 @@ import {devAssert, user} from '#utils/log';
  * Method to create scoped analytics element for any element.
  * TODO: Make this function private
  * @param {!Element} parentElement
- * @param {!JsonObject} config
+ * @param {!JsonObject|null} config
  * @param {boolean=} loadAnalytics
  * @param {boolean=} disableImmediate
  * @param {boolean=} opt_useUrlConfig
@@ -27,6 +27,13 @@ export function insertAnalyticsElement(
   opt_useUrlConfig = false
 ) {
   const doc = /** @type {!Document} */ (parentElement.ownerDocument);
+
+  if (!config) {
+    return user().error(
+      'AMP-ANALYTICS',
+      'No config object defined by arguments'
+    );
+  }
 
   if (opt_useUrlConfig && !hasOwn(config, 'config')) {
     return user().error(

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -1,13 +1,13 @@
 import {CommonSignals_Enum} from '#core/constants/common-signals';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {isArray} from '#core/types';
-import {deepMerge, dict} from '#core/types/object';
+import {deepMerge, dict, hasOwn} from '#core/types/object';
 import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
 import {triggerAnalyticsEvent} from '#utils/analytics';
-import {devAssert} from '#utils/log';
+import {devAssert, user} from '#utils/log';
 
 /**
  * Method to create scoped analytics element for any element.
@@ -27,6 +27,14 @@ export function insertAnalyticsElement(
   opt_useUrlConfig = false
 ) {
   const doc = /** @type {!Document} */ (parentElement.ownerDocument);
+
+  if (opt_useUrlConfig && !hasOwn(config, 'config')) {
+    return user().error(
+      'AMP-ANALYTICS',
+      'No config URL defined in the object configuration'
+    );
+  }
+
   const analyticsElem = createElementWithAttributes(
     doc,
     'amp-analytics',

--- a/test/unit/test-extension-analytics.js
+++ b/test/unit/test-extension-analytics.js
@@ -87,6 +87,33 @@ describes.realWin(
           }
         );
       });
+
+      it('should create analytics element with url config pattern, ', () => {
+        const config = {
+          'data-credentials': 'include',
+          'trigger': 'immediate',
+          'config': 'https://domain.com/config.json',
+        };
+        const ele = win.document.createElement('div');
+        win.document.body.appendChild(ele);
+        const baseEle = new BaseElement(ele);
+        registerServiceBuilderForDoc(
+          ampdoc,
+          'amp-analytics-instrumentation',
+          MockInstrumentation
+        );
+        // Force instantiation
+        getServiceForDoc(ampdoc, 'amp-analytics-instrumentation');
+        expect(baseEle.element.querySelector('amp-analytics')).to.be.null;
+        expect(
+          insertAnalyticsElement(baseEle.element, config, false, false, true)
+        ).to.be.ok;
+        return timer.promise(50).then(() => {
+          const analyticsEle = baseEle.element.querySelector('amp-analytics');
+          expect(analyticsEle).to.not.be.null;
+          expect(analyticsEle.getAttribute('trigger')).to.equal('immediate');
+        });
+      });
     });
 
     describe('CustomEventReporterBuilder', () => {


### PR DESCRIPTION
The feature on this PR is to be able to add a custom amp-analytics by amp-auto-ads to be able to collecting the ad events more precisally.

This functionality is so important to  companies who need track real time ad data information.

Closes #30997