### PR TITLE
`BentoStreamGallery`: Use `toChildArray` to get the `length`

### DIFF
--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -7,7 +7,6 @@ import {
   useCallback,
   useImperativeHandle,
   useLayoutEffect,
-  useMemo,
   useRef,
   useState,
 } from '#preact';
@@ -41,7 +40,7 @@ function BentoStreamGalleryWithRef(props, ref) {
   const classes = useStyles();
   const carouselRef = useRef(null);
   const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT);
-  const length = useMemo(() => toChildArray(children), [children]);
+  const {length} = toChildArray(children);
   const measure = useCallback(
     (containerWidth) =>
       getVisibleCount(

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -1,12 +1,13 @@
 import * as Preact from '#preact';
 import {BentoBaseCarousel} from '../../amp-base-carousel/1.0/component';
-import {forwardRef} from '#preact/compat';
+import {forwardRef, toChildArray} from '#preact/compat';
 import {setStyle} from '#core/dom/style';
 import {toWin} from '#core/window';
 import {
   useCallback,
   useImperativeHandle,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from '#preact';
@@ -40,7 +41,7 @@ function BentoStreamGalleryWithRef(props, ref) {
   const classes = useStyles();
   const carouselRef = useRef(null);
   const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT);
-
+  const length = useMemo(() => toChildArray(children), [children]);
   const measure = useCallback(
     (containerWidth) =>
       getVisibleCount(
@@ -48,7 +49,7 @@ function BentoStreamGalleryWithRef(props, ref) {
         minItemWidth,
         maxVisibleCount,
         minVisibleCount,
-        children.length,
+        length,
         outsetArrows,
         peek,
         containerWidth,
@@ -59,7 +60,7 @@ function BentoStreamGalleryWithRef(props, ref) {
       minItemWidth,
       maxVisibleCount,
       minVisibleCount,
-      children.length,
+      length,
       outsetArrows,
       peek,
     ]


### PR DESCRIPTION
Use `toChildArray` to get the `children.length`, partial for #35678