### PR TITLE
Update `BentoFitText` Storybook title to 'FitText'

### DIFF
--- a/extensions/amp-fit-text/1.0/storybook/Basic.js
+++ b/extensions/amp-fit-text/1.0/storybook/Basic.js
@@ -3,7 +3,7 @@ import {BentoFitText} from '../component';
 import {number, text, withKnobs} from '@storybook/addon-knobs';
 
 export default {
-  title: 'BentoFitText',
+  title: 'FitText',
   component: BentoFitText,
   decorators: [withKnobs],
 };


### PR DESCRIPTION
Last week's Bento meeting, we decided the Storybook titles should not be `Bento` prefixed so that they can be more easily delineated in the sidebar where samples are displayed.