### PR TITLE
🖍 [story desktop panel] make aspect ratio match `2021-background` for short viewports

### DIFF
--- a/css/amp-story-player-shadow.css
+++ b/css/amp-story-player-shadow.css
@@ -102,6 +102,7 @@
 
   /* Override if iframe height is less than 538px. */
  .i-amphtml-story-player-panel.i-amphtml-story-player-panel-small  {
+    /** If changing this, also change amp-story-desktop-one-panel.css **/
     --i-amphtml-story-player-panel-ratio: 36 / 53;
   }
 

--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -34,6 +34,7 @@ amp-story[standalone] {
 
   @media(max-height: 538px) {
     :root:not([data-story-supports-landscape]) {
+      /** If changing this, also change amp-story-player-shadow.css **/
       --i-amphtml-story-desktop-one-panel-ratio: 36 / 53;
     }
   }


### PR DESCRIPTION
Closes #35796 and avoids situations like this one:

![image](https://user-images.githubusercontent.com/4594196/136373875-8b2b2b13-00ba-4713-b174-474231a540ca.png)
