### PR TITLE
build-system: only write version.txt once per dir

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -23,6 +23,9 @@ const {
 const {
   displayLifecycleDebugging,
 } = require('../compile/debug-compilation-lifecycle');
+const {
+  VERSION: internalRuntimeVersion,
+} = require('../compile/internal-version');
 const {buildCompiler} = require('../compile/build-compiler');
 const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
 const {buildVendorConfigs} = require('./3p-vendor-helpers');
@@ -118,6 +121,7 @@ async function dist() {
     await compileCoreRuntime(options);
   } else {
     await Promise.all([
+      writeVersionFile(),
       buildExperiments(),
       buildLoginDone('0.1'),
       buildWebPushPublisherFiles(),
@@ -145,6 +149,17 @@ async function dist() {
   if (!argv.watch) {
     exitCtrlcHandler(handlerProcess);
   }
+}
+
+/**
+ * Writes the verion.txt file.
+ * @return {!Promise}
+ */
+async function writeVersionFile() {
+  return fs.writeFile(
+    path.join('dist', 'v0', 'version.txt'),
+    internalRuntimeVersion
+  );
 }
 
 /**

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -158,13 +158,14 @@ async function dist() {
 async function writeVersionFiles() {
   // TODO: determine which of these are necessary and trim the rest via an I2D.
   const paths = [
-    path.join('dist'),
-    path.join('dist', 'v0'),
-    path.join('dist', 'v0', 'examples'),
-    path.join('dist.tools', 'experiments'),
-    path.join('dist.3p', internalRuntimeVersion),
-    path.join('dist.3p', internalRuntimeVersion, 'vendor'),
-  ].map((p) => path.join(p, 'version.txt'));
+    'dist',
+    'dist/v0',
+    'dist/v0/examples',
+    'dist.tools/experiments',
+    `dist.3p/${internalRuntimeVersion}`,
+    `dist.3p/${internalRuntimeVersion}/vendor`,
+  ].map((p) => path.join(...p.split('/'), 'version.txt'));
+
   return Promise.all(
     paths.map((p) => fs.outputFile(p, internalRuntimeVersion))
   );

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -158,11 +158,11 @@ async function dist() {
 async function writeVersionFiles() {
   // TODO: determine which of these are necessary and trim the rest via an I2D.
   const paths = [
-    path.join('dist.tools', 'experiments'),
-    path.join('dist', 'v0'),
     path.join('dist'),
-    path.join('dist.3p', internalRuntimeVersion),
+    path.join('dist', 'v0'),
     path.join('dist', 'v0', 'examples'),
+    path.join('dist.tools', 'experiments'),
+    path.join('dist.3p', internalRuntimeVersion),
     path.join('dist.3p', internalRuntimeVersion, 'vendor'),
   ];
   return Promise.all(

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -164,7 +164,7 @@ async function writeVersionFiles() {
     path.join('dist.tools', 'experiments'),
     path.join('dist.3p', internalRuntimeVersion),
     path.join('dist.3p', internalRuntimeVersion, 'vendor'),
-  ];
+  ].map((p) => path.join(p, 'version.txt'));
   return Promise.all(
     paths.map((p) => fs.outputFile(p, internalRuntimeVersion))
   );

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -121,7 +121,7 @@ async function dist() {
     await compileCoreRuntime(options);
   } else {
     await Promise.all([
-      writeVersionFile(),
+      writeVersionFiles(),
       buildExperiments(),
       buildLoginDone('0.1'),
       buildWebPushPublisherFiles(),
@@ -155,10 +155,18 @@ async function dist() {
  * Writes the verion.txt file.
  * @return {!Promise}
  */
-async function writeVersionFile() {
-  return fs.writeFile(
-    path.join('dist', 'v0', 'version.txt'),
-    internalRuntimeVersion
+async function writeVersionFiles() {
+  // TODO: determine which of these are necessary and trim the rest via an I2D.
+  const paths = [
+    path.join('dist.tools', 'experiments'),
+    path.join('dist', 'v0'),
+    path.join('dist'),
+    path.join('dist.3p', internalRuntimeVersion),
+    path.join('dist', 'v0', 'examples'),
+    path.join('dist.3p', internalRuntimeVersion, 'vendor'),
+  ];
+  return Promise.all(
+    paths.map((p) => fs.outputFile(p, internalRuntimeVersion))
   );
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -313,7 +313,6 @@ async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
 
   const destPath = path.join(destDir, minifiedName);
   combineWithCompiledFile(srcFilename, destPath, options);
-  fs.writeFileSync(path.join(destDir, 'version.txt'), internalRuntimeVersion);
   if (options.latestName) {
     fs.copySync(
       destPath,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -402,14 +402,6 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     return watchedTargets.get(entryPoint).rebuild();
   }
 
-  // TODO(36162): Only write this once as part of the dist() function.
-  if (options.minify) {
-    fs.outputFileSync(
-      path.join(destDir, 'version.txt'),
-      internalRuntimeVersion
-    );
-  }
-
   /**
    * Splits up the wrapper to compute the banner and footer
    * @return {Object}


### PR DESCRIPTION
**summary**
We currently write `version.txt` hundreds of times during an `amp dist`, usually to the same exact file (`dist/v0/version.txt`), but sometimes elsewhere. My instinct is that most of these writes were accidental, but I'm not going to fry that 🐟 here.

This PR extracts the logic to only happen once per dir.

Full set before:
```
[
  './dist.tools/experiments/',
  './dist/v0/',
  './dist/v0',
  './dist',
  './dist.3p/2109241350001',
  './dist/v0/examples',
  './dist.3p/2109241350001/vendor/',
  'extensions/amp-accordion/1.0/dist',
  'extensions/amp-base-carousel/1.0/dist',
  'extensions/amp-date-countdown/1.0/dist',
  'extensions/amp-date-display/1.0/dist',
  'extensions/amp-facebook/1.0/dist',
  'extensions/amp-embedly-card/1.0/dist',
  'extensions/amp-fit-text/1.0/dist',
  'extensions/amp-inline-gallery/1.0/dist',
  'extensions/amp-instagram/1.0/dist',
  'extensions/amp-lightbox/1.0/dist',
  'extensions/amp-lightbox-gallery/1.0/dist',
  'extensions/amp-selector/1.0/dist',
  'extensions/amp-sidebar/1.0/dist',
  'extensions/amp-soundcloud/1.0/dist',
  'extensions/amp-social-share/1.0/dist',
  'extensions/amp-stream-gallery/1.0/dist',
  'extensions/amp-timeago/1.0/dist',
  'extensions/amp-twitter/1.0/dist',
  'extensions/amp-video-iframe/1.0/dist',
  'extensions/amp-wordpress-embed/1.0/dist',
  'extensions/amp-vimeo/1.0/dist',
  'extensions/amp-youtube/1.0/dist',
  'extensions/amp-video/1.0/dist'
]
```

After trimming the bento directories, which were almost definitely an accident and nobody can be depending on yet, we are left with:
```
[
  './dist.tools/experiments/',
  './dist/v0',
  './dist',
  './dist.3p/2109241350001',
  './dist/v0/examples',
  './dist.3p/2109241350001/vendor/',
]
```

cc @danielrozenberg @caroqliu