### PR TITLE
Reenable EsbuildCompilation on EXP_C

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -7,5 +7,11 @@
     "expiration_date_utc": "2021-06-30",
     "define_experiment_constant": "R1_IMG_DEFERRED_BUILD"
   },
-  "experimentC": {}
+  "experimentC": {
+    "name": "EsbuildCompilation",
+    "environment": "AMP",
+    "issue": "https://github.com/ampproject/amphtml/issues/35264",
+    "expiration_date_utc": "2021-10-30",
+    "define_experiment_constant": "ESBUILD_COMPILATION"
+  }
 }

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -113,9 +113,13 @@ function checkSourcemapMappings(sourcemapJson, map) {
     throw new Error('Could not find mappings array');
   }
 
-  // Zeroth sub-array corresponds to ';' and has no mappings.
-  // See https://www.npmjs.com/package/sourcemap-codec#usage
+  // See https://www.npmjs.com/package/sourcemap-codec#usage.
   const firstLineMapping = decode(sourcemapJson.mappings)[
+    // In closure builds there is a newline immediately after the AMP_CONFIG.
+    // This whole segment has no mapping to the original source.
+    // Therefore we must skip the zeroth sub-array, indicated by a ';'.
+
+    // In esbuild compiled binaries there is no newline after the config, so the first line is fair game.
     shouldUseClosure() ? 1 : 0
   ][0];
   const [, sourceIndex = 0, sourceCodeLine = 0, sourceCodeColumn] =

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -113,15 +113,15 @@ function checkSourcemapMappings(sourcemapJson, map) {
     throw new Error('Could not find mappings array');
   }
 
-  // See https://www.npmjs.com/package/sourcemap-codec#usage.
-  const firstLineMapping = decode(sourcemapJson.mappings)[
-    // In closure builds there is a newline immediately after the AMP_CONFIG.
-    // This whole segment has no mapping to the original source.
-    // Therefore we must skip the zeroth sub-array, indicated by a ';'.
+  // In closure builds there is a newline immediately after the AMP_CONFIG.
+  // This whole segment has no mapping to the original source.
+  // Therefore we must skip the zeroth sub-array, indicated by a ';'.
+  // In  esbuild builds there is no newline after the config, so the
+  // first line is fair game.
+  const firstLineIndex = shouldUseClosure() ? 1 : 0;
 
-    // In esbuild compiled binaries there is no newline after the config, so the first line is fair game.
-    shouldUseClosure() ? 1 : 0
-  ][0];
+  // See https://www.npmjs.com/package/sourcemap-codec#usage.
+  const firstLineMapping = decode(sourcemapJson.mappings)[firstLineIndex][0];
   const [, sourceIndex = 0, sourceCodeLine = 0, sourceCodeColumn] =
     firstLineMapping;
 

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -115,7 +115,9 @@ function checkSourcemapMappings(sourcemapJson, map) {
 
   // Zeroth sub-array corresponds to ';' and has no mappings.
   // See https://www.npmjs.com/package/sourcemap-codec#usage
-  const firstLineMapping = decode(sourcemapJson.mappings)[1][0];
+  const firstLineMapping = decode(sourcemapJson.mappings)[
+    shouldUseClosure() ? 1 : 0
+  ][0];
   const [, sourceIndex = 0, sourceCodeLine = 0, sourceCodeColumn] =
     firstLineMapping;
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -417,7 +417,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     };
   }
   const {banner, footer} = splitWrapper();
-  const config = await getAmpConfigForFile(srcFilename, options);
+  const config = await getAmpConfigForFile(destFilename, options);
   const compiledFile = await getCompiledFile(srcFilename);
   banner.js = config + banner.js + compiledFile;
 

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -198,7 +198,7 @@ async function getConfig(
  * @return {!Promise<string>}
  */
 async function getAmpConfigForFile(filename, options) {
-  const targets = MINIFIED_TARGETS.concat(UNMINIFIED_TARGETS);
+  const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;
   const target = path.basename(filename, path.extname(filename));
   if (!!argv.noconfig || !targets.includes(target)) {
     return '';

--- a/build-system/tasks/prepend-global/index.js
+++ b/build-system/tasks/prepend-global/index.js
@@ -198,7 +198,7 @@ async function getConfig(
  * @return {!Promise<string>}
  */
 async function getAmpConfigForFile(filename, options) {
-  const targets = options.minify ? MINIFIED_TARGETS : UNMINIFIED_TARGETS;
+  const targets = MINIFIED_TARGETS.concat(UNMINIFIED_TARGETS);
   const target = path.basename(filename, path.extname(filename));
   if (!!argv.noconfig || !targets.includes(target)) {
     return '';

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -810,7 +810,7 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
   }
 
   if (argv.nobuild) {
-    const isInTestMode = /AMP_CONFIG=\{(?:.+,)?"test":true\b/.test(
+    const isInTestMode = /AMP_CONFIG=\{(?:.+,)?"test":(!0|true)\b/.test(
       fs.readFileSync('dist/v0.js', 'utf8')
     );
     if (!isInTestMode) {


### PR DESCRIPTION
**summary**
See https://github.com/ampproject/amphtml/pull/35816 for a PR that forces `esbuild` to be true and has all of CI green. Adds in one important fix for EXP_C, and then two fixes that only matter when it is the primary bundler:

1. ~(important): accept either unminified or minified name for `getAmpConfigForFile`. The distinction wasn't useful and forced us to pass in the minified name for minified builds (`srcFilename` is more ergonomic)~. Instead I pass `destFilename`
2. visual-diff:`test:true` check should also allow `!0` since that is the minified version of `true`
3. check-sourcemaps: esbuild has first line of the output on the first line instead of the second.

**confidence checks**
- prop mangling has been disabled for now. this is the riskiest optimization we could do, and my goal now is to create a baseline of how this branch performs _without_ it. If equivalent to the closure version, we can then pursue mangling separately.
- all automated tests pass
- manual testing of many sites (ping for details)
- [ ] full manual qa pass