### PR TITLE
Ensures Story Player always uses /v/.

### DIFF
--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -1317,12 +1317,14 @@ export class AmpStoryPlayer {
   maybeGetCacheUrl_(url) {
     const ampCache = this.element_.getAttribute('amp-cache');
 
-    if (
-      !ampCache ||
-      isProxyOrigin(url) ||
-      !SUPPORTED_CACHES.includes(ampCache)
-    ) {
+    if (!ampCache || !SUPPORTED_CACHES.includes(ampCache)) {
       return Promise.resolve(url);
+    }
+
+    if (isProxyOrigin(url)) {
+      // Ensures serving type is 'viewer' (/v/) when publishers provide their
+      // own cached URL.
+      return Promise.resolve(url.replace('/c/', '/v/'));
     }
 
     return ampToolboxCacheUrl


### PR DESCRIPTION
AMP Story Player configured with `<amp-story-player cache="cdn.ampproject.org"` will always get a cached URL with `/v/` and `amp_js_v` parameter.

However, if a publisher specifies their own cached URL, it could contain `/c/`, and we would add a `amp_js_v` parameter to it.
This PR replaces `/c/` with `/v/` when publishers provide their own URL, so the Player can only produce `/v/` + `amp_js_v` URLs.

cc @ampproject/wg-stories 