### PR TITLE
📖  amp-analytics: Change documentation link for `top100`

### DIFF
--- a/extensions/amp-analytics/analytics-vendors-list.md
+++ b/extensions/amp-analytics/analytics-vendors-list.md
@@ -575,7 +575,7 @@ Adds support for Tealium Collect. More details for adding Tealium Collect suppor
 
 Type attribute value: `top100`
 
-Adds support for Rambler/TOP-100. Configuration details can be found at [top100.rambler.ru](https://top100.rambler.ru).
+Adds support for Rambler/TOP-100. Configuration details can be found at [Top100 Documentation](https://top-100-writer.gitbook.io/top100-documentation/amp-i-turbo-stranicy/podderzhka-amp).
 
 ### Top.Mail.Ru
 


### PR DESCRIPTION
We updated our documentation and changed link. In this PR we correct link for amp settings.
