### PR TITLE
♻️ configs: Separate user configs from output files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,7 +13,6 @@ build-system/dist
 build-system/server/new-server/transforms/dist
 build-system/tasks/performance/cache
 build-system/tasks/performance/results.json
-build-system/global-configs/custom-config.json
 dist
 dist.3p
 dist.tools
@@ -27,6 +26,11 @@ test/coverage
 test/coverage-e2e
 validator/**/dist
 validator/export
+
+# User configuration files
+# Keep this list in sync with .gitignore, .prettierignore, and build-system/tasks/clean.js
+build-system/global-configs/custom-config.json
+build-system/global-configs/custom-flavors-config.json
 
 # Files and directories explicitly ignored by eslint
 **/node_modules/**

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ build-system/dist
 build-system/server/new-server/transforms/dist
 build-system/tasks/performance/cache
 build-system/tasks/performance/results.json
-build-system/global-configs/custom-config.json
-build-system/global-configs/custom-flavors-config.json
 dist
 dist.3p
 dist.tools
@@ -28,6 +26,11 @@ test/coverage
 test/coverage-e2e
 validator/**/dist
 validator/export
+
+# User configuration files
+# Keep this list in sync with .eslintignore, .prettierignore, and build-system/tasks/clean.js
+build-system/global-configs/custom-config.json
+build-system/global-configs/custom-flavors-config.json
 
 # OS level files
 .DS_Store

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,7 +13,6 @@ build-system/dist
 build-system/server/new-server/transforms/dist
 build-system/tasks/performance/cache
 build-system/tasks/performance/results.json
-build-system/global-configs/custom-config.json
 dist
 dist.3p
 dist.tools
@@ -27,6 +26,11 @@ test/coverage
 test/coverage-e2e
 validator/**/dist
 validator/export
+
+# User configuration files
+# Keep this list in sync with .gitignore, .eslintignore, and build-system/tasks/clean.js
+build-system/global-configs/custom-config.json
+build-system/global-configs/custom-flavors-config.json
 
 # Files and directories explicitly ignored by prettier
 **/package*.json

--- a/build-system/tasks/clean.js
+++ b/build-system/tasks/clean.js
@@ -47,6 +47,8 @@ async function clean() {
   if (argv.include_subpackages) {
     pathsToDelete.push('**/node_modules', '!node_modules');
   }
+  // User configuration files
+  // Keep this list in sync with .gitignore, .eslintignore, and .prettierignore
   const customConfigs = [
     'build-system/global-configs/custom-config.json',
     'build-system/global-configs/custom-flavors-config.json',


### PR DESCRIPTION
Identify user configuration files under build-system/global-configs as
distinct from generated output. This will help avoid accidentally
including them in the cleanup script in the future.