### PR TITLE
🐛 [story-ads] Fix yellow chip in `supports-landscape` mode.

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -185,7 +185,7 @@
   background-color: #fbc02d !important;
   height: 100% !important;
   position: relative !important;
-  top: -2px !important;
+  top: -100% !important;
   transform-origin: left !important;
   width: 100% !important;
 }


### PR DESCRIPTION
The height of the progress chip is `3px` instead of `2px` in supports landscape mode. Switch to `100%` so that the CSS handles both correctly.

Closes https://github.com/ampproject/amphtml/issues/36336