### PR TITLE
🐛 [Story animations] Fix prerender resume animation

### DIFF
--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -400,7 +400,11 @@ export class AnimationRunner {
     }
 
     if (this.runner_) {
-      this.runner_.resume();
+      try {
+        this.runner_.resume();
+      } catch (e) {
+        // This fails when the story animations are not initialized and resume is called. Context on #35161.
+      }
     }
   }
 

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -403,7 +403,7 @@ export class AnimationRunner {
       try {
         this.runner_.resume();
       } catch (e) {
-        // This fails when the story animations are not initialized and resume is called. Context on #35161.
+        // This fails when the story animations are not initialized and resume is called. Context on #35987.
       }
     }
   }


### PR DESCRIPTION
When state is prerender ([example story](https://www.herzindagi.com/amp-stories/hindi/diary/pani-puri-recipe-article-655#visibilityState=prerender)) long pressing on the story will throw an error because it will try to pause and resume the animations on the page. This makes it so that long pressing breaks the system layer, since the long press logic is interrupted by the error and doesn't execute until the end.

# Alternative 1
Adding a `try/catch` just like the `pause` method could work, but when releasing the long press, the system layer is shown but the animations don't play (you need to come back to the page for them to start playing).

# Alternative 2
We can use the `start` method instead of `resume` so that the animations will be initiated if they are not, and then resumed (the implementation of `start` is `if (!players) init(); resume();`). However, when the vertical/bot rendering is enabled, there's a chain of method calls that finalize the animations without initializing them, so they could be initialized with long press. The chain is `onUIStateUpdate_(VERTICAL)->AmpStoryPage.maybeFinishAnimations()->AnimationManager.applyLastFrame()->AnimationRunner.applyLastFrame()->NativeWebAnimationRunner.finish(pauseOnError=true)->this.players_ = null`.

And this would also break the method `finishAll` which is currently not used (the code path is `AnimationRunner.finish()->AnimationRunner.playback_(FINISH)->AnimationRunner.playbackWhenReady_(FINISH)->AnimationRunner.finishWhenReady()->NativeWebAnimationRunner.finish()->this.players_=null`), so we'd need to remove it or refactor it.

# Solution

Alternative 1 doesn't introduce as much technical debt or room for errors, and it stops the errors as well as prevents the system layer from breaking. It will not play the animations on the first page, but the scenario to trigger this bug is not the intended use of stories on players anyways, so failing silently to resume the story is ok (especially since in the long press, it's failing to pause the story as well). This behavior is more consistent between pausing and resuming on these scenarios.