### PR TITLE
✨  add new analytics vendor infonline_base to amp project

### DIFF
--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -201,6 +201,10 @@
     "pageview": "!url?st=!st&sv=ke&ap=1&co=!co&cp=!cp&ps=!ps&act=_consent_string_&acs=_if(_equals(_consent_state_%2Csufficient)_%2C1)__if(_equals(_consent_state_%2Cinsufficient)_%2C0)__if(_equals(_consent_state_%2C)_%2C-1)_&host=_canonical_host_&path=_canonical_path_&type=pageview",
     "event": "!url?st=!st&ev=!ev&sv=ke&ap=1&co=!co&cp=!cp&ps=!ps&act=_consent_string_&acs=_if(_equals(_consent_state_%2Csufficient)_%2C1)__if(_equals(_consent_state_%2Cinsufficient)_%2C0)__if(_equals(_consent_state_%2C)_%2C-1)_&host=_canonical_host_&path=_canonical_path_&type=event"
   },
+  "infonline_base": {
+    "pageview": "!url?dn=!dn&cn=!cn&st=!st&co=!co&cp=!cp&au=_canonical_url_&tp=pageview",
+    "event": "!url?dn=!dn&cn=!cn&ev=!ev&st=!st&co=!co&cp=!cp&au=_canonical_url_&tp=event"
+  },
   "infonline_anonymous": {
     "pageview": "!url?ap=1&dn=!dn&cn=!cn&st=!st&co=!co&cp=!cp&au=_canonical_url_&ar=_document_referrer_&ash=_screen_height_&asw=_screen_width_&tp=pageview",
     "event": "!url?ap=1&dn=!dn&cn=!cn&ev=!ev&st=!st&co=!co&cp=!cp&au=_canonical_url_&ar=_document_referrer_&ash=_screen_height_&asw=_screen_width_&tp=event"

--- a/extensions/amp-analytics/0.1/vendors/infonline_base.json
+++ b/extensions/amp-analytics/0.1/vendors/infonline_base.json
@@ -1,0 +1,18 @@
+{
+  "transport": {
+    "beacon": false,
+    "xhrpost": false,
+    "image": true
+  },
+  "requests": {
+    "pageview": "${url}?dn=${dn}&cn=${cn}&st=${st}&co=${co}&cp=${cp}&au=${canonicalUrl}&tp=pageview",
+    "event": "${url}?dn=${dn}&cn=${cn}&ev=${ev}&st=${st}&co=${co}&cp=${cp}&au=${canonicalUrl}&tp=event"
+  },
+  "triggers": {
+    "pageview": {
+      "on": "visible",
+      "request": "pageview",
+      "iframePing": true
+    }
+  }
+}


### PR DESCRIPTION
This will add a basic variant of INFOnline analytics to the AMP project.

Why a new analytic vendor?

In Germany, a new law will come into force on December 1st, 2021 (called and abbreviated TTDSG) which massively tightened data protection regulations and forbids any non-technically necessary information processing that takes place without the consent of the user. Since the two other variants ```infonline_anonymous``` and ```infonline``` each store information on the user's device, this form of information processing is only possible with the consent of the user.

Since INFOnline provides a kind of census measurement for the German advertising market, we are unfortunately forced to register a new analytics vendor for AMP who transmits a minimal amount of information and completely dispenses with the storage of information on the user's device.