### PR TITLE
🧪Update OT token for `attribution-reporting`

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -100,7 +100,7 @@ const CDN_PROXY_REGEXP =
 
 /** @const {string} */
 export const TOKEN_VALUE =
-  'A560Vqrj/cxoDr3Ldu+cN8qcpkaPx5Yh67pvGScX0kOke10st2EAEQmfQrDKSlVJtF+oZ0WqUYbPLmY6nRQq5wAAAACVeyJvcmlnaW4iOiJodHRwczovL2FtcHByb2plY3Qub3JnOjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2MzE2NjM5OTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWUsInVzYWdlIjoic3Vic2V0In0=';
+  'A2dINGotLJuPqM6Wgp0s4V3te749O/VZEHqN0YsG4pfY+1pcjS5UaX1Bvcyz4aiShd8ZXPcT5spJazIzrbi5AwUAAACVeyJvcmlnaW4iOiJodHRwczovL2FtcHByb2plY3Qub3JnOjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2MzQwODMxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWUsInVzYWdlIjoic3Vic2V0In0=';
 
 /**
  * Inserts origin-trial token for `attribution-reporting` if not already


### PR DESCRIPTION
Previous token expired. This one is good until 10/12/21 which really isn't long enough for prod release, but should be ok for local testing.