### PR TITLE
🏗 Fix nightly cut job to use the correct API endpoint for status checks and GitHub access token

### DIFF
--- a/.github/workflows/cut-nightly.yml
+++ b/.github/workflows/cut-nightly.yml
@@ -8,7 +8,8 @@ on:
     - cron: '0 8 * * 2-6'
 
 jobs:
-  sweep-experiments:
+  cut-nightly:
+    environment: release_tagger
     if: github.repository == 'ampproject/amphtml'
     name: Cut Nightly Branch
     runs-on: ubuntu-latest
@@ -28,3 +29,5 @@ jobs:
 
       - name: ⭐ Cut Nightly Branch ⭐
         run: node --unhandled-rejections=strict build-system/release-workflows/cut-nightly.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.AMPPROJECTBOT }}

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -4,20 +4,12 @@
  * @fileoverview Script that cuts a nightly branch.
  */
 
-const {cyan, green, red, yellow} = require('kleur/colors');
+const {cyan, green, red} = require('kleur/colors');
+>>>>>>> 33959af59 (🏗 Restore direct requires of kleur/colors (#35905))
 const {log} = require('../common/logging');
 const {Octokit} = require('@octokit/rest');
 
 const params = {owner: 'ampproject', repo: 'amphtml'};
-
-const colorizeState = (state) =>
-  state == 'error' || state == 'failure'
-    ? red(state)
-    : state == 'pending'
-    ? yellow(state)
-    : state == 'success'
-    ? green(state)
-    : state;
 
 /**
  * Perform nightly branch cut.
@@ -32,7 +24,7 @@ async function cutNightlyBranch() {
       cyan(options.method),
       cyan(options.url)
     );
-    throw new Error(error.message);
+    throw error;
   });
 
   const commits = await octokit.rest.repos.listCommits({
@@ -48,48 +40,76 @@ async function cutNightlyBranch() {
   );
 
   for (const {sha} of commits.data) {
-    const commitStatus = await octokit.rest.repos.getCombinedStatusForRef({
-      ...params,
-      ref: sha,
-    });
-    const {state} = commitStatus.data;
-
-    log('Status of commit', cyan(sha), 'is', colorizeState(state));
-
-    if (state === 'success') {
-      const response = await octokit.rest.git.updateRef({
+    const {'check_runs': checkRuns} = (
+      await octokit.rest.checks.listForRef({
         ...params,
-        ref: 'heads/nightly',
-        sha,
-      });
-
-      // Casting to Number because the return type in Octokit is incorrectly
-      // annotated to only ever return 200.
-      switch (Number(response.status)) {
-        case 201:
-          log('Cut a new', cyan('nightly'), 'with', cyan(sha));
-          break;
-        case 200:
-          log(
-            'The',
-            cyan('nightly'),
-            'branch is already at the latest',
-            green('green'),
-            'sha',
-            cyan(sha)
-          );
-          break;
-        default:
-          log(
-            red('An error occurred while attempting to fast-forward the'),
-            cyan('nightly'),
-            red('branch to sha'),
-            cyan(sha)
-          );
-      }
-
-      break;
+        ref: sha,
+      })
+    ).data;
+    if (checkRuns.some(({status}) => status != 'completed')) {
+      log(
+        'Not all check runs for commit',
+        cyan(sha),
+        'are completed. Checking next commit...'
+      );
+      continue;
     }
+
+    if (
+      !checkRuns.every(({conclusion}) =>
+        ['success', 'neutral', 'skipped'].includes(conclusion ?? '')
+      )
+    ) {
+      log(
+        'Not all check runs for commit',
+        cyan(sha),
+        'are successful. Checking next commit...'
+      );
+      continue;
+    }
+
+    log(
+      'All check runs for commit',
+      cyan(sha),
+      'have completed successfully. Cutting a new nightly at this commit...'
+    );
+    const response = await octokit.rest.git.updateRef({
+      ...params,
+      ref: 'heads/nightly',
+      sha,
+    });
+
+    // Casting to Number because the return type in Octokit is incorrectly
+    // annotated to only ever return 200.
+    switch (Number(response.status)) {
+      case 201:
+        log(
+          'A new',
+          cyan('nightly'),
+          'branch was successfully cut at commit',
+          cyan(sha)
+        );
+        break;
+      case 200:
+        log(
+          'The',
+          cyan('nightly'),
+          'branch is already at the latest',
+          green('green'),
+          'commit',
+          cyan(sha)
+        );
+        break;
+      default:
+        log(
+          red('An error occurred while attempting to fast-forward the'),
+          cyan('nightly'),
+          red('branch to commit'),
+          cyan(sha)
+        );
+    }
+
+    break;
   }
 }
 

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -101,11 +101,14 @@ async function cutNightlyBranch() {
         break;
       default:
         log(
-          red('An error occurred while attempting to fast-forward the'),
+          red(
+            'An uncaught status was returned while attempting to fast-forward the'
+          ),
           cyan('nightly'),
           red('branch to commit'),
           cyan(sha)
         );
+        log('See full response:', response);
     }
 
     break;

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -5,7 +5,6 @@
  */
 
 const {cyan, green, red} = require('kleur/colors');
->>>>>>> 33959af59 (🏗 Restore direct requires of kleur/colors (#35905))
 const {log} = require('../common/logging');
 const {Octokit} = require('@octokit/rest');
 


### PR DESCRIPTION
* Adds the `release_tagger` environment (we should probably create a new environment just for releases, but for now this would do!)
* Explicitly pass the environment's GITHUB_TOKEN as an env variable
* Use `octokit.rest.checks.listForRef` instead of `octokit.rest.repos.getCombinedStatusForRef` because the former returns *all* statuses, while the latter misses some (such as, critically, CircleCI!)
* Better logging