### PR TITLE
🏗 Fetch more than 1 commit for nightly job

### DIFF
--- a/.github/workflows/cut-nightly.yml
+++ b/.github/workflows/cut-nightly.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 100
 
       - name: Set Up Node
         uses: actions/setup-node@v2.4.0

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -116,7 +116,7 @@ async function updateBranch(octokit, sha) {
 
 /**
  * Create GitHub tag
- * @param {any} octokit
+ * @param {Octokit} octokit
  * @param {string} sha
  * @return {Promise<void>}
  */


### PR DESCRIPTION
`actions/checkout@v2` defaults to fetching 1 commit; set it to 100.

tagalong - use `Octokit` instead of `any` in typedef.