### PR TITLE
Do not disable clicking for 3p sticky ads

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -195,21 +195,6 @@ export class AmpAdXOriginIframeHandler {
       )
     );
 
-    if (this.uiHandler_.isStickyAd()) {
-      setStyle(iframe, 'pointer-events', 'none');
-      this.unlisteners_.push(
-        listenFor(
-          this.iframe,
-          'signal-interactive',
-          () => {
-            setStyle(iframe, 'pointer-events', 'auto');
-          },
-          true,
-          true
-        )
-      );
-    }
-
     this.unlisteners_.push(
       this.baseInstance_.getAmpDoc().onVisibilityChanged(() => {
         this.sendEmbedInfo_(this.inViewport_);


### PR DESCRIPTION
This is the reason why 3p sticky ads are not clickable. This is intended to prevent misclicks from sidekick ads while motion is still ongoing. Will explore some better ways of doing it for regular sticky ads (maybe block clicks right after requestResize).