### PR TITLE
🏗 Update @types/fs-extra to 9.0.13 and standardize readJson calls to pass string encoding instead of options object

### DIFF
--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -64,7 +64,7 @@ async function postClosureBabel(file) {
   const {compressed, terserMap} = await terserMinify(code);
   await fs.outputFile(file, compressed);
 
-  const closureMap = await fs.readJson(`${file}.map`, {encoding: 'utf8'});
+  const closureMap = await fs.readJson(`${file}.map`, 'utf8');
   const sourceMap = remapping(
     [terserMap, babelMap, closureMap],
     () => null,

--- a/build-system/tasks/check-exact-versions.js
+++ b/build-system/tasks/check-exact-versions.js
@@ -12,7 +12,7 @@ const {log, logLocalDev, logWithoutTimestamp} = require('../common/logging');
  * @return {boolean}
  */
 function check(file) {
-  const json = fs.readJsonSync(file, {encoding: 'utf8'});
+  const json = fs.readJsonSync(file, 'utf8');
 
   // We purposfully ignore peerDependencies here, because that's that's for the
   // consumer to decide.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6152,9 +6152,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.12.tgz",
-      "integrity": "sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==",
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/chai": "4.2.21",
     "@types/eslint": "7.28.0",
     "@types/minimist": "1.2.2",
-    "@types/fs-extra": "9.0.12",
+    "@types/fs-extra": "9.0.13",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.12",
     "acorn-globals": "6.0.0",


### PR DESCRIPTION
Type annotations fixed in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/55845