### PR TITLE
🏗 Output distinct `bento-*.js`

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -56,7 +56,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -199,7 +199,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -233,7 +233,7 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -299,7 +299,7 @@
     "latestVersion": "0.1",
     "options": {
       "npm": true,
-      "wrapper": "bento",
+      "wrapper": ["extension", "bento"],
       "hasCss": true
     }
   },
@@ -314,7 +314,7 @@
     "latestVersion": "0.1",
     "options": {
       "npm": true,
-      "wrapper": "bento",
+      "wrapper": ["extension", "bento"],
       "hasCss": true
     }
   },
@@ -351,7 +351,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -374,7 +374,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -407,7 +407,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -481,7 +481,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -548,7 +548,7 @@
         "amp-inline-gallery-pagination"
       ],
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -571,7 +571,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -614,7 +614,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -632,7 +632,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -827,7 +827,7 @@
     "version": "1.0",
     "latestVersion": "1.0",
     "options": {
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -863,7 +863,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -892,7 +892,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -927,7 +927,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -942,7 +942,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1088,7 +1088,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1127,7 +1127,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1154,7 +1154,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1177,7 +1177,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1200,7 +1200,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1227,7 +1227,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1265,7 +1265,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   },
   {
@@ -1285,7 +1285,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": "bento"
+      "wrapper": ["extension", "bento"]
     }
   }
 ]

--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -678,7 +678,7 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "wrapper": "bento",
+      "wrapper": ["extension", "bento"],
       "npm": true
     }
   },

--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -56,7 +56,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -199,7 +199,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -233,7 +233,7 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -299,7 +299,7 @@
     "latestVersion": "0.1",
     "options": {
       "npm": true,
-      "wrapper": ["extension", "bento"],
+      "bento": true,
       "hasCss": true
     }
   },
@@ -314,7 +314,7 @@
     "latestVersion": "0.1",
     "options": {
       "npm": true,
-      "wrapper": ["extension", "bento"],
+      "bento": true,
       "hasCss": true
     }
   },
@@ -351,7 +351,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -374,7 +374,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -407,7 +407,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -481,7 +481,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -548,7 +548,7 @@
         "amp-inline-gallery-pagination"
       ],
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -571,7 +571,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -614,7 +614,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -632,7 +632,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -678,7 +678,7 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "wrapper": ["extension", "bento"],
+      "bento": true,
       "npm": true
     }
   },
@@ -827,7 +827,7 @@
     "version": "1.0",
     "latestVersion": "1.0",
     "options": {
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -863,7 +863,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -892,7 +892,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -927,7 +927,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -942,7 +942,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1088,7 +1088,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1127,7 +1127,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1154,7 +1154,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1177,7 +1177,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1200,7 +1200,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1227,7 +1227,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1265,7 +1265,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   },
   {
@@ -1285,7 +1285,7 @@
     "options": {
       "hasCss": true,
       "npm": true,
-      "wrapper": ["extension", "bento"]
+      "bento": true
     }
   }
 ]

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -99,23 +99,19 @@ function extensionPayload(name, version, latest, isModule, loadPriority) {
  * binaries and the script check should not be present at all.
  */
 const bentoLoaderFn = removeWhitespace(`
-function (payload) {
-  self.AMP
-    ? self.AMP.push(payload)
-    : document.head.querySelector('script[src$="v0.js"],script[src$="v0.mjs"],script[src$="/amp.mjs"],script[src$="/amp.js"]')
-    ? (self.AMP = [payload])
-    : payload.f({
-        registerElement: function (n, b, s) {
-          if (s)
-            document.head.appendChild(
-              document.createElement("style")
-            ).textContent = s;
-          customElements.define(
-            n.replace(/^amp-/, 'bento-'),
-            b.CustomElement(b)
-          );
-        },
-      });
+function (p) {
+  p.f({
+    registerElement: function (n, b, s) {
+      if (s)
+        document.head.appendChild(
+          document.createElement("style")
+        ).textContent = s;
+      customElements.define(
+        n.replace(/^amp-/, 'bento-'),
+        b.CustomElement(b)
+      );
+    },
+  });
 }
 `);
 

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -1,11 +1,5 @@
 const {VERSION} = require('./internal-version');
 
-const removeWhitespace = (str) =>
-  str
-    .replace(/\s+/g, '')
-    // <%=contents%> is ignored down the line, so we restore its whitespace
-    .replace('<%=contents%>', '<%= contents %>');
-
 // If there is a sync JS error during initial load,
 // at least try to unhide the body.
 // If "AMP" is already an object then that means another runtime has already
@@ -86,31 +80,5 @@ function extensionPayload(name, version, latest, isModule, loadPriority) {
     '}'
   );
 }
-
-/**
- * Wraps extension code to install a Bento component.
- *
- * On Bento documents, the extension's function (f) is executed immediately.
- * In this case, a barebones `AMP.registerElement` is also provided.
- * It uses a CustomElement implementation provided by the extension class
- * itself, and installs extension-specific CSS as soon as possible.
- *
- * The provided AMP.registerElement function has the same signature as
- * `Extensions.addElement` on extensions-impl.js. In order:
- * - `name` (n): the name of the custom element tag
- * - `Ctor` (c): the constructor function (class) for the custom element
- * - `style` (s): optional string to install CSS for the custom element
- */
-exports.bento = removeWhitespace(`
-  (function(AMP,_){<%= contents %>})({
-    registerElement: function (n, b, s) {
-      if (s)
-        document.head.appendChild(
-          document.createElement("style")
-        ).textContent = s;
-      customElements.define(n, b.CustomElement(b));
-    },
-  });
-`);
 
 exports.none = '<%= contents %>';

--- a/build-system/compile/compile-wrappers.js
+++ b/build-system/compile/compile-wrappers.js
@@ -1,6 +1,10 @@
 const {VERSION} = require('./internal-version');
 
-const removeWhitespace = (str) => str.replace(/\s+/g, '');
+const removeWhitespace = (str) =>
+  str
+    .replace(/\s+/g, '')
+    // <%=contents%> is ignored down the line, so we restore its whitespace
+    .replace('<%=contents%>', '<%= contents %>');
 
 // If there is a sync JS error during initial load,
 // at least try to unhide the body.
@@ -84,66 +88,29 @@ function extensionPayload(name, version, latest, isModule, loadPriority) {
 }
 
 /**
- * Anonymous function to load a Bento extension's payload (p).
+ * Wraps extension code to install a Bento component.
+ *
+ * On Bento documents, the extension's function (f) is executed immediately.
+ * In this case, a barebones `AMP.registerElement` is also provided.
+ * It uses a CustomElement implementation provided by the extension class
+ * itself, and installs extension-specific CSS as soon as possible.
  *
  * The provided AMP.registerElement function has the same signature as
  * `Extensions.addElement` on extensions-impl.js. In order:
  * - `name` (n): the name of the custom element tag
  * - `Ctor` (c): the constructor function (class) for the custom element
  * - `style` (s): optional string to install CSS for the custom element
- * @see {@link bento}
- * TODO(alanorozco): It would be cleaner if we used a "bento-foo" literal for
- * the tag name instead of replacing the prefix in "amp-foo".
- * TODO(alanorozco): `/amp.js` is relevant only for unminified builds. We add
- * this only so that tests can pass during CI. Eventually, we'll create separate
- * binaries and the script check should not be present at all.
  */
-const bentoLoaderFn = removeWhitespace(`
-function (p) {
-  p.f({
+exports.bento = removeWhitespace(`
+  (function(AMP,_){<%= contents %>})({
     registerElement: function (n, b, s) {
       if (s)
         document.head.appendChild(
           document.createElement("style")
         ).textContent = s;
-      customElements.define(
-        n.replace(/^amp-/, 'bento-'),
-        b.CustomElement(b)
-      );
+      customElements.define(n, b.CustomElement(b));
     },
   });
-}
 `);
-
-/**
- * Wraps to load an extension's payload (p) as a Bento component.
- *
- * It tries to use AMP's loading mechanism (`(self.AMP = self.AMP || []).push`)
- * when detecting the runtime either by a global, or the presence of a `script`
- * tag.
- *
- * On Bento documents, the extension's function (f) is executed immediately.
- * In this case, a barebones `AMP.registerElement` is also provided.
- * It uses a CustomElement implementation provided by the extension class
- * itself, and installs extension-specific CSS as soon as possible.
- * @param {string} name
- * @param {string} version
- * @param {boolean} latest
- * @param {boolean=} isModule
- * @param {ExtensionLoadPriorityDef=} loadPriority
- * @return {string}
- */
-function bento(name, version, latest, isModule, loadPriority) {
-  const payload = extensionPayload(
-    name,
-    version,
-    latest,
-    isModule,
-    loadPriority
-  );
-  return `(${bentoLoaderFn})(${payload});`;
-}
-
-exports.bento = bento;
 
 exports.none = '<%= contents %>';

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -36,6 +36,7 @@ async function clean() {
     'dist.tools',
     'export',
     'examples/storybook',
+    'extensions/**/build',
     'extensions/**/dist',
     'release',
     'result-reports',

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -15,6 +15,7 @@ const ROOT_DIR = path.resolve(__dirname, '../../');
  * @return {Promise<void>}
  */
 async function clean() {
+  // TODO(https://go.amp.dev/issue/36354): We can simplify this list
   const pathsToDelete = [
     // Local cache directories
     // Keep this list in sync with .gitignore, .eslintignore, and .prettierignore

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -738,8 +738,8 @@ async function buildExtensionJs(
   const wrapperNames = arrayOrItemToArray(options.wrapper || 'extension');
 
   const builds = wrapperNames.map(async (wrapperName) => {
-    // TODO(alanorozco): Use a `bento` option instead. The outer function can
-    // then be called twice at a higher level.
+    // TODO(https://go.amp.dev/issue/36351): Use a `bento` flag instead.
+    // The outer function can then be called twice at a higher level.
     const isBento = wrapperName === 'bento';
 
     const resolvedName = isBento ? name.replace(/^amp-/, 'bento-') : name;

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -781,8 +781,8 @@ async function buildExtensionJs(
 
 /**
  * Extensions may specify their own bento-install.js to install multiple
- * elements or otherwise specify custom install logic. Otherwise, we provide
- * an installer with the most common configuration.
+ * elements or to specify custom install logic. Otherwise, we generate an
+ * install script with the default configuration.
  * @param {string} sourceDir
  * @param {string} name
  * @param {string} version

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -790,11 +790,12 @@ async function buildExtensionJs(
  * @return {Promise<string>}
  */
 async function getBentoFilename(sourceDir, name, version, options) {
-  const optionalSpecified = `${name}.js`;
-  if (await fs.pathExists(`${sourceDir}/${optionalSpecified}`)) {
-    return sourceDir;
+  const filename = `${name}.js`;
+  if (await fs.pathExists(`${sourceDir}/${filename}`)) {
+    return filename;
   }
-  const source = `
+  const generatedFilename = `build/${filename}`;
+  const generatedSource = `
 import {BaseElement} from '../base-element';
 ${
   options.hasCss
@@ -807,11 +808,11 @@ ${
 }
 AMP.registerElement('${name}', BaseElement, CSS);
   `.trim();
-  const written = `build/${name}.js`;
+
   // Include code in extension directory outside /build
   options.extraGlobs = [...(options.extraGlobs || []), `${sourceDir}/**/*.js`];
-  await fs.outputFile(`${sourceDir}/${written}`, source);
-  return written;
+  await fs.outputFile(`${sourceDir}/${generatedFilename}`, generatedSource);
+  return generatedFilename;
 }
 
 /**
@@ -821,12 +822,8 @@ AMP.registerElement('${name}', BaseElement, CSS);
  * @return {string}
  */
 function getBentoCssImportPath(sourceDir, name, version) {
-  // TODO(alanorozco): This should instead be the bento-*.css output that
-  // should be available after this is submitted:
-  // https://github.com/ampproject/amphtml/pull/36221
-  const ampName = name.replace(/^bento-/, 'amp-');
   const root = sourceDir.split('/').fill('..').join('/');
-  return `${root}/build/${ampName}-${version}.css`;
+  return `${root}/build/${name}-${version}.css`;
 }
 
 /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -746,9 +746,9 @@ function defineElement() {
   ${
     css
       ? `
-const style = document.createElement('style');
-style.textContent = ${JSON.stringify(css)};
-document.head.appendChild(style);
+  const style = document.createElement('style');
+  style.textContent = ${JSON.stringify(css)};
+  document.head.appendChild(style);
   `.trim()
       : ''
   }

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -713,10 +713,13 @@ function buildBinaries(extDir, binaries, options) {
  */
 async function buildBentoExtensionJs(dir, name, options) {
   const bentoName = name.replace(/^amp-/, 'bento-');
-  options = {...options};
-  options.wrapper = 'none';
-  options.filename = await getBentoFilename(dir, bentoName, options);
-  return buildExtensionJs(dir, bentoName, options);
+  return buildExtensionJs(dir, bentoName, {
+    ...options,
+    wrapper: 'none',
+    filename: await getBentoFilename(dir, bentoName, options),
+    // Include extension directory since our entrypoint may be elsewhere.
+    extraGlobs: [...(options.extraGlobs || []), `${dir}/**/*.js`],
+  });
 }
 
 /**
@@ -759,10 +762,6 @@ defineElement();
   `.trim();
   const generatedFilename = `build/${name}.js`;
   await fs.outputFile(`${dir}/${generatedFilename}`, generatedSource);
-
-  // Include code in extension directory outside /build
-  options.extraGlobs = [...(options.extraGlobs || []), `${dir}/**/*.js`];
-
   return generatedFilename;
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -755,10 +755,9 @@ async function generateBentoEntryPointSource(name, options) {
 
   const source = dedent(`
     import {BaseElement} from '../base-element';
-
-    const css = __css__;
-
+    
     function defineElement() {
+      const css = __css__;
       if (css) {
         const style = document.createElement('style');
         style.textContent = css;

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -810,7 +810,7 @@ AMP.registerElement('${name}', BaseElement, CSS);
   const written = `build/${name}.js`;
   // Include code in extension directory outside /build
   options.extraGlobs = [...(options.extraGlobs || []), `${sourceDir}/**/*.js`];
-  await fs.writeFile(`${sourceDir}/${written}`, source);
+  await fs.outputFile(`${sourceDir}/${written}`, source);
   return written;
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -753,7 +753,7 @@ async function generateBentoEntryPointSource(name, options) {
     ? await fs.readFile(`build/${name}-${options.version}.css`, 'utf8')
     : null;
 
-  const source = dedent(`
+  return dedent(`
     import {BaseElement} from '../base-element';
     
     function defineElement() {
@@ -773,7 +773,6 @@ async function generateBentoEntryPointSource(name, options) {
   `)
     .replace('__css__', JSON.stringify(css))
     .replace('__name__', JSON.stringify(name));
-  return source;
 }
 
 /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -733,10 +733,9 @@ async function getBentoFilename(dir, name, options) {
   if (await fs.pathExists(`${dir}/${filename}`)) {
     return filename;
   }
-  let css;
-  if (options.hasCss) {
-    css = await fs.readFile(`build/${name}-${options.version}.css`, 'utf8');
-  }
+  const css = options.hasCss
+    ? await fs.readFile(`build/${name}-${options.version}.css`, 'utf8')
+    : null;
   const generatedSource = `
 import {BaseElement} from '../base-element';
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -794,17 +794,15 @@ async function getBentoFilename(sourceDir, name, version, options) {
   if (await fs.pathExists(`${sourceDir}/${filename}`)) {
     return filename;
   }
+  const sourceDirToRoot = sourceDir.split('/').fill('..').join('/');
   const generatedFilename = `build/${filename}`;
   const generatedSource = `
 import {BaseElement} from '../base-element';
 ${
   options.hasCss
-    ? `import {CSS} from '../${getBentoCssImportPath(
-        sourceDir,
-        name,
-        version
-      )}';`
-    : 'let CSS;' // undefined, gets DCE'd
+    ? `import {CSS} from '../${sourceDirToRoot}/build/${name}-${version}.css';`
+    : // undefined, gets DCE'd:
+      'let CSS;'
 }
 AMP.registerElement('${name}', BaseElement, CSS);
   `.trim();
@@ -813,17 +811,6 @@ AMP.registerElement('${name}', BaseElement, CSS);
   options.extraGlobs = [...(options.extraGlobs || []), `${sourceDir}/**/*.js`];
   await fs.outputFile(`${sourceDir}/${generatedFilename}`, generatedSource);
   return generatedFilename;
-}
-
-/**
- * @param {string} sourceDir
- * @param {string} name
- * @param {string} version
- * @return {string}
- */
-function getBentoCssImportPath(sourceDir, name, version) {
-  const root = sourceDir.split('/').fill('..').join('/');
-  return `${root}/build/${name}-${version}.css`;
 }
 
 /**

--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -279,7 +279,10 @@ async function makeExtensionFromTemplates(
     bundleConfig.options = {...bundleConfig.options, hasCss: true};
   }
   if (options.bento) {
-    bundleConfig.options = {...bundleConfig.options, wrapper: 'bento'};
+    bundleConfig.options = {
+      ...bundleConfig.options,
+      wrapper: ['extension', 'bento'],
+    };
   }
 
   await insertExtensionBundlesConfig(

--- a/build-system/tasks/make-extension/index.js
+++ b/build-system/tasks/make-extension/index.js
@@ -279,10 +279,7 @@ async function makeExtensionFromTemplates(
     bundleConfig.options = {...bundleConfig.options, hasCss: true};
   }
   if (options.bento) {
-    bundleConfig.options = {
-      ...bundleConfig.options,
-      wrapper: ['extension', 'bento'],
-    };
+    bundleConfig.options = {...bundleConfig.options, bento: true};
   }
 
   await insertExtensionBundlesConfig(


### PR DESCRIPTION
Before this change, output `bento-*.js` files are identical as `amp-*.js`, and not as they should be:

1. They should only work on Bento standalone mode, not AMP mode
2. They should not attempt to use AMP runtime features.

Bento components directories include both `amp-*.js` and `base-element.js`. The former exports an AMP extension, while the latter exports a component-specific `BaseElement` that does not attempt to use AMP runtime features. 

This change generates a `bento-*.js` source file that uses the `BaseElement` implementation without AMP usage.