### PR TITLE
🏗  Create tag as part of nightly cut

### DIFF
--- a/build-system/common/git.js
+++ b/build-system/common/git.js
@@ -164,10 +164,11 @@ function gitCommitterEmail() {
  * from <branch> are prefixed with '- ', and those that were not are prefixed
  * with '+ '.
  *
+ * @param {string} ref
  * @return {!Array<string>}
  */
-function gitCherryMain() {
-  const stdout = getStdout('git cherry main').trim();
+function gitCherryMain(ref = 'HEAD') {
+  const stdout = getStdout(`git cherry main ${ref}`).trim();
   return stdout ? stdout.split('\n') : [];
 }
 

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -60,9 +60,10 @@ const argv = minimist(process.argv.slice(2), {
  * The version number can be manually overridden by passing --version_override
  * to the `amp build`/`amp dist` command.
  *
+ * @param {string} ref
  * @return {string} AMP version number (always 13 digits long)
  */
-function getVersion() {
+function getVersion(ref = 'HEAD') {
   if (argv.version_override) {
     const version = String(argv.version_override);
     if (!/^\d{13}$/.test(version)) {
@@ -71,7 +72,7 @@ function getVersion() {
     return version;
   }
 
-  const numberOfCherryPicks = gitCherryMain().length;
+  const numberOfCherryPicks = gitCherryMain(ref).length;
   if (numberOfCherryPicks > 999) {
     throw new Error(
       `This branch has ${numberOfCherryPicks} cherry-picks, which is more ` +
@@ -81,7 +82,7 @@ function getVersion() {
   }
 
   const lastCommitFormattedTime = gitCommitFormattedTime(
-    `HEAD~${numberOfCherryPicks}`
+    `${ref}~${numberOfCherryPicks}`
   ).slice(0, -2);
 
   const numberOfCherryPicksStr = String(numberOfCherryPicks).padStart(3, '0');
@@ -90,3 +91,4 @@ function getVersion() {
 
 // Used to e.g. references the ads binary from the runtime to get version lock.
 exports.VERSION = getVersion();
+module.exports = {getVersion};

--- a/build-system/compile/internal-version.js
+++ b/build-system/compile/internal-version.js
@@ -90,5 +90,9 @@ function getVersion(ref = 'HEAD') {
 }
 
 // Used to e.g. references the ads binary from the runtime to get version lock.
-exports.VERSION = getVersion();
-module.exports = {getVersion};
+const VERSION = getVersion();
+
+module.exports = {
+  VERSION,
+  getVersion,
+};

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -183,7 +183,6 @@ async function cutNightlyBranch() {
     throw error;
   });
 
-  // get last green commit
   const sha = await getCommit(octokit);
   if (!sha) {
     throw new Error(
@@ -196,7 +195,7 @@ async function cutNightlyBranch() {
     await createTag(octokit, sha),
   ]);
 
-  log('Successly cut nightly');
+  log('Successfully cut nightly');
 }
 
 cutNightlyBranch();

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -4,8 +4,8 @@
  * @fileoverview Script that cuts a nightly branch.
  */
 
-const moment = require('moment');
 const {cyan, green, red} = require('kleur/colors');
+const {getVersion} = require('../compile/internal-version');
 const {log} = require('../common/logging');
 const {Octokit} = require('@octokit/rest');
 const params = {owner: 'ampproject', repo: 'amphtml'};
@@ -121,13 +121,7 @@ async function updateBranch(octokit, sha) {
  * @return {Promise<void>}
  */
 async function createTag(octokit, sha) {
-  // get commit time using octokit instead of git
-  const commit = await octokit.rest.git.getCommit({...params, sha});
-
-  // generate an AMP version according to `build-system/compile/internal-version.js`
-  // NOTE: this does NOT account for cherry-picked commits
-  const date = moment(commit.committer.date).format('YYMMDDHHmmss');
-  const ampVersion = date.slice(0, -2) + '000';
+  const ampVersion = getVersion(sha);
 
   await octokit.rest.git.createTag({
     ...params,


### PR DESCRIPTION
Reorganizes nightly script into separate functions.

Open to thoughts on using octokit instead of git to generate AMP version.