### PR TITLE
🖍 Restrict page attachment sticky header to non-iOS, non-Safari surfaces

### DIFF
--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -197,13 +197,18 @@ export class DraggableDrawer extends AMP.BaseElement {
       this.close_();
     });
 
-    // For displaying sticky header on mobile.
-    new this.win.IntersectionObserver((e) => {
-      this.headerEl.classList.toggle(
-        'i-amphtml-story-draggable-drawer-header-stuck',
-        !e[0].isIntersecting
-      );
-    }).observe(spacerEl);
+    // For displaying sticky header on mobile. iOS devices & Safari are
+    // excluded because the sticky positon has more restrictive functionality
+    // on those surfaces that prevents it from behaving as intended.
+    const platform = Services.platformFor(this.win);
+    if (!platform.isSafari() && !platform.isIos()) {
+      new this.win.IntersectionObserver((e) => {
+        this.headerEl.classList.toggle(
+          'i-amphtml-story-draggable-drawer-header-stuck',
+          !e[0].isIntersecting
+        );
+      }).observe(spacerEl);
+    }
 
     // Update spacerElHeight_ on resize for drag offset.
     new this.win.ResizeObserver((e) => {


### PR DESCRIPTION
The sticky positioning of the page attachment header does not work on iOS because of a known Safari issue where `position: sticky` fails if a parent element has `overflow: auto` set (see [caniuse](https://caniuse.com/?search=sticky)). I attempted to replicate sticky positioning via JS by setting the header's `position: fixed` whenever the sticky header was expected to be seen, but this also resulted in the header's layout being incorrectly altered.

The current behavior on iOS page attachments is such that the header transitions to its sticky layout whenever the attachment reaches full height, only for the header to be scrolled out of view. We have decided that we will prevent the sticky header layout from being shown on iOS at all, until a working solution for sticky positioning has been implemented.

**Before:**
<img src="https://user-images.githubusercontent.com/2376601/134390331-bfeaef9a-9a83-4164-bb70-62018fb16e4b.gif">

**After:**
<img src="https://user-images.githubusercontent.com/2376601/134389732-2f9bcc0c-f993-4b64-bfd4-bf6d5c409fe7.gif" width="200px">

/cc @gmajoulet 

#34504 
#35569 