### PR TITLE
SwG Release 0.1.22.184

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.183 */
+/** Version: 0.1.22.184 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *

--- a/third_party/subscriptions-project/swg-gaa.js
+++ b/third_party/subscriptions-project/swg-gaa.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.183 */
+/** Version: 0.1.22.184 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *
@@ -243,6 +243,7 @@ const AnalyticsEvent = {
   EVENT_OFFERED_METER: 3011,
   EVENT_UNLOCKED_FREE_PAGE: 3012,
   EVENT_INELIGIBLE_PAYWALL: 3013,
+  EVENT_UNLOCKED_FOR_CRAWLER: 3014,
   EVENT_SUBSCRIPTION_STATE: 4000,
 };
 /** @enum {number} */


### PR DESCRIPTION
- Demos: Load correct JS for qual autoprompt demo (#1900)
- Demos: Add qual pages (#1899)
- Analytics: Logs special event when unlocking for crawlers (#1898)
- Update dependency chromedriver to v93 (#1891)
- Analytics: Avoid logging subscription unlock events for crawlers (#1897)
- Update dependency @babel/preset-env to v7.15.6 (#1896)
- Update dependency prettier to v2.4.0 (#1895)
- Allow Dialog to be contained in a given element and iframe CSS class (#1894)