### PR TITLE
🐛 Fix attribution reporting OT token in FIE

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -99,7 +99,7 @@ const CDN_PROXY_REGEXP =
   /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org((\/.*)|($))+/;
 
 /** @const {string} */
-const TOKEN_VALUE =
+export const TOKEN_VALUE =
   'A560Vqrj/cxoDr3Ldu+cN8qcpkaPx5Yh67pvGScX0kOke10st2EAEQmfQrDKSlVJtF+oZ0WqUYbPLmY6nRQq5wAAAACVeyJvcmlnaW4iOiJodHRwczovL2FtcHByb2plY3Qub3JnOjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2MzE2NjM5OTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWUsInVzYWdlIjoic3Vic2V0In0=';
 
 /**

--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -1,3 +1,5 @@
+import {TOKEN_VALUE} from '#ads/google/a4a/utils';
+
 import {createElementWithAttributes, escapeHtml} from '#core/dom';
 import {dict} from '#core/types/object';
 
@@ -51,6 +53,7 @@ export const createSecureDocSkeleton = (url, sanitizedHeadElements, body) =>
       default-src 'none';
       style-src ${fontProviderAllowList} 'unsafe-inline';
     ">
+    <meta http-equiv="origin-trial" content=${TOKEN_VALUE}>    
     ${sanitizedHeadElements}
   </head>
   <body>${body}</body>

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -434,9 +434,9 @@ export class AmpAdExit extends AMP.BaseElement {
    * @return {boolean}
    */
   detectAttributionReportingSupport() {
-    return this.win.document.featurePolicy
-      ?.features()
-      .includes('attribution-reporting');
+    return this.win.document.featurePolicy?.allowsFeature(
+      'attribution-reporting'
+    );
   }
 
   /**


### PR DESCRIPTION
Includes the token in FIE rendering as this is needed even if iframe is friendly. Also updates the enablement check because `document.featurePolicy.features().includes('attribution-reporting')` will always return `true` if token is present, but `document.featurePolicy.allowsFeature('attribution-reporting')` will only return true if OT token present && `allow=attribution-reporting` is correctly set on the frame.

Partial #35347