### PR TITLE
🐛 Fix pre-upgrade Bento styles for sizer element

### DIFF
--- a/docs/building-a-bento-amp-extension.md
+++ b/docs/building-a-bento-amp-extension.md
@@ -487,7 +487,8 @@ amp-my-element:not(.i-amphtml-built) {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-my-element:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-my-element:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.css
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -12,7 +10,8 @@ amp-base-carousel {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-base-carousel:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-base-carousel:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-brightcove/1.0/amp-brightcove.css
+++ b/extensions/amp-brightcove/1.0/amp-brightcove.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -12,7 +10,8 @@ amp-brightcove {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-brightcove:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-brightcove:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-date-countdown/1.0/amp-date-countdown.css
+++ b/extensions/amp-date-countdown/1.0/amp-date-countdown.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -18,7 +16,7 @@ amp-date-countdown:not(.i-amphtml-built) {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-date-countdown:not(.i-amphtml-built)
-  > :not([placeholder]):not(.i-amphtml-svc) {
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-date-display/1.0/amp-date-display.css
+++ b/extensions/amp-date-display/1.0/amp-date-display.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -18,7 +16,7 @@ amp-date-display:not(.i-amphtml-built) {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-date-display:not(.i-amphtml-built)
-  > :not([placeholder]):not(.i-amphtml-svc) {
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-facebook/1.0/amp-facebook.css
+++ b/extensions/amp-facebook/1.0/amp-facebook.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -23,13 +21,14 @@ amp-facebook-page:not(.i-amphtml-built) {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-facebook:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc),
+amp-facebook:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']),
 amp-facebook-comments:not(.i-amphtml-built)
-  > :not([placeholder]):not(.i-amphtml-svc),
+  > :not([placeholder]):not([slot='i-amphtml-svc']),
 amp-facebook-like:not(.i-amphtml-built)
-  > :not([placeholder]):not(.i-amphtml-svc),
+  > :not([placeholder]):not([slot='i-amphtml-svc']),
 amp-facebook-pagee:not(.i-amphtml-built)
-  > :not([placeholder]):not(.i-amphtml-svc) {
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-fit-text/1.0/amp-fit-text.css
+++ b/extensions/amp-fit-text/1.0/amp-fit-text.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -17,7 +15,8 @@ amp-fit-text:not(.i-amphtml-built) {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-fit-text:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-fit-text:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery.css
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery.css
@@ -1,5 +1,3 @@
-
-
 /* Pre-upgrade: display:block element */
 amp-inline-gallery,
 amp-inline-gallery-pagination,
@@ -20,8 +18,10 @@ amp-inline-gallery-thumbnails {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-inline-gallery-pagination:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc),
-amp-inline-gallery-thumbnails:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-inline-gallery-pagination:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']),
+amp-inline-gallery-thumbnails:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-instagram/1.0/amp-instagram.css
+++ b/extensions/amp-instagram/1.0/amp-instagram.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -12,7 +10,8 @@ amp-instagram {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-instagram:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-instagram:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-social-share/1.0/amp-social-share.css
+++ b/extensions/amp-social-share/1.0/amp-social-share.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:inline-block element
@@ -16,7 +14,8 @@ amp-social-share {
 }
 
 /* Pre-upgrade: size-defining element - hide children until build. */
-amp-social-share:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-social-share:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -12,7 +10,8 @@ amp-stream-gallery {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-stream-gallery:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-stream-gallery:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-timeago/1.0/amp-timeago.css
+++ b/extensions/amp-timeago/1.0/amp-timeago.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -17,7 +15,8 @@ amp-timeago:not(.i-amphtml-built) {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-timeago:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-timeago:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-twitter/1.0/amp-twitter.css
+++ b/extensions/amp-twitter/1.0/amp-twitter.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -17,7 +15,8 @@ amp-twitter:not(.i-amphtml-built) {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-twitter:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-twitter:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-video-iframe/1.0/amp-video-iframe.css
+++ b/extensions/amp-video-iframe/1.0/amp-video-iframe.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -12,7 +10,8 @@ amp-video-iframe {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-video-iframe:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-video-iframe:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-video/1.0/amp-video.css
+++ b/extensions/amp-video/1.0/amp-video.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -12,7 +10,8 @@ amp-video {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-video:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-video:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-vimeo/1.0/amp-vimeo.css
+++ b/extensions/amp-vimeo/1.0/amp-vimeo.css
@@ -1,18 +1,17 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
  * - size-defined element
  */
- amp-vimeo {
+amp-vimeo {
   display: block;
   overflow: hidden;
   position: relative;
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-vimeo:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-vimeo:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-wordpress-embed/1.0/amp-wordpress-embed.css
+++ b/extensions/amp-wordpress-embed/1.0/amp-wordpress-embed.css
@@ -16,7 +16,7 @@ amp-wordpress-embed:not(.i-amphtml-built) {
 
 /* Pre-upgrade: size-defining element - hide children. */
 amp-wordpress-embed:not(.i-amphtml-built)
-  > :not([placeholder]):not(.i-amphtml-svc) {
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }

--- a/extensions/amp-youtube/1.0/amp-youtube.css
+++ b/extensions/amp-youtube/1.0/amp-youtube.css
@@ -1,5 +1,3 @@
-
-
 /*
  * Pre-upgrade:
  * - display:block element
@@ -12,7 +10,8 @@ amp-youtube {
 }
 
 /* Pre-upgrade: size-defining element - hide children. */
-amp-youtube:not(.i-amphtml-built) > :not([placeholder]):not(.i-amphtml-svc) {
+amp-youtube:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
   display: none;
   content-visibility: hidden;
 }


### PR DESCRIPTION
Fixes #35805

The previously excluded classname `.i-amphtml-svc` is **never** added by the runtime. The original CSS pre-upgrade selector that has been carried over across extensions meant to target `[slot='i-amphtml-svc']` instead, which refers to sizer elements used for e.g. `layout=intrinsic`. 