### PR TITLE
Partially revert "🏗 Parallelize `dist` steps (#35943)"

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -122,8 +122,8 @@ async function dist() {
       buildLoginDone('0.1'),
       buildWebPushPublisherFiles(),
       buildCompiler(),
+      compileAllJs(options),
     ]);
-    await compileAllJs(options);
   }
 
   // This step internally parses the various extension* flags.

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -117,10 +117,12 @@ async function dist() {
   if (argv.core_runtime_only) {
     await compileCoreRuntime(options);
   } else {
-    await buildExperiments();
-    await buildLoginDone('0.1');
-    await buildWebPushPublisherFiles();
-    await buildCompiler();
+    await Promise.all([
+      buildExperiments(),
+      buildLoginDone('0.1'),
+      buildWebPushPublisherFiles(),
+      buildCompiler(),
+    ]);
     await compileAllJs(options);
   }
 

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -114,19 +114,18 @@ async function dist() {
   await runPreDistSteps(options);
 
   // These steps use closure compiler. Small ones before large (parallel) ones.
-  const steps = [];
   if (argv.core_runtime_only) {
-    steps.push(compileCoreRuntime(options));
+    await compileCoreRuntime(options);
   } else {
-    steps.push(buildExperiments());
-    steps.push(buildLoginDone('0.1'));
-    steps.push(buildWebPushPublisherFiles());
-    steps.push(buildCompiler());
-    steps.push(compileAllJs(options));
+    await buildExperiments();
+    await buildLoginDone('0.1');
+    await buildWebPushPublisherFiles();
+    await buildCompiler();
+    await compileAllJs(options);
   }
 
   // This step internally parses the various extension* flags.
-  steps.push(buildExtensions(options));
+  await buildExtensions(options);
 
   // This step is to be run only during a full `amp dist`.
   if (
@@ -135,10 +134,8 @@ async function dist() {
     !argv.extensions_from &&
     !argv.noextensions
   ) {
-    steps.push(buildVendorConfigs(options));
+    await buildVendorConfigs(options);
   }
-
-  await Promise.all(steps);
 
   // This step is required no matter which binaries are built.
   await formatExtractedMessages();


### PR DESCRIPTION
This PR partially reverts commit 1e2c80849657030c90aaae5b8568611148227797.

The parallelization of these steps are causing a rare (3-6%) crash on CircleCI builds. For now it's probably worth to revert it. See #36164 for more info.

We allow parallelization only for the smaller tasks, before the main esbuild run. See [results](https://app.circleci.com/pipelines/github/ampproject/amphtml/17030/workflows/f78b6748-55a2-43da-a885-e27eb3d439a0/jobs/308263) of attempting this change on 100 VMs