### PR TITLE
Generated ads localhost should follow baseURI port if one exists

### DIFF
--- a/src/3p-frame.js
+++ b/src/3p-frame.js
@@ -294,7 +294,11 @@ function getAdsLocalhost(win) {
   if (adsUrl == 'https://3p.ampproject.net') {
     adsUrl = 'http://ads.localhost'; // local dev with a localhost server
   }
-  return adsUrl + ':' + (win.location.port || win.parent.location.port);
+  return (
+    adsUrl + ':' + new URL(win.document.baseURI)?.port ||
+    win.location.port ||
+    win.parent.location.port
+  );
 }
 
 /**


### PR DESCRIPTION
Storybook environments are lazy building most binaries as they are needed but not the 3p vendors. This is because the 3p vendors are requesting to the Storybook ports (9001/9002 by default) but our lazy builds listen on the local server port (8000 by default).

Most assets are in fact requested via the local server port because of the way our Storybook environment is set up. The Storybook task, while instantiated on its own default ports, set the [default `<base>` to be that of the local server](https://github.com/ampproject/storybook-addon-amp/blob/20f8510d16304f09a5dda465cab09d7a93c681eb/src/register/components/PreactDecorator.tsx#L83), causing most relative requests to go to the local server.
<img width="604" alt="Screen Shot 2021-10-04 at 12 08 16 PM" src="https://user-images.githubusercontent.com/10456171/135885894-34fa978f-7363-4a69-bef6-f813d1897499.png">

The exception to this is the requests for the vendor binaries, whose request urls are generated from the window port: https://github.com/ampproject/amphtml/blob/f23e77d1428a64c5039887fd05f3e73581f506cf/src/3p-frame.js#L297

This PR has the generated url account for any port specified at the base and defer to that if available. Another option could be to have the Storybook AMP add on _not_ hardcode the 8000 port, but that would require changing the package upstream and would be harder to coordinate (larger feedback loop requires modifying in that repo _then_ upgrading in this repo):

https://github.com/ampproject/storybook-addon-amp/blob/20f8510d16304f09a5dda465cab09d7a93c681eb/src/register/components/config.tsx#L28

That alternative would also require further lazy building changes on our end once we do get off of the two-port dynamic. 

Finally, this PR only fixes things for the AMP mode Storybook which does have the localhost:8000 base. The Preact and Bento modes don't have this, so the recommendation is either to run both AMP and Preact Storybook environments simultaneously while lazy building 3p vendor JS is necessary, or to modify the Preact and Bento environments so they do not need the AMP one to do the building for it.

Related to #35676