### PR TITLE
🏗  Rename beta to beta-percent for release tagger

### DIFF
--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -12,7 +12,7 @@ on:
         description: 'base AMP version'
         required: true
       channel:
-        description: 'release channel (beta | stable | lts)'
+        description: 'release channel (beta-opt-in | beta-percent | stable | lts)'
         required: true
 jobs:
   tagger:

--- a/build-system/release-tagger/index.js
+++ b/build-system/release-tagger/index.js
@@ -5,7 +5,7 @@
  * 1. action (promote|rollback)
  * 2. head (AMP version)
  * 3. base (AMP version)
- * 4. channel (beta|stable|lts)
+ * 4. channel (beta-percent|stable|lts)
  */
 
 const [action, head, base, channel] = process.argv.slice(2);
@@ -20,6 +20,11 @@ const {publishRelease, rollbackRelease} = require('./update-release');
  * @return {Promise<void>}
  */
 async function _promote() {
+  const supportedChannels = ['beta-percent', 'stable', 'lts'];
+  if (!supportedChannels.includes(channel)) {
+    return;
+  }
+
   try {
     await publishRelease(head);
     log('Published release', head);
@@ -37,6 +42,11 @@ async function _promote() {
  * @return {Promise<void>}
  */
 async function _rollback() {
+  const supportedChannels = ['beta-percent', 'stable', 'lts'];
+  if (!supportedChannels.includes(channel)) {
+    return;
+  }
+
   try {
     await rollbackRelease(head);
     log('Rolled back release', head);

--- a/build-system/release-tagger/label-pull-requests.js
+++ b/build-system/release-tagger/label-pull-requests.js
@@ -12,7 +12,7 @@ const {
 } = require('./utils');
 
 const labelConfig = {
-  beta: 'PR Use: In Beta / Experimental',
+  'beta-percent': 'PR Use: In Beta / Experimental',
   lts: 'PR Use: In LTS',
   stable: 'PR Use: In Stable',
 };

--- a/build-system/release-tagger/make-release.js
+++ b/build-system/release-tagger/make-release.js
@@ -13,7 +13,7 @@ const {getExtensions, getSemver} = require('../npm-publish/utils');
 const {GraphQlQueryResponseData} = require('@octokit/graphql'); //eslint-disable-line no-unused-vars
 
 const prereleaseConfig = {
-  'beta': true,
+  'beta-percent': true,
   'stable': false,
   'lts': false,
 };

--- a/build-system/release-tagger/test/label-pull-requests.test.js
+++ b/build-system/release-tagger/test/label-pull-requests.test.js
@@ -239,7 +239,7 @@ test('unlabel', async (t) => {
     )
     .reply(200, {data: {}});
 
-  await removeLabels('2107280123000', '2107210123000', 'beta');
+  await removeLabels('2107280123000', '2107210123000', 'beta-percent');
   t.true(rest.isDone());
   t.true(graphql.isDone());
 });

--- a/build-system/release-tagger/test/make-release.test.js
+++ b/build-system/release-tagger/test/make-release.test.js
@@ -176,7 +176,7 @@ test('create', async (t) => {
       },
     });
 
-  await makeRelease('2107280123000', '2107210123000', 'beta');
+  await makeRelease('2107280123000', '2107210123000', 'beta-percent');
   t.true(rest.isDone());
   t.true(graphql.isDone());
 });


### PR DESCRIPTION
This is because we now need the distinction of `beta-opt-in` and `beta-percent` for updating the release issue trackers.