### PR TITLE
Add documentation and CSS for `bento-wordpress-embed` and `BentoWordPressEmbed`

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -1240,6 +1240,7 @@
     "version": "1.0",
     "latestVersion": "1.0",
     "options": {
+      "hasCss": true,
       "npm": true,
       "wrapper": "bento"
     }

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -51,7 +51,7 @@ import '@ampproject/bento-wordpress-embed';
   </style>
   <script async src="https://cdn.ampproject.org/v0/bento-wordpress-embed-1.0.js"></script>
 </head>
-<bento-wordpress-embed id="my-embed
+<bento-wordpress-embed id="my-embed"
   data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
 ></bento-wordpress-embed>
 <div class="buttons" style="margin-top: 8px;">

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -1,0 +1,174 @@
+---
+$category@: presentation
+formats:
+  - websites
+teaser:
+  text: Embeds a WordPress post.
+---
+
+# Bento Wordpress Embed
+
+## Usage
+
+An iframe displaying the [excerpt](https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/) of a WordPress post or page. Use Bento Wordpress Embed as a web component [`<bento-wordpress-embed>`](#web-component), or a Preact/React functional component [`<BentoWordPressEmbed>`](#preact/react-Component).
+
+### Web Component
+
+You must include each Bento component's required CSS library to guarantee proper loading and before adding custom styles. Or use the light-weight pre-upgrade styles available inline. See [Layout and style](#layout-and-style).
+
+The examples below demonstrate use of the `<bento-wordpress-embed>` web component.
+
+#### Example: Import via npm
+
+[example preview="top-frame" playground="false"]
+
+Install via npm:
+
+```sh
+npm install @ampproject/bento-wordpress-embed
+```
+
+```javascript
+import '@ampproject/bento-wordpress-embed';
+```
+
+[/example]
+
+#### Example: Include via `<script>`
+
+[example preview="top-frame" playground="false"]
+
+```html
+<head>
+  <script src="https://cdn.ampproject.org/custom-elements-polyfill.js"></script>
+  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+  <style data-bento-boilerplate>
+    bento-wordpress-embed {
+      display: block;
+      overflow: hidden;
+      position: relative;
+    }
+  </style>
+  <script async src="https://cdn.ampproject.org/v0/bento-wordpress-embed-1.0.js"></script>
+</head>
+<bento-wordpress-embed id="my-embed
+  data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+></bento-wordpress-embed>
+<div class="buttons" style="margin-top: 8px;">
+  <button id="switch-button">Switch embed</button>
+</div>
+
+<script>
+  (async () => {
+    const embed = document.querySelector('#my-embed');
+    await customElements.whenDefined('bento-wordpress-embed');
+
+    // set up button actions
+    document.querySelector('#switch-button').onclick = () => embed.setAttribute('data-url', 'https://make.wordpress.org/core/2021/09/09/core-editor-improvement-cascading-impact-of-improvements-to-featured-images/');
+  })();
+</script>
+```
+
+[/example]
+
+#### Layout and style
+
+Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.
+
+```html
+<link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-wordpress-embed-1.0.css">
+```
+
+Alternatively, you may also make the light-weight pre-upgrade styles available inline:
+
+```html
+<style data-bento-boilerplate>
+  bento-wordpress-embed {
+    display: block;
+    overflow: hidden;
+    position: relative;
+  }
+</style>
+```
+
+**Container type**
+
+The `bento-wordpress-embed` component has a defined layout size type. To ensure the component renders correctly, be sure to apply a size to the component and its immediate children (slides) via a desired CSS layout (such as one defined with `height`, `width`, `aspect-ratio`, or other such properties):
+
+```css
+bento-wordpress-embed {
+  height: 100px;
+  width: 100%;
+}
+```
+
+#### Attributes
+
+##### data-url (required)
+
+The URL of the post to embed.
+
+### Preact/React Component
+
+The examples below demonstrate use of the `<BentoWordPressEmbed>` as a functional component usable with the Preact or React libraries.
+
+#### Example: Import via npm
+
+[example preview="top-frame" playground="false"]
+
+Install via npm:
+
+```sh
+npm install @ampproject/bento-wordpress-embed
+```
+
+```javascript
+import React from 'react';
+import {BaseCarousel} from '@ampproject/bento-wordpress-embed/react';
+import '@ampproject/bento-wordpress-embed/styles.css';
+
+function App() {
+  return (
+    <BaseCarousel>
+      <img src="puppies.jpg" />
+      <img src="kittens.jpg" />
+      <img src="hamsters.jpg" />
+    </BaseCarousel>
+  );
+}
+```
+
+[/example]
+
+#### Layout and style
+
+**Container type**
+
+The `BentoWordPressEmbed` component has a defined layout size type. To ensure the component renders correctly, be sure to apply a size to the component and its immediate children (slides) via a desired CSS layout (such as one defined with `height`, `width`, `aspect-ratio`, or other such properties). These can be applied inline:
+
+```jsx
+<BentoWordPressEmbed style={{width: '100%', height: '100px'}}
+  url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+></BentoWordPressEmbed>
+```
+
+Or via `className`:
+
+```jsx
+<BentoWordPressEmbed className="custom-styles"
+  url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+></BentoWordPressEmbed>
+```
+
+```css
+.custom-styles {
+  height: 100px;
+  width: 100%;
+}
+```
+
+#### Props
+
+##### url (required)
+
+The URL of the post to embed.

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -124,16 +124,13 @@ npm install @ampproject/bento-wordpress-embed
 
 ```javascript
 import React from 'react';
-import {BaseCarousel} from '@ampproject/bento-wordpress-embed/react';
-import '@ampproject/bento-wordpress-embed/styles.css';
+import {BentoWordPressEmbed} from '@ampproject/bento-wordpress-embed/react';
 
 function App() {
   return (
-    <BaseCarousel>
-      <img src="puppies.jpg" />
-      <img src="kittens.jpg" />
-      <img src="hamsters.jpg" />
-    </BaseCarousel>
+    <BentoWordPressEmbed
+      url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+    ></BentoWordPressEmbed>
   );
 }
 ```

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -122,7 +122,7 @@ Install via npm:
 npm install @ampproject/bento-wordpress-embed
 ```
 
-```javascript
+```jsx
 import React from 'react';
 import {BentoWordPressEmbed} from '@ampproject/bento-wordpress-embed/react';
 

--- a/extensions/amp-wordpress-embed/1.0/amp-wordpress-embed.css
+++ b/extensions/amp-wordpress-embed/1.0/amp-wordpress-embed.css
@@ -1,0 +1,22 @@
+/*
+ * Pre-upgrade:
+ * - display:block element
+ * - size-defined element
+ */
+amp-wordpress-embed {
+  display: block;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Pre-upgrade: size-defining element - hide text. */
+amp-wordpress-embed:not(.i-amphtml-built) {
+  color: transparent !important;
+}
+
+/* Pre-upgrade: size-defining element - hide children. */
+amp-wordpress-embed:not(.i-amphtml-built)
+  > :not([placeholder]):not(.i-amphtml-svc) {
+  display: none;
+  content-visibility: hidden;
+}

--- a/extensions/amp-wordpress-embed/amp-wordpress-embed.md
+++ b/extensions/amp-wordpress-embed/amp-wordpress-embed.md
@@ -14,6 +14,10 @@ bento: true
 
 This extension creates an iframe and displays the [excerpt](https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/) of a WordPress post or page.
 
+### Standalone use outside valid AMP documents
+
+Bento AMP allows you to use AMP components in non-AMP pages without needing to commit to fully valid AMP. You can take these components and place them in implementations with frameworks and CMSs that don't support AMP. Read more in our guide [Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/). To find the standalone version of `amp-my-element`, see [`bento-wordpress-embed`](./1.0/README.md).
+
 #### Example: Embedding a WordPress post
 
 ```html


### PR DESCRIPTION
Documentation is needed for publishing on npm, and CSS is needed for providing layout stabilizing CSS (pre-upgrade)