### PR TITLE
♻️  core: add getWin to core/window

### DIFF
--- a/extensions/amp-a4a/0.1/within-viewport.js
+++ b/extensions/amp-a4a/0.1/within-viewport.js
@@ -1,7 +1,7 @@
 import {Deferred} from '#core/data-structures/promise';
 import {isIframed} from '#core/dom';
 import {memo} from '#core/types/object';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {getMode} from '../../../src/mode';
 
@@ -20,7 +20,7 @@ export function whenWithinViewport(element, viewportNum) {
     return Promise.reject('!WITHIN_VIEWPORT_INOB');
   }
 
-  const win = toWin(element.ownerDocument.defaultView);
+  const win = getWin(element);
   const observersMap = memo(win, OBSERVERS_MAP_PROP, createObserversMap);
 
   let observer = observersMap.get(viewportNum);

--- a/extensions/amp-accordion/1.0/amp-accordion.js
+++ b/extensions/amp-accordion/1.0/amp-accordion.js
@@ -1,5 +1,5 @@
 import {ActionTrust} from '#core/constants/action-constants';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {isExperimentOn} from '#experiments';
 
@@ -35,7 +35,7 @@ class AmpAccordion extends BaseElement {
   /** @override */
   triggerEvent(section, eventName, detail) {
     const event = createCustomEvent(
-      toWin(section.ownerDocument.defaultView),
+      getWin(section),
       `accordionSection.${eventName}`,
       detail
     );

--- a/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/responsive-state.js
@@ -10,7 +10,7 @@ import {computedStyle, getStyle, setStyle} from '#core/dom/style';
 import {clamp} from '#core/math';
 import {hasOwn} from '#core/types/object';
 import {tryParseJson} from '#core/types/object/json';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {randomlySelectUnsetExperiments} from '#experiments';
 
@@ -65,7 +65,7 @@ export class ResponsiveState {
     this.isContainerWidth_ = !!isContainerWidth;
 
     /** @private {!Window} */
-    this.win_ = toWin(element.ownerDocument.defaultView);
+    this.win_ = getWin(element);
   }
 
   /**
@@ -153,7 +153,7 @@ export class ResponsiveState {
    * @return {!Promise<?ResponsiveState>} a promise that return container width responsive state.
    */
   static convertToContainerWidth(element) {
-    const vsync = Services.vsyncFor(toWin(element.ownerDocument.defaultView));
+    const vsync = Services.vsyncFor(getWin(element));
 
     return vsync
       .runPromise(
@@ -201,7 +201,7 @@ export class ResponsiveState {
     const savePromise = new Promise((resolve) => {
       promiseResolver = resolve;
     });
-    const win = toWin(element.ownerDocument.defaultView);
+    const win = getWin(element);
 
     const listener = (event) => {
       const data = getData(event);

--- a/extensions/amp-ad/0.1/amp-ad-3p-impl.js
+++ b/extensions/amp-ad/0.1/amp-ad-3p-impl.js
@@ -35,7 +35,7 @@ import {getIframe, preloadBootstrap} from '../../../src/3p-frame';
 import {intersectionEntryToJson} from '#core/dom/layout/intersection';
 import {moveLayoutRect} from '#core/dom/layout/rect';
 import {observeIntersections} from '#core/dom/layout/viewport-observer';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /** @const {string} Tag name for 3P AD implementation. */
 export const TAG_3P_IMPL = 'amp-ad-3p-impl';
@@ -396,7 +396,7 @@ export class AmpAd3PImpl extends AMP.BaseElement {
 
         const intersection = this.element.getIntersectionChangeEntry();
         const iframe = getIframe(
-          toWin(this.element.ownerDocument.defaultView),
+          getWin(this.element),
           this.element,
           this.type_,
           opt_context,

--- a/extensions/amp-analytics/0.1/analytics-group.js
+++ b/extensions/amp-analytics/0.1/analytics-group.js
@@ -3,7 +3,7 @@ import {Deferred} from '#core/data-structures/promise';
 import {dev, userAssert} from '#utils/log';
 import {getMode} from '../../../src/mode';
 import {getTrackerKeyName, getTrackerTypesForParentType} from './events';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /**
  * @const {number}
@@ -39,7 +39,7 @@ export class AnalyticsGroup {
     this.triggerCount_ = 0;
 
     /** @private @const {!Window} */
-    this.win_ = toWin(analyticsElement.ownerDocument.defaultView);
+    this.win_ = getWin(analyticsElement);
   }
 
   /** @override */

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -22,7 +22,7 @@ import {getTopWindow} from '../../../src/service-helpers';
 
 import {loadPromise} from '#utils/event-helper';
 import {removeElement} from '#core/dom';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {toggle} from '#core/dom/style';
 
 /** @const {string} */
@@ -154,7 +154,7 @@ export class Transport {
     }
 
     // In the case of FIE rendering, we should be using the parent doc win.
-    const topWin = getTopWindow(toWin(element.ownerDocument.defaultView));
+    const topWin = getTopWindow(getWin(element));
     const type = element.getAttribute('type');
     // In inabox there is no amp-ad element.
     const ampAdResourceId = this.isInabox_

--- a/extensions/amp-animation/0.1/parsers/keyframes-extractor.js
+++ b/extensions/amp-animation/0.1/parsers/keyframes-extractor.js
@@ -1,5 +1,5 @@
 import {endsWith} from '#core/types/string';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /**
  * Finds and extracts keyframes definition for Web Animations from CSS styles.
@@ -12,7 +12,7 @@ export function extractKeyframes(rootNode, name) {
   if (!styleSheets) {
     return null;
   }
-  const win = toWin((rootNode.ownerDocument || rootNode).defaultView);
+  const win = getWin(rootNode);
   // Go from the last to first since the last rule wins in CSS.
   for (let i = styleSheets.length - 1; i >= 0; i--) {
     const keyframes = scanStyle(

--- a/extensions/amp-auto-ads/0.1/adsense-network-config.js
+++ b/extensions/amp-auto-ads/0.1/adsense-network-config.js
@@ -1,7 +1,7 @@
 import {buildUrl} from '#ads/google/a4a/shared/url-builder';
 
 import {dict} from '#core/types/object';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -34,7 +34,7 @@ export class AdSenseNetworkConfig {
   getConfigUrl() {
     const docInfo = Services.documentInfoForDoc(this.autoAmpAdsElement_);
     const canonicalHostname = parseUrlDeprecated(docInfo.canonicalUrl).hostname;
-    const win = toWin(this.autoAmpAdsElement_.ownerDocument.defaultView);
+    const win = getWin(this.autoAmpAdsElement_);
     return buildUrl(
       '//pagead2.googlesyndication.com/getconfig/ama',
       {

--- a/extensions/amp-auto-ads/0.1/measure-page-layout-box.js
+++ b/extensions/amp-auto-ads/0.1/measure-page-layout-box.js
@@ -1,5 +1,5 @@
 import {getPageLayoutBoxBlocking} from '#core/dom/layout/page-layout-box';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '.../../../src/service';
 
@@ -8,6 +8,6 @@ import {Services} from '.../../../src/service';
  * @return {!Promise<!../layout-rect.LayoutRectDef>}
  */
 export function measurePageLayoutBox(element) {
-  const vsync = Services.vsyncFor(toWin(element.ownerDocument.defaultView));
+  const vsync = Services.vsyncFor(getWin(element));
   return vsync.measurePromise(() => getPageLayoutBoxBlocking(element));
 }

--- a/extensions/amp-base-carousel/1.0/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/1.0/amp-base-carousel.js
@@ -4,7 +4,7 @@ import {CSS} from '../../../build/amp-base-carousel-1.0.css';
 import {Services} from '#service';
 import {createCustomEvent} from '#utils/event-helper';
 import {isExperimentOn} from '#experiments';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {userAssert} from '#utils/log';
 
 /** @const {string} */
@@ -41,7 +41,7 @@ class AmpBaseCarousel extends BaseElement {
   /** @override */
   triggerEvent(element, eventName, detail) {
     const event = createCustomEvent(
-      toWin(element.ownerDocument.defaultView),
+      getWin(element),
       `amp-base-carousel.${eventName}`,
       detail
     );

--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -15,7 +15,7 @@ import {WithAmpContext} from '#preact/context';
 import {forwardRef, toChildArray} from '#preact/compat';
 import {isRTL} from '#core/dom';
 import {sequentialIdGenerator} from '#core/data-structures/id-generator';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {
   cloneElement,
   useCallback,
@@ -159,7 +159,7 @@ function BentoBaseCarouselWithRef(
     if (!shouldAutoAdvance || !containRef.current) {
       return;
     }
-    const win = toWin(containRef.current.ownerDocument.defaultView);
+    const win = getWin(containRef.current);
     const interval = win.setInterval(() => {
       const autoAdvanced = autoAdvance();
       if (!autoAdvanced) {

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -11,7 +11,7 @@ import {debounce} from '#core/types/function';
 import {forwardRef} from '#preact/compat';
 import {mod} from '#core/math';
 import {setStyle} from '#core/dom/style';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {
   useCallback,
   useImperativeHandle,
@@ -180,7 +180,7 @@ function ScrollerWithRef(
       return;
     }
     // Use local window.
-    const win = toWin(node.ownerDocument.defaultView);
+    const win = getWin(node);
     if (!win) {
       return undefined;
     }
@@ -192,9 +192,7 @@ function ScrollerWithRef(
   // Trigger render by setting the resting index to the current scroll state.
   const debouncedResetScrollReferencePoint = useMemo(() => {
     // Use local window if possible.
-    const win = containerRef.current
-      ? toWin(containerRef.current.ownerDocument.defaultView)
-      : window;
+    const win = containerRef.current ? getWin(containerRef.current) : window;
     return debounce(
       win,
       () => {

--- a/extensions/amp-fit-text/1.0/component.js
+++ b/extensions/amp-fit-text/1.0/component.js
@@ -2,7 +2,7 @@ import * as Preact from '#preact';
 import {ContainWrapper} from '#preact/component';
 import {LINE_HEIGHT_EM_, useStyles} from './component.jss';
 import {px, resetStyles, setStyle, setStyles} from '#core/dom/style';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {useCallback, useLayoutEffect, useRef} from '#preact';
 
 /**
@@ -43,7 +43,7 @@ export function BentoFitText({
     if (!container || !content) {
       return;
     }
-    const win = toWin(container.ownerDocument.defaultView);
+    const win = getWin(container);
     if (!win) {
       return undefined;
     }

--- a/extensions/amp-form/0.1/form-proxy.js
+++ b/extensions/amp-form/0.1/form-proxy.js
@@ -1,4 +1,4 @@
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -32,7 +32,7 @@ export function setDenylistedPropertiesForTesting(properties) {
  * @return {!Object}
  */
 export function installFormProxy(form) {
-  const constr = getFormProxyConstr(toWin(form.ownerDocument.defaultView));
+  const constr = getFormProxyConstr(getWin(form));
   const proxy = new constr(form);
   if (!('action' in proxy)) {
     setupLegacyProxy(form, proxy);

--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -1,5 +1,5 @@
 import {iterateCursor} from '#core/dom';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -175,7 +175,7 @@ export class FormValidator {
     const previousValidity = this.formValidity_;
     this.formValidity_ = this.checkFormValidity(this.form);
     if (previousValidity !== this.formValidity_) {
-      const win = toWin(this.form.ownerDocument.defaultView);
+      const win = getWin(this.form);
       const type = this.formValidity_ ? FormEvents.VALID : FormEvents.INVALID;
       const event = createCustomEvent(win, type, null, {bubbles: true});
       this.form.dispatchEvent(event);

--- a/extensions/amp-iframe/1.0/component.js
+++ b/extensions/amp-iframe/1.0/component.js
@@ -1,7 +1,7 @@
 import * as Preact from '#preact';
 import {useCallback, useEffect, useMemo, useRef} from '#preact';
 import {MessageType} from '#core/3p-frame-messaging';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {ContainWrapper, useIntersectionObserver} from '#preact/component';
 import {setStyle} from '#core/dom/style';
 import {useMergeRefs} from '#preact/utils';
@@ -63,7 +63,7 @@ export function BentoIframe({
       return;
     }
     targetOriginRef.current = event.origin;
-    const win = toWin(iframe.ownerDocument.defaultView);
+    const win = getWin(iframe);
     observerRef.current = new win.IntersectionObserver(viewabilityCb, {
       threshold: DEFAULT_THRESHOLD,
     });
@@ -77,7 +77,7 @@ export function BentoIframe({
     if (!iframe?.ownerDocument.defaultView) {
       return;
     }
-    const win = toWin(iframe.ownerDocument.defaultView);
+    const win = getWin(iframe);
     win.addEventListener('message', handleSendIntersectionsPostMessage);
     let observer = observerRef.current;
 
@@ -152,7 +152,7 @@ export function BentoIframe({
     if (!iframe) {
       return;
     }
-    const win = toWin(iframe.ownerDocument.defaultView);
+    const win = getWin(iframe);
     if (!win) {
       return;
     }

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -4,7 +4,7 @@ import {CSS} from '../../../build/amp-lightbox-1.0.css';
 import {Services} from '#service';
 import {createCustomEvent} from '#utils/event-helper';
 import {isExperimentOn} from '#experiments';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {userAssert} from '#utils/log';
 
 /** @const {string} */
@@ -41,7 +41,7 @@ class AmpLightbox extends BaseElement {
   /** @override */
   triggerEvent(element, eventName, detail) {
     const event = createCustomEvent(
-      toWin(element.ownerDocument.defaultView),
+      getWin(element),
       `amp-lightbox.${eventName}`,
       detail
     );

--- a/extensions/amp-pinterest/0.1/pin-widget.js
+++ b/extensions/amp-pinterest/0.1/pin-widget.js
@@ -1,6 +1,6 @@
 import {Keys} from '#core/constants/key-codes';
 import {measureIntersection} from '#core/dom/layout/intersection';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -32,7 +32,7 @@ export class PinWidget {
       'The data-url attribute is required for Pin widgets'
     );
     this.element = rootElement;
-    this.xhr = Services.xhrFor(toWin(rootElement.ownerDocument.defaultView));
+    this.xhr = Services.xhrFor(getWin(rootElement));
     this.pinId = '';
     this.alt = '';
     this.pinUrl = '';

--- a/extensions/amp-pinterest/0.1/save-button.js
+++ b/extensions/amp-pinterest/0.1/save-button.js
@@ -1,4 +1,4 @@
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -43,7 +43,7 @@ export class SaveButton {
       'The data-description attribute is required for Save buttons'
     );
     this.element = rootElement;
-    this.xhr = Services.xhrFor(toWin(rootElement.ownerDocument.defaultView));
+    this.xhr = Services.xhrFor(getWin(rootElement));
     this.color = rootElement.getAttribute('data-color');
     this.count = rootElement.getAttribute('data-count');
     this.lang = rootElement.getAttribute('data-lang');

--- a/extensions/amp-selector/1.0/amp-selector.js
+++ b/extensions/amp-selector/1.0/amp-selector.js
@@ -1,6 +1,6 @@
 import {ActionTrust} from '#core/constants/action-constants';
 import {dict} from '#core/types/object';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {isExperimentOn} from '#experiments';
 
@@ -52,7 +52,7 @@ class AmpSelector extends BaseElement {
   /** @override */
   triggerEvent(element, eventName, detail) {
     const event = createCustomEvent(
-      toWin(element.ownerDocument.defaultView),
+      getWin(element),
       `amp-selector.${eventName}`,
       detail
     );

--- a/extensions/amp-social-share/1.0/amp-social-share.js
+++ b/extensions/amp-social-share/1.0/amp-social-share.js
@@ -3,7 +3,7 @@ import {Layout} from '#core/dom/layout';
 import {toggle} from '#core/dom/style';
 import {dict} from '#core/types/object';
 import {parseQueryString} from '#core/types/string/url';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {isExperimentOn} from '#experiments';
 
@@ -33,9 +33,7 @@ const DEFAULT_RESPONSIVE_DIMENSIONS = dict({
  */
 const getTypeConfigOrUndefined = (element) => {
   const viewer = Services.viewerForDoc(element);
-  const platform = Services.platformFor(
-    toWin(element.ownerDocument.defaultView)
-  );
+  const platform = Services.platformFor(getWin(element));
   const type = userAssert(
     element.getAttribute('type'),
     'The type attribute is required. %s',

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -12,7 +12,7 @@ import {
   maybeMakeProxyUrl,
 } from './utils';
 import {htmlFor, htmlRefs} from '#core/dom/static-template';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /**
  * @enum {string}
@@ -238,7 +238,7 @@ export const setCustomThemeStyles = (attachmentEl, openAttachmentEl) => {
     'background-color': accentColor,
   });
 
-  const win = toWin(attachmentEl.ownerDocument.defaultView);
+  const win = getWin(attachmentEl);
   const styles = computedStyle(win, attachmentEl);
   const rgb = getRGBFromCssColorValue(styles['background-color']);
   contrastColor = getTextColorForRGB(rgb);

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -19,7 +19,7 @@ import {dev, devAssert} from '#utils/log';
 import {findIndex} from '#core/types/array';
 import {isConnectedNode} from '#core/dom';
 import {matches} from '#core/dom/query';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {userInteractedWith} from '../../../src/video-interface';
 
 /** @const @enum {string} */
@@ -977,7 +977,7 @@ export class MediaPool {
     const newId = String(nextInstanceId++);
     element[POOL_MEDIA_ELEMENT_PROPERTY_NAME] = newId;
     instances[newId] = new MediaPool(
-      toWin(root.getElement().ownerDocument.defaultView),
+      getWin(root.getElement()),
       root.getMaxMediaElementCounts(),
       (element) => root.getElementDistance(element)
     );

--- a/extensions/amp-story/1.0/prerender-active-page.js
+++ b/extensions/amp-story/1.0/prerender-active-page.js
@@ -1,6 +1,6 @@
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
 import {parseQueryString} from '#core/types/string/url';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /**
  * Returns true if the page should be prerendered (for being an active page or
@@ -9,7 +9,7 @@ import {toWin} from '#core/window';
  * @return {boolean}
  */
 export function isPrerenderActivePage(pageElement) {
-  const win = toWin(pageElement.ownerDocument.defaultView);
+  const win = getWin(pageElement);
   const hashId = parseQueryString(win.location.href)['page'];
   let selector = 'amp-story-page:first-of-type';
   if (hashId) {

--- a/extensions/amp-story/1.0/toast.js
+++ b/extensions/amp-story/1.0/toast.js
@@ -1,6 +1,6 @@
 import {Services} from '#service';
 import {createElementWithAttributes, removeElement} from '#core/dom';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /** @private @const {string} */
 const TOAST_CLASSNAME = 'i-amphtml-story-toast';
@@ -27,7 +27,7 @@ export class Toast {
    * @param {!Node|string} childNodeOrText
    */
   static show(storyEl, childNodeOrText) {
-    const win = toWin(storyEl.ownerDocument.defaultView);
+    const win = getWin(storyEl);
 
     const toast = createElementWithAttributes(
       win.document,

--- a/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/1.0/amp-stream-gallery.js
@@ -4,7 +4,7 @@ import {CSS} from '../../../build/amp-stream-gallery-1.0.css';
 import {Services} from '#service';
 import {createCustomEvent} from '#utils/event-helper';
 import {isExperimentOn} from '#experiments';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {userAssert} from '#utils/log';
 
 /** @const {string} */
@@ -40,7 +40,7 @@ class AmpStreamGallery extends BaseElement {
   /** @override */
   triggerEvent(element, eventName, detail) {
     const event = createCustomEvent(
-      toWin(element.ownerDocument.defaultView),
+      getWin(element),
       `amp-stream-gallery.${eventName}`,
       detail
     );

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -2,7 +2,7 @@ import * as Preact from '#preact';
 import {BentoBaseCarousel} from '../../amp-base-carousel/1.0/component';
 import {forwardRef, toChildArray} from '#preact/compat';
 import {setStyle} from '#core/dom/style';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 import {
   useCallback,
   useImperativeHandle,
@@ -86,7 +86,7 @@ function BentoStreamGalleryWithRef(props, ref) {
       return;
     }
     // Use local window.
-    const win = toWin(node.ownerDocument.defaultView);
+    const win = getWin(node);
     if (!win) {
       return undefined;
     }

--- a/extensions/amp-timeago/1.0/component.js
+++ b/extensions/amp-timeago/1.0/component.js
@@ -1,6 +1,6 @@
 import {devAssertElement} from '#core/assert';
 import {getDate} from '#core/types/date';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import * as Preact from '#preact';
 import {useCallback, useRef, useState} from '#preact';
@@ -47,7 +47,7 @@ export function BentoTimeago({
       }
       const node = devAssertElement(ref.current);
       let {lang} = node.ownerDocument.documentElement;
-      const win = toWin(node.ownerDocument?.defaultView);
+      const win = getWin(node);
       if (lang === 'unknown') {
         lang = win.navigator?.language || DEFAULT_LOCALE;
       }

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -2,7 +2,7 @@ import {ActionTrust, DEFAULT_ACTION} from '#core/constants/action-constants';
 import {dispatchCustomEvent} from '#core/dom';
 import {Layout, LayoutPriority} from '#core/dom/layout';
 import {isArray} from '#core/types';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -218,7 +218,7 @@ export class BaseElement {
     this.element = element;
 
     /** @public @const {!Window} */
-    this.win = toWin(element.ownerDocument.defaultView);
+    this.win = getWin(element);
 
     /*
     \   \  /  \  /   / /   \     |   _  \     |  \ |  | |  | |  \ |  |  /  ____|

--- a/src/core/dom/index.js
+++ b/src/core/dom/index.js
@@ -1,7 +1,7 @@
 import * as mode from '#core/mode';
 import {dict} from '#core/types/object';
 import {parseJson} from '#core/types/object/json';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {childElementsByTag, matches} from './query';
 
@@ -38,7 +38,7 @@ export function waitForChild(parent, checkFunc, callback) {
     callback();
     return;
   }
-  const win = toWin(parent.ownerDocument.defaultView);
+  const win = getWin(parent);
   if (mode.isEsm() || win.MutationObserver) {
     const observer = new win.MutationObserver(() => {
       if (checkFunc(parent)) {

--- a/src/core/dom/layout/intersection-no-root.js
+++ b/src/core/dom/layout/intersection-no-root.js
@@ -1,6 +1,6 @@
 import {Deferred} from '#core/data-structures/promise';
 import {createViewportObserver} from '#core/dom/layout/viewport-observer';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /**
  * @fileoverview
@@ -67,7 +67,7 @@ export function measureIntersectionNoRoot(el) {
     return intersectionDeferreds.get(el).promise;
   }
 
-  const inOb = getInOb(toWin(el.ownerDocument.defaultView));
+  const inOb = getInOb(getWin(el));
   inOb.observe(el);
 
   const deferred = new Deferred();

--- a/src/core/dom/layout/intersection.js
+++ b/src/core/dom/layout/intersection.js
@@ -1,6 +1,6 @@
 import {Deferred} from '#core/data-structures/promise';
 import {dict} from '#core/types/object';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {LayoutRectDef, layoutRectFromDomRect} from './rect';
 import {createViewportObserver} from './viewport-observer';
@@ -60,7 +60,7 @@ export function measureIntersection(el) {
     return intersectionDeferreds.get(el).promise;
   }
 
-  const inOb = getInOb(toWin(el.ownerDocument.defaultView));
+  const inOb = getInOb(getWin(el));
   inOb.observe(el);
 
   const deferred = new Deferred();

--- a/src/core/dom/layout/size-observer.js
+++ b/src/core/dom/layout/size-observer.js
@@ -1,7 +1,7 @@
 import {computedStyle} from '#core/dom/style';
 import {tryCallback} from '#core/error';
 import {remove} from '#core/types/array';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {LayoutSizeDef} from './rect';
 
@@ -216,7 +216,7 @@ function computeAndCall(type, callback, entry) {
     } else {
       // `borderBoxSize` is not supported: polyfill it via blocking measures.
       const {target} = entry;
-      const win = toWin(target.ownerDocument.defaultView);
+      const win = getWin(target);
       const isVertical = VERTICAL_RE.test(
         computedStyle(win, target)['writing-mode']
       );

--- a/src/core/dom/layout/viewport-observer.js
+++ b/src/core/dom/layout/viewport-observer.js
@@ -1,6 +1,6 @@
 import {isIframed} from '#core/dom';
 import {removeItem} from '#core/types/array';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /**
  * Returns an IntersectionObserver tracking the Viewport.
@@ -42,7 +42,7 @@ const viewportCallbacks = new WeakMap();
  * @return {!UnlistenDef} clean up closure to unobserve the element
  */
 export function observeIntersections(element, callback) {
-  const win = toWin(element.ownerDocument.defaultView);
+  const win = getWin(element);
   let viewportObserver = viewportObservers.get(win);
   if (!viewportObserver) {
     viewportObservers.set(
@@ -80,7 +80,7 @@ function unobserveIntersections(element, callback) {
     return;
   }
   // If an element has no more observer callbacks, then unobserve it.
-  const win = toWin(element.ownerDocument.defaultView);
+  const win = getWin(element);
   const viewportObserver = viewportObservers.get(win);
   viewportObserver?.unobserve(element);
   viewportCallbacks.delete(element);

--- a/src/core/window/index.js
+++ b/src/core/window/index.js
@@ -11,3 +11,15 @@
 export function toWin(winOrNull) {
   return /** @type {!Window} */ (winOrNull);
 }
+
+/**
+ * Returns the associated Window for a node.
+ *
+ * @param {!Node} node
+ * @return {!Window}
+ */
+export function getWin(node) {
+  return toWin(
+    (node.ownerDocument || /** @type {!Document} */ (node))?.defaultView
+  );
+}

--- a/src/core/window/index.js
+++ b/src/core/window/index.js
@@ -20,6 +20,6 @@ export function toWin(winOrNull) {
  */
 export function getWin(node) {
   return toWin(
-    (node.ownerDocument || /** @type {!Document} */ (node))?.defaultView
+    (node.ownerDocument || /** @type {!Document} */ (node)).defaultView
   );
 }

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -13,7 +13,7 @@ import {MediaQueryProps} from '#core/dom/media-query-props';
 import * as query from '#core/dom/query';
 import {setStyle} from '#core/dom/style';
 import {rethrowAsync} from '#core/error';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 import {ResourceState} from '#service/resource';
@@ -571,7 +571,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
           if (this.actionQueue_) {
             // Only schedule when the queue is not empty, which should be
             // the case 99% of the time.
-            Services.timerFor(toWin(this.ownerDocument.defaultView)).delay(
+            Services.timerFor(getWin(this)).delay(
               this.dequeueActions_.bind(this),
               1
             );
@@ -1167,7 +1167,7 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
 
       if (!this.ampdoc_) {
         // Ampdoc can now be initialized.
-        const win = toWin(this.ownerDocument.defaultView);
+        const win = getWin(this);
         const ampdocService = Services.ampdocServiceFor(win);
         const ampdoc = ampdocService.getAmpDoc(this);
         this.ampdoc_ = ampdoc;

--- a/src/extension-analytics.js
+++ b/src/extension-analytics.js
@@ -2,7 +2,7 @@ import {CommonSignals} from '#core/constants/common-signals';
 import {createElementWithAttributes, removeElement} from '#core/dom';
 import {isArray} from '#core/types';
 import {dict} from '#core/types/object';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -47,9 +47,7 @@ export function insertAnalyticsElement(
   // Force load analytics extension if script not included in page.
   if (loadAnalytics) {
     // Get Extensions service and force load analytics extension.
-    const extensions = Services.extensionsFor(
-      toWin(parentElement.ownerDocument.defaultView)
-    );
+    const extensions = Services.extensionsFor(getWin(parentElement));
     const ampdoc = Services.ampdoc(parentElement);
     extensions./*OK*/ installExtensionForDoc(ampdoc, 'amp-analytics');
   } else {

--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -14,7 +14,7 @@ import {
 } from '#core/dom/style';
 import {rethrowAsync} from '#core/error';
 import * as mode from '#core/mode';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {install as installAbortController} from '#polyfills/abort-controller';
 import {install as installCustomElements} from '#polyfills/custom-elements';
@@ -140,7 +140,7 @@ export function installFriendlyIframeEmbed(
   opt_preinstallCallback // TODO(#22733): remove "window" argument.
 ) {
   /** @const {!Window} */
-  const win = getTopWindow(toWin(iframe.ownerDocument.defaultView));
+  const win = getTopWindow(getWin(iframe));
   /** @const {!./service/extensions-impl.Extensions} */
   const extensionsService = Services.extensionsFor(win);
   /** @const {!./service/ampdoc-impl.AmpDocService} */
@@ -723,7 +723,7 @@ export class Installers {
     opt_installComplete
   ) {
     const childWin = ampdoc.win;
-    const parentWin = toWin(childWin.frameElement.ownerDocument.defaultView);
+    const parentWin = getWin(childWin.frameElement);
     setParentWindow(childWin, parentWin);
     const getDelayPromise = getDelayPromiseProducer();
 

--- a/src/gesture.js
+++ b/src/gesture.js
@@ -1,7 +1,7 @@
 import {Observable} from '#core/data-structures/observable';
 import {supportsPassiveEventListener} from '#core/dom/event-helper-listen';
 import {findIndex} from '#core/types/array';
-import {toWin} from '#core/window';
+import {getWin, toWin} from '#core/window';
 
 import {devAssert} from '#utils/log';
 
@@ -108,10 +108,7 @@ export class Gestures {
     this.wasEventing_ = false;
 
     /** @private {!Pass} */
-    this.pass_ = new Pass(
-      toWin(element.ownerDocument.defaultView),
-      this.doPass_.bind(this)
-    );
+    this.pass_ = new Pass(getWin(element), this.doPass_.bind(this));
 
     /** @private {!Observable} */
     this.pointerDownObservable_ = new Observable();

--- a/src/preact/bento-ce.js
+++ b/src/preact/bento-ce.js
@@ -1,5 +1,5 @@
 import {isEsm} from '#core/mode';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 /**
  * @param {T} klass
@@ -43,7 +43,7 @@ if (typeof AMP !== 'undefined' && AMP.BaseElement) {
       this.element = element;
 
       /** @const {!Window} */
-      this.win = toWin(element.ownerDocument.defaultView);
+      this.win = getWin(element);
     }
 
     /**

--- a/src/service-helpers.js
+++ b/src/service-helpers.js
@@ -5,7 +5,7 @@
  */
 
 import {Deferred} from '#core/data-structures/promise';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {dev, devAssert} from '#utils/log';
 
@@ -301,10 +301,7 @@ export function getParentWindowFrameElement(node, opt_topWin) {
  */
 export function getAmpdoc(nodeOrDoc) {
   if (nodeOrDoc.nodeType) {
-    const win = toWin(
-      /** @type {!Document} */ (nodeOrDoc.ownerDocument || nodeOrDoc)
-        .defaultView
-    );
+    const win = getWin(nodeOrDoc);
     return getAmpdocService(win).getAmpDoc(/** @type {!Node} */ (nodeOrDoc));
   }
   return /** @type {!./service/ampdoc-impl.AmpDoc} */ (nodeOrDoc);

--- a/src/service/action-impl.js
+++ b/src/service/action-impl.js
@@ -11,7 +11,7 @@ import {isFiniteNumber} from '#core/types';
 import {isArray, toArray} from '#core/types/array';
 import {debounce, throttle} from '#core/types/function';
 import {dict, getValueForExpr, hasOwn, map} from '#core/types/object';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -468,7 +468,7 @@ export class ActionService {
     const queuedInvocations = target[ACTION_QUEUE_];
     if (isArray(queuedInvocations)) {
       // Invoke and clear all queued invocations now handler is installed.
-      Services.timerFor(toWin(target.ownerDocument.defaultView)).delay(() => {
+      Services.timerFor(getWin(target)).delay(() => {
         // TODO(dvoytenko, #1260): dedupe actions.
         queuedInvocations.forEach((invocation) => {
           try {

--- a/src/service/navigation.js
+++ b/src/service/navigation.js
@@ -3,7 +3,7 @@ import {isIframed} from '#core/dom';
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
 import {closestAncestorElementBySelector} from '#core/dom/query';
 import {dict} from '#core/types/object';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -445,7 +445,7 @@ export class Navigation {
     }
 
     /** @const {!Window} */
-    const win = toWin(element.ownerDocument.defaultView);
+    const win = getWin(element);
     const url = element.href;
     const {protocol} = location;
 

--- a/src/service/standard-actions-impl.js
+++ b/src/service/standard-actions-impl.js
@@ -3,7 +3,7 @@ import {tryFocus} from '#core/dom';
 import {Layout, getLayoutClass} from '#core/dom/layout';
 import {computedStyle, toggle} from '#core/dom/style';
 import {isFiniteNumber} from '#core/types';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -320,7 +320,7 @@ export class StandardActions {
   handleShow_(invocation) {
     const {node} = invocation;
     const target = dev().assertElement(node);
-    const ownerWindow = toWin(target.ownerDocument.defaultView);
+    const ownerWindow = getWin(target);
 
     if (target.classList.contains(getLayoutClass(Layout.NODISPLAY))) {
       user().warn(
@@ -453,16 +453,6 @@ export class StandardActions {
 
     return null;
   }
-}
-
-/**
- * @param {!Node} node
- * @return {!Window}
- */
-function getWin(node) {
-  return toWin(
-    (node.ownerDocument || /** @type {!Document} */ (node)).defaultView
-  );
 }
 
 /**

--- a/src/shadow-embed.js
+++ b/src/shadow-embed.js
@@ -7,7 +7,7 @@ import {
   isShadowCssSupported,
 } from '#core/dom/web-components';
 import {toArray} from '#core/types/array';
-import {toWin} from '#core/window';
+import {getWin, toWin} from '#core/window';
 
 import {Services} from '#service';
 
@@ -38,7 +38,7 @@ let shadowDomStreamingSupported;
  * @return {!ShadowRoot}
  */
 export function createShadowRoot(hostElement) {
-  const win = toWin(hostElement.ownerDocument.defaultView);
+  const win = getWin(hostElement);
 
   const existingRoot = hostElement.shadowRoot || hostElement.__AMP_SHADOW_ROOT;
   if (existingRoot) {

--- a/src/static-layout.js
+++ b/src/static-layout.js
@@ -10,7 +10,7 @@ import {
 } from '#core/dom/layout';
 import {htmlFor} from '#core/dom/static-template';
 import {setStyle, setStyles, toggle} from '#core/dom/style';
-import {toWin} from '#core/window';
+import {getWin} from '#core/window';
 
 import {isExperimentOn} from '#experiments';
 
@@ -171,7 +171,7 @@ export function applyStaticLayout(element) {
   } else if (layout == Layout.FIXED_HEIGHT) {
     setStyle(element, 'height', devAssertString(height));
   } else if (layout == Layout.RESPONSIVE) {
-    if (shouldUseAspectRatioCss(toWin(element.ownerDocument.defaultView))) {
+    if (shouldUseAspectRatioCss(getWin(element))) {
       setStyle(
         element,
         'aspect-ratio',


### PR DESCRIPTION
**summary**
Priority: low

Small refactor that moves `getWin` into core, and takes advantage of it most places that `toWin` was being used.