### PR TITLE
Remove frontmatter from Bento component `README` files

### DIFF
--- a/extensions/amp-accordion/1.0/README.md
+++ b/extensions/amp-accordion/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: layout
-formats:
-  - websites
-teaser:
-  text: A stacked list of headers that collapse or expand content sections with user interaction.
----
-
 # Bento Accordion
 
 ## Usage

--- a/extensions/amp-base-carousel/1.0/README.md
+++ b/extensions/amp-base-carousel/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: layout
-formats:
-  - websites
-teaser:
-  text: Displays multiple similar pieces of content along a horizontal axis or vertical axis.
----
-
 # Bento Carousel
 
 ## Usage

--- a/extensions/amp-date-countdown/1.0/README.md
+++ b/extensions/amp-date-countdown/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: presentation
-formats:
-  - websites
-teaser:
-  text: Displays a countdown sequence to a specified date.
----
-
 # Bento Date Countdown
 
 ## Usage

--- a/extensions/amp-date-display/1.0/README.md
+++ b/extensions/amp-date-display/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: presentation
-formats:
-  - websites
-teaser:
-  text: The Bento Date Display component displays time data that you can render in your page.
----
-
 # Bento Date Display
 
 ## Usage

--- a/extensions/amp-embedly-card/1.0/README.md
+++ b/extensions/amp-embedly-card/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: media
-formats:
-  - websites
-teaser:
-  text: Displays an Embedly card.
----
-
 # Bento Embedly Card
 
 ## Behavior

--- a/extensions/amp-fit-text/1.0/README.md
+++ b/extensions/amp-fit-text/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: presentation
-formats:
-  - websites
-teaser:
-  text: Expands or shrinks font size to fit the content within the space given.
----
-
 # Bento Fit Text
 
 ## Usage

--- a/extensions/amp-inline-gallery/1.0/README.md
+++ b/extensions/amp-inline-gallery/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: layout
-formats:
-  - websites
-teaser:
-  text: Displays multiple similar pieces of content along a horizontal axis, with optional pagination dots and thumbnails.
----
-
 # Bento Inline Gallery
 
 ## Usage

--- a/extensions/amp-soundcloud/1.0/README.md
+++ b/extensions/amp-soundcloud/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: media
-formats:
-  - websites
-teaser:
-  text: Displays a Soundcloud clip.
----
-
 # Bento Soundcloud
 
 ## Usage

--- a/extensions/amp-stream-gallery/1.0/README.md
+++ b/extensions/amp-stream-gallery/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: layout
-formats:
-  - websites
-teaser:
-  text: Displays multiple similar pieces of content at a time, for features like related products or articles.
----
-
 # Bento Stream Gallery
 
 ## Usage

--- a/extensions/amp-twitter/1.0/README.md
+++ b/extensions/amp-twitter/1.0/README.md
@@ -1,13 +1,3 @@
----
-$category@: social
-formats:
-  - websites
-teaser:
-  text: Displays a Twitter Tweet or Moment.
-experimental: true
-bento: true
----
-
 # Bento Twitter
 
 ## Behavior

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -1,11 +1,3 @@
----
-$category@: presentation
-formats:
-  - websites
-teaser:
-  text: Embeds a WordPress post.
----
-
 # Bento Wordpress Embed
 
 ## Usage


### PR DESCRIPTION
The frontmatter annotation is specific to amp.dev, which will not be surfacing these files. Instead, they will be published on npm where these annotations currently look very bad. :)
![Screen Shot 2021-09-21 at 1 31 29 PM](https://user-images.githubusercontent.com/10456171/134219262-1408bf2b-5020-40e6-9709-6112cfaadd42.png)
