### PR TITLE
set correct ad network name

### DIFF
--- a/ads/vendors/broadbandy.md
+++ b/ads/vendors/broadbandy.md
@@ -1,4 +1,4 @@
-# DigitalExchange
+# Broadbandy
 
 ## Example
 


### PR DESCRIPTION
Hi, our amp integration was successful but the name in documentation is wrong
this will fix the Company name mb file