### PR TITLE
esbuild: disable prop mangling

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -643,10 +643,7 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
     const buildResult =
       options.minify && shouldUseClosure()
         ? compileMinifiedJs(srcDir, srcFilename, destDir, options)
-        : esbuildCompile(srcDir, srcFilename, destDir, {
-            ...options,
-            mangle: true,
-          });
+        : esbuildCompile(srcDir, srcFilename, destDir, options);
     if (options.onWatchBuild) {
       options.onWatchBuild(buildResult);
     }


### PR DESCRIPTION
**summary**
- Since we are running a performance experiment, may as well start with the safer version first and see if it already good enough.
- We can iterate and ensure mangling is 100% safe by applying a simple babel transform to add a suffix to all of our private vars. (i.e. `AMP_PRIVATE_`), that way our regex would not collide with any imported 3p libraries.