### PR TITLE
🏗  Add `exports` for stylesheets to `package.json`

### DIFF
--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -9,6 +9,7 @@ const {getSemver} = require('./utils');
 const {log} = require('../common/logging');
 const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
+const path = require('path');
 
 /**
  * Determines whether to skip
@@ -27,16 +28,14 @@ async function shouldSkip() {
 /**
  * Returns relative paths to all the extension's CSS file
  *
- * @return {Promise<boolean>}
+ * @return {Promise<string[]>}
  */
 async function getStylesheets() {
-  const files = await fastGlob(
-    `extensions/${extension}/${extensionVersion}/dist/**/*.css`
-  );
-
-  return files.map((path) =>
-    path.replace(`extensions/${extension}/${extensionVersion}/dist/`, '')
-  );
+  const extDir = `extensions/${extension}/${extensionVersion}/dist`
+    .split('/')
+    .join(path.sep);
+  const files = await fastGlob(path.join(extDir, '**', '*.css'));
+  return files.map((file) => path.relative(extDir, file));
 }
 
 /**

--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -4,9 +4,10 @@
  */
 
 const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
+const fastGlob = require('fast-glob');
 const {getSemver} = require('./utils');
 const {log} = require('../common/logging');
-const {readdir, stat, writeFile} = require('fs/promises');
+const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
 
 /**
@@ -24,14 +25,18 @@ async function shouldSkip() {
 }
 
 /**
- * Determines whether a given directory path contains CSS files
+ * Determines whether the current extension contains CSS files
  *
- * @param {string} path Path to a directory.
  * @return {Promise<boolean>}
  */
-async function hasStylesheets(path) {
-  const files = await readdir(path);
-  return files.some((file) => file.endsWith('.css'));
+async function hasStylesheets() {
+  return (
+    (
+      await fastGlob(
+        `extensions/${extension}/${extensionVersion}/dist/**/*.css`
+      )
+    ).length > 0
+  );
 }
 
 /**
@@ -65,9 +70,7 @@ async function writePackageJson() {
     },
   };
 
-  if (
-    await hasStylesheets(`extensions/${extension}/${extensionVersion}/dist`)
-  ) {
+  if (await hasStylesheets()) {
     exports['./css/*'] = './dist/*';
   }
 

--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -25,17 +25,17 @@ async function shouldSkip() {
 }
 
 /**
- * Determines whether the current extension contains CSS files
+ * Returns relative paths to all the extension's CSS file
  *
  * @return {Promise<boolean>}
  */
-async function hasStylesheets() {
-  return (
-    (
-      await fastGlob(
-        `extensions/${extension}/${extensionVersion}/dist/**/*.css`
-      )
-    ).length > 0
+async function getStylesheets() {
+  const files = await fastGlob(
+    `extensions/${extension}/${extensionVersion}/dist/**/*.css`
+  );
+
+  return files.map((path) =>
+    path.replace(`extensions/${extension}/${extensionVersion}/dist/`, '')
   );
 }
 
@@ -70,8 +70,8 @@ async function writePackageJson() {
     },
   };
 
-  if (await hasStylesheets()) {
-    exports['./css/*'] = './dist/*';
+  for (const stylesheet of await getStylesheets()) {
+    exports[`./${stylesheet}`] = `./dist/${stylesheet}`;
   }
 
   const json = {

--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -5,11 +5,11 @@
 
 const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
 const fastGlob = require('fast-glob');
+const path = require('path');
 const {getSemver} = require('./utils');
 const {log} = require('../common/logging');
 const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
-const path = require('path');
 
 /**
  * Determines whether to skip

--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -60,6 +60,7 @@ async function writePackageJson() {
         import: './dist/component-react.module.js',
         require: './dist/component-react.js',
       },
+      './styles.css': './dist/styles.css',
     },
     files: ['dist/*', 'react.js'],
     repository: {


### PR DESCRIPTION
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->

This addresses #35870 by adding a new export directive for stylesheets to the generated `package.json` files. For each existing stylesheet, an export as follows is added:

```json
{
	  "./<path_to_file>.css": "./dist/<path_to_file>.css",
}
```

Example:

```json
{
	  "./styles.css": "./dist/styles.css",
}
```

This allows using imports as follows in modern bundlers like webpack v5:

```js
import '@ampproject/amp-base-carousel/styles.css';
```

No export directive is added if there are no stylesheets.

**See also:**

* [Node.js documentation about package entry points](https://nodejs.org/api/packages.html#packages_package_entry_points)

Fixes #35870