### PR TITLE
sxg e2e test: fix outdated check

### DIFF
--- a/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
+++ b/extensions/amp-subscriptions-google/0.1/test-e2e/test-amp-subscriptions-google.js
@@ -44,9 +44,9 @@ describes.endtoend(
         'Basic access charged weekly..'
       );
 
-      const basicAccessPrice = await controller.findElement('.mojnzf');
+      const basicAccessPrice = await controller.findElement('.e02Wob', 130000);
       await expect(controller.getElementText(basicAccessPrice)).to.equal(
-        '$1.99/week*'
+        '$3.98\n$1.99/week*'
       );
     });
   }


### PR DESCRIPTION
**summary**
Sometime over the past 24 hours, sxg e2e has started failing 100% of the time ([example](https://app.circleci.com/pipelines/github/ampproject/amphtml/17462/workflows/85513875-8ce8-49b3-9f22-695909a11513/jobs/319157)).
<img width="1186" alt="Screen Shot 2021-10-08 at 10 26 52 AM" src="https://user-images.githubusercontent.com/4656974/136574390-ddc2c0f8-57b9-45a3-934f-ec350da8280f.png">

**root cause**
The content which the iframe points to has changed. 
To fix, I modified the test to check for the updated content.

**follow ups**
- Why did sxg iframe change? Was this unintentional?
- Are there any other consumers of sxg iframe that are potentially breaking as well?
- How can we prevent this from happening again?

@jpettitt 