### PR TITLE
🏗  Trigger issue tracker management with release-tagger action 

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-tracker.yml
+++ b/.github/ISSUE_TEMPLATE/release-tracker.yml
@@ -1,6 +1,6 @@
 ---
 name: Release Tracker
-description: Track a new AMP release.
+description: Manually track a new AMP release. (This is automatically updated by the release-tagger GitHub Action).
 labels: 'Type: Release'
 title: "\U0001F684 Release VERSION"
 body:
@@ -17,12 +17,12 @@ body:
     id: promotions
     attributes:
       label: Promotions
-      description: Replace VERSION with AMP version and PROMOTE_TIME with CL submit time.
+      description: Replace `VERSION` with AMP version and `<!-- promote-time -->` with CL submit time.
       value: |
-        - [ ] VERSION promoted to Experimental and Beta (opt-in) channels (PROMOTE_TIME)
-        - [ ] VERSION promoted to Experimental and Beta (1% traffic) channels (PROMOTE_TIME)
-        - [ ] VERSION promoted to Stable channel (PROMOTE_TIME)
-        - [ ] (optional) VERSION promoted to LTS channel (PROMOTE_TIME)
+        - [ ] <!-- amp-version=VERSION channel=beta-opt-in -->VERSION promoted to Experimental and Beta (opt-in) channels <!-- promote-time -->
+        - [ ] <!-- amp-version=VERSION channel=beta-percent -->VERSION promoted to Experimental and Beta (1% traffic) channels <!-- promote-time -->
+        - [ ] <!-- amp-version=VERSION channel=stable -->VERSION promoted to Stable channel <!-- promote-time -->
+        - [ ] <!-- amp-version=VERSION channel=lts -->VERSION promoted to LTS channel <!-- promote-time -->
 
         /cc @ampproject/release-on-duty
     validations:

--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -30,6 +30,7 @@ jobs:
             ${{ github.event.inputs.action }} \
             ${{ github.event.inputs.head }} \
             ${{ github.event.inputs.base }} \
-            ${{ github.event.inputs.channel }}
+            ${{ github.event.inputs.channel }} \
+            ${{ github.event.inputs.time }}
         env:
           GITHUB_TOKEN: ${{ secrets.AMPPROJECTBOT }}

--- a/build-system/release-tagger/index.js
+++ b/build-system/release-tagger/index.js
@@ -8,9 +8,10 @@
  * 4. channel (beta|stable|lts)
  */
 
-const [action, head, base, channel] = process.argv.slice(2);
+const [action, head, base, channel, time] = process.argv.slice(2);
 
 const {addLabels, removeLabels} = require('./label-pull-requests');
+const {createOrUpdateTracker} = require('./update-issue-tracker');
 const {log} = require('../common/logging');
 const {makeRelease} = require('./make-release');
 const {publishRelease, rollbackRelease} = require('./update-release');
@@ -30,6 +31,9 @@ async function _promote() {
 
   await addLabels(head, base, channel);
   log('Labeled PRs for release', head, 'and channel', channel);
+
+  await createOrUpdateTracker(head, base, channel, time);
+  log('Updated issue tracker for release', head, 'and channel', channel);
 }
 
 /**

--- a/build-system/release-tagger/test/update-issue-tracker.test.js
+++ b/build-system/release-tagger/test/update-issue-tracker.test.js
@@ -29,7 +29,7 @@ test('create', async (t) => {
         '(https://github.com/ampproject/amphtml/releases/tag/2109080123000)\n\n' +
         '### Promotions\n\n' +
         '- [x] <!-- amp-version=2109080123000 channel=beta-opt-in -->' +
-        '2109080123000 promoted to Experimental and Beta (opt-in) channels (testtime)\n' +
+        '2109080123000 promoted to Experimental and Beta (opt-in) channels (9/15/2021, 8:34:56 AM ET)\n' +
         '- [ ] <!-- amp-version=2109080123000 channel=beta-percent -->' +
         '2109080123000 promoted to Experimental and Beta (1% traffic) channels <!-- promote-time -->\n' +
         '- [ ] <!-- amp-version=2109080123000 channel=stable -->' +
@@ -44,7 +44,7 @@ test('create', async (t) => {
     '2109080123000',
     '2109010123000',
     'beta-opt-in',
-    'testtime'
+    '2021-09-15 12:34:56'
   );
   t.true(graphql.isDone());
   t.true(rest.isDone());
@@ -118,7 +118,7 @@ test('mark task complete', async (t) => {
         '- [x] <!-- amp-version=2109080123000 channel=beta-percent -->' +
         '2109080123000 promoted to Experimental and Beta (1% traffic) channels (percenttime)\n' +
         '- [x] <!-- amp-version=2109080123000 channel=stable -->' +
-        '2109080123000 promoted to Stable channel (testtime)\n' +
+        '2109080123000 promoted to Stable channel (9/15/2021, 8:34:56 AM ET)\n' +
         '- [ ] <!-- amp-version=2109080123000 channel=lts -->' +
         '2109080123000 promoted to LTS channel <!-- promote-time -->\n\n' +
         '/cc @ampproject/release-on-duty',
@@ -137,7 +137,7 @@ test('mark task complete', async (t) => {
     '2109080123000',
     '2109010123000',
     'stable',
-    'testtime'
+    '2021-09-15 12:34:56'
   );
   t.true(graphql.isDone());
   t.true(rest.isDone());
@@ -194,7 +194,7 @@ test('add cherrypick tasks', async (t) => {
         '2109080123000 promoted to Stable channel (stabletime)\n' +
         '🌸 2109080123000 was cherry-picked to create 2109080123001\n' +
         '- [x] <!-- amp-version=2109080123001 channel=stable -->' +
-        '2109080123001 promoted to Stable channel (testtime)\n' +
+        '2109080123001 promoted to Stable channel (9/15/2021, 8:34:56 AM ET)\n' +
         '- [ ] <!-- amp-version=2109080123001 channel=lts -->' +
         '2109080123001 promoted to LTS channel <!-- promote-time -->\n\n' +
         '/cc @ampproject/release-on-duty',
@@ -206,7 +206,7 @@ test('add cherrypick tasks', async (t) => {
     '2109080123001',
     '2109080123000',
     'stable',
-    'testtime'
+    '2021-09-15 12:34:56'
   );
   t.true(graphql.isDone());
   t.true(rest.isDone());

--- a/build-system/release-tagger/test/update-issue-tracker.test.js
+++ b/build-system/release-tagger/test/update-issue-tracker.test.js
@@ -29,7 +29,7 @@ test('create', async (t) => {
         '(https://github.com/ampproject/amphtml/releases/tag/2109080123000)\n\n' +
         '### Promotions\n\n' +
         '- [x] <!-- amp-version=2109080123000 channel=beta-opt-in -->' +
-        '2109080123000 promoted to Experimental and Beta (opt-in) channels (9/15/2021, 8:34:56 AM ET)\n' +
+        '2109080123000 promoted to Experimental and Beta (opt-in) channels (9/15/2021, 5:34:56 AM PT)\n' +
         '- [ ] <!-- amp-version=2109080123000 channel=beta-percent -->' +
         '2109080123000 promoted to Experimental and Beta (1% traffic) channels <!-- promote-time -->\n' +
         '- [ ] <!-- amp-version=2109080123000 channel=stable -->' +
@@ -118,7 +118,7 @@ test('mark task complete', async (t) => {
         '- [x] <!-- amp-version=2109080123000 channel=beta-percent -->' +
         '2109080123000 promoted to Experimental and Beta (1% traffic) channels (percenttime)\n' +
         '- [x] <!-- amp-version=2109080123000 channel=stable -->' +
-        '2109080123000 promoted to Stable channel (9/15/2021, 8:34:56 AM ET)\n' +
+        '2109080123000 promoted to Stable channel (9/15/2021, 5:34:56 AM PT)\n' +
         '- [ ] <!-- amp-version=2109080123000 channel=lts -->' +
         '2109080123000 promoted to LTS channel <!-- promote-time -->\n\n' +
         '/cc @ampproject/release-on-duty',
@@ -194,7 +194,7 @@ test('add cherrypick tasks', async (t) => {
         '2109080123000 promoted to Stable channel (stabletime)\n' +
         '🌸 2109080123000 was cherry-picked to create 2109080123001\n' +
         '- [x] <!-- amp-version=2109080123001 channel=stable -->' +
-        '2109080123001 promoted to Stable channel (9/15/2021, 8:34:56 AM ET)\n' +
+        '2109080123001 promoted to Stable channel (9/15/2021, 5:34:56 AM PT)\n' +
         '- [ ] <!-- amp-version=2109080123001 channel=lts -->' +
         '2109080123001 promoted to LTS channel <!-- promote-time -->\n\n' +
         '/cc @ampproject/release-on-duty',

--- a/build-system/release-tagger/update-issue-tracker.js
+++ b/build-system/release-tagger/update-issue-tracker.js
@@ -102,6 +102,9 @@ class IssueTracker {
  * @return {Promise<void>}
  */
 async function createOrUpdateTracker(head, base, channel, time) {
+  const timeET = new Date(time).toLocaleString('en-US', {
+    timeZone: 'America/New_York',
+  });
   const isCherrypick = Number(head) - Number(base) < 1000;
   const issue = isCherrypick
     ? await getIssue(`Release ${base}`)
@@ -110,7 +113,7 @@ async function createOrUpdateTracker(head, base, channel, time) {
   // create new tracker
   if (!issue) {
     const tracker = new IssueTracker(head, base);
-    tracker.checkTask(channel, time);
+    tracker.checkTask(channel, timeET);
     const {footer, header, label, main, title} = tracker;
     const body = `${header}\n\n${main}\n\n${footer}`;
     return await createIssue(body, label, title);
@@ -121,7 +124,7 @@ async function createOrUpdateTracker(head, base, channel, time) {
   if (isCherrypick) {
     tracker.addCherrypickTasks(channel);
   }
-  tracker.checkTask(channel, time);
+  tracker.checkTask(channel, timeET);
   const {footer, header, main, number, title} = tracker;
   const body = `${header}\n\n${main}\n\n${footer}`;
   await updateIssue(body, number, title);

--- a/build-system/release-tagger/update-issue-tracker.js
+++ b/build-system/release-tagger/update-issue-tracker.js
@@ -102,9 +102,10 @@ class IssueTracker {
  * @return {Promise<void>}
  */
 async function createOrUpdateTracker(head, base, channel, time) {
-  const timeET = new Date(time).toLocaleString('en-US', {
-    timeZone: 'America/New_York',
-  });
+  const timeET =
+    new Date(`${time} UTC`).toLocaleString('en-US', {
+      timeZone: 'America/New_York',
+    }) + ' ET';
   const isCherrypick = Number(head) - Number(base) < 1000;
   const issue = isCherrypick
     ? await getIssue(`Release ${base}`)

--- a/build-system/release-tagger/update-issue-tracker.js
+++ b/build-system/release-tagger/update-issue-tracker.js
@@ -102,10 +102,10 @@ class IssueTracker {
  * @return {Promise<void>}
  */
 async function createOrUpdateTracker(head, base, channel, time) {
-  const timeET =
+  const timePT =
     new Date(`${time} UTC`).toLocaleString('en-US', {
-      timeZone: 'America/New_York',
-    }) + ' ET';
+      timeZone: 'America/Los_Angeles',
+    }) + ' PT';
   const isCherrypick = Number(head) - Number(base) < 1000;
   const issue = isCherrypick
     ? await getIssue(`Release ${base}`)
@@ -114,7 +114,7 @@ async function createOrUpdateTracker(head, base, channel, time) {
   // create new tracker
   if (!issue) {
     const tracker = new IssueTracker(head, base);
-    tracker.checkTask(channel, timeET);
+    tracker.checkTask(channel, timePT);
     const {footer, header, label, main, title} = tracker;
     const body = `${header}\n\n${main}\n\n${footer}`;
     return await createIssue(body, label, title);
@@ -125,7 +125,7 @@ async function createOrUpdateTracker(head, base, channel, time) {
   if (isCherrypick) {
     tracker.addCherrypickTasks(channel);
   }
-  tracker.checkTask(channel, timeET);
+  tracker.checkTask(channel, timePT);
   const {footer, header, main, number, title} = tracker;
   const body = `${header}\n\n${main}\n\n${footer}`;
   await updateIssue(body, number, title);

--- a/build-system/release-tagger/utils.js
+++ b/build-system/release-tagger/utils.js
@@ -13,7 +13,7 @@ const {Octokit} = require('@octokit/rest');
 const octokit = new Octokit({
   auth: process.env.GITHUB_TOKEN,
   userAgent: 'amp release tagger',
-  timeZone: 'America/New_York',
+  timeZone: 'America/Los_Angeles',
 });
 
 const graphqlWithAuth = graphql.defaults({


### PR DESCRIPTION
To submit at the end of the week, avoiding active on-duty stuff.