### PR TITLE
🐛  bind-impl: missing <amp-state> specified as an amp-list data source is a user error

### DIFF
--- a/extensions/amp-bind/0.1/bind-impl.js
+++ b/extensions/amp-bind/0.1/bind-impl.js
@@ -550,7 +550,7 @@ export class Bind {
         `#${escapeCssSelectorIdent(stateId)}`
       );
       if (!ampStateEl) {
-        throw new Error(`#${stateId} does not exist.`);
+        throw user().createError(TAG, `#${stateId} does not exist.`);
       }
 
       return whenUpgradedToCustomElement(ampStateEl)


### PR DESCRIPTION
**summary**
Addresses https://github.com/ampproject/error-reporting/issues/105#issuecomment-919406318

If a pub specifies an `<amp-state>` as a data source for `amp-list`, then it is not a framework error if that element does not exist. We should mark it as such for correct error reporting.