### PR TITLE
🚮 [amp story 360] Remove unnecessary .then statement

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -665,7 +665,6 @@ export class AmpStory360 extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    console.log('layoutCallback');
     const ampImgEl = this.element.querySelector('amp-img');
     // Used to update the video in animate_.
     this.ampVideoEl_ = this.element.querySelector('amp-video');


### PR DESCRIPTION
The promise.all resolves when the services's promises resolve. 
There is no need for the additional `.then`.