### PR TITLE
🐛 Fix top sticky ad auto hiding on fast fetch networks and bottom sticky css

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/amp-ad-xorigin-iframe-handler.js
@@ -457,7 +457,7 @@ export class AmpAdXOriginIframeHandler {
             } else {
               this.lastRejectedResizeTime_ = 0;
             }
-            this.uiHandler_.onResizeSuccess();
+            this.uiHandler_.adjustPadding();
             this.sendEmbedSizeResponse_(
               info.success,
               id,

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -118,18 +118,6 @@ amp-ad[sticky='left'] .amp-ad-close-button {
   left: 0;
 }
 
-amp-ad-sticky-padding {
-  display: block;
-  width: 100% !important;
-  background: #fff;
-  height: 4px;
-  max-height: 5px !important;
-  overflow-x: hidden;
-  overflow-y: hidden;
-  /** Must be above the dismiss button to cover bottom shadow */
-  z-index: 12;
-}
-
 amp-ad[sticky] {
   z-index: 11;
   position: fixed;
@@ -153,7 +141,7 @@ amp-ad[sticky='bottom'] {
   padding-bottom: env(safe-area-inset-bottom, 0px);
   background: #fff;
   bottom: 0;
-  padding-top: 5px;
+  padding-top: 4px;
 }
 
 amp-ad[sticky='bottom-right'] {

--- a/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-ui.js
@@ -326,9 +326,9 @@ describes.realWin(
           .not.null;
       });
 
-      it('onResizeSuccess top sticky ads shall cause padding top adjustment', () => {
+      it('top sticky ads shall cause scroll trigger', () => {
         uiHandler.stickyAdPosition_ = 'top';
-        uiHandler.onResizeSuccess();
+        uiHandler.maybeInitStickyAd();
         expect(uiHandler.topStickyAdScrollListener_).to.not.be.undefined;
       });
 

--- a/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
+++ b/extensions/amp-ad/0.1/test/test-amp-ad-xorigin-iframe-handler.js
@@ -43,7 +43,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
     };
     document.body.appendChild(adElement);
     adImpl.uiHandler = new AmpAdUIHandler(adImpl);
-    adImpl.uiHandler.onResizeSuccess = env.sandbox.spy();
+    adImpl.uiHandler.adjustPadding = env.sandbox.spy();
     iframeHandler = new AmpAdXOriginIframeHandler(adImpl);
     testIndex++;
 
@@ -445,7 +445,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
             type: 'embed-size-changed',
             sentinel: 'amp3ptest' + testIndex,
           });
-          expect(adImpl.uiHandler.onResizeSuccess).to.be.called;
+          expect(adImpl.uiHandler.adjustPadding).to.be.called;
         });
     });
 
@@ -471,7 +471,7 @@ describes.sandboxed('amp-ad-xorigin-iframe-handler', {}, (env) => {
             type: 'embed-size-changed',
             sentinel: 'amp3ptest' + testIndex,
           });
-          expect(adImpl.uiHandler.onResizeSuccess).to.be.called;
+          expect(adImpl.uiHandler.adjustPadding).to.be.called;
         });
     });
 


### PR DESCRIPTION
On fast fetch networks, onResizeSuccess will not run and the logic will not be triggered correctly.

In addition, it fixes the off-by-one-pixel that offsets the ads by 4 pixels.
![Screen Shot 2021-10-15 at 17 41 11](https://user-images.githubusercontent.com/1321403/137567446-35489bb3-5e0d-4665-8c6a-b9a0ae36ee74.jpg)
![Screen Shot 2021-10-15 at 17 41 22](https://user-images.githubusercontent.com/1321403/137567447-cff9ad53-7648-4522-aaf0-d4a55077a86c.jpg)


