### PR TITLE
🏗 Sync client-side-experiments-config.json to the CDN

### DIFF
--- a/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
+++ b/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
@@ -1,4 +1,4 @@
-name: Sync configuration to the CDN
+name: CDN config sync
 
 on:
   push:

--- a/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
+++ b/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - build-system/global-configs/client-side-experiments-config.json
-  pull_request:  # DO NOT MERGE
 
 jobs:
   sync:

--- a/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
+++ b/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
@@ -1,0 +1,36 @@
+name: Sync configuration to the CDN
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - build-system/global-configs/client-side-experiments-config.json
+  pull_request:  # DO NOT MERGE
+
+jobs:
+  sync:
+    if: github.repository == 'ampproject/amphtml'
+    name: client-side-experiments-config.json
+    runs-on: ubuntu-latest
+    environment: wrangler
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Install Dependencies
+        run: npm i -g @cloudflare/wrangler
+
+      - run: echo ${{ secrets.CF_API_TOKEN }} | wrangler config
+        env:
+          RUST_LOG: debug
+
+      - name: ⭐ Sync client-side-experiments-config.json to the CDN ⭐
+        run: wrangler kv:key put AMP_EXP "$(cat build-system/global-configs/client-side-experiments-config.json)" --config .github/workflows/wrangler.toml --binding AMP_EXP
+        env:
+          RUST_LOG: debug
+          # CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          # CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
+++ b/.github/workflows/sync-client-side-experiments-config-to-cdn.yml
@@ -24,13 +24,8 @@ jobs:
       - name: Install Dependencies
         run: npm i -g @cloudflare/wrangler
 
-      - run: echo ${{ secrets.CF_API_TOKEN }} | wrangler config
-        env:
-          RUST_LOG: debug
-
       - name: ⭐ Sync client-side-experiments-config.json to the CDN ⭐
         run: wrangler kv:key put AMP_EXP "$(cat build-system/global-configs/client-side-experiments-config.json)" --config .github/workflows/wrangler.toml --binding AMP_EXP
         env:
-          RUST_LOG: debug
-          # CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          # CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/.github/workflows/wrangler.toml
+++ b/.github/workflows/wrangler.toml
@@ -1,0 +1,11 @@
+name = "cdn-worker"
+type = "javascript"
+zone_id = ""
+account_id = "78e1d5140b47fc9dab18dc8b25351b7a"
+compatibility_date = "2021-10-08"
+route = ""
+workers_dev = true
+kv_namespaces = [
+  { binding = "RTV", id = "f33b97f2e1434004975c0d8553f70488", preview_id = "192df3dff1b345ce8e7c794329bb7ccd" },
+  { binding = "AMP_EXP", id = "b03e5db05f3e4d068508da267e248949", preview_id = "69318ded67c0477b85d73ec801b47543" }
+]


### PR DESCRIPTION
Example of this running: https://github.com/ampproject/amphtml/pull/36308/checks?check_run_id=3842831917
(I removed the trigger on `pull_request` in 695215e)