### PR TITLE
🐛 `<amp-next-page>`: Propagate host's message deliverer

### DIFF
--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -608,7 +608,24 @@ export class NextPageService {
       // Even though we have multiple instances of the Viewer service, we only
       // have a single messaging channel.
       const messageDeliverer = this.viewer_.maybeGetMessageDeliverer();
-      amp.onMessage(messageDeliverer);
+
+      if (messageDeliverer) {
+        amp.onMessage((eventType, data, awaitResponse) => {
+          // Some Viewer messages are suppressed when coming from the inserted
+          // document. These are related to the viewport, so we allow the host
+          // document to handle these events instead.
+          // Otherwise, we would confuse the viewer and observe issues like the
+          // header appearing unexpectedly.
+          if (
+            eventType === 'documentHeight' ||
+            eventType === 'scroll' ||
+            eventType === 'viewport'
+          ) {
+            return;
+          }
+          messageDeliverer(eventType, data, awaitResponse);
+        });
+      }
 
       const ampdoc = devAssert(amp.ampdoc);
       installStylesForDoc(ampdoc, CSS, null, false, TAG);

--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -604,6 +604,12 @@ export class NextPageService {
         }
       );
 
+      // Reuse message deliverer from existing viewer.
+      // Even though we have multiple instances of the Viewer service, we only
+      // have a single messaging channel.
+      const messageDeliverer = this.viewer_.maybeGetMessageDeliverer();
+      amp.onMessage(messageDeliverer);
+
       const ampdoc = devAssert(amp.ampdoc);
       installStylesForDoc(ampdoc, CSS, null, false, TAG);
 

--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -610,7 +610,7 @@ export class NextPageService {
       const messageDeliverer = this.viewer_.maybeGetMessageDeliverer();
       if (messageDeliverer) {
         amp.onMessage((eventType, data, awaitResponse) => {
-          // Some Viewer messages are suppressed when coming from the inserted
+          // Some messages should be suppressed when coming from the inserted
           // document. These are related to the viewport, so we allow the host
           // document to handle these events instead.
           // Otherwise, we would confuse the viewer and observe issues like the

--- a/extensions/amp-next-page/1.0/service.js
+++ b/extensions/amp-next-page/1.0/service.js
@@ -608,7 +608,6 @@ export class NextPageService {
       // Even though we have multiple instances of the Viewer service, we only
       // have a single messaging channel.
       const messageDeliverer = this.viewer_.maybeGetMessageDeliverer();
-
       if (messageDeliverer) {
         amp.onMessage((eventType, data, awaitResponse) => {
           // Some Viewer messages are suppressed when coming from the inserted

--- a/extensions/amp-next-page/1.0/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/1.0/test/test-amp-next-page.js
@@ -617,6 +617,30 @@ describes.realWin(
           ).to.equal('cid');
         });
       });
+
+      it('shadow-doc Viewer calls host-doc messageDeliverer', async () => {
+        const initialMessageDeliverer = env.sandbox.spy();
+        const initialViewer = Services.viewerForDoc(ampdoc);
+        initialViewer.setMessageDeliverer(initialMessageDeliverer, '');
+
+        await fetchDocuments(service, MOCK_NEXT_PAGE, 2);
+
+        [1, 2].forEach((index) => {
+          const {ampdoc} = service.pages_[index].shadowDoc;
+          const viewer = Services.viewerForDoc(ampdoc);
+          expect(viewer).to.not.equal(initialViewer);
+
+          const messageDeliverer = viewer.maybeGetMessageDeliverer();
+          expect(messageDeliverer).to.be.ok;
+
+          const args = [`event${index}`, `data${index}`, true];
+
+          messageDeliverer(...args);
+
+          expect(initialMessageDeliverer.withArgs(...args)).to.have.been
+            .calledOnce;
+        });
+      });
     });
 
     describe('default separators & footers', () => {

--- a/extensions/amp-next-page/1.0/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/1.0/test/test-amp-next-page.js
@@ -625,7 +625,7 @@ describes.realWin(
 
         await fetchDocuments(service, MOCK_NEXT_PAGE, 2);
 
-        [1, 2].forEach((index) => {
+        for (const index of [1, 2]) {
           const {ampdoc} = service.pages_[index].shadowDoc;
           const viewer = Services.viewerForDoc(ampdoc);
           expect(viewer).to.not.equal(initialViewer);
@@ -639,7 +639,33 @@ describes.realWin(
 
           expect(initialMessageDeliverer.withArgs(...args)).to.have.been
             .calledOnce;
-        });
+        }
+      });
+
+      it('shadow-doc Viewer supresses viewport message requests', async () => {
+        const initialMessageDeliverer = env.sandbox.spy();
+        const initialViewer = Services.viewerForDoc(ampdoc);
+        initialViewer.setMessageDeliverer(initialMessageDeliverer, '');
+
+        await fetchDocuments(service, MOCK_NEXT_PAGE, 2);
+
+        for (const eventType of ['documentHeight', 'scroll', 'viewport']) {
+          for (const index of [1, 2]) {
+            const {ampdoc} = service.pages_[index].shadowDoc;
+            const viewer = Services.viewerForDoc(ampdoc);
+            expect(viewer).to.not.equal(initialViewer);
+
+            const messageDeliverer = viewer.maybeGetMessageDeliverer();
+            expect(messageDeliverer).to.be.ok;
+
+            const args = [eventType, `data${index}`, true];
+
+            messageDeliverer(...args);
+
+            expect(initialMessageDeliverer.withArgs(...args)).to.not.have.been
+              .called;
+          }
+        }
       });
     });
 

--- a/extensions/amp-next-page/1.0/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/1.0/test/test-amp-next-page.js
@@ -642,7 +642,7 @@ describes.realWin(
         }
       });
 
-      it('shadow-doc Viewer supresses viewport message requests', async () => {
+      it('shadow-doc Viewer suppresses viewport message requests', async () => {
         const initialMessageDeliverer = env.sandbox.spy();
         const initialViewer = Services.viewerForDoc(ampdoc);
         initialViewer.setMessageDeliverer(initialMessageDeliverer, '');

--- a/extensions/amp-next-page/1.0/test/test-amp-next-page.js
+++ b/extensions/amp-next-page/1.0/test/test-amp-next-page.js
@@ -631,7 +631,7 @@ describes.realWin(
           expect(viewer).to.not.equal(initialViewer);
 
           const messageDeliverer = viewer.maybeGetMessageDeliverer();
-          expect(messageDeliverer).to.be.ok;
+          expect(messageDeliverer).to.not.be.null;
 
           const args = [`event${index}`, `data${index}`, true];
 
@@ -656,7 +656,7 @@ describes.realWin(
             expect(viewer).to.not.equal(initialViewer);
 
             const messageDeliverer = viewer.maybeGetMessageDeliverer();
-            expect(messageDeliverer).to.be.ok;
+            expect(messageDeliverer).to.not.be.null;
 
             const args = [eventType, `data${index}`, true];
 

--- a/src/inabox/inabox-viewer.js
+++ b/src/inabox/inabox-viewer.js
@@ -121,6 +121,11 @@ class InaboxViewer {
   setMessageDeliverer() {}
 
   /** @override */
+  maybeGetMessageDeliverer() {
+    return null;
+  }
+
+  /** @override */
   sendMessage() {}
 
   /** @override */

--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -136,9 +136,7 @@ export class MultidocManager {
       }
 
       // All other messages.
-      if (onMessage) {
-        return onMessage(eventType, data, awaitResponse);
-      }
+      return onMessage?.(eventType, data, awaitResponse);
     }, origin);
 
     /**

--- a/src/multidoc-manager.js
+++ b/src/multidoc-manager.js
@@ -116,13 +116,13 @@ export class MultidocManager {
      */
     amp['postMessage'] = viewer.receiveMessage.bind(viewer);
 
-    /** @type {function(string, *, boolean):(!Promise<*>|undefined)} */
+    /** @type {?function(string, *, boolean):(!Promise<*>|undefined)|undefined} */
     let onMessage;
 
     /**
      * Provides a message delivery mechanism by which AMP document can send
      * messages to the viewer.
-     * @param {function(string, *, boolean):(!Promise<*>|undefined)} callback
+     * @param {?function(string, *, boolean):(!Promise<*>|undefined)} callback
      */
     amp['onMessage'] = function (callback) {
       onMessage = callback;

--- a/src/service/viewer-impl.js
+++ b/src/service/viewer-impl.js
@@ -759,6 +759,11 @@ export class ViewerImpl {
   }
 
   /** @override */
+  maybeGetMessageDeliverer() {
+    return this.messageDeliverer_;
+  }
+
+  /** @override */
   sendMessage(eventType, data, cancelUnsent = false) {
     this.sendMessageInternal_(eventType, data, cancelUnsent, false);
   }

--- a/src/service/viewer-interface.js
+++ b/src/service/viewer-interface.js
@@ -163,6 +163,11 @@ export class ViewerInterface {
   setMessageDeliverer(deliverer, origin) {}
 
   /**
+   * @return {?function(string, (?JsonObject|string|undefined), boolean):(!Promise<*>|undefined)}
+   */
+  maybeGetMessageDeliverer() {}
+
+  /**
    * Sends the message to the viewer without waiting for any response.
    * If cancelUnsent is true, the previous message of the same message type will
    * be canceled.


### PR DESCRIPTION
Fixes #35488

Messages meant for the Viewer are lost on documents loaded by `<amp-next-page>`.

This fix reuses the existing `messageDeliverer` from the host document's `Viewer` instance as the deliverer for the second document's `Viewer`. This way, messages are
received the same way.
