### PR TITLE
🖍 [Attachment Forms] Shorten the width of the publisher domain label

### DIFF
--- a/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer-header.css
@@ -81,6 +81,7 @@
   text-overflow: ellipsis !important;
   top: 35px !important;
   white-space: nowrap !important;
+  width: calc(100% - 112px) !important;
 }
 
 .i-amphtml-story-draggable-drawer-header .i-amphtml-story-draggable-drawer-header-title-and-close {


### PR DESCRIPTION
The publisher domain label currently spans the entire width of the page attachment header. This PR shortens the label width in accordance with UX mocks.

**Before**
<img src="https://user-images.githubusercontent.com/2376601/134121102-a258115a-9d4c-4271-854b-e73e4c8ce3c0.jpeg" width="200px">

**After**
<img src="https://user-images.githubusercontent.com/2376601/134120962-cfb95903-77a0-4487-a94b-043079233cb7.jpeg" width="200px">

#35569 


