### PR TITLE
🚀  [Video] Sort video sources by tuples of (codec, bitrate)

### DIFF
--- a/extensions/amp-video/0.1/test/test-video-cache.js
+++ b/extensions/amp-video/0.1/test/test-video-cache.js
@@ -139,14 +139,47 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
       expect(addedSource.getAttribute('type')).to.equal('video/mp4');
     });
 
-    it('should add the sources sorted by bitrate', async () => {
+    it('should add the sources sorted first by codec priority and then by bitrate value', async () => {
       env.sandbox.stub(xhrService, 'fetch').resolves({
         json: () =>
           Promise.resolve({
             sources: [
-              {'url': 'video1.mp4', 'bitrate_kbps': 700, type: 'video/mp4'},
-              {'url': 'video2.mp4', 'bitrate_kbps': 2000, type: 'video/mp4'},
-              {'url': 'video3.mp4', 'bitrate_kbps': 1500, type: 'video/mp4'},
+              {
+                'url': 'video1.mp4',
+                'bitrate_kbps': 700,
+                'codec': 'h264',
+                type: 'video/mp4',
+              },
+              {
+                'url': 'video2.mp4',
+                'bitrate_kbps': 2000,
+                'codec': 'h264',
+                type: 'video/mp4',
+              },
+              {
+                'url': 'video3.mp4',
+                'bitrate_kbps': 1500,
+                'codec': 'h264',
+                type: 'video/mp4',
+              },
+              {
+                'url': 'video4.mp4',
+                'bitrate_kbps': 300,
+                'codec': 'vp09.00.30.08',
+                type: 'video/mp4',
+              },
+              {
+                'url': 'video5.mp4',
+                'bitrate_kbps': 200,
+                'codec': 'vp09.00.21.08',
+                type: 'video/mp4',
+              },
+              {
+                'url': 'video6.mp4',
+                'bitrate_kbps': 100,
+                'codec': 'vp09.00.21.09',
+                type: 'video/mp4',
+              },
             ],
           }),
       });
@@ -156,9 +189,12 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
       await fetchCachedSources(videoEl, env.ampdoc);
 
       const addedSources = videoEl.querySelectorAll('source');
-      expect(addedSources[0].getAttribute('data-bitrate')).to.equal('2000');
-      expect(addedSources[1].getAttribute('data-bitrate')).to.equal('1500');
-      expect(addedSources[2].getAttribute('data-bitrate')).to.equal('700');
+      expect(addedSources[0].getAttribute('data-bitrate')).to.equal('300');
+      expect(addedSources[1].getAttribute('data-bitrate')).to.equal('200');
+      expect(addedSources[2].getAttribute('data-bitrate')).to.equal('100');
+      expect(addedSources[3].getAttribute('data-bitrate')).to.equal('2000');
+      expect(addedSources[4].getAttribute('data-bitrate')).to.equal('1500');
+      expect(addedSources[5].getAttribute('data-bitrate')).to.equal('700');
     });
 
     it('should add video[src] as the last fallback source', async () => {

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -103,13 +103,10 @@ function applySourcesToVideo(videoEl, sources, maxBitrate) {
         } else if (aCodec !== codec && bCodec === codec) {
           // A negative value results in b being sorted before a.
           return -1;
-        } else if (aCodec === codec && bCodec === codec) {
-          // If both codecs are equivalent, sort by descending bitrate.
-          return a['bitrate_kbps'] - b['bitrate_kbps'];
         }
       }
 
-      // If both codecs have unprioritized values, sort by descending bitrate.
+      // If neither codec has greater priority, sort by descending bitrate.
       return a['bitrate_kbps'] - b['bitrate_kbps'];
     })
     .forEach((source) => {

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -97,18 +97,18 @@ function applySourcesToVideo(videoEl, sources, maxBitrate) {
 
       CODECS_IN_DESCENDING_PRIORITY.forEach((codec) => {
         if (aCodec === codec && bCodec !== codec) {
-          // A negative value results in a being sorted before b.
-          return -1;
-        } else if (aCodec !== codec && bCodec === codec) {
-          // A positive value results in b being sorted before a.
+          // A positive value results in a being sorted before b.
           return 1;
+        } else if (aCodec !== codec && bCodec === codec) {
+          // A negative value results in b being sorted before a.
+          return -1;
         } else if (aCodec === codec && bCodec === codec) {
           // If both codecs are equivalent, sort by descending bitrate.
-          return b['bitrate_kbps'] - a['bitrate_kbps'];
+          return a['bitrate_kbps'] - b['bitrate_kbps'];
         }
       });
       // If both codecs have unprioritized values, sort by descending bitrate.
-      return b['bitrate_kbps'] - a['bitrate_kbps'];
+      return a['bitrate_kbps'] - b['bitrate_kbps'];
     })
     .forEach((source) => {
       if (source['bitrate_kbps'] > maxBitrate) {

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -95,7 +95,8 @@ function applySourcesToVideo(videoEl, sources, maxBitrate) {
       const aCodec = a['codec']?.split('.')[0];
       const bCodec = b['codec']?.split('.')[0];
 
-      CODECS_IN_DESCENDING_PRIORITY.forEach((codec) => {
+      for (let i = 0; i < CODECS_IN_DESCENDING_PRIORITY.length; i++) {
+        const codec = CODECS_IN_DESCENDING_PRIORITY[i];
         if (aCodec === codec && bCodec !== codec) {
           // A positive value results in a being sorted before b.
           return 1;
@@ -106,7 +107,8 @@ function applySourcesToVideo(videoEl, sources, maxBitrate) {
           // If both codecs are equivalent, sort by descending bitrate.
           return a['bitrate_kbps'] - b['bitrate_kbps'];
         }
-      });
+      }
+
       // If both codecs have unprioritized values, sort by descending bitrate.
       return a['bitrate_kbps'] - b['bitrate_kbps'];
     })


### PR DESCRIPTION
Video sources are currently sorted only by bitrate, and the source that contains the highest bitrate is prioritized. Because we want to prioritize the VP9 codec, this PR uses `codec` values as the primary means of sorting all potential sources for each video. As a result, `bitrate_kbps` will be used only as a secondary factor in the sort.