### PR TITLE
🚀 babel/terser: rename all amp privates with sentinel suffix

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -31,6 +31,7 @@ function getMinifiedConfig() {
     './build-system/babel-plugins/babel-plugin-transform-inline-isenumvalue',
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
+    './build-system/babel-plugins/babel-plugin-transform-rename-privates',
     '@babel/plugin-transform-react-constant-elements',
     reactJsxPlugin,
     (argv.esm || argv.sxg) &&

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -2,27 +2,40 @@
  * Renames all of AMP's class properties to have a unique suffix, `AMP_PRIVATE_`.
  * This acts as an indicator for terser to mangle the names even when combined with 3p files.
  *
+ * @param {babel} babel
  * @interface {babel.PluginPass}
  * @return {babel.PluginObj}
  */
 module.exports = function (babel) {
   const {types: t} = babel;
+
   /**
-   * Adds trailing AMP_PRIVATE_ suffix to an identifier.
+   * Adds trailing AMP_PRIVATE_ suffix to private identifiers.
    * @param {string} field
+   * @return {function(*,*):void}
    */
   function renamePrivate(field) {
     return function (path, state) {
-      if (!isAmpSrc(state)) return;
-      if (path.node.computed) return;
+      if (!isAmpSrc(state)) {
+        return;
+      }
+      if (path.node.computed) {
+        return;
+      }
 
       const key = path.get(field);
-      if (!key.isIdentifier()) return;
+      if (!key.isIdentifier()) {
+        return;
+      }
 
       const {name} = key.node;
-      if (name.endsWith('_AMP_PRIVATE_')) return;
+      if (name.endsWith('_AMP_PRIVATE_')) {
+        return;
+      }
 
-      if (!name.endsWith('_')) return;
+      if (!name.endsWith('_')) {
+        return;
+      }
       key.replaceWith(t.identifier(`${name}AMP_PRIVATE_`));
     };
   }

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -1,0 +1,34 @@
+/**
+ * Renames all private variables within AMP to end with AMP_PRIVATE_ for safe
+ * identification later w/ terser. At that point it may be combined with files from 3p or node_modules,
+ * where we cannot guarantee that the `_` suffix means private.
+ *
+ * @interface {babel.PluginPass}
+ * @param {babel} babel
+ * @return {babel.PluginObj}
+ */
+module.exports = function (babel) {
+  return {
+    visitor: {
+      Identifier(path, state) {
+        const filename = state.file.opts.filenameRelative;
+        if (!filename) {
+          throw new Error('Cannot use plugin without providing a filename');
+        }
+
+        const isAmpSrcCode =
+          filename.startsWith('src/') || filename.startsWith('extensions/');
+        if (!isAmpSrcCode) {
+          return;
+        }
+
+        // AMP Privates are marked via trailing suffix.
+        if (!path.node.name.endsWith('_')) {
+          return;
+        }
+
+        path.node.name += `AMP_PRIVATE_`;
+      },
+    },
+  };
+};

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -21,6 +21,13 @@ module.exports = function () {
           return;
         }
 
+        // If not within a class, then it isn't a private.
+        // It could also be exported, which could cause issues.
+        const isWithinClass = !!path.findParent((p) => p.isClassDeclaration());
+        if (!isWithinClass) {
+          return;
+        }
+
         // AMP Privates are marked via trailing suffix.
         if (!path.node.name.endsWith('_')) {
           return;

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -23,8 +23,7 @@ module.exports = function () {
         // If not within a class, then it isn't a private.
         // It could also be exported, which could cause issues.
         const isWithinClass =
-          !path.parentPath.isClassDeclaration() &&
-          !!path.findParent((p) => p.isClassDeclaration());
+          !path.parentPath.isClass() && !!path.findParent((p) => p.isClass());
         if (!isWithinClass) {
           return;
         }

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -29,6 +29,13 @@ module.exports = function () {
           return;
         }
 
+        const isProp =
+          path.parent.type === 'MemberExpression' &&
+          path.parent.object.type === 'ThisExpression';
+        if (!isProp) {
+          return false;
+        }
+
         // AMP Privates are marked via trailing suffix.
         if (!path.node.name.endsWith('_')) {
           return;

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -52,12 +52,14 @@ module.exports = function (babel) {
 
 /**
  * @param {*} state
- * @return {string}
+ * @return {boolean}
  */
 function isAmpSrc(state) {
   const filename = state.file.opts.filenameRelative;
   if (!filename) {
     throw new Error('Cannot use plugin without providing a filename');
   }
-  return filename.startsWith('src/') || filename.startsWith('extensions/');
+  return !(
+    filename.startsWith('node_modules') || filename.startsWith('third_party')
+  );
 }

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -4,10 +4,9 @@
  * where we cannot guarantee that the `_` suffix means private.
  *
  * @interface {babel.PluginPass}
- * @param {babel} babel
  * @return {babel.PluginObj}
  */
-module.exports = function (babel) {
+module.exports = function () {
   return {
     visitor: {
       Identifier(path, state) {

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -13,7 +13,7 @@ module.exports = function (babel) {
    */
   function renamePrivate(field) {
     return function (path, state) {
-      if (isAmpSrc(state)) return;
+      if (!isAmpSrc(state)) return;
       if (path.node.computed) return;
 
       const key = path.get(field);

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -1,7 +1,6 @@
 /**
- * Renames all private variables within AMP to end with AMP_PRIVATE_ for safe
- * identification later w/ terser. At that point it may be combined with files from 3p or node_modules,
- * where we cannot guarantee that the `_` suffix means private.
+ * Renames all of AMP's class properties to have a unique suffix, `AMP_PRIVATE_`.
+ * This acts as an indicator for terser to mangle the names even when combined with 3p files.
  *
  * @interface {babel.PluginPass}
  * @return {babel.PluginObj}
@@ -23,7 +22,9 @@ module.exports = function () {
 
         // If not within a class, then it isn't a private.
         // It could also be exported, which could cause issues.
-        const isWithinClass = !!path.findParent((p) => p.isClassDeclaration());
+        const isWithinClass =
+          !path.parentPath.isClassDeclaration() &&
+          !!path.findParent((p) => p.isClassDeclaration());
         if (!isWithinClass) {
           return;
         }

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -20,21 +20,6 @@ module.exports = function () {
           return;
         }
 
-        // If not within a class, then it isn't a private.
-        // It could also be exported, which could cause issues.
-        const isWithinClass =
-          !path.parentPath.isClass() && !!path.findParent((p) => p.isClass());
-        if (!isWithinClass) {
-          return;
-        }
-
-        const isProp =
-          path.parent.type === 'MemberExpression' &&
-          path.parent.object.type === 'ThisExpression';
-        if (!isProp) {
-          return false;
-        }
-
         // AMP Privates are marked via trailing suffix.
         if (!path.node.name.endsWith('_')) {
           return;

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -1,0 +1,9 @@
+class Foo {
+  constructor() {
+    /**
+     * @type {string}
+     * @private
+     */
+    this.hello_ = 'world';
+  }
+}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -2,6 +2,8 @@ class Foo {
   constructor() {
     // Properties within a class should be renamed
     this.hello_ = 'world';
+    let bar_ = 'world';
+    console.log(zoo_);
   }
 }
 

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -1,18 +1,67 @@
-class Foo {
-  constructor() {
-    this.hello_ = 'world';
-    let bar_ = 'world';
-    console.log(zoo_, this?.zeb_);
-  }
+const obj = {
+  test_: 1,
+  method_() {},
+  get getter_() {},
+  set setter_(v) {},
+  shorthand_,
+  
+  [test_]: 1,
+  [method_]() {},
+  get [getter_]() {},
+  set [setter_](v) {},
 
-  doFoo_() {}
-  doBar() {
-    const {foo_} = this;
-    this?.bar_();
-    this.bar_?.();
-  }
+  'test_': 1,
+  'method_'() {},
+  get 'getter_'() {},
+  set 'setter_'(v) {},
+};
+
+class Instance {
+  test_ = 1;
+  method_() {}
+  get getter_() {}
+  set setter_(v) {}
+  
+  [test_] = 1;
+  [method_]() {}
+  get [getter_]() {}
+  set [setter_](v) {}
+
+  'test_' = 1
+  'method_'() {}
+  get 'getter_'() {}
+  set 'setter_'(v) {}
 }
 
-class Foo_ {}
+class Static {
+  static test_ = 1;
+  static method_() {}
+  static get getter_() {}
+  static set setter_(v) {}
+  
+  static [test_] = 1;
+  static [method_]() {}
+  static get [getter_]() {}
+  static set [setter_](v) {}
 
-let hello_ = 'world';
+  static 'test_' = 1
+  static 'method_'() {}
+  static get 'getter_'() {}
+  static set 'setter_'(v) {}
+}
+
+foo.bar_;
+foo[bar_];
+foo['bar_'];
+
+foo?.bar_;
+foo?.[bar_];
+foo?.['bar_'];
+
+deep.foo?.bar_;
+deep.foo?.[bar_];
+deep.foo?.['bar_'];
+
+deep?.foo.bar_;
+deep?.foo.[bar_];
+deep?.foo.['bar_'];

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -1,14 +1,16 @@
 class Foo {
   constructor() {
-    // Properties within a class should be renamed
     this.hello_ = 'world';
     let bar_ = 'world';
     console.log(zoo_);
   }
+
+  doFoo_() {}
+  doBar() {
+    const {foo_} = this;
+  }
 }
 
-// Classes themselves should not be renamed.
 class Foo_ {}
 
-// Variables outside of a class should not be renamed
 let hello_ = 'world';

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -1,9 +1,12 @@
 class Foo {
   constructor() {
-    /**
-     * @type {string}
-     * @private
-     */
+    // Properties within a class should be renamed
     this.hello_ = 'world';
   }
 }
+
+// Classes themselves should not be renamed.
+class Foo_ {}
+
+// Variables outside of a class should not be renamed
+let hello_ = 'world';

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -2,7 +2,7 @@ class Foo {
   constructor() {
     this.hello_ = 'world';
     let bar_ = 'world';
-    console.log(zoo_);
+    console.log(zoo_, this?.zeb_);
   }
 
   doFoo_() {}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -8,6 +8,8 @@ class Foo {
   doFoo_() {}
   doBar() {
     const {foo_} = this;
+    this?.bar_();
+    this.bar_?.();
   }
 }
 

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "../../../.."
+  ],
+  "sourceType": "module",
+  "filenameRelative": "src/foo.js"
+}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -1,22 +1,94 @@
-class Foo {
-  constructor() {
-    this.hello_AMP_PRIVATE_ = 'world';
-    let bar_ = 'world';
-    console.log(zoo_, this?.zeb_AMP_PRIVATE_);
-  }
+const obj = {
+  test_AMP_PRIVATE_: 1,
 
-  doFoo_AMP_PRIVATE_() {}
+  method_AMP_PRIVATE_() {},
 
-  doBar() {
-    const {
-      foo_AMP_PRIVATE_: foo_
-    } = this;
-    this?.bar_AMP_PRIVATE_();
-    this.bar_AMP_PRIVATE_?.();
-  }
+  get getter_AMP_PRIVATE_() {},
+
+  set setter_AMP_PRIVATE_(v) {},
+
+  shorthand_AMP_PRIVATE_: shorthand_,
+  [test_AMP_PRIVATE_]: 1,
+
+  [method_AMP_PRIVATE_]() {},
+
+  get [getter_AMP_PRIVATE_]() {},
+
+  set [setter_AMP_PRIVATE_](v) {},
+
+  'test_': 1,
+
+  'method_'() {},
+
+  get 'getter_'() {},
+
+  set 'setter_'(v) {}
+
+};
+
+class Instance {
+  test_AMP_PRIVATE_ = 1;
+
+  method_AMP_PRIVATE_() {}
+
+  get getter_AMP_PRIVATE_() {}
+
+  set setter_AMP_PRIVATE_(v) {}
+
+  [test_AMP_PRIVATE_] = 1;
+
+  [method_AMP_PRIVATE_]() {}
+
+  get [getter_AMP_PRIVATE_]() {}
+
+  set [setter_AMP_PRIVATE_](v) {}
+
+  'test_' = 1;
+
+  'method_'() {}
+
+  get 'getter_'() {}
+
+  set 'setter_'(v) {}
 
 }
 
-class Foo_ {}
+class Static {
+  static test_AMP_PRIVATE_ = 1;
 
-let hello_ = 'world';
+  static method_AMP_PRIVATE_() {}
+
+  static get getter_AMP_PRIVATE_() {}
+
+  static set setter_AMP_PRIVATE_(v) {}
+
+  static [test_AMP_PRIVATE_] = 1;
+
+  static [method_AMP_PRIVATE_]() {}
+
+  static get [getter_AMP_PRIVATE_]() {}
+
+  static set [setter_AMP_PRIVATE_](v) {}
+
+  static 'test_' = 1;
+
+  static 'method_'() {}
+
+  static get 'getter_'() {}
+
+  static set 'setter_'(v) {}
+
+}
+
+foo.bar_AMP_PRIVATE_;
+foo[bar_AMP_PRIVATE_];
+foo['bar_'];
+foo?.bar_AMP_PRIVATE_;
+foo?.[bar_AMP_PRIVATE_];
+foo?.['bar_'];
+deep.foo?.bar_AMP_PRIVATE_;
+deep.foo?.[bar_AMP_PRIVATE_];
+deep.foo?.['bar_'];
+deep?.foo.bar_AMP_PRIVATE_;
+deep?.foo[bar_AMP_PRIVATE_];
+deep?.foo['bar_'];

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -1,20 +1,22 @@
 class Foo {
   constructor() {
     this.hello_AMP_PRIVATE_ = 'world';
-    let bar_AMP_PRIVATE_ = 'world';
-    console.log(zoo_AMP_PRIVATE_, this?.zeb_AMP_PRIVATE_);
+    let bar_ = 'world';
+    console.log(zoo_, this?.zeb_AMP_PRIVATE_);
   }
 
   doFoo_AMP_PRIVATE_() {}
 
   doBar() {
     const {
-      foo_AMP_PRIVATE_
+      foo_AMP_PRIVATE_: foo_
     } = this;
+    this?.bar_AMP_PRIVATE_();
+    this.bar_AMP_PRIVATE_?.();
   }
 
 }
 
-class Foo_AMP_PRIVATE_ {}
+class Foo_ {}
 
-let hello_AMP_PRIVATE_ = 'world';
+let hello_ = 'world';

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -2,7 +2,7 @@ class Foo {
   constructor() {
     this.hello_AMP_PRIVATE_ = 'world';
     let bar_AMP_PRIVATE_ = 'world';
-    console.log(zoo_AMP_PRIVATE_);
+    console.log(zoo_AMP_PRIVATE_, this?.zeb_AMP_PRIVATE_);
   }
 
   doFoo_AMP_PRIVATE_() {}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -1,10 +1,13 @@
 class Foo {
   constructor() {
-    /**
-     * @type {string}
-     * @private
-     */
+    // Properties within a class should be renamed
     this.hello_AMP_PRIVATE_ = 'world';
   }
 
-}
+} // Classes themselves should not be renamed.
+
+
+class Foo_ {} // Variables outside of a class should not be renamed
+
+
+let hello_ = 'world';

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -8,13 +8,13 @@ const obj = {
   set setter_AMP_PRIVATE_(v) {},
 
   shorthand_AMP_PRIVATE_: shorthand_,
-  [test_AMP_PRIVATE_]: 1,
+  [test_]: 1,
 
-  [method_AMP_PRIVATE_]() {},
+  [method_]() {},
 
-  get [getter_AMP_PRIVATE_]() {},
+  get [getter_]() {},
 
-  set [setter_AMP_PRIVATE_](v) {},
+  set [setter_](v) {},
 
   'test_': 1,
 
@@ -35,13 +35,13 @@ class Instance {
 
   set setter_AMP_PRIVATE_(v) {}
 
-  [test_AMP_PRIVATE_] = 1;
+  [test_] = 1;
 
-  [method_AMP_PRIVATE_]() {}
+  [method_]() {}
 
-  get [getter_AMP_PRIVATE_]() {}
+  get [getter_]() {}
 
-  set [setter_AMP_PRIVATE_](v) {}
+  set [setter_](v) {}
 
   'test_' = 1;
 
@@ -62,13 +62,13 @@ class Static {
 
   static set setter_AMP_PRIVATE_(v) {}
 
-  static [test_AMP_PRIVATE_] = 1;
+  static [test_] = 1;
 
-  static [method_AMP_PRIVATE_]() {}
+  static [method_]() {}
 
-  static get [getter_AMP_PRIVATE_]() {}
+  static get [getter_]() {}
 
-  static set [setter_AMP_PRIVATE_](v) {}
+  static set [setter_](v) {}
 
   static 'test_' = 1;
 
@@ -81,14 +81,14 @@ class Static {
 }
 
 foo.bar_AMP_PRIVATE_;
-foo[bar_AMP_PRIVATE_];
+foo[bar_];
 foo['bar_'];
 foo?.bar_AMP_PRIVATE_;
-foo?.[bar_AMP_PRIVATE_];
+foo?.[bar_];
 foo?.['bar_'];
 deep.foo?.bar_AMP_PRIVATE_;
-deep.foo?.[bar_AMP_PRIVATE_];
+deep.foo?.[bar_];
 deep.foo?.['bar_'];
 deep?.foo.bar_AMP_PRIVATE_;
-deep?.foo[bar_AMP_PRIVATE_];
+deep?.foo[bar_];
 deep?.foo['bar_'];

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -2,6 +2,8 @@ class Foo {
   constructor() {
     // Properties within a class should be renamed
     this.hello_AMP_PRIVATE_ = 'world';
+    let bar_ = 'world';
+    console.log(zoo_);
   }
 
 } // Classes themselves should not be renamed.

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -1,0 +1,10 @@
+class Foo {
+  constructor() {
+    /**
+     * @type {string}
+     * @private
+     */
+    this.hello_AMP_PRIVATE_ = 'world';
+  }
+
+}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -1,15 +1,20 @@
 class Foo {
   constructor() {
-    // Properties within a class should be renamed
     this.hello_AMP_PRIVATE_ = 'world';
-    let bar_ = 'world';
-    console.log(zoo_);
+    let bar_AMP_PRIVATE_ = 'world';
+    console.log(zoo_AMP_PRIVATE_);
   }
 
-} // Classes themselves should not be renamed.
+  doFoo_AMP_PRIVATE_() {}
 
+  doBar() {
+    const {
+      foo_AMP_PRIVATE_
+    } = this;
+  }
 
-class Foo_ {} // Variables outside of a class should not be renamed
+}
 
+class Foo_AMP_PRIVATE_ {}
 
-let hello_ = 'world';
+let hello_AMP_PRIVATE_ = 'world';

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/skip-nonamp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/skip-nonamp-privates/input.js
@@ -1,0 +1,9 @@
+class Foo {
+  constructor() {
+    /**
+     * @type {string}
+     * @private
+     */
+    this.hello_ = 'world';
+  }
+}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/skip-nonamp-privates/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/skip-nonamp-privates/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    [
+      "../../../.."
+    ]
+  ],
+  "sourceType": "module",
+  "filenameRelative": "node_modules/foo.js"
+}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/skip-nonamp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/skip-nonamp-privates/output.mjs
@@ -1,0 +1,10 @@
+class Foo {
+  constructor() {
+    /**
+     * @type {string}
+     * @private
+     */
+    this.hello_ = 'world';
+  }
+
+}

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/index.js
@@ -1,0 +1,3 @@
+const runner = require('@babel/helper-plugin-test-runner').default;
+
+runner(__dirname);

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -111,10 +111,12 @@ function getFileBabelOptions(babelOptions, filename) {
     babelOptions = {...babelOptions, plugins};
   }
 
+  // The amp runner automatically sets cwd to the `amphtml` directory.
+  const root = process.cwd();
   return {
     ...babelOptions,
     filename,
-    filenameRelative: path.basename(filename),
+    filenameRelative: path.relative(root, filename),
   };
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -798,7 +798,7 @@ function shouldUseClosure() {
   // the release process automatically. Since this experiment is actually on the build system
   // itself instead of runtime, it is never run through babel (where the replacements usually happen).
   // Therefore we must compute this one by hand.
-  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION' && false;
+  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION';
 }
 
 module.exports = {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -462,9 +462,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     let map = result.outputFiles.find(({path}) => path.endsWith('.map')).text;
 
     if (options.minify) {
-      ({code, map} = await minify(code, map, {
-        mangle: !compiledFile && options.mangle,
-      }));
+      ({code, map} = await minify(code, map));
       map = await massageSourcemaps(map, options);
     }
 
@@ -533,12 +531,15 @@ const nameCache = {};
  *
  * @param {string} code
  * @param {string} map
- * @param {{mangle: boolean}} options
  * @return {!Promise<{code: string, map: *, error?: Error}>}
  */
-async function minify(code, map, {mangle} = {mangle: false}) {
+async function minify(code, map) {
   const terserOptions = {
-    mangle: {},
+    mangle: {
+      properties: {
+        regex: '_AMP_PRIVATE_$',
+      },
+    },
     compress: {
       // Settled on this count by incrementing number until there was no more
       // effect on minification quality.
@@ -551,21 +552,11 @@ async function minify(code, map, {mangle} = {mangle: false}) {
     },
     sourceMap: {content: map},
     module: !!argv.esm,
+    nameCache,
   };
-
-  // Enabling property mangling requires disabling two other optimization.
-  // - Should not mangle quoted properties (often used for cross-binary purposes)
-  // - Should not convert computed properties into regular property definition
-  if (mangle) {
-    // eslint-disable-next-line google-camelcase/google-camelcase
-    terserOptions.mangle.properties = {keep_quoted: 'strict', regex: '_$'};
-    terserOptions.nameCache = nameCache;
-
-    // TODO: uncomment once terser bugs related to these are fixed
-    // https://github.com/terser/terser/pull/1058
-    terserOptions.compress.computed_props = false; // eslint-disable-line google-camelcase/google-camelcase
-    terserOptions.compress.properties = false;
-  }
+  // TS complains if defined inline, since it sees type `string` but needs type ("strict" | boolean).
+  // eslint-disable-next-line google-camelcase/google-camelcase
+  terserOptions.mangle.properties.keep_quoted = 'strict';
 
   const minified = await terser.minify(code, terserOptions);
   return {code: minified.code ?? '', map: minified.map};
@@ -807,7 +798,7 @@ function shouldUseClosure() {
   // the release process automatically. Since this experiment is actually on the build system
   // itself instead of runtime, it is never run through babel (where the replacements usually happen).
   // Therefore we must compute this one by hand.
-  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION';
+  return argv.define_experiment_constant !== 'ESBUILD_COMPILATION' && false;
 }
 
 module.exports = {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -538,6 +538,8 @@ async function minify(code, map) {
     mangle: {
       properties: {
         regex: '_AMP_PRIVATE_$',
+        // eslint-disable-next-line google-camelcase/google-camelcase
+        keep_quoted: /** @type {'strict'} */ ('strict'),
       },
     },
     compress: {
@@ -555,8 +557,6 @@ async function minify(code, map) {
     nameCache,
   };
   // TS complains if defined inline, since it sees type `string` but needs type ("strict" | boolean).
-  // eslint-disable-next-line google-camelcase/google-camelcase
-  terserOptions.mangle.properties.keep_quoted = 'strict';
 
   const minified = await terser.minify(code, terserOptions);
   return {code: minified.code ?? '', map: minified.map};

--- a/extensions/amp-iframe/1.0/component.js
+++ b/extensions/amp-iframe/1.0/component.js
@@ -72,7 +72,7 @@ export function BentoIframe({
 
   useEffect(() => {
     const iframe = iframeRef.current;
-    if (!iframe?.ownerDocument.defaultView) {
+    if (!iframe) {
       return;
     }
     const win = toWin(iframe.ownerDocument.defaultView);

--- a/extensions/amp-iframe/1.0/component.js
+++ b/extensions/amp-iframe/1.0/component.js
@@ -72,7 +72,7 @@ export function BentoIframe({
 
   useEffect(() => {
     const iframe = iframeRef.current;
-    if (!iframe) {
+    if (!iframe?.ownerDocument.defaultView) {
       return;
     }
     const win = toWin(iframe.ownerDocument.defaultView);


### PR DESCRIPTION
## summary
This PR renames all of AMP's private vars so that we can safely enable terser prop mangle during minification.

|                                 | v0.js brotli | v0.js  | v0.mjs brotli | v0.mjs |
|---------------------------------|--------------|--------|---------------|--------|
| closure compiler                | 69.33        | 269.42 | 60.93         | 213.00 |
| esbuild/terser with prop mangle | 71.38        | 281.43 | 63.40         | 233.13 |
| esbuild/terser                  | 74.50        | 314.80 | 66.42         | 266.23 |

**explanation**
Normally enabling prop mangling requires [significant attention to detail](https://terser.org/docs/cli-usage#cli-mangling-property-names-mangle-props) to perform safely. Creating a babel transform that marks all AMP private properties with a unique suffix allows us to accurately target AMP variables on bundled binaries which may includes bth AMP and non-AMP code (i.e. node_modules, or third_party libs).

**bonus fix**
We were incorrectly calculating `filenameRelative` in our babel transforms.

**PC** (pr credits):
@jridgewell, thank you for essentially writing the whole thing in astexplorer.

Note: I've currently forced `esbuild` within this PR, but will remove it before merging.

cc @ampproject/wg-performance 