### PR TITLE
bento amp-iframe: guard effect from running without a win

### DIFF
--- a/extensions/amp-iframe/1.0/component.js
+++ b/extensions/amp-iframe/1.0/component.js
@@ -72,7 +72,9 @@ export function BentoIframe({
 
   useEffect(() => {
     const iframe = iframeRef.current;
-    if (!iframe) {
+    // TODO(36239): Ensure that effects are properly isolated between test runs.
+    // Guarding for iframe truthiness should be enough.
+    if (!iframe?.ownerDocument.defaultView) {
       return;
     }
     const win = toWin(iframe.ownerDocument.defaultView);


### PR DESCRIPTION
**summary**
First order superficial fix for https://github.com/ampproject/amphtml/issues/36239 in order to unblock https://github.com/ampproject/amphtml/pull/36143.
We still need to address the root cause of useEffect hooks running during the wrong tests.

**to test**

Run the iframe and render tests together before and after this commit:
```
npx amp unit --headless --files=extensions/amp-iframe/1.0/test/test-amp-iframe.js,extensions/amp-render/1.0/test/test-amp-render.js
```