### PR TITLE
🏗 Persist test sharding filelist as an artifact on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,6 +148,10 @@ commands:
           path: result-reports
       - store_test_results:
           path: result-reports
+  store_filelist:
+    steps:
+      - store_artifacts:
+          path: /tmp/filelist.txt
   skip_on_push_builds:
     steps:
       - when:
@@ -299,6 +303,7 @@ jobs:
           name: '⭐ All Unit Tests ⭐'
           command: node build-system/pr-check/unit-tests.js
       - store_test_output
+      - store_filelist
       - teardown_vm
   unminified_tests:
     executor:
@@ -354,6 +359,7 @@ jobs:
           name: '⭐ End-to-End Tests ⭐'
           command: node build-system/pr-check/e2e-tests.js
       - store_test_output
+      - store_filelist
       - teardown_vm
   browser_tests_safari:
     executor:
@@ -433,6 +439,7 @@ jobs:
           name: '⭐ Experiment << parameters.exp >> End-to-End Tests ⭐'
           command: node build-system/pr-check/experiment-e2e-tests.js --experiment=experiment<< parameters.exp >>
       - store_test_output
+      - store_filelist
       - teardown_vm
   amp_release:
     executor:

--- a/build-system/pr-check/e2e-tests.js
+++ b/build-system/pr-check/e2e-tests.js
@@ -5,7 +5,7 @@
  */
 
 const {
-  TEST_FILES_LIST_FILE_NAME,
+  FILELIST_PATH,
   generateCircleCiShardTestFileList,
   skipDependentJobs,
   timedExecOrDie,
@@ -24,7 +24,7 @@ function pushBuildWorkflow() {
   try {
     generateCircleCiShardTestFileList(e2eTestPaths);
     timedExecOrThrow(
-      `amp e2e --nobuild --headless --minified --report --filelist ${TEST_FILES_LIST_FILE_NAME}`,
+      `amp e2e --nobuild --headless --minified --report --filelist ${FILELIST_PATH}`,
       'End-to-end tests failed!'
     );
   } catch (e) {
@@ -43,7 +43,7 @@ function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.E2E_TEST)) {
     generateCircleCiShardTestFileList(e2eTestPaths);
     timedExecOrDie(
-      `amp e2e --nobuild --headless --minified --filelist ${TEST_FILES_LIST_FILE_NAME}`
+      `amp e2e --nobuild --headless --minified --filelist ${FILELIST_PATH}`
     );
   } else {
     skipDependentJobs(

--- a/build-system/pr-check/experiment-e2e-tests.js
+++ b/build-system/pr-check/experiment-e2e-tests.js
@@ -5,7 +5,7 @@
  */
 
 const {
-  TEST_FILES_LIST_FILE_NAME,
+  FILELIST_PATH,
   generateCircleCiShardTestFileList,
   skipDependentJobs,
   timedExecOrDie,
@@ -31,7 +31,7 @@ function runExperimentTests(config) {
     const reportFlag = isPushBuild() ? '--report' : '';
     generateCircleCiShardTestFileList(e2eTestPaths);
     timedExecOrThrow(
-      `amp e2e --nobuild --minified --headless ${experimentFlag} ${defineFlag} ${reportFlag} --filelist ${TEST_FILES_LIST_FILE_NAME}`
+      `amp e2e --nobuild --minified --headless ${experimentFlag} ${defineFlag} ${reportFlag} --filelist ${FILELIST_PATH}`
     );
   } catch (e) {
     if (e.status) {

--- a/build-system/pr-check/unit-tests.js
+++ b/build-system/pr-check/unit-tests.js
@@ -5,7 +5,7 @@
  */
 
 const {
-  TEST_FILES_LIST_FILE_NAME,
+  FILELIST_PATH,
   generateCircleCiShardTestFileList,
   skipDependentJobs,
   timedExecOrDie,
@@ -24,7 +24,7 @@ function pushBuildWorkflow() {
   try {
     generateCircleCiShardTestFileList(unitTestPaths);
     timedExecOrThrow(
-      `amp unit --headless --coverage --report --filelist ${TEST_FILES_LIST_FILE_NAME}`,
+      `amp unit --headless --coverage --report --filelist ${FILELIST_PATH}`,
       'Unit tests failed!'
     );
     timedExecOrThrow(
@@ -47,7 +47,7 @@ function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.UNIT_TEST)) {
     generateCircleCiShardTestFileList(unitTestPaths);
     timedExecOrDie(
-      `amp unit --headless --coverage --filelist ${TEST_FILES_LIST_FILE_NAME}`
+      `amp unit --headless --coverage --filelist ${FILELIST_PATH}`
     );
     timedExecOrDie('amp codecov-upload');
   } else {

--- a/build-system/pr-check/utils.js
+++ b/build-system/pr-check/utils.js
@@ -30,7 +30,7 @@ const MODULE_CONTAINER_DIRECTORY = 'module';
 
 const ARTIFACT_DIRECTORY = '/tmp/artifacts/';
 const ARTIFACT_FILE_NAME = `${ARTIFACT_DIRECTORY}/amp_nomodule_build.tar.gz`;
-const TEST_FILES_LIST_FILE_NAME = '/tmp/testfiles.txt';
+const FILELIST_PATH = '/tmp/filelist.txt';
 
 const BUILD_OUTPUT_DIRS = ['build', 'dist', 'dist.3p', 'dist.tools'];
 const APP_SERVING_DIRS = [
@@ -327,17 +327,17 @@ function generateCircleCiShardTestFileList(globs) {
   )
     .trim()
     .replace(/\s+/g, ',');
-  fs.writeFileSync(TEST_FILES_LIST_FILE_NAME, fileList, 'utf8');
+  fs.writeFileSync(FILELIST_PATH, fileList, 'utf8');
   logWithoutTimestamp(
     'Stored list of',
     cyan(fileList.split(',').length),
     'test files in',
-    cyan(TEST_FILES_LIST_FILE_NAME)
+    cyan(FILELIST_PATH)
   );
 }
 
 module.exports = {
-  TEST_FILES_LIST_FILE_NAME,
+  FILELIST_PATH,
   abortTimedJob,
   printChangeSummary,
   skipDependentJobs,


### PR DESCRIPTION
**Highlights:**
- Persist the test sharding filelist used during E2E and unit tests as a CircleCI artifact
- Rename the value of the `--filelist` argument from `TEST_FILES_LIST_FILE_NAME` to `FILELIST_PATH` for simplicity

[**Results:**](https://app.circleci.com/pipelines/github/ampproject/amphtml/17490/workflows/6a133921-3d69-47b4-bf3b-96f289eef645/jobs/319800/artifacts)

![image](https://user-images.githubusercontent.com/26553114/136596809-ecb0c456-c9c2-4ab5-ae20-21f8d62d6370.png)


Implements https://github.com/ampproject/amphtml/issues/35580#issuecomment-895587167