### PR TITLE
Make amp-form failure message developer-friendlier

### DIFF
--- a/src/ssr-template-helper.js
+++ b/src/ssr-template-helper.js
@@ -106,7 +106,7 @@ export class SsrTemplateHelper {
     if (this.isEnabled()) {
       userAssert(
         typeof data['html'] === 'string',
-        'Server side html response must be defined'
+        'Skipping template rendering due to failed fetch'
       );
       renderTemplatePromise = this.assertTrustedViewer(element).then(() => {
         return this.templates_.findAndSetHtmlForTemplate(

--- a/test/unit/test-ssr-template-helper.js
+++ b/test/unit/test-ssr-template-helper.js
@@ -176,7 +176,7 @@ describes.fakeWin(
           allowConsoleError(() => {
             expect(() => {
               ssrTemplateHelper.applySsrOrCsrTemplate({}, {html: null});
-            }).to.throw(/Server side html response must be defined/);
+            }).to.throw(/Skipping template rendering due to failed fetch/);
           });
         });
 


### PR DESCRIPTION
This can happen whenever the XHR proxy server returns an error and
doesn't include the HTML to render the submit-failure template (e.g.,
AMP CORS failure, unreachable proxy). Sever-side rendering of template
is an implementation detail of AMP for Email that developers shouldn't
care about so it makes sense to change this to one that would make more
sense for developers.

/to @caroqliu 
