### PR TITLE
migrate builder types to array instead of map

### DIFF
--- a/src/compiler/builders.js
+++ b/src/compiler/builders.js
@@ -20,11 +20,10 @@ export function getBuilders(versions) {
   /** @type {import('./types').BuilderMap} */
   const builders = {};
 
-  for (const tag of Object.keys(versions)) {
-    const version = versions[tag];
-    const builder = builderMap?.[version]?.[tag];
+  for (const {component, version} of versions) {
+    const builder = builderMap?.[version]?.[component];
     if (builder) {
-      builders[tag] = builder;
+      builders[component] = builder;
     }
   }
 

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -16,7 +16,9 @@ function compile(request) {
     tree: [{tagid: 92, children: []}],
     'quirks_mode': false,
   };
-  const versions = request.versions ?? {'amp-layout': 'v0'};
+  const versions = request.versions ?? [
+    {component: 'amp-layout', version: 'v0'},
+  ];
 
   return {document: compiler.renderAst(document, getBuilders(versions))};
 }

--- a/src/compiler/types.d.ts
+++ b/src/compiler/types.d.ts
@@ -16,7 +16,7 @@ export type BuildDom = (Element) => void;
 /**
  * Contains component versioning data via a map from tagName --> version.
  */
-export type Versions = {[tagName: string]: string};
+export type Versions = Array<{component: string; version: string}>;
 
 export type CompilerRequest = {document: TreeProto; versions: Versions};
 

--- a/test/unit/compiler/test-builders.js
+++ b/test/unit/compiler/test-builders.js
@@ -2,24 +2,27 @@ import {getBuilders} from '#compiler/builders';
 
 describes.sandboxed('getBuilders', {}, () => {
   it('should return an empty list for empty component list', () => {
-    const components = {};
+    const components = [];
     expect(getBuilders(components)).to.eql({});
   });
 
   it('should return eligible builtins when provided them as components', () => {
-    const components = {'amp-layout': 'v0'};
+    const components = [{component: 'amp-layout', version: 'v0'}];
     const builders = getBuilders(components);
     expect(builders).have.all.keys(['amp-layout']);
   });
 
   it('eligible component with ineligible version is not used', () => {
-    const components = {'amp-fit-text': '1.0'};
+    const components = [{component: 'amp-fit-text', version: '1.0'}];
     const builders = getBuilders(components);
     expect(builders).to.eql({});
   });
 
   it('should return eligible components', () => {
-    const components = {'amp-fit-text': '0.1', 'amp-layout': 'v0'};
+    const components = [
+      {component: 'amp-fit-text', version: '0.1'},
+      {component: 'amp-layout', version: 'v0'},
+    ];
     const builders = getBuilders(components);
     expect(builders).have.all.keys(['amp-layout', 'amp-fit-text']);
   });


### PR DESCRIPTION
**summary**
Migrate ComponentVersion to be of type `Array<{component, version}>`, which plays a bit better with proto.
