### PR TITLE
🐛 Fix doubleclick rendering issues when converted from amp-sticky-ad

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -22,5 +22,5 @@
   "story-load-inactive-outside-viewport": 1,
   "story-disable-animations-first-page": 0.5,
   "amp-story-page-attachment-ui-v2": 1,
-  "amp-sticky-ad-to-amp-ad-v2": 0
+  "amp-sticky-ad-to-amp-ad-v3": 0
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -19,5 +19,5 @@
   "story-load-first-page-only": 1,
   "story-load-inactive-outside-viewport": 1,
   "amp-story-page-attachment-ui-v2": 1,
-  "amp-sticky-ad-to-amp-ad-v2": 0
+  "amp-sticky-ad-to-amp-ad-v3": 0
 }

--- a/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
+++ b/extensions/amp-sticky-ad/1.0/amp-sticky-ad.js
@@ -104,7 +104,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
   /** @override */
   upgradeCallback() {
-    if (!isExperimentOn(this.win, 'amp-sticky-ad-to-amp-ad-v2')) {
+    if (!isExperimentOn(this.win, 'amp-sticky-ad-to-amp-ad-v3')) {
       return null;
     }
 
@@ -119,7 +119,7 @@ class AmpStickyAd extends AMP.BaseElement {
 
     const adType = (ad.getAttribute('type') || '').toLowerCase();
     if (adType == 'doubleclick' || adType == 'adsense') {
-      addExperimentIdToElement(enableConversion ? '31062372' : '31062371', ad);
+      addExperimentIdToElement(enableConversion ? '31062661' : '31062660', ad);
     }
 
     if (!enableConversion) {
@@ -130,10 +130,13 @@ class AmpStickyAd extends AMP.BaseElement {
     }
 
     ad.setAttribute('sticky', 'bottom');
-    this.element.parentElement.replaceChild(ad, this.element);
+
+    // Rebuild the ad element since the attributes have changed
+    const newAd = ad.cloneNode();
+    this.element.parentElement.replaceChild(newAd, this.element);
     return Services.extensionsFor(this.win)
       .loadElementClass('amp-ad', '0.1')
-      .then((AmpAd) => new AmpAd(ad));
+      .then((AmpAd) => new AmpAd(newAd));
   }
 
   /** @override */


### PR DESCRIPTION
The ad element currently is not being rebuilt after amp-sticky-ad is converted into an amp-ad. This is causing issues sometimes (especially doubleclick) where the state of the ads impl could be messed up. This PR will change to rebuild the ad once converted.

On my machine, it appears to be causing daily mail ads to drop 50% and works after patching this. It should be the culprit of the metrics drop.