### PR TITLE
Stopping amp-sticky-ad-to-amp-ad-v2 experiment

### DIFF
--- a/build-system/global-configs/client-side-experiments-config.json
+++ b/build-system/global-configs/client-side-experiments-config.json
@@ -23,10 +23,6 @@
     {
       "name": "story-load-inactive-outside-viewport",
       "percentage": 1
-    },
-    {
-      "name": "amp-sticky-ad-to-amp-ad-v2",
-      "percentage": 0.05
     }
   ]
 }


### PR DESCRIPTION
We are still getting similar regressions here, and it proves that there might be some visibility issues rather than performance issues. Reverting it for now as we investigate.