### PR TITLE
bento iframe: small test improvement

### DIFF
--- a/extensions/amp-iframe/1.0/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/1.0/test/test-amp-iframe.js
@@ -16,8 +16,11 @@ describes.realWin(
 
     async function waitRendered() {
       await whenUpgradedToCustomElement(element);
-      await element.buildInternal();
-      await waitFor(() => element.isConnected, 'element connected');
+      await element.mount();
+      await waitFor(
+        () => element.shadowRoot.querySelector('iframe'),
+        'iframe rendered'
+      );
     }
 
     beforeEach(() => {
@@ -34,9 +37,11 @@ describes.realWin(
       doc.body.appendChild(element);
 
       await waitRendered();
+      const iframe = element.shadowRoot.querySelector('iframe');
 
       expect(element.parentNode).to.equal(doc.body);
       expect(element.getAttribute('src')).to.equal('https://www.wikipedia.org');
+      expect(iframe.getAttribute('src')).to.equal('https://www.wikipedia.org');
     });
   }
 );


### PR DESCRIPTION
**summary**
A few small improvements to the `amp-iframe` tests:

1. Tests for the rendered iframe via shadowRoot.querySelector. This IMO is the most important part of the test.
1. Use `mount` instead of `buildInternal`. Since we have a public API to use that roughly does an equivalent, we should always prefer it.