### PR TITLE
♻️ Use 1p OT token in FIE

### DIFF
--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -1,5 +1,3 @@
-import {TOKEN_VALUE} from '#ads/google/a4a/utils';
-
 import {createElementWithAttributes, escapeHtml} from '#core/dom';
 import {dict} from '#core/types/object';
 
@@ -28,6 +26,9 @@ const sandboxVals =
   'allow-scripts ' +
   'allow-top-navigation';
 
+const TOKEN_VALUE_1P =
+  'AzKSXqpxJ3GJ4xUcmPM97hZVJG1MQdsBvJDfIuF7mkjVveoiTyt11U3+HIw4U2VdqQ3CNKMUoohEGtHUnS3h8wAAAACBeyJvcmlnaW4iOiJodHRwczovL2FtcHByb2plY3Qub3JnOjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2MzQwODMxOTksImlzU3ViZG9tYWluIjp0cnVlLCJ1c2FnZSI6InN1YnNldCJ9';
+
 /**
  * Create the starting html for all FIE ads. If streaming is supported body will be
  * piped in later.
@@ -53,7 +54,7 @@ export const createSecureDocSkeleton = (url, sanitizedHeadElements, body) =>
       default-src 'none';
       style-src ${fontProviderAllowList} 'unsafe-inline';
     ">
-    <meta http-equiv="origin-trial" content=${TOKEN_VALUE}>    
+    <meta http-equiv="origin-trial" content=${TOKEN_VALUE_1P}>    
     ${sanitizedHeadElements}
   </head>
   <body>${body}</body>


### PR DESCRIPTION
After manual testing we realized that the 3p token may not work as expected when written using `srcdoc`. Chrome folks suggested using a 1p token to test if that makes a difference.