### PR TITLE
Revert "Revert "Improve AMP_CONFIG handling during build (#35773)" (#35819)"

### DIFF
--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -8,6 +8,7 @@ const {checkForUnknownDeps} = require('./check-for-unknown-deps');
 const {CLOSURE_SRC_GLOBS} = require('./sources');
 const {cpus} = require('os');
 const {cyan, green} = require('kleur/colors');
+const {getAmpConfigForFile} = require('../tasks/prepend-global');
 const {log, logLocalDev} = require('../common/logging');
 const {postClosureBabel} = require('./post-closure-babel');
 const {preClosureBabel} = require('./pre-closure-babel');
@@ -185,9 +186,9 @@ function getSrcs(entryModuleFilenames, options) {
  *
  * @param {string} outputFilename
  * @param {!OptionsDef} options
- * @return {!Object}
+ * @return {!Promise<!Object>}
  */
-function generateCompilerOptions(outputFilename, options) {
+async function generateCompilerOptions(outputFilename, options) {
   // Determine externs
   let externs = options.externs || [];
   if (!options.noAddDeps) {
@@ -220,10 +221,11 @@ function generateCompilerOptions(outputFilename, options) {
   if (argv.pseudo_names) {
     define.push('PSEUDO_NAMES=true');
   }
+  const ampConfig = await getAmpConfigForFile(outputFilename, options);
   let wrapper = options.wrapper
     ? options.wrapper.replace('<%= contents %>', '%output%')
     : `(function(){%output%})();`;
-  wrapper = `${wrapper}\n\n//# sourceMappingURL=${outputFilename}.map`;
+  wrapper = `${ampConfig}${wrapper}\n\n//# sourceMappingURL=${outputFilename}.map`;
 
   /**
    * TODO(#28387) write a type for this.
@@ -400,7 +402,10 @@ async function compile(
   }
   const destFile = `${outputDir}/${outputFilename}`;
   const sourcemapFile = `${destFile}.map`;
-  const compilerOptions = generateCompilerOptions(outputFilename, options);
+  const compilerOptions = await generateCompilerOptions(
+    outputFilename,
+    options
+  );
   const srcs = options.noAddDeps
     ? entryModuleFilenames.concat(options.extraGlobs || [])
     : getSrcs(entryModuleFilenames, options);

--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -6,21 +6,17 @@ const path = require('path');
 const Remapping = require('@ampproject/remapping');
 const terser = require('terser');
 const {CompilationLifecycles, debug} = require('./debug-compilation-lifecycle');
-const {jsBundles} = require('./bundles.config');
 
 /** @type {Remapping.default} */
 const remapping = /** @type {*} */ (Remapping);
-
-let mainBundles;
 
 /**
  * Minify passed string.
  *
  * @param {string} code
- * @param {string} filename
  * @return {Promise<Object<string, terser.SourceMapOptions['content']>>}
  */
-async function terserMinify(code, filename) {
+async function terserMinify(code) {
   const options = {
     mangle: false,
     compress: {
@@ -35,19 +31,6 @@ async function terserMinify(code, filename) {
     },
     sourceMap: true,
   };
-  const basename = path.basename(filename, argv.esm ? '.mjs' : '.js');
-  if (!mainBundles) {
-    mainBundles = Object.keys(jsBundles).map((key) => {
-      const bundle = jsBundles[key];
-      if (bundle.options && bundle.options.minifiedName) {
-        return path.basename(bundle.options.minifiedName, '.js');
-      }
-      return path.basename(key, '.js');
-    });
-  }
-  if (mainBundles.includes(basename)) {
-    options.output.preamble = ';';
-  }
   const minified = await terser.minify(code, options);
 
   return {
@@ -78,7 +61,7 @@ async function postClosureBabel(file) {
   }
 
   debug(CompilationLifecycles['closured-pre-terser'], file, code, babelMap);
-  const {compressed, terserMap} = await terserMinify(code, path.basename(file));
+  const {compressed, terserMap} = await terserMinify(code);
   await fs.outputFile(file, compressed);
 
   const closureMap = await fs.readJson(`${file}.map`, 'utf-8');

--- a/build-system/pr-check/module-tests.js
+++ b/build-system/pr-check/module-tests.js
@@ -5,7 +5,7 @@
  */
 
 const argv = require('minimist')(process.argv.slice(2));
-const {MINIFIED_TARGETS} = require('../tasks/helpers');
+const {MINIFIED_TARGETS} = require('../tasks/prepend-global');
 const {runCiJob} = require('./ci-job');
 const {skipDependentJobs, timedExecOrDie} = require('./utils');
 const {Targets, buildTargetsInclude} = require('./build-targets');

--- a/build-system/pr-check/nomodule-tests.js
+++ b/build-system/pr-check/nomodule-tests.js
@@ -10,7 +10,7 @@ const {
   timedExecOrDie,
   timedExecOrThrow,
 } = require('./utils');
-const {MINIFIED_TARGETS} = require('../tasks/helpers');
+const {MINIFIED_TARGETS} = require('../tasks/prepend-global');
 const {runCiJob} = require('./ci-job');
 const {Targets, buildTargetsInclude} = require('./build-targets');
 

--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -84,6 +84,7 @@ async function build(bundles, name, buildFunc) {
   bundle.pendingBuild = buildFunc(bundles, name, {
     watch: true,
     minify: argv.minified,
+    localDev: true,
     onWatchBuild: async (bundlePromise) => {
       bundle.pendingBuild = bundlePromise;
       await bundlePromise;

--- a/build-system/tasks/build.js
+++ b/build-system/tasks/build.js
@@ -36,6 +36,7 @@ async function build() {
   process.env.NODE_ENV = 'development';
   const options = {
     fortesting: argv.fortesting,
+    localDev: true,
     minify: false,
     watch: argv.watch,
   };

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -13,9 +13,9 @@ const wrappers = require('../compile/compile-wrappers');
 const {
   VERSION: internalRuntimeVersion,
 } = require('../compile/internal-version');
-const {applyConfig, removeConfig} = require('./prepend-global');
 const {closureCompile} = require('../compile/compile');
 const {cyan, green, red} = require('kleur/colors');
+const {getAmpConfigForFile} = require('./prepend-global');
 const {getEsbuildBabelPlugin} = require('../common/esbuild-babel');
 const {getSourceRoot} = require('../compile/helpers');
 const {isCiBuild} = require('../common/ci');
@@ -51,16 +51,6 @@ const EXTENSION_BUNDLE_MAP = {
     'node_modules/@webcomponents/webcomponentsjs/bundles/webcomponents-sd.install.js',
   ],
 };
-
-/**
- * List of unminified targets to which AMP_CONFIG should be written
- */
-const UNMINIFIED_TARGETS = ['alp.max', 'amp-inabox', 'amp-shadow', 'amp'];
-
-/**
- * List of minified targets to which AMP_CONFIG should be written
- */
-const MINIFIED_TARGETS = ['alp', 'amp4ads-v0', 'shadow-v0', 'v0'];
 
 /**
  * Used while building the 3p frame
@@ -336,15 +326,6 @@ async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
     name += ` → ${maybeToEsmName(options.latestName)}`;
   }
   endBuildStep('Minified', name, timeInfo.startTime);
-
-  const target = path.basename(minifiedName, path.extname(minifiedName));
-  if (!argv.noconfig && MINIFIED_TARGETS.includes(target)) {
-    await applyAmpConfig(
-      maybeToEsmName(`${destDir}/${minifiedName}`),
-      /* localDev */ options.fortesting,
-      /* fortesting */ options.fortesting
-    );
-  }
 }
 
 /**
@@ -397,16 +378,6 @@ async function finishBundle(destDir, destFilename, options, startTime) {
         : destFilename;
     endBuildStep(logPrefix, loggingName, startTime);
   }
-
-  const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;
-  const target = path.basename(destFilename, path.extname(destFilename));
-  if (targets.includes(target)) {
-    await applyAmpConfig(
-      path.join(destDir, destFilename),
-      /* localDev */ true,
-      /* fortesting */ options.fortesting
-    );
-  }
 }
 
 /**
@@ -437,7 +408,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
    * @return {Object}
    */
   function splitWrapper() {
-    const wrapper = options.wrapper || wrappers.none;
+    const wrapper = options.wrapper ?? wrappers.none;
     const sentinel = '<%= contents %>';
     const start = wrapper.indexOf(sentinel);
     return {
@@ -446,8 +417,9 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     };
   }
   const {banner, footer} = splitWrapper();
+  const config = await getAmpConfigForFile(srcFilename, options);
   const compiledFile = await getCompiledFile(srcFilename);
-  banner.js += compiledFile;
+  banner.js = config + banner.js + compiledFile;
 
   const babelPlugin = getEsbuildBabelPlugin(
     options.minify ? 'minified' : 'unminified',
@@ -502,7 +474,6 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
       fs.outputFile(`${destFile}.map`, map),
     ]);
 
-    // TODO: finishBundle should operate in-mem instead of reading/writing from FS.
     await finishBundle(destDir, destFilename, options, startTime);
   }
 
@@ -578,8 +549,6 @@ async function minify(code, map, {mangle} = {mangle: false}) {
       beautify: !!argv.pretty_print,
       // eslint-disable-next-line google-camelcase/google-camelcase
       keep_quoted_props: true,
-      // // TODO: only add preamble for mainBundles?
-      preamble: ';',
     },
     sourceMap: {content: map},
     module: !!argv.esm,
@@ -735,33 +704,6 @@ async function maybePrintCoverageMessage(covPath = '') {
 }
 
 /**
- * Writes AMP_CONFIG to a runtime file. Optionally enables localDev mode and
- * fortesting mode. Called by "amp build" and "amp dist" while building
- * various runtime files.
- *
- * @param {string} targetFile File to which the config is to be written.
- * @param {boolean} localDev Whether or not to enable local development.
- * @param {boolean} fortesting Whether or not to enable testing mode.
- * @return {!Promise}
- */
-async function applyAmpConfig(targetFile, localDev, fortesting) {
-  const config = argv.config === 'canary' ? 'canary' : 'prod';
-  const baseConfigFile =
-    'build-system/global-configs/' + config + '-config.json';
-
-  await removeConfig(targetFile);
-  await applyConfig(
-    config,
-    targetFile,
-    baseConfigFile,
-    /* opt_localDev */ localDev,
-    /* opt_localBranch */ true,
-    /* opt_branch */ undefined,
-    /* opt_fortesting */ fortesting
-  );
-}
-
-/**
  * Copies frame.html to output folder, replaces js references to minified
  * copies, and generates symlink to it.
  *
@@ -873,8 +815,6 @@ function shouldUseClosure() {
 }
 
 module.exports = {
-  MINIFIED_TARGETS,
-  applyAmpConfig,
   bootstrapThirdPartyFrames,
   compileAllJs,
   compileCoreRuntime,

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -211,7 +211,7 @@ async function getAmpConfigForFile(filename, options) {
     type,
     filename,
     baseConfigFile,
-    /* opt_localDev */ !!options.fortesting,
+    /* opt_localDev */ !!options.localDev,
     /* opt_localBranch */ true,
     /* opt_branch */ undefined,
     /* opt_fortesting */ !!options.fortesting
@@ -326,7 +326,6 @@ module.exports = {
   sanityCheck,
   valueOrDefault,
   MINIFIED_TARGETS,
-  UNMINIFIED_TARGETS,
 };
 
 prependGlobal.description = 'Prepend a json config to a target file';

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -12,6 +12,16 @@ const exec = util.promisify(childProcess.exec);
 
 const {cyan, red} = colors;
 
+/**
+ * List of unminified targets to which AMP_CONFIG should be written
+ */
+const UNMINIFIED_TARGETS = ['alp.max', 'amp-inabox', 'amp-shadow', 'amp'];
+
+/**
+ * List of minified targets to which AMP_CONFIG should be written
+ */
+const MINIFIED_TARGETS = ['alp', 'amp4ads-v0', 'shadow-v0', 'v0'];
+
 // custom-config.json overlays the active config. It is not part of checked-in
 // source (.gitignore'd). See:
 // https://github.com/ampproject/amphtml/blob/main/build-system/global-configs/README.md#custom-configjson
@@ -58,18 +68,6 @@ async function fetchConfigFromBranch_(filename, opt_localBranch, opt_branch) {
 }
 
 /**
- * @param {string} configString String containing the AMP config
- * @param {string} fileString String containing the AMP runtime
- * @return {string}
- */
-function prependConfig(configString, fileString) {
-  return (
-    `self.AMP_CONFIG||(self.AMP_CONFIG=${configString});` +
-    `/*AMP_CONFIG*/${fileString}`
-  );
-}
-
-/**
  * @param {string} filename Destination filename
  * @param {string} fileString String to write
  * @param {boolean=} opt_dryrun If true, print the contents without writing them
@@ -97,7 +95,30 @@ function valueOrDefault(value, defaultValue) {
 }
 
 /**
- * @param {string} config Prod or canary
+ * @param {string} type Prod or canary
+ * @param {string} target File containing the AMP runtime (amp.js or v0.js)
+ * @param {string} filename File containing the (prod or canary) config
+ * @return {!Promise<void>}
+ */
+async function applyConfig(type, target, filename) {
+  const config = await getConfig(
+    type,
+    target,
+    filename,
+    argv.local_dev,
+    argv.local_branch,
+    argv.branch,
+    argv.fortesting,
+    argv.derandomize
+  );
+  const targetString = await fs.promises.readFile(target, 'utf8');
+  const fileString = config + targetString;
+  sanityCheck(fileString);
+  await writeTarget_(target, fileString, argv.dryrun);
+}
+
+/**
+ * @param {string} type Prod or canary
  * @param {string} target File containing the AMP runtime (amp.js or v0.js)
  * @param {string} filename File containing the (prod or canary) config
  * @param {boolean=} opt_localDev Whether to enable local development
@@ -105,10 +126,10 @@ function valueOrDefault(value, defaultValue) {
  * @param {string=} opt_branch If not the local branch, which branch to use
  * @param {boolean=} opt_fortesting Whether to force getMode().test to be true
  * @param {boolean=} opt_derandomize Whether to remove experiment randomization
- * @return {!Promise<void>}
+ * @return {!Promise<string>}
  */
-async function applyConfig(
-  config,
+async function getConfig(
+  type,
   target,
   filename,
   opt_localDev,
@@ -117,19 +138,18 @@ async function applyConfig(
   opt_fortesting,
   opt_derandomize
 ) {
-  const configString = await fetchConfigFromBranch_(
+  const fsConfigString = await fetchConfigFromBranch_(
     filename,
     opt_localBranch,
     opt_branch
   );
-  const [targetString, overlayString] = await Promise.all([
-    fs.promises.readFile(target, 'utf8'),
-    fs.promises.readFile(customConfigFile, 'utf8').catch(() => {}),
-  ]);
+  const overlayString = await fs.promises
+    .readFile(customConfigFile, 'utf8')
+    .catch(() => {});
 
   let configJson;
   try {
-    configJson = JSON.parse(configString);
+    configJson = JSON.parse(fsConfigString);
   } catch (e) {
     log(red(`Error parsing config file: ${filename}`));
     throw e;
@@ -155,20 +175,47 @@ async function applyConfig(
   if (opt_derandomize) {
     configJson = derandomize_(target, configJson);
   }
-  const fileString = await prependConfig(
-    JSON.stringify(configJson),
-    targetString
-  );
-  sanityCheck(fileString);
-  await writeTarget_(target, fileString, argv.dryrun);
+
   const details =
     '(' +
-    cyan(config) +
+    cyan(type) +
     (opt_localDev ? ', ' + cyan('localDev') : '') +
     (opt_fortesting ? ', ' + cyan('test') : '') +
     (opt_derandomize ? ', ' + cyan('derandomized') : '') +
     ')';
-  log('Applied AMP config', details, 'to', cyan(path.basename(target)));
+  log('Generated AMP config', details, 'for', cyan(target));
+
+  const configString = JSON.stringify(configJson);
+  return `self.AMP_CONFIG||(self.AMP_CONFIG=${configString});/*AMP_CONFIG*/`;
+}
+
+/**
+ * Given a target, retrieves the appropriate AMP_CONFIG string to prepend.
+ * Returns an empty string if no AMP_CONFIG is necessary.
+ *
+ * @param {string} filename the file being operated on.
+ * @param {Object} options
+ * @return {!Promise<string>}
+ */
+async function getAmpConfigForFile(filename, options) {
+  const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;
+  const target = path.basename(filename, path.extname(filename));
+  if (!!argv.noconfig || !targets.includes(target)) {
+    return '';
+  }
+
+  const type = argv.config === 'canary' ? 'canary' : 'prod';
+  const baseConfigFile = 'build-system/global-configs/' + type + '-config.json';
+
+  return getConfig(
+    type,
+    filename,
+    baseConfigFile,
+    /* opt_localDev */ !!options.fortesting,
+    /* opt_localBranch */ true,
+    /* opt_branch */ undefined,
+    /* opt_fortesting */ !!options.fortesting
+  );
 }
 
 /**
@@ -228,7 +275,8 @@ async function removeConfig(target) {
     return;
   }
   sanityCheck(contents);
-  const config = /self\.AMP_CONFIG\|\|\(self\.AMP_CONFIG=.*?\/\*AMP_CONFIG\*\//;
+  const config =
+    /self\.AMP_CONFIG\|\|\(self\.AMP_CONFIG=(.|\n)*?\/\*AMP_CONFIG\*\//;
   contents = contents.replace(config, '');
   await writeTarget_(target, contents, argv.dryrun);
   log('Removed existing config from', cyan(target));
@@ -252,7 +300,7 @@ async function prependGlobal() {
   let filename = '';
 
   // Prod by default.
-  const config = argv.canary ? 'canary' : 'prod';
+  const type = argv.canary ? 'canary' : 'prod';
   if (argv.canary) {
     filename = valueOrDefault(
       argv.canary,
@@ -265,30 +313,20 @@ async function prependGlobal() {
     );
   }
   await Promise.all([...targets.map(removeConfig)]);
-  await Promise.all([
-    ...targets.map((target) =>
-      applyConfig(
-        config,
-        target,
-        filename,
-        argv.local_dev,
-        argv.local_branch,
-        argv.branch,
-        argv.fortesting,
-        argv.derandomize
-      )
-    ),
-  ]);
+  await Promise.all(
+    targets.map((target) => applyConfig(type, target, filename))
+  );
 }
 
 module.exports = {
-  applyConfig,
+  getAmpConfigForFile,
   numConfigs,
-  prependConfig,
   prependGlobal,
   removeConfig,
   sanityCheck,
   valueOrDefault,
+  MINIFIED_TARGETS,
+  UNMINIFIED_TARGETS,
 };
 
 prependGlobal.description = 'Prepend a json config to a target file';

--- a/build-system/tasks/prepend-global/prepend-global.test.js
+++ b/build-system/tasks/prepend-global/prepend-global.test.js
@@ -3,16 +3,6 @@
 const m = require('.');
 const test = require('ava');
 
-test('sync - prepends global config', (t) => {
-  t.plan(1);
-  const res = m.prependConfig('{"hello":"world"}', 'var x = 1 + 1;');
-  t.is(
-    res,
-    'self.AMP_CONFIG||(self.AMP_CONFIG={"hello":"world"});' +
-      '/*AMP_CONFIG*/var x = 1 + 1;'
-  );
-});
-
 test('sync - valueOrDefault', (t) => {
   t.plan(2);
   let res = m.valueOrDefault(true, 'hello');

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -40,7 +40,7 @@ const tar = require('tar');
 const {cyan, green} = require('kleur/colors');
 const {execOrDie} = require('../../common/exec');
 const {log} = require('../../common/logging');
-const {MINIFIED_TARGETS} = require('../helpers');
+const {MINIFIED_TARGETS} = require('../prepend-global');
 const {VERSION} = require('../../compile/internal-version');
 
 // Flavor config for the base flavor type.

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -638,7 +638,6 @@ const forbiddenTermsGlobal = {
       'build-system/tasks/build.js',
       'build-system/tasks/default-task.js',
       'build-system/tasks/dist.js',
-      'build-system/tasks/helpers.js',
       'src/config.js',
       'src/core/window/window.extern.js',
       'src/experiments/index.js',


### PR DESCRIPTION
**summary**
See Attempt 1 for full PR description: https://github.com/ampproject/amphtml/pull/35773

In the prior attempt, the `npx amp` command was not setting `localDev: true` for the `amp build` and `amp` default task  commands. This caused all extension loading to default to `cdn` instead of localhost. This should be fixed via 3d1d2fe05b5258d6ceba41306e0170998808e3de. Note: this PR is also important for migrating to a different bundler, so that we can separate out the notion of bundler being directly tied to mode. Before this PR, closure-->(localDev=false), esbuild-->(localDev=true). After the PR they are tied to the build command instead (build, dist etc)

**testing done**
- All CI passes
- Verified that `npx amp`, `npx amp build`,  and `npx amp dist` all have identical AMP_CONFIG's to their counterparts on main. Technically `npx amp dist` has a slightly different output, but I verified it is functionally the same. The config is now minified via terser in the closure flow, and therefore values like `0.01` --> `.01`