### PR TITLE
🐛(amp-lightbox-gallery): opens to selected image, resolve #35920

### DIFF
--- a/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js
@@ -919,13 +919,6 @@ export class AmpLightboxGallery extends AMP.BaseElement {
     };
 
     const mutate = () => {
-      if (enter) {
-        Services.ownersForDoc(this.element)./*OK*/ scheduleUnlayout(
-          this.element,
-          this.carousel_
-        );
-      }
-
       toggle(carousel, enter);
       // Undo opacity 0 from `openLightboxGallery_`
       setStyle(this.element, 'opacity', '');

--- a/extensions/amp-lightbox-gallery/0.1/test-e2e/test-open-close.js
+++ b/extensions/amp-lightbox-gallery/0.1/test-e2e/test-open-close.js
@@ -52,5 +52,27 @@ describes.endtoend(
       await controller.click(closeButton);
       await controller.findElement('amp-lightbox-gallery[hidden]');
     });
+
+    it('should display the image that opened the lightbox', async () => {
+      const clickedImage = await controller.findElement('#basic-2');
+
+      const imageSrc = await controller.getElementAttribute(
+        clickedImage,
+        'src'
+      );
+
+      await controller.click(clickedImage);
+
+      const slideImage = await controller.findElement(
+        // pick the img element with the same src as the clickedImage,
+        // inside the non hidden slide (this is the active slide),
+        // that is inside the amp-light-box with the default group id
+        `[amp-lightbox-group="default"] .amp-carousel-slide[aria-hidden="false"] img[src="${imageSrc}"]`
+      );
+
+      const activeImageRect = await controller.getElementRect(slideImage);
+      // If x is negative, it means this is the previous active slide, if positive it is the next slide. But if 0, it is the active slide
+      await expect(activeImageRect.x).to.equal(0);
+    });
   }
 );

--- a/test/fixtures/e2e/amp-lightbox/amp-lightbox-gallery-launch.amp.html
+++ b/test/fixtures/e2e/amp-lightbox/amp-lightbox-gallery-launch.amp.html
@@ -61,11 +61,11 @@ The amp-lightbox-gallery component provides a "lightbox” experience for AMP co
   This is a basic example that demonstrates lightboxed `<amp-img>`s. You have one or more `<amp-img>` elements on the page. Just add the "lightbox" attribute to each image that you wish to view in a lightbox.
   -->
   <div class="container">
-    <amp-img lightbox src="../amp-base-carousel/img/bluegradient.png" width="300" height="200" layout="responsive"></amp-img>
+    <amp-img lightbox src="../amp-base-carousel/img/bluegradient.png" width="300" height="200" layout="responsive" id="basic-1"></amp-img>
     <p class="paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <amp-img lightbox src="../amp-base-carousel/img/redgradient.png" width="300" height="200" layout="responsive"></amp-img>
+    <amp-img lightbox src="../amp-base-carousel/img/redgradient.png" width="300" height="200" layout="responsive" id="basic-2"></amp-img>
     <p class="paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-    <amp-img lightbox src="../amp-base-carousel/img/lemonyellowgradient.png" width="300" height="200" layout="responsive"></amp-img>
+    <amp-img lightbox src="../amp-base-carousel/img/lemonyellowgradient.png" width="300" height="200" layout="responsive"  id="basic-3"></amp-img>
     <p class="paragraph">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
   </div>
 


### PR DESCRIPTION
Issue #35920 requests to have the clicked on amp-image be the selected slide.

It appears this was an unintentional side effect of performing an unlayout on the carousel after waiting for the image transition to finish. I removed the unlayout call and added a e2e test to ensure we don't accidently break this functionality in the future.
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
