### PR TITLE
Update Storybook template to differentiate between `Foo` and `BentoFoo`

### DIFF
--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -226,6 +226,7 @@ async function makeExtensionFromTemplates(
     '__component_name_hyphenated__': name,
     '__component_name_hyphenated_capitalized__': name.toUpperCase(),
     '__component_name_pascalcase__': namePascalCase,
+    '__bento_component_name_pascalcase__': `Bento${namePascalCase}`,
     // TODO(alanorozco): Remove __storybook_experiments...__ once we stop
     // requiring the bento experiment.
     '__storybook_experiments_do_not_add_trailing_comma__':

--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -226,7 +226,6 @@ async function makeExtensionFromTemplates(
     '__component_name_hyphenated__': name,
     '__component_name_hyphenated_capitalized__': name.toUpperCase(),
     '__component_name_pascalcase__': namePascalCase,
-    '__bento_component_name_pascalcase__': `Bento${namePascalCase}`,
     // TODO(alanorozco): Remove __storybook_experiments...__ once we stop
     // requiring the bento experiment.
     '__storybook_experiments_do_not_add_trailing_comma__':

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
@@ -1,11 +1,11 @@
 __jss_import_component_css__;
-import {__bento_component_name_pascalcase__} from './component';
+import {Bento__component_name_pascal_case__} from './component';
 import {PreactBaseElement} from '#preact/base-element';
 
 export class BaseElement extends PreactBaseElement {}
 
 /** @override */
-BaseElement['Component'] = __bento_component_name_pascalcase__;
+BaseElement['Component'] = Bento__component_name_pascal_case__;
 
 /** @override */
 BaseElement['props'] = {

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
@@ -1,11 +1,11 @@
 __jss_import_component_css__;
-import {__component_name_pascalcase__} from './component';
+import {__bento_component_name_pascalcase__} from './component';
 import {PreactBaseElement} from '#preact/base-element';
 
 export class BaseElement extends PreactBaseElement {}
 
 /** @override */
-BaseElement['Component'] = __component_name_pascalcase__;
+BaseElement['Component'] = __bento_component_name_pascalcase__;
 
 /** @override */
 BaseElement['props'] = {

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
@@ -11,10 +11,10 @@ import {
 __jss_import_use_styles__;
 
 /**
- * @param {!__bento_component_name_pascalcase__.Props} props
+ * @param {!Bento__component_name_pascal_case__.Props} props
  * @return {PreactDef.Renderable}
  */
-export function __bento_component_name_pascalcase__({exampleTagNameProp, ...rest}) {
+export function Bento__component_name_pascal_case__({exampleTagNameProp, ...rest}) {
   // Examples of state and hooks
   // __do_not_submit__: This is example code only.
   const [exampleValue, setExampleValue] = useState(0);

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
@@ -11,10 +11,10 @@ import {
 __jss_import_use_styles__;
 
 /**
- * @param {!__component_name_pascalcase__Def.Props} props
+ * @param {!__bento_component_name_pascalcase__.Props} props
  * @return {PreactDef.Renderable}
  */
-export function __component_name_pascalcase__({exampleTagNameProp, ...rest}) {
+export function __bento_component_name_pascalcase__({exampleTagNameProp, ...rest}) {
   // Examples of state and hooks
   // __do_not_submit__: This is example code only.
   const [exampleValue, setExampleValue] = useState(0);

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
@@ -1,17 +1,17 @@
 /** @externs */
 
 /** @const */
-var __bento_component_name_pascalcase__Def = {};
+var Bento__component_name_pascal_case__Def = {};
 
 /**
  * @typedef {{
  *   exampleProperty: (string|undefined), (__do_not_submit__)
  * }}
  */
-__bento_component_name_pascalcase__Def.Props;
+Bento__component_name_pascal_case__Def.Props;
 
 /** @interface */
-__bento_component_name_pascalcase__Def.__bento_component_name_pascalcase__Api = class {
+Bento__component_name_pascal_case__Def.Bento__component_name_pascal_case__Api = class {
   /** Example: API method to toggle the component */
   exampleToggle() {} // __do_not_submit__
 };

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
@@ -1,17 +1,17 @@
 /** @externs */
 
 /** @const */
-var __component_name_pascalcase__Def = {};
+var __bento_component_name_pascalcase__Def = {};
 
 /**
  * @typedef {{
  *   exampleProperty: (string|undefined), (__do_not_submit__)
  * }}
  */
-__component_name_pascalcase__Def.Props;
+__bento_component_name_pascalcase__Def.Props;
 
 /** @interface */
-__component_name_pascalcase__Def.__component_name_pascalcase__Api = class {
+__bento_component_name_pascalcase__Def.__bento_component_name_pascalcase__Api = class {
   /** Example: API method to toggle the component */
   exampleToggle() {} // __do_not_submit__
 };

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
@@ -1,9 +1,9 @@
 import * as Preact from '#preact';
-import {__component_name_pascalcase__} from '../component'
+import {__bento_component_name_pascalcase__} from '../component'
 
 export default {
   title: '__component_name_pascalcase__',
-  component: __component_name_pascalcase__,
+  component: __bento_component_name_pascalcase__,
   args: {
     'exampleProperty': 'example string property argument'
   }
@@ -12,11 +12,11 @@ export default {
 // __do_not_submit__: This is example code only.
 export const _default = (args) => {
   return (
-    <__component_name_pascalcase__
+    <__bento_component_name_pascalcase__
       style={{width: 300, height: 200}}
       {...args}
     >
       This text is inside.
-    </__component_name_pascalcase__>
+    </__bento_component_name_pascalcase__>
   );
 };

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
@@ -1,9 +1,9 @@
 import * as Preact from '#preact';
-import {__bento_component_name_pascalcase__} from '../component'
+import {Bento__component_name_pascal_case__} from '../component'
 
 export default {
   title: '__component_name_pascalcase__',
-  component: __bento_component_name_pascalcase__,
+  component: Bento__component_name_pascal_case__,
   args: {
     'exampleProperty': 'example string property argument'
   }
@@ -12,11 +12,11 @@ export default {
 // __do_not_submit__: This is example code only.
 export const _default = (args) => {
   return (
-    <__bento_component_name_pascalcase__
+    <Bento__component_name_pascal_case__
       style={{width: 300, height: 200}}
       {...args}
     >
       This text is inside.
-    </__bento_component_name_pascalcase__>
+    </Bento__component_name_pascal_case__>
   );
 };

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
@@ -1,16 +1,16 @@
 import * as Preact from '#preact';
-import {__component_name_pascalcase__} from '../component';
+import {__bento_component_name_pascalcase__} from '../component';
 import {mount} from 'enzyme';
 import {waitFor} from '#testing/test-helper';
 
-describes.sandboxed('__component_name_pascalcase__ preact component v1.0', {}, (env) => {
+describes.sandboxed('__bento_component_name_pascalcase__ preact component v1.0', {}, (env) => {
   // __do_not_submit__: This is example code only.
   it('should render', () => {
     const wrapper = mount(
-      <__component_name_pascalcase__ testProp={true}/>
+      <__bento_component_name_pascalcase__ testProp={true}/>
     );
 
-    const component = wrapper.find(__component_name_pascalcase__.name);
+    const component = wrapper.find(__bento_component_name_pascalcase__.name);
     expect(component).to.have.lengthOf(1);
     expect(component.prop('testProp')).to.be.true;
   });

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
@@ -1,16 +1,16 @@
 import * as Preact from '#preact';
-import {__bento_component_name_pascalcase__} from '../component';
+import {Bento__component_name_pascal_case__} from '../component';
 import {mount} from 'enzyme';
 import {waitFor} from '#testing/test-helper';
 
-describes.sandboxed('__bento_component_name_pascalcase__ preact component v1.0', {}, (env) => {
+describes.sandboxed('Bento__component_name_pascal_case__ preact component v1.0', {}, (env) => {
   // __do_not_submit__: This is example code only.
   it('should render', () => {
     const wrapper = mount(
-      <__bento_component_name_pascalcase__ testProp={true}/>
+      <Bento__component_name_pascal_case__ testProp={true}/>
     );
 
-    const component = wrapper.find(__bento_component_name_pascalcase__.name);
+    const component = wrapper.find(Bento__component_name_pascal_case__.name);
     expect(component).to.have.lengthOf(1);
     expect(component.prop('testProp')).to.be.true;
   });


### PR DESCRIPTION
Replaces `__component_name_pascalcase__` with `Bento__component_name_pascalcase__` in all cases except:
- `class Amp__component_name_pascalcase__ extends BaseElement`
- Storybook `title: '__component_name_pascalcase__'`