### PR TITLE
🧪 Set animations experiment to 0

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -19,7 +19,7 @@
   "story-ad-placements": 1,
   "story-load-first-page-only": 1,
   "story-load-inactive-outside-viewport": 1,
-  "story-disable-animations-first-page": 0.5,
+  "story-disable-animations-first-page": 0,
   "amp-story-page-attachment-ui-v2": 1,
   "amp-sticky-ad-to-amp-ad-v3": 0
 }

--- a/build-system/global-configs/client-side-experiments-config.json
+++ b/build-system/global-configs/client-side-experiments-config.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "story-disable-animations-first-page",
-      "percentage": 0.5
+      "percentage": 0
     },
     {
       "name": "story-load-first-page-only",

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -14,7 +14,7 @@
   "disable-a4a-non-sd": 1,
   "amp-cid-backup": 1,
   "story-ad-placements": 0.01,
-  "story-disable-animations-first-page": 0.5,
+  "story-disable-animations-first-page": 0,
   "story-load-first-page-only": 1,
   "story-load-inactive-outside-viewport": 1,
   "amp-story-page-attachment-ui-v2": 1,


### PR DESCRIPTION
We already have the results of the experiment, so we're disabling it to allow animations to play again on stories