### PR TITLE
🐛 Correctly detect P tags as text element types

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -61,23 +61,23 @@ function getElementType(node) {
     return ELEMENT_TYPE.other;
   }
   const outer = getOutermostAmpElement(node);
-  const tagName = outer.tagName || '';
-  if (tagName === 'IMG' || tagName === 'AMP-IMG') {
+  const {nodeName} = outer;
+  if (nodeName === 'IMG' || nodeName === 'AMP-IMG') {
     return ELEMENT_TYPE.image;
   }
-  if (tagName === 'VIDEO' || tagName === 'AMP-VIDEO') {
+  if (nodeName === 'VIDEO' || nodeName === 'AMP-VIDEO') {
     return ELEMENT_TYPE.video;
   }
-  if (tagName === 'AMP-CAROUSEL') {
+  if (nodeName === 'AMP-CAROUSEL') {
     return ELEMENT_TYPE.carousel;
   }
-  if (tagName === 'AMP-BASE-CAROUSEL') {
+  if (nodeName === 'AMP-BASE-CAROUSEL') {
     return ELEMENT_TYPE.bcarousel;
   }
-  if (tagName === 'AMP-AD') {
+  if (nodeName === 'AMP-AD') {
     return ELEMENT_TYPE.ad;
   }
-  if (!tagName.startsWith('AMP-') && outer.textContent) {
+  if (!nodeName.startsWith('AMP-') && outer.textContent) {
     return ELEMENT_TYPE.text;
   }
   return ELEMENT_TYPE.other;
@@ -930,7 +930,7 @@ export class Performance {
 function getOutermostAmpElement(node) {
   let max = node;
   while ((node = node.parentNode) != null) {
-    if (node.tagName.startsWith('AMP-')) {
+    if (node.nodeName.startsWith('AMP-')) {
       max = node;
     }
   }

--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -60,10 +60,8 @@ function getElementType(node) {
   if (node == null) {
     return ELEMENT_TYPE.other;
   }
-  const {tagName} = getOutermostAmpElement(node);
-  if (tagName == null) {
-    return ELEMENT_TYPE.text;
-  }
+  const outer = getOutermostAmpElement(node);
+  const tagName = outer.tagName || '';
   if (tagName === 'IMG' || tagName === 'AMP-IMG') {
     return ELEMENT_TYPE.image;
   }
@@ -78,6 +76,9 @@ function getElementType(node) {
   }
   if (tagName === 'AMP-AD') {
     return ELEMENT_TYPE.ad;
+  }
+  if (!tagName.startsWith('AMP-') && outer.textContent) {
+    return ELEMENT_TYPE.text;
   }
   return ELEMENT_TYPE.other;
 }
@@ -923,13 +924,13 @@ export class Performance {
  * Traverse node ancestors and return the highest level amp element.
  * Returns the given node if none are found.
  *
- * @param {!HTMLElement} node
- * @return {!HTMLElement}
+ * @param {!Node} node
+ * @return {!Node}
  */
 function getOutermostAmpElement(node) {
   let max = node;
   while ((node = node.parentNode) != null) {
-    if (node.nodeName.startsWith('AMP-')) {
+    if (node.tagName.startsWith('AMP-')) {
       max = node;
     }
   }

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1095,6 +1095,23 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
       // Flush LCP again.
       toggleVisibility(perf, false);
 
+      // A textual paragraph
+      const p = document.createElement('p');
+      p.textContent = 'hello';
+      performanceObserver.triggerCallback({
+        getEntries() {
+          return [
+            {
+              entryType: 'largest-contentful-paint',
+              startTime: 25,
+              element: p,
+            },
+          ];
+        },
+      });
+      // Flush LCP again.
+      toggleVisibility(perf, false);
+
       const lcptEvents = perf.events_.filter(({label}) =>
         label.startsWith('lcpt')
       );
@@ -1105,6 +1122,10 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
       expect(lcptEvents).deep.include({
         label: 'lcpt',
         delta: ELEMENT_TYPE.carousel,
+      });
+      expect(lcptEvents).deep.include({
+        label: 'lcpt',
+        delta: ELEMENT_TYPE.text,
       });
     });
   });


### PR DESCRIPTION
The LCP's target is an element, but I had assumed it would be a `#text` node if the LCP was textual. When we retrieve the outermost element, it'll be something like a `<p>`/`<h1>` tag. The `tagName` isn't `null`, so we incorrectly labeled them as `other` type instead of `text` type.