### PR TITLE
🐛[story-ads] Fix missing timestamps in analytics

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/story-ad-page-manager.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page-manager.js
@@ -88,11 +88,11 @@ export class StoryAdPageManager {
    * Called when ad has failed or been placed and we should move to next ad.
    */
   discardCurrentAd() {
+    this.adsConsumed_++;
     this.analyticsEvent_(AnalyticsEvents.AD_DISCARDED, {
       [AnalyticsVars.AD_INDEX]: this.adsConsumed_,
       [AnalyticsVars.AD_DISCARDED]: Date.now(),
     });
-    this.adsConsumed_++;
   }
 
   /**
@@ -216,11 +216,11 @@ export class StoryAdPageManager {
    *
    */
   currentAdInserted_() {
+    this.adsConsumed_++;
     this.analyticsEvent_(AnalyticsEvents.AD_INSERTED, {
       [AnalyticsVars.AD_INDEX]: this.adsConsumed_,
       [AnalyticsVars.AD_INSERTED]: Date.now(),
     });
-    this.adsConsumed_++;
   }
 
   /**


### PR DESCRIPTION
Story ads save a timestamp for ad lifecycle events that are exposed as analytics vars. Certain call sites (`story-ad-inserted`, `story-ad-discarded`) had an off-by-one error causing them to not be correctly associated with their correct timestamps from previous lifecycle events.