### PR TITLE
esbuild compile: also write version.txt

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -402,6 +402,8 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
   if (watchedTargets.has(entryPoint)) {
     return watchedTargets.get(entryPoint).rebuild();
   }
+  // TODO(36162): Only write this once as part of the dist() function.
+  fs.writeFileSync(path.join(destDir, 'version.txt'), internalRuntimeVersion);
 
   /**
    * Splits up the wrapper to compute the banner and footer

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -405,7 +405,10 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
 
   // TODO(36162): Only write this once as part of the dist() function.
   if (options.minify) {
-    fs.writeFileSync(path.join(destDir, 'version.txt'), internalRuntimeVersion);
+    fs.outputFileSync(
+      path.join(destDir, 'version.txt'),
+      internalRuntimeVersion
+    );
   }
 
   /**

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -402,8 +402,11 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
   if (watchedTargets.has(entryPoint)) {
     return watchedTargets.get(entryPoint).rebuild();
   }
+
   // TODO(36162): Only write this once as part of the dist() function.
-  fs.writeFileSync(path.join(destDir, 'version.txt'), internalRuntimeVersion);
+  if (options.minify) {
+    fs.writeFileSync(path.join(destDir, 'version.txt'), internalRuntimeVersion);
+  }
 
   /**
    * Splits up the wrapper to compute the banner and footer


### PR DESCRIPTION
**summary**
Silly code, but technically equivalent to what already exists in `compileMinified` (closure) path.
Hopefully can move to the solution outlined in https://github.com/ampproject/amphtml/pull/36162 in the future.

cc @danielrozenberg 