### PR TITLE
🏗 Pin Chrome version used during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,11 @@ commands:
             - workspace
   install_chrome:
     steps:
+      - run:
+          name: 'Get Pinned Chrome Version'
+          command: ./.circleci/get_pinned_chrome_version.sh
       - browser-tools/install-chrome:
+          chrome-version: ${CHROME_VERSION}
           replace-existing: true
       - browser-tools/install-chromedriver
   install_firefox:

--- a/.circleci/get_pinned_chrome_version.sh
+++ b/.circleci/get_pinned_chrome_version.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#
+# Script used to determine the pinned version of Google Chrome on CircleCI.
+
+set -e
+
+GREEN() { echo -e "\033[0;32m$1\033[0m"; }
+RED() { echo -e "\033[0;31m$1\033[0m"; }
+CYAN() { echo -e "\033[0;36m$1\033[0m"; }
+
+# Extract the chromedriver version used by AMP's E2E tests
+# See https://www.npmjs.com/package/chromedriver
+echo "$(GREEN "Extracting Chromedriver version from") $(CYAN "build-system/tasks/e2e/package.json")$(GREEN "...")"
+CHROMEDRIVER_VERSION="$(cat build-system/tasks/e2e/package.json | jq -r .devDependencies.chromedriver)"
+if [[ -z "$CHROMEDRIVER_VERSION" ]]; then
+  echo "$(RED "Could not extract Chromedriver version from") $(CYAN "build-system/tasks/e2e/package.json"))"
+  exit 1
+fi
+echo "$(GREEN "Chromedriver version is") $(CYAN "${CHROMEDRIVER_VERSION}")"
+
+# Determine the Chrome major version to be installed
+echo "$(GREEN "Determining Chrome major version...")"
+CHROME_MAJOR_VERSION="$(echo $CHROMEDRIVER_VERSION | cut -d'.' -f1)"
+if [[ -z "$CHROME_MAJOR_VERSION" ]]; then
+  echo "$(RED "Could not determine Chrome major version")"
+  exit 1
+fi
+echo "$(GREEN "Chrome major version is") $(CYAN "${CHROME_MAJOR_VERSION}")"
+
+# Determine the Chrome version history URL based on the platform identifier
+# See https://developer.chrome.com/docs/versionhistory/reference/#platform-identifiers
+echo "$(GREEN "Determining Chrome version history URL...")"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  PLATFORM_IDENTIFIER="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  PLATFORM_IDENTIFIER="mac"
+elif [[ "$OSTYPE" == "win32" ]]; then
+  PLATFORM_IDENTIFIER="win"
+else
+  echo "$(RED "Incompatible OS") $(CYAN "${OSTYPE}")"
+  exit 1
+fi
+CHROME_VERSION_HISTORY_URL="https://versionhistory.googleapis.com/v1/chrome/platforms/${PLATFORM_IDENTIFIER}/channels/stable/versions"
+echo "$(GREEN "Chrome version history URL is") $(CYAN "${CHROME_VERSION_HISTORY_URL}")"
+
+# Determine the Chrome version
+# See https://developer.chrome.com/docs/versionhistory/guide
+echo "$(GREEN "Determining Chrome version...")"
+CHROME_VERSION="$(curl -sS ${CHROME_VERSION_HISTORY_URL} | jq -r ".versions[]|.version" | grep -m 1 "${CHROME_MAJOR_VERSION}\.")"
+if [[ -z "$CHROME_VERSION" ]]; then
+  echo "$(RED "Could not determine Chrome version")"
+  exit 1
+fi
+echo "$(GREEN "Chrome version is") $(CYAN "${CHROME_VERSION}")"
+
+echo "export CHROME_VERSION=$CHROME_VERSION" >> $BASH_ENV
+echo $(GREEN "Successfully determined pinned version of Chrome")

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -25,6 +25,14 @@
       "automerge": true
     },
     {
+      "groupName": "chrome and chromedriver",
+      "matchFiles": ["build-system/tasks/e2e/package.json"],
+      "matchPackageNames": ["chromedriver"],
+      "labels": ["WG: infra"],
+      "rebaseWhen": "never",
+      "automerge": true
+    },
+    {
       "groupName": "build-system devDependencies",
       "matchPaths": ["build-system/**"],
       "labels": ["WG: infra"],


### PR DESCRIPTION
This PR pins the Chrome version used during CI so that a new browser release cannot inadvertently break tests.

**Highlights:**

- Extract major version of the [`chromedriver`](https://www.npmjs.com/package/chromedriver) npm package used by the E2E tests
- Determine the latest Chrome release matching that version from versionhistory.googleapis.com
- Configure Renovate to auto-update it whenever a new version of Chrome is released

With this PR, when Chrome 95 is released and the `chromedriver` npm package is updated, a new renovate PR will be generated to test our CI systems with the new version. Until then, existing CI builds will continue to use Chrome 94.

**Screenshots:**

**Pinned to v93:** [logs](https://app.circleci.com/pipelines/github/ampproject/amphtml/17698/workflows/805964e7-a6d3-49d0-82df-93aba16b5e1c/jobs/325076?invite=true#step-113-8)

![image](https://user-images.githubusercontent.com/26553114/137211174-f9d02d90-f414-4a54-bf95-cc23bc327b11.png)
![image](https://user-images.githubusercontent.com/26553114/137211191-7ef2f21d-aefb-4b5c-806a-a7cd0915efc9.png)


**Pinned to v94:** [logs](https://app.circleci.com/pipelines/github/ampproject/amphtml/17701/workflows/bcd97045-e83c-4105-ad08-707b6b3a8cb9/jobs/325126?invite=true#step-113-10)

![image](https://user-images.githubusercontent.com/26553114/137211080-96968dff-909d-425c-acb3-803409c2fd1e.png)
![image](https://user-images.githubusercontent.com/26553114/137211137-6db0ad72-dcf4-4e54-9f14-40dcac9c16ea.png)


Implements https://github.com/ampproject/amphtml/pull/36205#issuecomment-930556603