### PR TITLE
🏗 Run closure compiler inside a compilation worker

### DIFF
--- a/build-system/compile/compile-worker.js
+++ b/build-system/compile/compile-worker.js
@@ -1,0 +1,360 @@
+'use strict';
+const argv = require('minimist')(process.argv.slice(2));
+const fastGlob = require('fast-glob');
+const fs = require('fs-extra');
+const path = require('path');
+const {checkForUnknownDeps} = require('./check-for-unknown-deps');
+const {CLOSURE_SRC_GLOBS} = require('./sources');
+const {getAmpConfigForFile} = require('../tasks/prepend-global');
+const {postClosureBabel} = require('./post-closure-babel');
+const {preClosureBabel} = require('./pre-closure-babel');
+const {runClosure} = require('./closure-compile');
+const {sanitize} = require('./sanitize');
+const {VERSION: internalRuntimeVersion} = require('./internal-version');
+const {writeSourcemaps} = require('./helpers');
+
+/**
+ * @typedef {{
+ *  esmPassCompilation?: string,
+ *  wrapper?: string,
+ *  extraGlobs?: string,
+ *  include3pDirectories?: boolean,
+ *  includePolyfills?: boolean,
+ *  externs?: string[],
+ *  compilationLevel?: string,
+ *  verboseLogging?: boolean,
+ *  typeCheckOnly?: boolean,
+ *  skipUnknownDepsCheck?: boolean,
+ *  warningLevel?: boolean,
+ *  noAddDeps?: boolean,
+ *  continueOnError?: boolean,
+ *  errored?: boolean,
+ * }}
+ */
+let OptionsDef;
+
+/**
+ * Generates a list of source files based on various factors.
+ * TODO(wg-infra, wg-performance): Clean up unnecessary files.
+ *
+ * @param {string[]} entryModuleFilenames
+ * @param {!OptionsDef} options
+ * @return {!Array<string>}
+ */
+function getSrcs(entryModuleFilenames, options) {
+  const unneededFiles = [
+    'build/fake-module/third_party/babel/custom-babel-helpers.js',
+  ];
+  const srcs = [...CLOSURE_SRC_GLOBS];
+  entryModuleFilenames.forEach((filename) => {
+    // For extensions, include all JS files in the extension directory.
+    // Note: The glob added to srcs must be a posix glob on all platforms.
+    if (filename.startsWith('extensions')) {
+      srcs.push(
+        filename
+          .replace(path.basename(filename), path.join('**', '*.js'))
+          .split(path.win32.sep)
+          .join(path.posix.sep)
+      );
+    }
+  });
+  if (options.extraGlobs) {
+    srcs.push.apply(srcs, options.extraGlobs);
+  }
+  if (options.include3pDirectories) {
+    srcs.push('3p/**/*.js', 'ads/**/*.js');
+  }
+  // Many files include the polyfills, but we only want to deliver them
+  // once. Since all files automatically wait for the main binary to load
+  // this works fine.
+  if (options.includePolyfills) {
+    srcs.push(
+      '!build/fake-module/src/polyfills/index.js',
+      '!build/fake-module/src/polyfills/**/*.js',
+      '!build/fake-polyfills/**/*.js'
+    );
+  } else {
+    srcs.push('!src/polyfills/index.js', '!build/fake-polyfills/**/*.js');
+    unneededFiles.push('build/fake-module/src/polyfills/index.js');
+  }
+  // Negative globstars must come at the end.
+  srcs.push(
+    // Don't include rollup configs
+    '!**/rollup.config.js',
+    // Don't include tests.
+    '!**_test.js',
+    '!**/test-*.js',
+    '!**/test-e2e/*.js',
+    // Don't include externs.
+    '!**/*.extern.js'
+  );
+  unneededFiles.forEach(function (fake) {
+    if (!fs.existsSync(fake)) {
+      fs.writeFileSync(
+        fake,
+        '// Not needed in closure compiler\nexport function deadCode() {}'
+      );
+    }
+  });
+  return srcs;
+}
+
+/**
+ * Generates the set of options with which to invoke Closure compiler.
+ * TODO(wg-infra,wg-performance): Clean up unnecessary options.
+ *
+ * @param {string} outputFilename
+ * @param {!OptionsDef} options
+ * @return {!Promise<!Object>}
+ */
+async function generateCompilerOptions(outputFilename, options) {
+  // Determine externs
+  let externs = options.externs || [];
+  if (!options.noAddDeps) {
+    externs = [
+      'third_party/web-animations-externs/web_animations.js',
+      'third_party/react-externs/externs.js',
+      'third_party/moment/moment.extern.js',
+      ...fastGlob.sync('src/core{,/**}/*.extern.js'),
+      ...fastGlob.sync('build-system/externs/*.extern.js'),
+      ...externs,
+    ];
+  }
+
+  const hideWarningsFor = [
+    'third_party/amp-toolbox-cache-url/',
+    'third_party/caja/',
+    'third_party/closure-library/sha384-generated.js',
+    'third_party/d3/',
+    'third_party/inputmask/',
+    'third_party/mustache/',
+    'third_party/react-dates/',
+    'third_party/resize-observer-polyfill/',
+    'third_party/set-dom/',
+    'third_party/subscriptions-project/',
+    'third_party/webcomponentsjs/',
+    'node_modules/',
+    'build/patched-module/',
+  ];
+  const define = [`VERSION=${internalRuntimeVersion}`, 'AMP_MODE=true'];
+  if (argv.pseudo_names) {
+    define.push('PSEUDO_NAMES=true');
+  }
+  const ampConfig = await getAmpConfigForFile(outputFilename, options);
+  let wrapper = options.wrapper
+    ? options.wrapper.replace('<%= contents %>', '%output%')
+    : `(function(){%output%})();`;
+  wrapper = `${ampConfig}${wrapper}\n\n//# sourceMappingURL=${outputFilename}.map`;
+
+  /**
+   * TODO(#28387) write a type for this.
+   * @type {Object}
+   */
+  /* eslint "local/camelcase": 0*/
+  const compilerOptions = {
+    compilation_level: options.compilationLevel || 'SIMPLE_OPTIMIZATIONS',
+    // Turns on more optimizations.
+    assume_function_wrapper: true,
+    language_in: 'ECMASCRIPT_2020',
+    // Do not transpile down to ES5 if running with `--esm`, since we do
+    // limited transpilation in Babel.
+    language_out: argv.esm || argv.sxg ? 'NO_TRANSPILE' : 'ECMASCRIPT5_STRICT',
+    // We do not use the polyfills provided by closure compiler.
+    // If you need a polyfill. Manually include them in the
+    // respective top level polyfills/*.js files.
+    rewrite_polyfills: false,
+    externs,
+    js_module_root: [
+      // Do _not_ include 'node_modules/' in js_module_root with 'NODE'
+      // resolution or bad things will happen (#18600).
+      'build/patched-module/',
+      'build/fake-module/',
+      'build/fake-polyfills/',
+    ],
+    module_resolution: 'NODE',
+    package_json_entry_names: 'module,main',
+    process_common_js_modules: true,
+    // PRUNE strips all files from the input set that aren't explicitly
+    // required.
+    dependency_mode: options.noAddDeps ? 'SORT_ONLY' : 'PRUNE',
+    output_wrapper: wrapper,
+    source_map_include_content: !!argv.full_sourcemaps,
+    // These arrays are filled in below.
+    jscomp_error: [],
+    jscomp_warning: [],
+    jscomp_off: [],
+    define,
+    hide_warnings_for: hideWarningsFor,
+    // TODO(amphtml): Change 'QUIET' to 'DEFAULT'.
+    warning_level: argv.warning_level ?? options.warningLevel ?? 'QUIET',
+    extra_annotation_name: ['visibleForTesting', 'restricted'],
+  };
+  if (argv.pseudo_names) {
+    // Some optimizations get turned off when pseudo_names is on.
+    // This causes some errors caused by the babel transformations
+    // that we apply like unreachable code because we turn a conditional
+    // falsey. (ex. is IS_PROD transformation which causes some conditionals
+    // to be unreachable/suspicious code since the whole expression is
+    // falsey)
+    compilerOptions.jscomp_off.push('uselessCode', 'externsValidation');
+  }
+  if (argv.pretty_print) {
+    compilerOptions.formatting = 'PRETTY_PRINT';
+  }
+
+  // See https://github.com/google/closure-compiler/wiki/Warnings#warnings-categories
+  // for a full list of closure's default error / warning levels.
+  // NOTE: We do not use jscomp_warning because they are silenced by closure
+  // unless there are accompanying errors. Pick a side and use either one of
+  // jscomp_error or jscomp_off.
+  if (options.typeCheckOnly) {
+    compilerOptions.checks_only = true;
+    // Note: compilation_level is SIMPLE_OPTIMIZATIONS during type checking.
+    // Making it WHITESPACE_ONLY will disable type-checking, so don't do that.
+    compilerOptions.define.push('TYPECHECK_ONLY=true');
+    // These aren't type-check errors by default, but should be.
+    compilerOptions.jscomp_error.push(
+      'accessControls',
+      'checkDebuggerStatement',
+      'conformanceViolations',
+      'checkTypes',
+      'const',
+      'constantProperty',
+      'globalThis',
+      'misplacedTypeAnnotation',
+      'missingProperties',
+      'strictMissingProperties',
+      'visibility'
+    );
+    // These are type-check errors / warnings by default, but cannot be.
+    compilerOptions.jscomp_off.push(
+      'moduleLoad', // Breaks type-only modules: google/closure-compiler#3041
+      'unknownDefines' // Closure complains about VERSION
+    );
+    compilerOptions.conformance_configs =
+      'build-system/test-configs/conformance-config.textproto';
+  } else {
+    // These aren't compilation errors by default, but should be.
+    compilerOptions.jscomp_error.push(
+      'missingProperties',
+      'strictMissingProperties',
+      'visibility'
+    );
+    // Thse are compilation errors / warnings by default, but cannot be.
+    compilerOptions.jscomp_off.push(
+      'accessControls', // Silences spurious JSC_BAD_PRIVATE_GLOBAL_ACCESS
+      'moduleLoad', // Breaks type-only modules: google/closure-compiler#3041
+      'unknownDefines' // Closure complains about VERSION
+    );
+  }
+
+  if (compilerOptions.define.length == 0) {
+    delete compilerOptions.define;
+  }
+  return compilerOptions;
+}
+
+/**
+ * Generates the full set of flags with which to invoke closure compiler.
+ *
+ * @param {!OptionsDef} options
+ * @param {!Object} compilerOptions
+ * @param {!Array<string>} entryModuleFilenames
+ * @param {string} destFile
+ * @param {string} sourcemapFile
+ * @return {!Array<string>}
+ */
+function generateFlags(
+  options,
+  compilerOptions,
+  entryModuleFilenames,
+  destFile,
+  sourcemapFile
+) {
+  const compilerFlags = [];
+  Object.keys(compilerOptions).forEach(function (option) {
+    const value = compilerOptions[option];
+    if (Array.isArray(value)) {
+      value.forEach(function (item) {
+        compilerFlags.push('--' + option + '=' + item);
+      });
+    } else {
+      if (value != null) {
+        compilerFlags.push('--' + option + '=' + value);
+      } else {
+        compilerFlags.push('--' + option);
+      }
+    }
+  });
+  const entryPointFlags = entryModuleFilenames.map(
+    (entryPoint) => `--entry_point=${entryPoint}`
+  );
+  compilerFlags.push(...entryPointFlags);
+  if (!options.typeCheckOnly) {
+    const outputFileFlag = `--js_output_file=${destFile}`;
+    const sourcemapFlag = `--create_source_map=${sourcemapFile}`;
+    compilerFlags.push(outputFileFlag, sourcemapFlag);
+  }
+  return compilerFlags;
+}
+
+/**
+ * Compiles AMP with the closure compiler. This is intended only for
+ * production use. During development we intend to continue using
+ * babel, as it has much faster incremental compilation.
+ *
+ * Worker used by compile.js. This is the only export from this file.
+ *
+ * @param {object} root0
+ * @param {string|string[]} root0.entryModuleFilenames
+ * @param {!OptionsDef} root0.options
+ * @param {string} root0.outputDir
+ * @param {string} root0.outputFilename
+ * @return {Promise<void>}
+ */
+module.exports = async ({
+  entryModuleFilenames,
+  options,
+  outputDir,
+  outputFilename,
+}) => {
+  if (!Array.isArray(entryModuleFilenames)) {
+    entryModuleFilenames = [entryModuleFilenames];
+  }
+  const destFile = `${outputDir}/${outputFilename}`;
+  const sourcemapFile = `${destFile}.map`;
+  const compilerOptions = await generateCompilerOptions(
+    outputFilename,
+    options
+  );
+  const srcs = options.noAddDeps
+    ? entryModuleFilenames.concat(options.extraGlobs || [])
+    : getSrcs(entryModuleFilenames, options);
+  const transformedSrcFiles = await Promise.all(
+    fastGlob
+      .sync(srcs)
+      .map((src) => preClosureBabel(src, outputFilename, options))
+  );
+  if (options.errored && options.continueOnError) {
+    return; // Watch build. Bail on transform errors.
+  }
+  const flags = generateFlags(
+    options,
+    compilerOptions,
+    entryModuleFilenames,
+    destFile,
+    sourcemapFile
+  );
+  await runClosure(outputFilename, options, flags, transformedSrcFiles);
+  if (options.errored && options.continueOnError) {
+    return; // Watch build. Bail on compilation errors.
+  }
+  if (!options.typeCheckOnly) {
+    if (!argv.pseudo_names && !options.skipUnknownDepsCheck) {
+      await checkForUnknownDeps(destFile);
+    }
+    await postClosureBabel(destFile);
+    await sanitize(destFile);
+    await writeSourcemaps(sourcemapFile, options);
+  }
+};

--- a/build-system/compile/compile.js
+++ b/build-system/compile/compile.js
@@ -1,463 +1,52 @@
-'use strict';
-const argv = require('minimist')(process.argv.slice(2));
-const del = require('del');
-const fastGlob = require('fast-glob');
-const fs = require('fs-extra');
 const path = require('path');
-const {checkForUnknownDeps} = require('./check-for-unknown-deps');
-const {CLOSURE_SRC_GLOBS} = require('./sources');
-const {cpus} = require('os');
-const {cyan, green} = require('kleur/colors');
-const {getAmpConfigForFile} = require('../tasks/prepend-global');
-const {log, logLocalDev} = require('../common/logging');
-const {postClosureBabel} = require('./post-closure-babel');
-const {preClosureBabel} = require('./pre-closure-babel');
-const {runClosure} = require('./closure-compile');
-const {sanitize} = require('./sanitize');
-const {VERSION: internalRuntimeVersion} = require('./internal-version');
-const {writeSourcemaps} = require('./helpers');
+const Piscina = require('piscina');
 
-const queue = [];
-let inProgress = 0;
-
-const MAX_PARALLEL_CLOSURE_INVOCATIONS =
-  parseInt(argv.closure_concurrency, 10) || cpus().length;
+let compileWorker = null;
 
 /**
- * @typedef {{
- *  esmPassCompilation?: string,
- *  wrapper?: string,
- *  extraGlobs?: string,
- *  include3pDirectories?: boolean,
- *  includePolyfills?: boolean,
- *  externs?: string[],
- *  compilationLevel?: string,
- *  verboseLogging?: boolean,
- *  typeCheckOnly?: boolean,
- *  skipUnknownDepsCheck?: boolean,
- *  warningLevel?: boolean,
- *  noAddDeps?: boolean,
- *  continueOnError?: boolean,
- *  errored?: boolean,
- * }}
+ * Initializes the worker instance if necessary.
  */
-let OptionsDef;
+function maybeInitializeWorker() {
+  if (!compileWorker) {
+    compileWorker = new Piscina({
+      filename: path.resolve(__dirname, 'compile-worker.js'),
+      env: Object.assign(process.env, {'FORCE_COLOR': 1}),
+      maxQueue: 'auto',
+    });
+  }
+}
 
 /**
  * Compiles AMP with the closure compiler. This is intended only for
  * production use. During development we intend to continue using
  * babel, as it has much faster incremental compilation.
  *
- * @param {string|string[]} entryModuleFilename
+ * @param {string|string[]} entryModuleFilenames
  * @param {string} outputDir
  * @param {string} outputFilename
- * @param {!OptionsDef} options
- * @param {{startTime?: number}=} timeInfo
- * @return {Promise<void>}
- */
-async function closureCompile(
-  entryModuleFilename,
-  outputDir,
-  outputFilename,
-  options,
-  timeInfo = {}
-) {
-  // Rate limit closure compilation to MAX_PARALLEL_CLOSURE_INVOCATIONS
-  // concurrent processes.
-  return new Promise(function (resolve, reject) {
-    /**
-     * Kicks off the first closure invocation.
-     */
-    function start() {
-      inProgress++;
-      compile(
-        entryModuleFilename,
-        outputDir,
-        outputFilename,
-        options,
-        timeInfo
-      ).then(
-        function () {
-          inProgress--;
-          next();
-          resolve();
-        },
-        (reason) => reject(reason)
-      );
-    }
-
-    /**
-     * Keeps track of the invocation count.
-     */
-    function next() {
-      if (!queue.length) {
-        return;
-      }
-      if (inProgress < MAX_PARALLEL_CLOSURE_INVOCATIONS) {
-        queue.shift()();
-      }
-    }
-    queue.push(start);
-    next();
-  });
-}
-
-/**
- * Cleans up the placeholder directories for fake build modules.
- */
-function cleanupBuildDir() {
-  del.sync('build/fake-module');
-  del.sync('build/patched-module');
-  del.sync('build/parsers');
-  fs.mkdirsSync('build/fake-module/third_party/babel');
-  fs.mkdirsSync('build/fake-module/src/polyfills/');
-  fs.mkdirsSync('build/fake-polyfills/src/polyfills');
-}
-
-/**
- * Generates a list of source files based on various factors.
- * TODO(wg-infra, wg-performance): Clean up unnecessary files.
- *
- * @param {string[]} entryModuleFilenames
- * @param {!OptionsDef} options
- * @return {!Array<string>}
- */
-function getSrcs(entryModuleFilenames, options) {
-  const unneededFiles = [
-    'build/fake-module/third_party/babel/custom-babel-helpers.js',
-  ];
-  const srcs = [...CLOSURE_SRC_GLOBS];
-  entryModuleFilenames.forEach((filename) => {
-    // For extensions, include all JS files in the extension directory.
-    // Note: The glob added to srcs must be a posix glob on all platforms.
-    if (filename.startsWith('extensions')) {
-      srcs.push(
-        filename
-          .replace(path.basename(filename), path.join('**', '*.js'))
-          .split(path.win32.sep)
-          .join(path.posix.sep)
-      );
-    }
-  });
-  if (options.extraGlobs) {
-    srcs.push.apply(srcs, options.extraGlobs);
-  }
-  if (options.include3pDirectories) {
-    srcs.push('3p/**/*.js', 'ads/**/*.js');
-  }
-  // Many files include the polyfills, but we only want to deliver them
-  // once. Since all files automatically wait for the main binary to load
-  // this works fine.
-  if (options.includePolyfills) {
-    srcs.push(
-      '!build/fake-module/src/polyfills/index.js',
-      '!build/fake-module/src/polyfills/**/*.js',
-      '!build/fake-polyfills/**/*.js'
-    );
-  } else {
-    srcs.push('!src/polyfills/index.js', '!build/fake-polyfills/**/*.js');
-    unneededFiles.push('build/fake-module/src/polyfills/index.js');
-  }
-  // Negative globstars must come at the end.
-  srcs.push(
-    // Don't include rollup configs
-    '!**/rollup.config.js',
-    // Don't include tests.
-    '!**_test.js',
-    '!**/test-*.js',
-    '!**/test-e2e/*.js',
-    // Don't include externs.
-    '!**/*.extern.js'
-  );
-  unneededFiles.forEach(function (fake) {
-    if (!fs.existsSync(fake)) {
-      fs.writeFileSync(
-        fake,
-        '// Not needed in closure compiler\nexport function deadCode() {}'
-      );
-    }
-  });
-  return srcs;
-}
-
-/**
- * Generates the set of options with which to invoke Closure compiler.
- * TODO(wg-infra,wg-performance): Clean up unnecessary options.
- *
- * @param {string} outputFilename
- * @param {!OptionsDef} options
- * @return {!Promise<!Object>}
- */
-async function generateCompilerOptions(outputFilename, options) {
-  // Determine externs
-  let externs = options.externs || [];
-  if (!options.noAddDeps) {
-    externs = [
-      'third_party/web-animations-externs/web_animations.js',
-      'third_party/react-externs/externs.js',
-      'third_party/moment/moment.extern.js',
-      ...fastGlob.sync('src/core{,/**}/*.extern.js'),
-      ...fastGlob.sync('build-system/externs/*.extern.js'),
-      ...externs,
-    ];
-  }
-
-  const hideWarningsFor = [
-    'third_party/amp-toolbox-cache-url/',
-    'third_party/caja/',
-    'third_party/closure-library/sha384-generated.js',
-    'third_party/d3/',
-    'third_party/inputmask/',
-    'third_party/mustache/',
-    'third_party/react-dates/',
-    'third_party/resize-observer-polyfill/',
-    'third_party/set-dom/',
-    'third_party/subscriptions-project/',
-    'third_party/webcomponentsjs/',
-    'node_modules/',
-    'build/patched-module/',
-  ];
-  const define = [`VERSION=${internalRuntimeVersion}`, 'AMP_MODE=true'];
-  if (argv.pseudo_names) {
-    define.push('PSEUDO_NAMES=true');
-  }
-  const ampConfig = await getAmpConfigForFile(outputFilename, options);
-  let wrapper = options.wrapper
-    ? options.wrapper.replace('<%= contents %>', '%output%')
-    : `(function(){%output%})();`;
-  wrapper = `${ampConfig}${wrapper}\n\n//# sourceMappingURL=${outputFilename}.map`;
-
-  /**
-   * TODO(#28387) write a type for this.
-   * @type {Object}
-   */
-  /* eslint "local/camelcase": 0*/
-  const compilerOptions = {
-    compilation_level: options.compilationLevel || 'SIMPLE_OPTIMIZATIONS',
-    // Turns on more optimizations.
-    assume_function_wrapper: true,
-    language_in: 'ECMASCRIPT_2020',
-    // Do not transpile down to ES5 if running with `--esm`, since we do
-    // limited transpilation in Babel.
-    language_out: argv.esm || argv.sxg ? 'NO_TRANSPILE' : 'ECMASCRIPT5_STRICT',
-    // We do not use the polyfills provided by closure compiler.
-    // If you need a polyfill. Manually include them in the
-    // respective top level polyfills/*.js files.
-    rewrite_polyfills: false,
-    externs,
-    js_module_root: [
-      // Do _not_ include 'node_modules/' in js_module_root with 'NODE'
-      // resolution or bad things will happen (#18600).
-      'build/patched-module/',
-      'build/fake-module/',
-      'build/fake-polyfills/',
-    ],
-    module_resolution: 'NODE',
-    package_json_entry_names: 'module,main',
-    process_common_js_modules: true,
-    // PRUNE strips all files from the input set that aren't explicitly
-    // required.
-    dependency_mode: options.noAddDeps ? 'SORT_ONLY' : 'PRUNE',
-    output_wrapper: wrapper,
-    source_map_include_content: !!argv.full_sourcemaps,
-    // These arrays are filled in below.
-    jscomp_error: [],
-    jscomp_warning: [],
-    jscomp_off: [],
-    define,
-    hide_warnings_for: hideWarningsFor,
-    // TODO(amphtml): Change 'QUIET' to 'DEFAULT'.
-    warning_level: argv.warning_level ?? options.warningLevel ?? 'QUIET',
-    extra_annotation_name: ['visibleForTesting', 'restricted'],
-  };
-  if (argv.pseudo_names) {
-    // Some optimizations get turned off when pseudo_names is on.
-    // This causes some errors caused by the babel transformations
-    // that we apply like unreachable code because we turn a conditional
-    // falsey. (ex. is IS_PROD transformation which causes some conditionals
-    // to be unreachable/suspicious code since the whole expression is
-    // falsey)
-    compilerOptions.jscomp_off.push('uselessCode', 'externsValidation');
-  }
-  if (argv.pretty_print) {
-    compilerOptions.formatting = 'PRETTY_PRINT';
-  }
-
-  // See https://github.com/google/closure-compiler/wiki/Warnings#warnings-categories
-  // for a full list of closure's default error / warning levels.
-  // NOTE: We do not use jscomp_warning because they are silenced by closure
-  // unless there are accompanying errors. Pick a side and use either one of
-  // jscomp_error or jscomp_off.
-  if (options.typeCheckOnly) {
-    compilerOptions.checks_only = true;
-    // Note: compilation_level is SIMPLE_OPTIMIZATIONS during type checking.
-    // Making it WHITESPACE_ONLY will disable type-checking, so don't do that.
-    compilerOptions.define.push('TYPECHECK_ONLY=true');
-    // These aren't type-check errors by default, but should be.
-    compilerOptions.jscomp_error.push(
-      'accessControls',
-      'checkDebuggerStatement',
-      'conformanceViolations',
-      'checkTypes',
-      'const',
-      'constantProperty',
-      'globalThis',
-      'misplacedTypeAnnotation',
-      'missingProperties',
-      'strictMissingProperties',
-      'visibility'
-    );
-    // These are type-check errors / warnings by default, but cannot be.
-    compilerOptions.jscomp_off.push(
-      'moduleLoad', // Breaks type-only modules: google/closure-compiler#3041
-      'unknownDefines' // Closure complains about VERSION
-    );
-    compilerOptions.conformance_configs =
-      'build-system/test-configs/conformance-config.textproto';
-  } else {
-    // These aren't compilation errors by default, but should be.
-    compilerOptions.jscomp_error.push(
-      'missingProperties',
-      'strictMissingProperties',
-      'visibility'
-    );
-    // Thse are compilation errors / warnings by default, but cannot be.
-    compilerOptions.jscomp_off.push(
-      'accessControls', // Silences spurious JSC_BAD_PRIVATE_GLOBAL_ACCESS
-      'moduleLoad', // Breaks type-only modules: google/closure-compiler#3041
-      'unknownDefines' // Closure complains about VERSION
-    );
-  }
-
-  if (compilerOptions.define.length == 0) {
-    delete compilerOptions.define;
-  }
-  return compilerOptions;
-}
-
-/**
- * Generates the full set of flags with which to invoke closure compiler.
- *
- * @param {!OptionsDef} options
- * @param {!Object} compilerOptions
- * @param {!Array<string>} entryModuleFilenames
- * @param {string} destFile
- * @param {string} sourcemapFile
- * @return {!Array<string>}
- */
-function generateFlags(
-  options,
-  compilerOptions,
-  entryModuleFilenames,
-  destFile,
-  sourcemapFile
-) {
-  const compilerFlags = [];
-  Object.keys(compilerOptions).forEach(function (option) {
-    const value = compilerOptions[option];
-    if (Array.isArray(value)) {
-      value.forEach(function (item) {
-        compilerFlags.push('--' + option + '=' + item);
-      });
-    } else {
-      if (value != null) {
-        compilerFlags.push('--' + option + '=' + value);
-      } else {
-        compilerFlags.push('--' + option);
-      }
-    }
-  });
-  const entryPointFlags = entryModuleFilenames.map(
-    (entryPoint) => `--entry_point=${entryPoint}`
-  );
-  compilerFlags.push(...entryPointFlags);
-  if (!options.typeCheckOnly) {
-    const outputFileFlag = `--js_output_file=${destFile}`;
-    const sourcemapFlag = `--create_source_map=${sourcemapFile}`;
-    compilerFlags.push(outputFileFlag, sourcemapFlag);
-  }
-  return compilerFlags;
-}
-
-/**
- * @param {string[]|string} entryModuleFilenames
- * @param {string} outputDir
- * @param {string} outputFilename
- * @param {!OptionsDef} options
+ * @param {!Object} options
  * @param {{startTime?: number}} timeInfo
  * @return {Promise<void>}
  */
-async function compile(
+async function closureCompile(
   entryModuleFilenames,
   outputDir,
   outputFilename,
   options,
   timeInfo
 ) {
+  maybeInitializeWorker();
   if (timeInfo) {
     timeInfo.startTime = Date.now();
   }
-  if (!Array.isArray(entryModuleFilenames)) {
-    entryModuleFilenames = [entryModuleFilenames];
-  }
-  const destFile = `${outputDir}/${outputFilename}`;
-  const sourcemapFile = `${destFile}.map`;
-  const compilerOptions = await generateCompilerOptions(
-    outputFilename,
-    options
-  );
-  const srcs = options.noAddDeps
-    ? entryModuleFilenames.concat(options.extraGlobs || [])
-    : getSrcs(entryModuleFilenames, options);
-  const transformedSrcFiles = await Promise.all(
-    fastGlob
-      .sync(srcs)
-      .map((src) => preClosureBabel(src, outputFilename, options))
-  );
-  if (options.errored && options.continueOnError) {
-    return; // Watch build. Bail on transform errors.
-  }
-  const flags = generateFlags(
-    options,
-    compilerOptions,
+  await compileWorker.run({
     entryModuleFilenames,
-    destFile,
-    sourcemapFile
-  );
-  await runClosure(outputFilename, options, flags, transformedSrcFiles);
-  if (options.errored && options.continueOnError) {
-    return; // Watch build. Bail on compilation errors.
-  }
-  if (!options.typeCheckOnly) {
-    if (!argv.pseudo_names && !options.skipUnknownDepsCheck) {
-      await checkForUnknownDeps(destFile);
-    }
-    await postClosureBabel(destFile);
-    await sanitize(destFile);
-    await writeSourcemaps(sourcemapFile, options);
-  }
-}
-
-/**
- * Indicates the current closure concurrency and how to override it.
- */
-function printClosureConcurrency() {
-  log(
-    green('Using up to'),
-    cyan(MAX_PARALLEL_CLOSURE_INVOCATIONS.toString()),
-    green('concurrent invocations of closure compiler.')
-  );
-  if (!argv.closure_concurrency) {
-    logLocalDev(
-      green('⤷ Use'),
-      cyan('--closure_concurrency=N'),
-      green('to change this number.')
-    );
-  }
+    options,
+    outputDir,
+    outputFilename,
+  });
 }
 
 module.exports = {
-  cleanupBuildDir,
   closureCompile,
-  printClosureConcurrency,
 };

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -7,7 +7,8 @@ const {
 const {
   displayLifecycleDebugging,
 } = require('../compile/debug-compilation-lifecycle');
-const {cleanupBuildDir, closureCompile} = require('../compile/compile');
+const {cleanupBuildDir} = require('./helpers');
+const {closureCompile} = require('../compile/compile');
 const {compileCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {cyan, green, red, yellow} = require('kleur/colors');

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -13,10 +13,6 @@ const {
   printNobuildHelp,
 } = require('./helpers');
 const {
-  cleanupBuildDir,
-  printClosureConcurrency,
-} = require('../compile/compile');
-const {
   createCtrlcHandler,
   exitCtrlcHandler,
 } = require('../common/ctrlcHandler');
@@ -29,6 +25,7 @@ const {
 const {buildCompiler} = require('../compile/build-compiler');
 const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
 const {buildVendorConfigs} = require('./3p-vendor-helpers');
+const {cleanupBuildDir} = require('./helpers');
 const {compileCss, copyCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {formatExtractedMessages} = require('../compile/log-messages');
@@ -111,7 +108,6 @@ async function dist() {
     minify: true,
     watch: argv.watch,
   };
-  printClosureConcurrency();
   printNobuildHelp();
   printDistHelp(options);
   await runPreDistSteps(options);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -1,5 +1,6 @@
 const argv = require('minimist')(process.argv.slice(2));
 const debounce = require('../common/debounce');
+const del = require('del');
 const esbuild = require('esbuild');
 /** @type {Object} */
 const experimentDefines = require('../global-configs/experiments-const.json');
@@ -67,6 +68,18 @@ const watchDebounceDelay = 1000;
  * @private @const {!Map<string, {rebuild: function():!Promise<void>}>}
  */
 const watchedTargets = new Map();
+
+/**
+ * Cleans up the placeholder directories for fake build modules.
+ */
+function cleanupBuildDir() {
+  del.sync('build/fake-module');
+  del.sync('build/patched-module');
+  del.sync('build/parsers');
+  fs.mkdirsSync('build/fake-module/third_party/babel');
+  fs.mkdirsSync('build/fake-module/src/polyfills/');
+  fs.mkdirsSync('build/fake-polyfills/src/polyfills');
+}
 
 /**
  * @param {!Object} jsBundles
@@ -804,6 +817,7 @@ function shouldUseClosure() {
 
 module.exports = {
   bootstrapThirdPartyFrames,
+  cleanupBuildDir,
   compileAllJs,
   compileCoreRuntime,
   compileJs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,7 @@
         "nock": "13.1.4",
         "node-fetch": "2.6.5",
         "open": "8.4.0",
+        "piscina": "3.1.0",
         "plugin-error": "1.0.1",
         "postcss": "8.3.11",
         "postcss-import": "14.0.2",
@@ -254,19 +255,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@ampproject/google-closure-compiler-linux": {
-      "version": "20210601.0.0",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@ampproject/google-closure-compiler-osx": {
       "version": "20210601.0.0",
       "cpu": [
@@ -278,19 +266,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@ampproject/google-closure-compiler-windows": {
-      "version": "20210601.0.0",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@ampproject/remapping": {
@@ -323,6 +298,12 @@
       "engines": {
         "node": ">=10.14"
       }
+    },
+    "node_modules/@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.15.8",
@@ -8000,19 +7981,6 @@
         "esbuild-windows-arm64": "0.13.9"
       }
     },
-    "node_modules/esbuild-android-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.9.tgz",
-      "integrity": "sha512-Ty0hKldtjJVLHwUwbKR4GFPiXBo5iQ3aE1OLBar9lh3myaRkUGEb+Ypl74LEKa0+t/9lS3Ev1N5+5P2Sq6UvNQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/esbuild-darwin-64": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.9.tgz",
@@ -8024,201 +7992,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/esbuild-darwin-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.9.tgz",
-      "integrity": "sha512-nJB8chaJdWathCe6EyIiMIqfyEzbuXPyNsPlL3bYRB1zFCF8feXT874D4IHbJ/w8B6BpY3sM1Clr/I/DK8E4ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/esbuild-freebsd-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.9.tgz",
-      "integrity": "sha512-ktaBujf12XLkVXLGx7WjFcmh1tt34tm7gP4pHkhvbzbHrq+BbXwcl4EsW+5JT9VNKl7slOGf4Qnua/VW7ZcnIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.9.tgz",
-      "integrity": "sha512-vVa5zps4dmwpXwv/amxVpIWvFJuUPWQkpV+PYtZUW9lqjXsQ3LBHP51Q1cXZZBIrqwszLsEyJPa5GuDOY15hzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/esbuild-linux-32": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.9.tgz",
-      "integrity": "sha512-HxoW9QNqhO8VW1l7aBiYQH4lobeHq85+blZ4nlZ7sg5CNhGRRwnMlV6S08VYKz6V0YKnHb5OqJxx2HZuTZ7tgQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.9.tgz",
-      "integrity": "sha512-L+eAR8o1lAUr9g64RXnBLuWZjAItAOWSUpvkchpa6QvSnXFA/nG6PgGsOBEqhDXl9qYEpGI0ReDrFkf8ByapvQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-arm": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.9.tgz",
-      "integrity": "sha512-DT0S+ufCVXatPZHjkCaBgZSFIV8FzY4GEHz/BlkitTWzUvT1dIUXjPIRPnqBUVa+0AyS1bZSfHzv9hTT4LHz7A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.9.tgz",
-      "integrity": "sha512-IjbhZpW5VQYK4nVI4dj/mLvH5oXAIf57OI8BYVkCqrdVXJwR8nVrSqux3zJSY+ElrkOK3DtG9iTPpmqvBXaU0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-mips64le": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.9.tgz",
-      "integrity": "sha512-ec9RgAM4r+fe1ZmG16qeMwEHdcIvqeW8tpnpkfSQu9T4487KtQF6lg3TQasTarrLLEe7Qpy+E+r4VwC8eeZySQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.9.tgz",
-      "integrity": "sha512-7b2/wg8T1n/L1BgCWlMSez0aXfGkNjFuOqMBQdnTti3LRuUwzGJcrhRf/FdZGJ5/evML9mqu60vLRuXW1TdXCg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/esbuild-netbsd-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.9.tgz",
-      "integrity": "sha512-PiZu3h4+Szj0iZPgvuD2Y0isOXnlNetmF6jMcOwW54BScwynW24/baE+z7PfDyNFgjV04Ga2THdcpbKBDhgWQw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ]
-    },
-    "node_modules/esbuild-openbsd-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.9.tgz",
-      "integrity": "sha512-SJKN4Ez+ilY7mu+1gAdGQ9N6dktBfbEkiOAvw+hT7xHrNnTnrTGH0FT4qx9dazB9HX6D04L4PXmVOyynqi+oEQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/esbuild-sunos-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.9.tgz",
-      "integrity": "sha512-9N0RjZ7cElE8ifrS0nBrLQgBMQNPiIIKO2GzLXy7Ms8AM3KjfLiV2G2+9O0B9paXjRAHchIwazTeOyeWb1vyWA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ]
-    },
-    "node_modules/esbuild-windows-32": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.9.tgz",
-      "integrity": "sha512-awxWs1kns+RfjhqBbTbdlePjqZrAE2XMaAQJNg9dtu+C7ghC3QKsqXbu0C26OuF5YeAdJcq9q+IdG6WPLjvj9w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/esbuild-windows-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.9.tgz",
-      "integrity": "sha512-VmA9GQMCzOr8rFfD72Dum1+AWhJui7ZO6sYwp6rBHYu4vLmWITTSUsd/zgXXmZuHBPkkvxLJLF8XsKFCRKflJA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/esbuild-windows-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.9.tgz",
-      "integrity": "sha512-P/jPY2JwmTpgEPh9BkXpCe690tcDSSo0K9BHTniSeEAEz26kPpqldVa4XDm0R+hNnFA7ecEgNskr4QAxE1ry0w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/escalade": {
@@ -9081,6 +8854,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter-asyncresource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz",
+      "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ==",
+      "dev": true
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
@@ -11095,6 +10874,23 @@
       "version": "0.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hdr-histogram-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.1.tgz",
+      "integrity": "sha512-uPZxl1dAFnjUFHWLZmt93vUUvtHeaBay9nVNHu38SdOjMSF/4KqJUqa1Seuj08ptU1rEb6AHvB41X8n/zFZ74Q==",
+      "dev": true,
+      "dependencies": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "node_modules/hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -17768,6 +17564,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nice-napi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
+      "integrity": "sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "!win32"
+      ],
+      "dependencies": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2"
+      }
+    },
     "node_modules/nise": {
       "version": "5.1.0",
       "dev": true,
@@ -17816,6 +17627,13 @@
         "node": ">= 10.13"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "dev": true,
@@ -17863,6 +17681,18 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {
@@ -18487,6 +18317,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/param-case": {
       "version": "2.1.1",
       "dev": true,
@@ -18681,6 +18517,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/piscina": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-3.1.0.tgz",
+      "integrity": "sha512-KTW4sjsCD34MHrUbx9eAAbuUSpVj407hQSgk/6Epkg0pbRBmv4a3UX7Sr8wxm9xYqQLnsN4mFOjqGDzHAdgKQg==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter-asyncresource": "^1.0.0",
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0"
+      },
+      "optionalDependencies": {
+        "nice-napi": "^1.0.2"
       }
     },
     "node_modules/pkg-conf": {
@@ -23420,17 +23270,7 @@
       "version": "20210601.0.0",
       "dev": true
     },
-    "@ampproject/google-closure-compiler-linux": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "optional": true
-    },
     "@ampproject/google-closure-compiler-osx": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "optional": true
-    },
-    "@ampproject/google-closure-compiler-windows": {
       "version": "20210601.0.0",
       "dev": true,
       "optional": true
@@ -23455,6 +23295,12 @@
     },
     "@ampproject/worker-dom": {
       "version": "0.32.1"
+    },
+    "@assemblyscript/loader": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.10.1.tgz",
+      "integrity": "sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.15.8",
@@ -28792,122 +28638,10 @@
         "esbuild-windows-arm64": "0.13.9"
       }
     },
-    "esbuild-android-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.9.tgz",
-      "integrity": "sha512-Ty0hKldtjJVLHwUwbKR4GFPiXBo5iQ3aE1OLBar9lh3myaRkUGEb+Ypl74LEKa0+t/9lS3Ev1N5+5P2Sq6UvNQ==",
-      "dev": true,
-      "optional": true
-    },
     "esbuild-darwin-64": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.9.tgz",
       "integrity": "sha512-Ay0/b98v0oYp3ApXNQ7QPbaSkCT9WjBU6h8bMB1SYrQ/PmHgwph91fb9V0pfOLKK1rYWypfrNbI0MyT2tWN+rQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-darwin-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.9.tgz",
-      "integrity": "sha512-nJB8chaJdWathCe6EyIiMIqfyEzbuXPyNsPlL3bYRB1zFCF8feXT874D4IHbJ/w8B6BpY3sM1Clr/I/DK8E4ow==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.9.tgz",
-      "integrity": "sha512-ktaBujf12XLkVXLGx7WjFcmh1tt34tm7gP4pHkhvbzbHrq+BbXwcl4EsW+5JT9VNKl7slOGf4Qnua/VW7ZcnIw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-freebsd-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.9.tgz",
-      "integrity": "sha512-vVa5zps4dmwpXwv/amxVpIWvFJuUPWQkpV+PYtZUW9lqjXsQ3LBHP51Q1cXZZBIrqwszLsEyJPa5GuDOY15hzQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-32": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.9.tgz",
-      "integrity": "sha512-HxoW9QNqhO8VW1l7aBiYQH4lobeHq85+blZ4nlZ7sg5CNhGRRwnMlV6S08VYKz6V0YKnHb5OqJxx2HZuTZ7tgQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.9.tgz",
-      "integrity": "sha512-L+eAR8o1lAUr9g64RXnBLuWZjAItAOWSUpvkchpa6QvSnXFA/nG6PgGsOBEqhDXl9qYEpGI0ReDrFkf8ByapvQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.9.tgz",
-      "integrity": "sha512-DT0S+ufCVXatPZHjkCaBgZSFIV8FzY4GEHz/BlkitTWzUvT1dIUXjPIRPnqBUVa+0AyS1bZSfHzv9hTT4LHz7A==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.9.tgz",
-      "integrity": "sha512-IjbhZpW5VQYK4nVI4dj/mLvH5oXAIf57OI8BYVkCqrdVXJwR8nVrSqux3zJSY+ElrkOK3DtG9iTPpmqvBXaU0g==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-mips64le": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.9.tgz",
-      "integrity": "sha512-ec9RgAM4r+fe1ZmG16qeMwEHdcIvqeW8tpnpkfSQu9T4487KtQF6lg3TQasTarrLLEe7Qpy+E+r4VwC8eeZySQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-linux-ppc64le": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.9.tgz",
-      "integrity": "sha512-7b2/wg8T1n/L1BgCWlMSez0aXfGkNjFuOqMBQdnTti3LRuUwzGJcrhRf/FdZGJ5/evML9mqu60vLRuXW1TdXCg==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-netbsd-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.9.tgz",
-      "integrity": "sha512-PiZu3h4+Szj0iZPgvuD2Y0isOXnlNetmF6jMcOwW54BScwynW24/baE+z7PfDyNFgjV04Ga2THdcpbKBDhgWQw==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-openbsd-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.9.tgz",
-      "integrity": "sha512-SJKN4Ez+ilY7mu+1gAdGQ9N6dktBfbEkiOAvw+hT7xHrNnTnrTGH0FT4qx9dazB9HX6D04L4PXmVOyynqi+oEQ==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-sunos-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.9.tgz",
-      "integrity": "sha512-9N0RjZ7cElE8ifrS0nBrLQgBMQNPiIIKO2GzLXy7Ms8AM3KjfLiV2G2+9O0B9paXjRAHchIwazTeOyeWb1vyWA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-32": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.9.tgz",
-      "integrity": "sha512-awxWs1kns+RfjhqBbTbdlePjqZrAE2XMaAQJNg9dtu+C7ghC3QKsqXbu0C26OuF5YeAdJcq9q+IdG6WPLjvj9w==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.9.tgz",
-      "integrity": "sha512-VmA9GQMCzOr8rFfD72Dum1+AWhJui7ZO6sYwp6rBHYu4vLmWITTSUsd/zgXXmZuHBPkkvxLJLF8XsKFCRKflJA==",
-      "dev": true,
-      "optional": true
-    },
-    "esbuild-windows-arm64": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.9.tgz",
-      "integrity": "sha512-P/jPY2JwmTpgEPh9BkXpCe690tcDSSo0K9BHTniSeEAEz26kPpqldVa4XDm0R+hNnFA7ecEgNskr4QAxE1ry0w==",
       "dev": true,
       "optional": true
     },
@@ -29471,6 +29205,12 @@
     },
     "event-target-shim": {
       "version": "5.0.1",
+      "dev": true
+    },
+    "eventemitter-asyncresource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter-asyncresource/-/eventemitter-asyncresource-1.0.0.tgz",
+      "integrity": "sha512-39F7TBIV0G7gTelxwbEqnwhp90eqCPON1k0NwNfwhgKn4Co4ybUbj2pECcXT0B3ztRKZ7Pw1JujUUgmQJHcVAQ==",
       "dev": true
     },
     "eventemitter3": {
@@ -30903,6 +30643,23 @@
     },
     "hash-stream-validation": {
       "version": "0.2.4",
+      "dev": true
+    },
+    "hdr-histogram-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-2.0.1.tgz",
+      "integrity": "sha512-uPZxl1dAFnjUFHWLZmt93vUUvtHeaBay9nVNHu38SdOjMSF/4KqJUqa1Seuj08ptU1rEb6AHvB41X8n/zFZ74Q==",
+      "dev": true,
+      "requires": {
+        "@assemblyscript/loader": "^0.10.1",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
       "dev": true
     },
     "he": {
@@ -35670,6 +35427,17 @@
       "version": "2.6.2",
       "dev": true
     },
+    "nice-napi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nice-napi/-/nice-napi-1.0.2.tgz",
+      "integrity": "sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "node-addon-api": "^3.0.0",
+        "node-gyp-build": "^4.2.2"
+      }
+    },
     "nise": {
       "version": "5.1.0",
       "dev": true,
@@ -35713,6 +35481,13 @@
         "propagate": "^2.0.0"
       }
     },
+    "node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "dev": true,
+      "optional": true
+    },
     "node-dir": {
       "version": "0.1.17",
       "dev": true,
@@ -35748,6 +35523,13 @@
     "node-forge": {
       "version": "0.10.0",
       "dev": true
+    },
+    "node-gyp-build": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "dev": true,
+      "optional": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -36146,6 +35928,12 @@
         }
       }
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "param-case": {
       "version": "2.1.1",
       "dev": true,
@@ -36264,6 +36052,18 @@
       "dev": true,
       "requires": {
         "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "piscina": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-3.1.0.tgz",
+      "integrity": "sha512-KTW4sjsCD34MHrUbx9eAAbuUSpVj407hQSgk/6Epkg0pbRBmv4a3UX7Sr8wxm9xYqQLnsN4mFOjqGDzHAdgKQg==",
+      "dev": true,
+      "requires": {
+        "eventemitter-asyncresource": "^1.0.0",
+        "hdr-histogram-js": "^2.0.1",
+        "hdr-histogram-percentiles-obj": "^3.0.0",
+        "nice-napi": "^1.0.2"
       }
     },
     "pkg-conf": {

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "nock": "13.1.4",
     "node-fetch": "2.6.5",
     "open": "8.4.0",
+    "piscina": "3.1.0",
     "plugin-error": "1.0.1",
     "postcss": "8.3.11",
     "postcss-import": "14.0.2",


### PR DESCRIPTION
This PR uses [`piscina`](https://www.npmjs.com/package/piscina) to run closure compiler inside a worker. With this, parallelism is automatically handled, and we can eliminate the (now ancient) rate-limiting code to throttle closure compiler invocations.

**Note:** This is still experimental. Right now, I'm hitting [out-of-memory errors](https://app.circleci.com/pipelines/github/ampproject/amphtml/17305/workflows/d57c474f-40ab-45bc-a6e6-a80da2def78e/jobs/315143/parallel-runs/0/steps/0-113), likely because of the interplay between `sync-rpc` and `piscina`. Once those are sorted out, we'll have to see if there are any actual gains and if this effort is worthwhile, or if we should abandon it in favor of #35264.