### PR TITLE
✨ compiler.js: myriad fixes

### DIFF
--- a/build-system/compile/build-compiler.js
+++ b/build-system/compile/build-compiler.js
@@ -1,0 +1,18 @@
+const esbuild = require('esbuild');
+const {endBuildStep} = require('../tasks/helpers');
+
+/**
+ * Builds the compiler.js binary.
+ *
+ * @return {Promise<void>}
+ */
+async function buildCompiler() {
+  const startTime = Date.now();
+  await esbuild.build({
+    entryPoints: ['src/compiler/index.js'],
+    outfile: 'dist/compiler.js',
+    bundle: true,
+  });
+  endBuildStep('Compiled', 'compiler.js', startTime);
+}
+module.exports = {buildCompiler};

--- a/build-system/compile/build-compiler.js
+++ b/build-system/compile/build-compiler.js
@@ -1,5 +1,4 @@
 const esbuild = require('esbuild');
-const {BUILD_CONSTANTS} = require('./build-constants');
 const {endBuildStep} = require('../tasks/helpers');
 
 /**
@@ -10,20 +9,16 @@ const {endBuildStep} = require('../tasks/helpers');
 async function buildCompiler() {
   const startTime = Date.now();
 
-  // Build constants used to replace mode constants.
-  const define = Object.fromEntries(
-    Object.entries(BUILD_CONSTANTS)
-      .filter(([unused, v]) => typeof v === 'boolean')
-      .map(([k, v]) => {
-        return [k, v.toString()];
-      })
-  );
-
   await esbuild.build({
     entryPoints: ['src/compiler/index.js'],
     outfile: 'dist/compiler.js',
     bundle: true,
-    define,
+    define: {
+      IS_PROD: 'true',
+      IS_MINIFIED: 'false',
+      IS_ESM: 'false',
+      IS_SXG: 'false',
+    },
   });
   endBuildStep('Compiled', 'compiler.js', startTime);
 }

--- a/build-system/compile/build-compiler.js
+++ b/build-system/compile/build-compiler.js
@@ -1,4 +1,5 @@
 const esbuild = require('esbuild');
+const {BUILD_CONSTANTS} = require('./build-constants');
 const {endBuildStep} = require('../tasks/helpers');
 
 /**
@@ -8,10 +9,21 @@ const {endBuildStep} = require('../tasks/helpers');
  */
 async function buildCompiler() {
   const startTime = Date.now();
+
+  // Build constants used to replace mode constants.
+  const define = Object.fromEntries(
+    Object.entries(BUILD_CONSTANTS)
+      .filter(([unused, v]) => typeof v === 'boolean')
+      .map(([k, v]) => {
+        return [k, v.toString()];
+      })
+  );
+
   await esbuild.build({
     entryPoints: ['src/compiler/index.js'],
     outfile: 'dist/compiler.js',
     bundle: true,
+    define,
   });
   endBuildStep('Compiled', 'compiler.js', startTime);
 }

--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -108,16 +108,6 @@ exports.jsBundles = {
       includePolyfills: true,
     },
   },
-  'compiler.js': {
-    srcDir: './src/compiler/',
-    srcFilename: 'index.js',
-    destDir: './dist',
-    minifiedDestDir: './dist',
-    options: {
-      minifiedName: 'compiler.js',
-      extraGlobs: ['src/builtins/**/*.js', 'extensions/amp-fit-text/**/*.js'],
-    },
-  },
   'amp-viewer-host.max.js': {
     srcDir: './extensions/amp-viewer-integration/0.1/examples/',
     srcFilename: 'amp-viewer-host.js',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -23,6 +23,7 @@ const {
 const {
   displayLifecycleDebugging,
 } = require('../compile/debug-compilation-lifecycle');
+const {buildCompiler} = require('../compile/build-compiler');
 const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
 const {buildVendorConfigs} = require('./3p-vendor-helpers');
 const {compileCss, copyCss} = require('./css');
@@ -120,6 +121,7 @@ async function dist() {
     steps.push(buildExperiments());
     steps.push(buildLoginDone('0.1'));
     steps.push(buildWebPushPublisherFiles());
+    steps.push(buildCompiler());
     steps.push(compileAllJs(options));
   }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -165,7 +165,6 @@ async function compileAllJs(options) {
     doBuildJs(jsBundles, 'iframe-transport-client-lib.js', options),
     doBuildJs(jsBundles, 'recaptcha.js', options),
     doBuildJs(jsBundles, 'amp-viewer-host.max.js', options),
-    doBuildJs(jsBundles, 'compiler.js', options),
     doBuildJs(jsBundles, 'video-iframe-integration.js', options),
     doBuildJs(jsBundles, 'amp-story-entry-point.js', options),
     doBuildJs(jsBundles, 'amp-story-player.js', options),

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -144,12 +144,13 @@ const forbiddenTermsGlobal = {
     message:
       'Do not use build constants directly. Instead, use the helpers in `#core/mode`.',
     allowlist: [
-      'src/core/mode/version.js',
+      'build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js',
+      'build-system/compile/build-compiler.js',
+      'build-system/compile/build-constants.js',
+      'src/core/mode/esm.js',
       'src/core/mode/minified.js',
       'src/core/mode/prod.js',
-      'src/core/mode/esm.js',
-      'build-system/compile/build-constants.js',
-      'build-system/babel-plugins/babel-plugin-amp-mode-transformer/index.js',
+      'src/core/mode/version.js',
     ],
   },
   '\\.prefetch\\(': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,18 +10,11 @@
       "integrity": "sha512-Ukegl+czEVP2S6Xd48d8vR/yL1bXd2A2ccUDztW29vVOC7XrJjKSa3bIqecYckuUI+mBfJtzHJKzN6rkscz3jw=="
     },
     "@ampproject/bento-compiler": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.2.tgz",
-      "integrity": "sha512-QQn/asy6hGcR9eLNcyx55bxqgigFgu8Sh/9zEeOtR9B9Ye5WJeEx3f0vCSXaoL8Beg2v6zG3fs5flv/KuOLVXw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.3.tgz",
+      "integrity": "sha512-8AzrERSsCFCm4tH3PRjmqdCb8kl4W/ot6vUUQGyJGs6TG5T1hwYk7yGgk+VfaMkn5rH85b674bfpGbOPb0cJqw==",
       "requires": {
-        "@ampproject/worker-dom": "0.29.3"
-      },
-      "dependencies": {
-        "@ampproject/worker-dom": {
-          "version": "0.29.3",
-          "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.29.3.tgz",
-          "integrity": "sha512-qVTmxOVaIeJ/94OymOfN/TZS2Z5IA/rXcGyRNusZEHk0P0qIAWnLu8bSx27wRkc3cCVn9HhBiLsXkMzxhL/UQA=="
-        }
+        "@ampproject/worker-dom": "0.30.1"
       }
     },
     "@ampproject/filesize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-Ukegl+czEVP2S6Xd48d8vR/yL1bXd2A2ccUDztW29vVOC7XrJjKSa3bIqecYckuUI+mBfJtzHJKzN6rkscz3jw=="
     },
     "@ampproject/bento-compiler": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.3.tgz",
-      "integrity": "sha512-8AzrERSsCFCm4tH3PRjmqdCb8kl4W/ot6vUUQGyJGs6TG5T1hwYk7yGgk+VfaMkn5rH85b674bfpGbOPb0cJqw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.4.tgz",
+      "integrity": "sha512-cYW3gebSMdwwO5jRxyTU/bxBEGKuPbAJsE8VNZ6P0UO9Lb+auPn+FXac7DtCOT1aFuxnI0wbwpSxXkWOcwoDog==",
       "requires": {
         "@ampproject/worker-dom": "0.30.1"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ampproject/animations": "0.2.2",
-    "@ampproject/bento-compiler": "0.0.2",
+    "@ampproject/bento-compiler": "0.0.3",
     "@ampproject/toolbox-cache-url": "2.8.0",
     "@ampproject/viewer-messaging": "1.1.2",
     "@ampproject/worker-dom": "0.30.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ampproject/animations": "0.2.2",
-    "@ampproject/bento-compiler": "0.0.3",
+    "@ampproject/bento-compiler": "0.0.4",
     "@ampproject/toolbox-cache-url": "2.8.0",
     "@ampproject/viewer-messaging": "1.1.2",
     "@ampproject/worker-dom": "0.30.1",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -14,8 +14,12 @@ function compile(request) {
   const document = request.document ?? {root: 0, tree: []};
   const versions = request.versions ?? {'amp-layout': 'v0'};
 
-  // TODO(samouri): handle type=error case.
-  return {document: compiler.renderAst(document, getBuilders(versions)).value};
+  const result = compiler.renderAst(document, getBuilders(versions));
+  if (result.error) {
+    const [tagName, errorMsg] = Array.from(result.error)[0];
+    throw new Error(`Failure to render: ${tagName}: ${errorMsg}`);
+  }
+  return {document: result.value};
 }
 
 globalThis['compile'] = compile;

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -14,7 +14,8 @@ function compile(request) {
   const document = request.document ?? {root: 0, tree: []};
   const versions = request.versions ?? {'amp-layout': 'v0'};
 
-  return {document: compiler.renderAst(document, getBuilders(versions))};
+  // TODO(samouri): handle type=error case.
+  return {document: compiler.renderAst(document, getBuilders(versions)).value};
 }
 
 globalThis['compile'] = compile;

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -6,18 +6,15 @@ import {getBuilders} from './builders';
 /**
  * Returns the AST for an AMP Document with eligible components server-rendered.
  *
- * @param {{
- *   document: !./types.TreeProtoDef,
- *   versions: !./types.VersionsDef
- * }} request
- * @return {!./types.TreeProtoDef}
+ * @param {!./types.CompilerRequest} request
+ * @return {!./types.CompilerResponse}
  */
 function compile(request) {
   // TODO(samouri): remove the defaults.
   const document = request.document ?? {root: 0, tree: []};
   const versions = request.versions ?? {'amp-layout': 'v0'};
 
-  return compiler.renderAst(document, getBuilders(versions));
+  return {document: compiler.renderAst(document, getBuilders(versions))};
 }
 
 globalThis['compile'] = compile;

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -14,12 +14,7 @@ function compile(request) {
   const document = request.document ?? {root: 0, tree: []};
   const versions = request.versions ?? {'amp-layout': 'v0'};
 
-  const result = compiler.renderAst(document, getBuilders(versions));
-  if (result.error) {
-    const [tagName, errorMsg] = Array.from(result.error)[0];
-    throw new Error(`Failure to render: ${tagName}: ${errorMsg}`);
-  }
-  return {document: result.value};
+  return {document: compiler.renderAst(document, getBuilders(versions))};
 }
 
 globalThis['compile'] = compile;

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -6,12 +6,18 @@ import {getBuilders} from './builders';
 /**
  * Returns the AST for an AMP Document with eligible components server-rendered.
  *
- * @param {!./types.TreeProtoDef} ast
- * @param {!./types.VersionsDef} versions
+ * @param {{
+ *   document: !./types.TreeProtoDef,
+ *   versions: !./types.VersionsDef
+ * }} request
  * @return {!./types.TreeProtoDef}
  */
-function compileAst(ast, versions) {
-  return compiler.renderAst(ast, getBuilders(versions));
+function compile(request) {
+  // TODO(samouri): remove the defaults.
+  const document = request.document ?? {root: 0, tree: []};
+  const versions = request.versions ?? {'amp-layout': 'v0'};
+
+  return compiler.renderAst(document, getBuilders(versions));
 }
 
-globalThis['compileAst'] = compileAst;
+globalThis['compile'] = compile;

--- a/src/compiler/polyfills.js
+++ b/src/compiler/polyfills.js
@@ -1,7 +1,6 @@
 /**
  * Polyfills for the compiler.js binary.
  * It is meant to run in a barebones v8 environment.
- *
  * That means no builtins provided by either Node.js or Browsers.
  * This includes: setTimeout, Node, self, etc.
  *

--- a/src/compiler/polyfills.js
+++ b/src/compiler/polyfills.js
@@ -1,2 +1,23 @@
-// compiler.js is meant to be run in server environments which do not have `self`.
-globalThis['self'] = globalThis;
+/**
+ * Polyfills for the compiler.js binary.
+ * It is meant to run in a barebones v8 environment.
+ *
+ * That means no builtins provided by either Node.js or Browsers.
+ * This includes: setTimeout, Node, self, etc.
+ *
+ * @fileoverview
+ */
+
+globalThis.self = globalThis;
+
+globalThis.Node = {
+  ELEMENT_NODE: 1,
+  ATTRIBUTE_NODE: 2,
+  TEXT_NODE: 3,
+  CDATA_SECTION_NODE: 4,
+  PROCESSING_INSTRUCTION_NODE: 7,
+  COMMENT_NODE: 8,
+  DOCUMENT_NODE: 9,
+  DOCUMENT_TYPE_NODE: 10,
+  DOCUMENT_FRAGMENT_NODE: 11,
+};

--- a/src/compiler/polyfills.js
+++ b/src/compiler/polyfills.js
@@ -7,9 +7,9 @@
  * @fileoverview
  */
 
-globalThis.self = globalThis;
+globalThis['self'] = globalThis;
 
-globalThis.Node = {
+globalThis['Node'] = {
   ELEMENT_NODE: 1,
   ATTRIBUTE_NODE: 2,
   TEXT_NODE: 3,

--- a/src/compiler/types.js
+++ b/src/compiler/types.js
@@ -25,3 +25,16 @@ export let TreeProtoDef;
  * @typedef {Object<string, string>}}
  */
 export let VersionsDef;
+
+/**
+ * @typedef {{
+ *   document: TreeProtoDef,
+ *   versions: VersionsDef
+ * }}
+ */
+export let CompilerRequest;
+
+/**
+ * @typedef {{ document: TreeProtoDef }}
+ */
+export let CompilerResponse;


### PR DESCRIPTION
**summary**
Myriad fixes to compiler.js as we iterate at both ends:
- Creates completely separate build path for `compiler.js` as its constraints are fairly different from the rest of our bundles. It does not need to be minified or transpiled. The new build step takes ~50ms. 
- Modified the parameter to `compilerAst` to match the latest proto def as well as created temporary defaults.
- Renames compileAst --> compile
- Adds a new polyfill for `Node`