### PR TITLE
🏗  Fix npm publishing

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -38,6 +38,8 @@ jobs:
           ref: ${{ github.events.inputs.ampversion }}
       - uses: actions/setup-node@v2
         with:
+          check-latest: true
+          registry-url: https://registry.npmjs.org
           node-version: lts/*
       - name: Get latest scripts
         run: |


### PR DESCRIPTION
Accidentally removed setup needed to publish to npm in https://github.com/ampproject/amphtml/commit/16822652135a855e1ac6bdf9df74de08c0917efe and the github action had been failing since 😂 