### PR TITLE
✨ Allow left/right sticky ads, strengthen unit tests

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -23,6 +23,8 @@ const TOP_STICKY_AD_TRIGGER_THRESHOLD = 200;
 const StickyAdPositions = {
   TOP: 'top',
   BOTTOM: 'bottom',
+  LEFT: 'left',
+  RIGHT: 'right',
   BOTTOM_RIGHT: 'bottom-right',
 };
 
@@ -63,6 +65,11 @@ export class AmpAdUIHandler {
         this.element_.getAttribute(STICKY_AD_PROP) ||
         StickyAdPositions.BOTTOM_RIGHT;
       this.element_.setAttribute(STICKY_AD_PROP, this.stickyAdPosition_);
+
+      if (!Object.values(StickyAdPositions).includes(this.stickyAdPosition_)) {
+        user().error(TAG, `Invalid sticky ad type: ${this.stickyAdPosition_}`);
+        this.stickyAdPosition_ = null;
+      }
     }
 
     /**
@@ -275,7 +282,10 @@ export class AmpAdUIHandler {
    * When a sticky ad is shown, the close button should be rendered at the same time.
    */
   onResizeSuccess() {
-    if (this.isStickyAd() && !this.topStickyAdScrollListener_) {
+    if (
+      this.stickyAdPosition_ == StickyAdPositions.TOP &&
+      !this.topStickyAdScrollListener_
+    ) {
       const doc = this.element_.getAmpDoc();
       this.topStickyAdScrollListener_ = Services.viewportForDoc(doc).onScroll(
         () => {

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -1,5 +1,3 @@
-
-
 /**
  * Force the layout box of the ad iframe to be exactly as big as the actual
  * iframe. The `amp-ad` tag itself can be freely styled.
@@ -90,17 +88,21 @@ amp-ad .amp-ad-close-button:before {
   bottom: 0;
 }
 
-amp-ad[sticky='bottom'] .amp-ad-close-button {
-  top: -28px;
-}
-
-amp-ad[sticky='bottom-right'] .amp-ad-close-button {
+amp-ad[sticky='bottom'] .amp-ad-close-button,
+amp-ad[sticky='bottom-right'] .amp-ad-close-button,
+amp-ad[sticky='left'] .amp-ad-close-button,
+amp-ad[sticky='right'] .amp-ad-close-button {
   top: -28px;
 }
 
 amp-ad[sticky='top'] .amp-ad-close-button {
   transform: rotate(270deg);
   bottom: -28px;
+}
+
+amp-ad[sticky='left'] .amp-ad-close-button {
+  transform: rotate(90deg);
+  left: 0;
 }
 
 [dir='rtl'] amp-ad .amp-ad-close-button {
@@ -157,4 +159,32 @@ amp-ad[sticky='bottom'] {
 amp-ad[sticky='bottom-right'] {
   bottom: 0;
   right: 0;
+}
+
+amp-ad[sticky='left'],
+amp-ad[sticky='right'] {
+  background: #fff;
+}
+
+amp-ad[sticky='left'] iframe,
+amp-ad[sticky='right'] iframe {
+  max-width: 120px !important;
+}
+
+amp-ad[sticky='left'] {
+  left: 0;
+}
+
+amp-ad[sticky='right'] {
+  right: 0;
+}
+
+/**
+  * Enforce no left/right sticky ads if not on a wide screen
+  */
+@media (max-width: 1024px) {
+  amp-ad[sticky='left'],
+  amp-ad[sticky='right'] {
+    display: none !important;
+  }
 }

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -310,6 +310,13 @@ describes.realWin(
     });
 
     describe('sticky ads', () => {
+      it('should reject invalid sticky type', () => {
+        expectAsyncConsoleError(/Invalid sticky ad type: invalid/, 1);
+        adElement.setAttribute('sticky', 'invalid');
+        const uiHandler = new AmpAdUIHandler(adImpl);
+        expect(uiHandler.stickyAdPosition_).to.be.null;
+      });
+
       it('should render close buttons', () => {
         expect(uiHandler.unlisteners_).to.be.empty;
         uiHandler.stickyAdPosition_ = 'bottom';


### PR DESCRIPTION
Following UI discussion, we are comfortable allowing desktop (defined as wider than 1024px viewport) using left/right sticky ads, with a hard width limit of 100px. No behavior changes. Publishers will be responsible for ensuring no content overlaps because it might not be occupying full height.

https://github.com/ampproject/amphtml/issues/18123