### PR TITLE
Rename viewportCallbackTemp --> viewportCallback

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -1316,7 +1316,7 @@ export class AmpA4A extends AMP.BaseElement {
     return this.attemptToRenderCreative().then(() => {
       this.unobserveIntersections_ = observeIntersections(
         this.element,
-        ({isIntersecting}) => this.viewportCallbackTemp(isIntersecting)
+        ({isIntersecting}) => this.viewportCallback(isIntersecting)
       );
     });
   }
@@ -1500,12 +1500,11 @@ export class AmpA4A extends AMP.BaseElement {
     }
   }
 
-  // TODO: Rename to viewportCallback once BaseElement.viewportCallback has been removed.
   /**
    * @param {boolean}  inViewport
    * @protected
    */
-  viewportCallbackTemp(inViewport) {
+  viewportCallback(inViewport) {
     if (this.xOriginIframeHandler_) {
       this.xOriginIframeHandler_.viewportCallback(inViewport);
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1234,8 +1234,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   }
 
   /** @override */
-  viewportCallbackTemp(inViewport) {
-    super.viewportCallbackTemp(inViewport);
+  viewportCallback(inViewport) {
+    super.viewportCallback(inViewport);
     if (this.reattemptToExpandFluidCreative_ && !inViewport) {
       // If the initial expansion attempt failed (e.g., the slot was within the
       // viewport), then we will re-attempt to expand it here whenever the slot

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-doubleclick-fluid.js
@@ -365,9 +365,9 @@ describes.realWin('DoubleClick Fast Fetch Fluid', realWinConfig, (env) => {
     impl.isVerifiedAmpCreative_ = true;
     impl.reattemptToExpandFluidCreative_ = true;
     // Should do nothing
-    impl.viewportCallbackTemp(true);
+    impl.viewportCallback(true);
     expect(attemptChangeHeightStub).to.not.be.called;
-    impl.viewportCallbackTemp(false);
+    impl.viewportCallback(false);
     expect(attemptChangeHeightStub).to.be.calledOnce;
   });
 

--- a/extensions/amp-carousel/0.1/base-carousel.js
+++ b/extensions/amp-carousel/0.1/base-carousel.js
@@ -60,14 +60,11 @@ export class BaseCarousel extends AMP.BaseElement {
     this.setControlsState();
   }
 
-  // TODO(samouri): rename to viewportCallback once
-  // BaseElement.viewportCallback is deleted
-
   /**
    * @param {boolean} inViewport
    * @protected
    */
-  viewportCallbackTemp(inViewport) {
+  viewportCallback(inViewport) {
     if (inViewport) {
       this.hintControls();
     }
@@ -236,7 +233,7 @@ export class BaseCarousel extends AMP.BaseElement {
   layoutCallback() {
     this.unobserveIntersections_ = observeIntersections(
       this.element,
-      ({isIntersecting}) => this.viewportCallbackTemp(isIntersecting)
+      ({isIntersecting}) => this.viewportCallback(isIntersecting)
     );
     return Promise.resolve();
   }

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -102,7 +102,7 @@ export class AmpScrollableCarousel extends BaseCarousel {
   layoutCallback() {
     this.unobserveIntersections_ = observeIntersections(
       this.element,
-      ({isIntersecting}) => this.viewportCallbackTemp(isIntersecting)
+      ({isIntersecting}) => this.viewportCallback(isIntersecting)
     );
 
     this.doLayout_(this.pos_);
@@ -119,8 +119,8 @@ export class AmpScrollableCarousel extends BaseCarousel {
   }
 
   /** @override */
-  viewportCallbackTemp(inViewport) {
-    super.viewportCallbackTemp(inViewport);
+  viewportCallback(inViewport) {
+    super.viewportCallback(inViewport);
     this.updateInViewport_(this.pos_, this.pos_);
   }
 

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -342,8 +342,8 @@ export class AmpSlideScroll extends BaseCarousel {
   }
 
   /** @override */
-  viewportCallbackTemp(inViewport) {
-    super.viewportCallbackTemp(inViewport);
+  viewportCallback(inViewport) {
+    super.viewportCallback(inViewport);
     if (inViewport) {
       this.autoplay_();
     } else {
@@ -416,7 +416,7 @@ export class AmpSlideScroll extends BaseCarousel {
   layoutCallback() {
     this.unobserveIntersections_ = observeIntersections(
       this.element,
-      ({isIntersecting}) => this.viewportCallbackTemp(isIntersecting)
+      ({isIntersecting}) => this.viewportCallback(isIntersecting)
     );
 
     // TODO(sparhami) #19259 Tracks a more generic way to do this. Remove once

--- a/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
@@ -45,7 +45,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     );
     viewportCallbackSpy = env.sandbox.spy(
       AmpSlideScroll.prototype,
-      'viewportCallbackTemp'
+      'viewportCallback'
     );
   });
 
@@ -151,7 +151,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
       })
     );
 
-    carousel.viewportCallbackTemp(true);
+    carousel.viewportCallback(true);
     expect(viewportCallbackSpy).to.have.been.calledWith(true);
     expect(hintControlsSpy).to.have.been.called;
     expect(autoplaySpy).to.have.been.called;
@@ -166,7 +166,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
       })
     );
 
-    carousel.viewportCallbackTemp(false);
+    carousel.viewportCallback(false);
     expect(viewportCallbackSpy).to.have.been.calledWith(false);
     expect(hintControlsSpy).to.not.have.been.called;
     expect(autoplaySpy).to.not.have.been.called;


### PR DESCRIPTION
**summary**
Renames `viewportCallbackTemp` --> `viewportCallback` now that there is no collision with BaseElement.viewportCallback.

Followup to https://github.com/ampproject/amphtml/pull/30859 and https://github.com/ampproject/amphtml/pull/30802