### PR TITLE
❄️ Disable flaky test in `extensions/amp-video/0.1/test-e2e/test-amp-video-flexible-bitrate.js`

### DIFF
--- a/extensions/amp-video/0.1/test-e2e/test-amp-video-flexible-bitrate.js
+++ b/extensions/amp-video/0.1/test-e2e/test-amp-video-flexible-bitrate.js
@@ -235,7 +235,8 @@ describes.endtoend(
         ).contains('#high');
       });
 
-      it('loads a low quality source on a far video when the connection drops and the user advances to that page', async () => {
+      // TODO(#35966): fix flaky test (disabled in #35967)
+      it.skip('loads a low quality source on a far video when the connection drops and the user advances to that page', async () => {
         await forceEventOnVideo(VIDEO_EVENTS.DOWNGRADE, 1);
         await forceEventOnVideo(VIDEO_EVENTS.UNLOAD, 4);
         await controller.click(story);


### PR DESCRIPTION
To unblock `main` builds

e.g., https://app.circleci.com/pipelines/github/ampproject/amphtml/16009/workflows/c8ef54fd-ca20-4d21-9825-d48fe76c5891/jobs/282926/tests