### PR TITLE
🐛 Fix extension template reference

### DIFF
--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/base-element.js
@@ -1,11 +1,11 @@
 __jss_import_component_css__;
-import {Bento__component_name_pascal_case__} from './component';
+import {Bento__component_name_pascalcase__} from './component';
 import {PreactBaseElement} from '#preact/base-element';
 
 export class BaseElement extends PreactBaseElement {}
 
 /** @override */
-BaseElement['Component'] = Bento__component_name_pascal_case__;
+BaseElement['Component'] = Bento__component_name_pascalcase__;
 
 /** @override */
 BaseElement['props'] = {

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.js
@@ -11,10 +11,10 @@ import {
 __jss_import_use_styles__;
 
 /**
- * @param {!Bento__component_name_pascal_case__.Props} props
+ * @param {!Bento__component_name_pascalcase__.Props} props
  * @return {PreactDef.Renderable}
  */
-export function Bento__component_name_pascal_case__({exampleTagNameProp, ...rest}) {
+export function Bento__component_name_pascalcase__({exampleTagNameProp, ...rest}) {
   // Examples of state and hooks
   // __do_not_submit__: This is example code only.
   const [exampleValue, setExampleValue] = useState(0);

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/component.type.js
@@ -1,17 +1,17 @@
 /** @externs */
 
 /** @const */
-var Bento__component_name_pascal_case__Def = {};
+var Bento__component_name_pascalcase__Def = {};
 
 /**
  * @typedef {{
  *   exampleProperty: (string|undefined), (__do_not_submit__)
  * }}
  */
-Bento__component_name_pascal_case__Def.Props;
+Bento__component_name_pascalcase__Def.Props;
 
 /** @interface */
-Bento__component_name_pascal_case__Def.Bento__component_name_pascal_case__Api = class {
+Bento__component_name_pascalcase__Def.Bento__component_name_pascalcase__Api = class {
   /** Example: API method to toggle the component */
   exampleToggle() {} // __do_not_submit__
 };

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/storybook/Basic.js
@@ -1,9 +1,9 @@
 import * as Preact from '#preact';
-import {Bento__component_name_pascal_case__} from '../component'
+import {Bento__component_name_pascalcase__} from '../component'
 
 export default {
   title: '__component_name_pascalcase__',
-  component: Bento__component_name_pascal_case__,
+  component: Bento__component_name_pascalcase__,
   args: {
     'exampleProperty': 'example string property argument'
   }
@@ -12,11 +12,11 @@ export default {
 // __do_not_submit__: This is example code only.
 export const _default = (args) => {
   return (
-    <Bento__component_name_pascal_case__
+    <Bento__component_name_pascalcase__
       style={{width: 300, height: 200}}
       {...args}
     >
       This text is inside.
-    </Bento__component_name_pascal_case__>
+    </Bento__component_name_pascalcase__>
   );
 };

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
@@ -10,7 +10,7 @@ describes.sandboxed('Bento__component_name_pascalcase__ preact component v1.0', 
       <Bento__component_name_pascalcase__ testProp={true}/>
     );
 
-    const component = wrapper.find(Bento__component_name_pascal_case__.name);
+    const component = wrapper.find(Bento__component_name_pascalcase__.name);
     expect(component).to.have.lengthOf(1);
     expect(component.prop('testProp')).to.be.true;
   });

--- a/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
+++ b/build-system/tasks/make-extension/template/bento/extensions/amp-__component_name_hyphenated__/__component_version__/test/test-component.js
@@ -1,13 +1,13 @@
 import * as Preact from '#preact';
-import {Bento__component_name_pascal_case__} from '../component';
+import {Bento__component_name_pascalcase__} from '../component';
 import {mount} from 'enzyme';
 import {waitFor} from '#testing/test-helper';
 
-describes.sandboxed('Bento__component_name_pascal_case__ preact component v1.0', {}, (env) => {
+describes.sandboxed('Bento__component_name_pascalcase__ preact component v1.0', {}, (env) => {
   // __do_not_submit__: This is example code only.
   it('should render', () => {
     const wrapper = mount(
-      <Bento__component_name_pascal_case__ testProp={true}/>
+      <Bento__component_name_pascalcase__ testProp={true}/>
     );
 
     const component = wrapper.find(Bento__component_name_pascal_case__.name);


### PR DESCRIPTION
Rename reference to use actual key:

https://github.com/ampproject/amphtml/blob/07da65927c96b26ab6dcea937793cab15126b350/build-system/tasks/make-extension/index.js#L228