### PR TITLE
♿ Add Accessibility attributes to iframes

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1883,6 +1883,9 @@ export class AmpA4A extends AMP.BaseElement {
           'allowtransparency': '',
           'scrolling': 'no',
           'title': this.getIframeTitle(),
+          'role': 'region',
+          'aria-label': 'Advertisement',
+          'tabindex': '0',
         })
       )
     );
@@ -2008,6 +2011,9 @@ export class AmpA4A extends AMP.BaseElement {
         'height': this.creativeSize_.height,
         'width': this.creativeSize_.width,
         'title': this.getIframeTitle(),
+        'role': 'region',
+        'aria-label': 'Advertisement',
+        'tabindex': '0',
       })
     );
 

--- a/extensions/amp-a4a/0.1/friendly-frame-util.js
+++ b/extensions/amp-a4a/0.1/friendly-frame-util.js
@@ -41,6 +41,9 @@ export function renderCreativeIntoFriendlyFrame(
         'allowfullscreen': '',
         'allowtransparency': '',
         'scrolling': 'no',
+        'role': 'region',
+        'aria-label': 'Advertisement',
+        'tabindex': '0',
       })
     )
   );

--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -84,6 +84,9 @@ export function createSecureFrame(win, title, height, width) {
         'allowtransparency': '',
         'scrolling': 'no',
         'sandbox': sandboxVals,
+        'role': 'region',
+        'aria-label': 'Advertisement',
+        'tabindex': '0',
       })
     )
   );

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -1625,6 +1625,9 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
         'allowfullscreen': '',
         'allowtransparency': '',
         'scrolling': 'no',
+        'role': 'region',
+        'aria-label': 'Advertisement',
+        'tabindex': '0',
       };
       Object.keys(expectedAttributes).forEach((key) => {
         expect(friendlyIframe.getAttribute(key)).to.equal(

--- a/extensions/amp-a4a/0.1/test/test-friendly-frame-util.js
+++ b/extensions/amp-a4a/0.1/test/test-friendly-frame-util.js
@@ -86,6 +86,9 @@ describes.realWin('FriendlyFrameUtil', realWinConfig, (env) => {
       expect(iframe.getAttribute('allowfullscreen')).to.equal('');
       expect(iframe.getAttribute('allowtransparency')).to.equal('');
       expect(iframe.getAttribute('scrolling')).to.equal('no');
+      expect(iframe.getAttribute('role')).to.equal('region');
+      expect(iframe.getAttribute('aria-label')).to.equal('Advertisement');
+      expect(iframe.getAttribute('tabindex')).to.equal('0');
     });
   });
 


### PR DESCRIPTION
Add the following attributes when creating ad iframes: aria-label, tabindex, and role.
