### PR TITLE
🧪 Promote amp-sticky-ad-to-amp-ad-v3 server-side experiment

### DIFF
--- a/build-system/global-configs/client-side-experiments-config.json
+++ b/build-system/global-configs/client-side-experiments-config.json
@@ -27,6 +27,10 @@
     {
       "name": "story-ad-page-outlink",
       "percentage": 0.02
+    },
+    {
+      "name": "amp-sticky-ad-to-amp-ad-v3",
+      "percentage": 0.05
     }
   ]
 }


### PR DESCRIPTION
The fix is now in. Promote to 5%.