### PR TITLE
🏗 Derive `ava` target paths

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -13,6 +13,7 @@ const {cyan} = require('kleur/colors');
 const {getLoggingPrefix, logWithoutTimestamp} = require('../common/logging');
 const {gitDiffNameOnlyMain} = require('../common/git');
 const {isCiBuild} = require('../common/ci');
+const {shouldTriggerAva} = require('../tasks/ava');
 
 /**
  * Used to prevent the repeated recomputing of build targets during PR jobs.
@@ -112,16 +113,7 @@ const targetMatchers = {
     if (isOwnersFile(file)) {
       return false;
     }
-    return (
-      file == 'build-system/tasks/ava.js' ||
-      file.startsWith('build-system/release-tagger/') ||
-      file.startsWith('build-system/server/') ||
-      file.startsWith('build-system/tasks/css/') ||
-      file.startsWith('build-system/tasks/get-zindex/') ||
-      file.startsWith('build-system/tasks/make-extension/') ||
-      file.startsWith('build-system/tasks/markdown-toc/') ||
-      file.startsWith('build-system/tasks/prepend-global/')
-    );
+    return shouldTriggerAva(file);
   },
   [Targets.BABEL_PLUGIN]: (file) => {
     if (isOwnersFile(file)) {

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -34,10 +34,7 @@ function shouldTriggerAva(changedFile) {
   }
   if (!testedDirs) {
     testedDirs = testFiles.map(
-      (pattern) =>
-        dirname(pattern)
-          .replace(/\/test\/?$/, '')
-          .replace(/\/$/, '') + '/'
+      (pattern) => dirname(pattern).replace(/\/test$/, '') + '/'
     );
   }
   return testedDirs.some((pattern) => changedFile.startsWith(pattern));

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -1,25 +1,53 @@
 'use strict';
 
 const argv = require('minimist')(process.argv.slice(2));
+const {dirname, relative} = require('path');
 const {execOrDie} = require('../common/exec');
+
+const testFiles = [
+  'build-system/release-tagger/test/*test*.js',
+  'build-system/server/app-index/test/*test*.js',
+  'build-system/server/test/app-utils.test.js',
+  'build-system/tasks/css/test/bento-css.test.js',
+  'build-system/tasks/get-zindex/get-zindex.test.js',
+  'build-system/tasks/make-extension/test/test.js',
+  'build-system/tasks/markdown-toc/test/test.js',
+  'build-system/tasks/prepend-global/prepend-global.test.js',
+];
+
+let thisFile;
+let testedDirs;
+
+/**
+ * Determines whether to trigger ava by a file change adjacent to a test file.
+ * Considered adjacent when the file changed is in the same directory as one of
+ * the listed test files, or its parent if the directory is named `test`.
+ * @param {string} changedFile
+ * @return {boolean}
+ */
+function shouldTriggerAva(changedFile) {
+  if (!thisFile) {
+    thisFile = relative(process.cwd(), __filename);
+  }
+  if (changedFile === thisFile) {
+    return true;
+  }
+  if (!testedDirs) {
+    testedDirs = testFiles.map(
+      (pattern) =>
+        dirname(pattern)
+          .replace(/\/test\/?$/, '')
+          .replace(/\/$/, '') + '/'
+    );
+  }
+  return testedDirs.some((pattern) => changedFile.startsWith(pattern));
+}
 
 /**
  * Runs ava tests.
  * @return {Promise<void>}
  */
 async function ava() {
-  // These need equivalents for CI in build-system/pr-check/build-targets.js
-  // (see targetMatchers[Targets.AVA])
-  const testFiles = [
-    'build-system/release-tagger/test/*test*.js',
-    'build-system/server/app-index/test/*test*.js',
-    'build-system/server/test/app-utils.test.js',
-    'build-system/tasks/css/test/bento-css.test.js',
-    'build-system/tasks/get-zindex/get-zindex.test.js',
-    'build-system/tasks/make-extension/test/test.js',
-    'build-system/tasks/markdown-toc/test/test.js',
-    'build-system/tasks/prepend-global/prepend-global.test.js',
-  ];
   execOrDie(
     [
       'npx ava',
@@ -32,6 +60,7 @@ async function ava() {
 
 module.exports = {
   ava,
+  shouldTriggerAva,
 };
 
 ava.description = "Run ava tests for AMP's tasks";

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -3,6 +3,7 @@
 const argv = require('minimist')(process.argv.slice(2));
 const {dirname, relative} = require('path');
 const {execOrDie} = require('../common/exec');
+const {sync: globbySync} = require('globby');
 
 const testFiles = [
   'build-system/release-tagger/test/*test*.js',
@@ -16,7 +17,7 @@ const testFiles = [
 ];
 
 let thisFile;
-let testedDirs;
+let targetFiles;
 
 /**
  * Determines whether to trigger ava by a file change adjacent to a test file.
@@ -32,12 +33,13 @@ function shouldTriggerAva(changedFile) {
   if (changedFile === thisFile) {
     return true;
   }
-  if (!testedDirs) {
-    testedDirs = testFiles.map(
+  if (!targetFiles) {
+    const targetFilePatterns = testFiles.map(
       (pattern) => dirname(pattern).replace(/\/test$/, '') + '/'
     );
+    targetFiles = new Set(globbySync(targetFilePatterns));
   }
-  return testedDirs.some((pattern) => changedFile.startsWith(pattern));
+  return targetFiles.has(changedFile);
 }
 
 /**

--- a/build-system/tasks/ava.js
+++ b/build-system/tasks/ava.js
@@ -16,7 +16,6 @@ const testFiles = [
   'build-system/tasks/prepend-global/prepend-global.test.js',
 ];
 
-let thisFile;
 let targetFiles;
 
 /**
@@ -27,17 +26,12 @@ let targetFiles;
  * @return {boolean}
  */
 function shouldTriggerAva(changedFile) {
-  if (!thisFile) {
-    thisFile = relative(process.cwd(), __filename);
-  }
-  if (changedFile === thisFile) {
-    return true;
-  }
   if (!targetFiles) {
-    const targetFilePatterns = testFiles.map(
+    const thisFile = relative(process.cwd(), __filename);
+    const patterns = testFiles.map(
       (pattern) => dirname(pattern).replace(/\/test$/, '') + '/'
     );
-    targetFiles = new Set(globbySync(targetFilePatterns));
+    targetFiles = new Set([thisFile, ...globbySync(patterns)]);
   }
   return targetFiles.has(changedFile);
 }


### PR DESCRIPTION
Derive directories that should trigger `amp ava` tests based on the test files location.

This prevents us from accidentally submitting new test files without a matching target directory (like I had to fix on 596fe2d6c).

Directories are the same as the test file, or its parent if the directory is named `test`. This matches the same of file set as before.