### PR TITLE
✨ [Story interactive] Enable interactive disclaimer dialog

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -21,6 +21,7 @@
   "story-load-first-page-only": 1,
   "story-load-inactive-outside-viewport": 1,
   "story-disable-animations-first-page": 0.5,
+  "amp-story-interactive-disclaimer": 1,
   "amp-story-page-attachment-ui-v2": 1,
   "amp-sticky-ad-to-amp-ad-v2": 0
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -18,6 +18,7 @@
   "story-disable-animations-first-page": 0.5,
   "story-load-first-page-only": 1,
   "story-load-inactive-outside-viewport": 1,
+  "amp-story-interactive-disclaimer": 1,
   "amp-story-page-attachment-ui-v2": 1,
   "amp-sticky-ad-to-amp-ad-v2": 0
 }

--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
@@ -270,7 +270,7 @@ export class AmpStoryInteractive extends AMP.BaseElement {
       this.rootEl_.classList.add('i-amphtml-story-interactive-container');
       if (
         isExperimentOn(this.win, 'amp-story-interactive-disclaimer') &&
-        this.element.hasAttribute('endpoint')
+        this.element.getAttribute('endpoint')
       ) {
         this.disclaimerIcon_ = buildInteractiveDisclaimerIcon(this);
         this.rootEl_.prepend(this.disclaimerIcon_);


### PR DESCRIPTION
Enables the disclaimer for interactive components that have a string on the `endopoint` attribute. If the atrtibute is empty, the icon won't show.