### PR TITLE
BaseElement: remove .getWin()

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -11,10 +11,6 @@ const privateServiceFactory =
 const shouldNeverBeUsed =
   'Usage of this API is not allowed - only for internal purposes.';
 
-const backwardCompat =
-  'This method must not be called. It is only retained ' +
-  'for backward compatibility during rollout.';
-
 const realiasGetMode =
   'Do not re-alias getMode or its return so it can be ' +
   'DCE\'d. Use explicitly like "getMode().localDev" instead.';
@@ -587,9 +583,6 @@ const forbiddenTermsGlobal = {
   '(win|Win)(dow)?(\\(\\))?\\.open\\W': {
     message: 'Use src/open-window-dialog',
     allowlist: ['src/open-window-dialog.js'],
-  },
-  '\\.getWin\\(': {
-    message: backwardCompat,
   },
   '/\\*\\* @type \\{\\!Element\\} \\*/': {
     message: 'Use assertElement instead of casting to !Element.',

--- a/docs/building-an-amp-extension.md
+++ b/docs/building-an-amp-extension.md
@@ -466,9 +466,9 @@ class AmpInstagram extends AMP.BaseElement {
   // ...
   /** @override */
   createPlaceholderCallback() {
-    const placeholder = this.getWin().document.createElement('div');
+    const placeholder = this.win.document.createElement('div');
     placeholder.setAttribute('placeholder', '');
-    const image = this.getWin().document.createElement('amp-img');
+    const image = this.win.document.createElement('amp-img');
     // This is always the same URL that is actually used inside of the embed.
     // This lets us avoid loading the image twice and make use of browser cache.
 

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -320,15 +320,6 @@ export class BaseElement {
   }
 
   /**
-   * DO NOT CALL. Retained for backward compat during rollout.
-   * @public
-   * @return {!Window}
-   */
-  getWin() {
-    return this.win;
-  }
-
-  /**
    * Returns the associated ampdoc. Only available when `buildCallback` and
    * going forward. It throws an exception before `buildCallback`.
    * @return {!./service/ampdoc-impl.AmpDoc}

--- a/src/service/ampdoc-impl.js
+++ b/src/service/ampdoc-impl.js
@@ -326,15 +326,6 @@ export class AmpDoc {
     return this.parent_;
   }
 
-  /**
-   * DO NOT CALL. Retained for backward compat during rollout.
-   * @return {!Window}
-   * @deprecated Use `ampdoc.win` instead.
-   */
-  getWin() {
-    return this.win;
-  }
-
   /** @return {!Signals} */
   signals() {
     return this.signals_;


### PR DESCRIPTION
Cleanup `getWin`, which has been deprecated since 2016: https://github.com/ampproject/amphtml/pull/4115