### PR TITLE
🚀 Delay marking unresolved AMP Elements until extension fails

### DIFF
--- a/extensions/amp-a4a/0.1/test/test-template-renderer.js
+++ b/extensions/amp-a4a/0.1/test/test-template-renderer.js
@@ -115,9 +115,8 @@ describes.realWin('TemplateRenderer', realWinConfig, (env) => {
               '"https://buy.com/buy-1">Click for ad!</a>' +
               '\n    <amp-analytics class="i-amphtml-element i-amphtml' +
               '-notbuilt amp-notbuilt i-amphtml-layout-fixed i-amphtml' +
-              '-layout-size-defined amp-unresolved i-amphtml-' +
-              'unresolved" i-amphtml-layout="fixed" style="width: 1px;' +
-              ' height: 1px;"></amp-analytics></div>'
+              '-layout-size-defined" i-amphtml-layout="fixed" style="width: ' +
+              '1px; height: 1px;"></amp-analytics></div>'
           );
         });
     });

--- a/src/amp.js
+++ b/src/amp.js
@@ -65,7 +65,7 @@ function bootstrap(ampdoc, perf) {
   startupChunk(self.document, function stub() {
     // Pre-stub already known elements.
     stubElementsForDoc(ampdoc);
-    whenDocumentComplete(self.document).then(markUnresolvedElements);
+    whenDocumentComplete(self.document).then(() => markUnresolvedElements());
   });
   startupChunk(
     self.document,

--- a/src/amp.js
+++ b/src/amp.js
@@ -6,6 +6,7 @@
 import './polyfills';
 
 import {TickLabel} from '#core/constants/enums';
+import {whenDocumentComplete} from '#core/document-ready';
 import * as mode from '#core/mode';
 
 import {Services} from '#service';
@@ -21,6 +22,7 @@ import {installPlatformService} from '#service/platform-impl';
 
 import {installAutoLightboxExtension} from './auto-lightbox';
 import {startupChunk} from './chunk';
+import {markUnresolvedElements} from './custom-element';
 import {installErrorReporting} from './error-reporting';
 import {fontStylesheetTimeout} from './font-stylesheet-timeout';
 import {maybeTrackImpression} from './impression';
@@ -63,6 +65,7 @@ function bootstrap(ampdoc, perf) {
   startupChunk(self.document, function stub() {
     // Pre-stub already known elements.
     stubElementsForDoc(ampdoc);
+    whenDocumentComplete(self.document).then(markUnresolvedElements);
   });
   startupChunk(
     self.document,

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -64,7 +64,7 @@ export const stubbedElements = [];
  * implClass available are marked unresolvable.
  * @type {Set<string>}
  */
-let unresolvableExtensions = new Set();
+const unresolvableExtensions = new Set();
 
 /**
  * Whether this platform supports template tags.

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -62,9 +62,9 @@ export const stubbedElements = [];
  * Extensions which have failed to load, making their elements unresolvable.
  * If null, then any remaining elements which don't immediately have their
  * implClass available are marked unresolvable.
- * @type {Array<string>|null}
+ * @type {Set<string>}
  */
-let unresolvableExtensions = [];
+let unresolvableExtensions = new Set();
 
 /**
  * Whether this platform supports template tags.
@@ -1206,8 +1206,8 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
         if (this.implClass_) {
           this.upgradeOrSchedule_();
         } else if (
-          unresolvableExtensions == null ||
-          unresolvableExtensions.includes(this.tagName.toLowerCase())
+          unresolvableExtensions.has('*') ||
+          unresolvableExtensions.has(this.tagName.toLowerCase())
         ) {
           this.markUnresolved();
         }
@@ -2207,11 +2207,7 @@ export function getActionQueueForTesting(element) {
  * @param {string=} opt_extension
  */
 export function markUnresolvedElements(opt_extension) {
-  if (opt_extension == null) {
-    unresolvableExtensions = null;
-  } else {
-    unresolvableExtensions?.push(opt_extension);
-  }
+  unresolvableExtensions.add(opt_extension || '*');
   for (const el of stubbedElements) {
     if (opt_extension == null || el.tagName.toLowerCase() === opt_extension) {
       el.markUnresolved();
@@ -2221,5 +2217,5 @@ export function markUnresolvedElements(opt_extension) {
 
 /** */
 export function resetUnresolvedElementsForTesting() {
-  unresolvableExtensions = [];
+  unresolvableExtensions.clear();
 }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -2218,3 +2218,8 @@ export function markUnresolvedElements(opt_extension) {
     }
   }
 }
+
+/** */
+export function resetUnresolvedElementsForTesting() {
+  unresolvableExtensions = [];
+}

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -378,7 +378,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     /**
      * When the document is ready (meaning all external resources are loaded or
      * failed), we mark any stubbed elements as unresolved. If they haven't
-     * been upgraded yet (or prending upgrade or deferredBuild elements), then
+     * been upgraded yet (or pending upgrade or deferredBuild elements), then
      * the extension failed to load.
      */
     markUnresolved() {

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -59,11 +59,12 @@ let templateTagSupported;
 export const stubbedElements = [];
 
 /**
- * Whether the document has already marked unresolved elements. After that
- * point, any elements that are created that don't immediately have their
- * implClass available will be marked unresolved.
+ * Extensions which have failed to load, making their elements unresolvable.
+ * If null, then any remaining elements which don't immediately have their
+ * implClass available are marked unresolvable.
+ * @type {Array<string>|null}
  */
-const markStubbedElements = false;
+let unresolvableExtensions = [];
 
 /**
  * Whether this platform supports template tags.
@@ -1204,7 +1205,10 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
 
         if (this.implClass_) {
           this.upgradeOrSchedule_();
-        } else if (markStubbedElements) {
+        } else if (
+          unresolvableExtensions == null ||
+          unresolvableExtensions.includes(this.tagName.toLowerCase())
+        ) {
           this.markUnresolved();
         }
 
@@ -2200,14 +2204,16 @@ export function getActionQueueForTesting(element) {
 
 /**
  * Marks each element that still stubbed as unresolved.
- * @param {string=} opt_tagName
+ * @param {string=} opt_extension
  */
-export function markUnresolvedElements(opt_tagName) {
-  if (opt_tagName == null) {
-    markUnresolvedElements = true;
+export function markUnresolvedElements(opt_extension) {
+  if (opt_extension == null) {
+    unresolvableExtensions = null;
+  } else {
+    unresolvableExtensions?.push(opt_extension);
   }
   for (const el of stubbedElements) {
-    if (opt_tagName == null || el.tagName === opt_tagName) {
+    if (opt_extension == null || el.tagName.toLowerCase() === opt_extension) {
       el.markUnresolved();
     }
   }

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -2,7 +2,11 @@ import {Services} from '#service';
 
 import {extensionScriptsInNode} from './extension-script';
 
-import {createCustomElementClass, stubbedElements, markUnresolvedElements} from '../custom-element';
+import {
+  createCustomElementClass,
+  markUnresolvedElements,
+  stubbedElements,
+} from '../custom-element';
 import {ElementStub} from '../element-stub';
 import {reportError} from '../error-reporting';
 import {userAssert} from '../log';

--- a/src/service/custom-element-registry.js
+++ b/src/service/custom-element-registry.js
@@ -2,7 +2,7 @@ import {Services} from '#service';
 
 import {extensionScriptsInNode} from './extension-script';
 
-import {createCustomElementClass, stubbedElements} from '../custom-element';
+import {createCustomElementClass, stubbedElements, markUnresolvedElements} from '../custom-element';
 import {ElementStub} from '../element-stub';
 import {reportError} from '../error-reporting';
 import {userAssert} from '../log';
@@ -120,8 +120,9 @@ function waitReadyForUpgrade(win, elementClass) {
  */
 export function stubElementsForDoc(ampdoc) {
   const extensions = extensionScriptsInNode(ampdoc.getHeadNode());
-  extensions.forEach(({extensionId, extensionVersion}) => {
+  extensions.forEach(({extensionId, extensionVersion, script}) => {
     ampdoc.declareExtension(extensionId, extensionVersion);
+    script.addEventListener('error', () => markUnresolvedElements(extensionId));
     stubElementIfNotKnown(ampdoc.win, extensionId);
   });
   if (ampdoc.isBodyAvailable()) {

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -197,7 +197,7 @@ export function getExtensionScripts(
 /**
  * Get list of all the extension JS files.
  * @param {HTMLHeadElement|Element|ShadowRoot|Document} head
- * @return {!Array<{extensionId: string, extensionVersion: string}>}
+ * @return {!Array<{script: HTMLScriptElement, extensionId: string, extensionVersion: string}>}
  */
 export function extensionScriptsInNode(head) {
   // ampdoc.getHeadNode() can return null.
@@ -216,9 +216,12 @@ export function extensionScriptsInNode(head) {
       script.getAttribute('custom-element') ||
       script.getAttribute('custom-template');
     const urlParts = parseExtensionUrl(script.src);
-    // TODO: register error handler
     if (extensionId && urlParts) {
-      scripts.push({extensionId, extensionVersion: urlParts.extensionVersion});
+      scripts.push({
+        script,
+        extensionId,
+        extensionVersion: urlParts.extensionVersion,
+      });
     }
   }
   return scripts;

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -144,7 +144,7 @@ export class Performance {
      * See https://github.com/GoogleChrome/web-vitals/blob/main/src/getCLS.ts
      * @private {Array<LayoutShift>}
      */
-    this.layoutShiftEntires_ = [];
+    this.layoutShiftEntries_ = [];
 
     /**
      * The sum of all layout shifts.
@@ -559,7 +559,7 @@ export class Performance {
     if (this.isVisibilityHidden_()) {
       return;
     }
-    const entries = this.layoutShiftEntires_;
+    const entries = this.layoutShiftEntries_;
     if (entries.length > 0) {
       const first = entries[0];
       const last = entries[entries.length - 1];
@@ -586,7 +586,7 @@ export class Performance {
    * See https://web.dev/evolving-cls/
    */
   flushLayoutShiftScore_() {
-    const entries = this.layoutShiftEntires_;
+    const entries = this.layoutShiftEntries_;
     const old = this.metrics_.get(TickLabel.CUMULATIVE_LAYOUT_SHIFT);
     let union = 0;
     let sum = 0;

--- a/test/unit/test-custom-element-registry.js
+++ b/test/unit/test-custom-element-registry.js
@@ -262,6 +262,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
         hasAttribute(name) {
           return name == 'custom-element' || name == 'src';
         },
+        addEventListener() {},
         src: 'https://cdn.ampproject.org/v0/amp-test1-0.2.js',
         ownerDocument: doc,
       };
@@ -326,6 +327,7 @@ describes.realWin('CustomElement register', {amp: true}, (env) => {
         hasAttribute(name) {
           return name == 'custom-element' || name == 'src';
         },
+        addEventListener() {},
         src: 'https://cdn.ampproject.org/v0/amp-test2-0.3.js',
         ownerDocument: doc,
       };

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -13,6 +13,8 @@ import {chunkInstanceForTesting} from '../../src/chunk';
 import {
   createAmpElementForTesting,
   getImplSyncForTesting,
+  markUnresolvedElements,
+  resetUnresolvedElementsForTesting,
 } from '../../src/custom-element';
 import {ElementStub} from '../../src/element-stub';
 
@@ -153,6 +155,7 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
       afterEach(() => {
         clock.uninstall();
         resourcesMock.verify();
+        resetUnresolvedElementsForTesting();
       });
 
       function skipMicroTask() {
@@ -948,9 +951,9 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
 
         expect(element.everAttached).to.equal(true);
         expect(element.getLayout()).to.equal(Layout.FILL);
-        // Not upgraded yet!
-        expect(element).to.have.class('amp-unresolved');
-        expect(element).to.have.class('i-amphtml-unresolved');
+        // Not upgraded yet, but extension hasn't failed.
+        expect(element).not.to.have.class('amp-unresolved');
+        expect(element).not.to.have.class('i-amphtml-unresolved');
 
         // Upgrade
         resourcesMock.expects('upgraded').withExactArgs(element).once();
@@ -965,6 +968,44 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         // Now it's called.
         expect(element).to.not.have.class('amp-unresolved');
         expect(element).to.not.have.class('i-amphtml-unresolved');
+      });
+
+      it('StubElement - attachedCallback after failed to load', () => {
+        const element = new StubElementClass();
+        markUnresolvedElements('amp-stub');
+        element.setAttribute('layout', 'fill');
+        expect(element.everAttached).to.equal(false);
+        expect(element.getLayout()).to.equal(Layout.NODISPLAY);
+
+        resourcesMock.expects('add').withExactArgs(element).atLeast(1);
+        container.appendChild(element);
+
+        expect(element.everAttached).to.equal(true);
+        expect(element.getLayout()).to.equal(Layout.FILL);
+        // Extension already failed before attachedCallback
+        expect(element).to.have.class('amp-unresolved');
+        expect(element).to.have.class('i-amphtml-unresolved');
+      });
+
+      it('StubElement - attachedCallback before failed to load', () => {
+        const element = new StubElementClass();
+        element.setAttribute('layout', 'fill');
+        expect(element.everAttached).to.equal(false);
+        expect(element.getLayout()).to.equal(Layout.NODISPLAY);
+
+        resourcesMock.expects('add').withExactArgs(element).atLeast(1);
+        container.appendChild(element);
+
+        expect(element.everAttached).to.equal(true);
+        expect(element.getLayout()).to.equal(Layout.FILL);
+        // Not upgraded yet, but extension hasn't failed.
+        expect(element).not.to.have.class('amp-unresolved');
+        expect(element).not.to.have.class('i-amphtml-unresolved');
+
+        // Now it's called.
+        markUnresolvedElements('amp-stub');
+        expect(element).to.have.class('amp-unresolved');
+        expect(element).to.have.class('i-amphtml-unresolved');
       });
 
       it('Element - detachedCallback', () => {


### PR DESCRIPTION
This permanently fixes the CLS caused by adblockers by delaying adding `.amp-unresovled` until we know the extension has been blocked. There's a race condition on when the element registry can register the `onerror` and when the script can actually load, so we listen for when the document is complete (which means all subresources have finished loading or failed to load) and mark any stragglers.