### PR TITLE
🏗 Add JSON schema for visual-tests and rename file to .jsonc extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,6 +49,10 @@
     {
       "fileMatch": ["build-system/tasks/bundle-size/filesize.json"],
       "url": "./build-system/json-schemas/filesize.json"
+    },
+    {
+      "fileMatch": ["test/visual-diff/visual-tests.jsonc"],
+      "url": "./build-system/json-schemas/visual-tests.json"
     }
   ]
 }

--- a/build-system/json-schemas/visual-tests.json
+++ b/build-system/json-schemas/visual-tests.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Visual tests JSON config",
+  "type": "object",
+  "required": [
+    "webpages"
+  ],
+  "properties": {
+    "webpages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "url",
+          "name"
+        ],
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "loading_incomplete_selectors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "loading_complete_selectors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "loading_complete_delay_ms": {
+            "type": "number",
+            "exclusiveMinimum": 0
+          },
+          "viewport": {
+            "type": "object",
+            "required": [
+              "width",
+              "height"
+            ],
+            "properties": {
+              "width": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              },
+              "height": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              }
+            },
+            "additionalProperties": false
+          },
+          "interactive_tests": {
+            "type": "string"
+          },
+          "flaky": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "enable_percy_javascript": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "no_base_test": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -206,7 +206,8 @@ const targetMatchers = {
   [Targets.JSON_FILES]: (file) => {
     return (
       jsonFilesWithSchemas.includes(file) ||
-      file == 'build-system/tasks/check-json-schemas.js'
+      file == 'build-system/tasks/check-json-schemas.js' ||
+      file == '.vscode/settings.json'
     );
   },
   [Targets.LINT]: (file) => {
@@ -318,7 +319,7 @@ const targetMatchers = {
     return (
       file.startsWith('build-system/tasks/visual-diff/') ||
       file.startsWith('examples/visual-tests/') ||
-      file == 'test/visual-diff/visual-tests'
+      file == 'test/visual-diff/visual-tests.jsonc'
     );
   },
 };

--- a/build-system/tasks/check-json-schemas.js
+++ b/build-system/tasks/check-json-schemas.js
@@ -9,7 +9,7 @@ const {default: Ajv} = require('ajv');
 const {log} = require('../common/logging');
 
 /**
- * Fetches the content of a JSON/JSON5 file.
+ * Fetches the content of a JSON/JSONC/JSON5 file.
  *
  * @param {string} file repo root relative.
  * @return {any}

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -789,7 +789,10 @@ async function performVisualTests(browserFetcher) {
       // Load and parse the config. Use JSON5 due to JSON comments in file.
       const visualTestsConfig = JSON5.parse(
         fs.readFileSync(
-          path.resolve(__dirname, '../../../test/visual-diff/visual-tests'),
+          path.resolve(
+            __dirname,
+            '../../../test/visual-diff/visual-tests.jsonc'
+          ),
           'utf8'
         )
       );

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -253,7 +253,7 @@ If a Percy test flakes and you would like to trigger a rerun, you can't do that 
 
 ### How Are Tests Executed
 
-Visual diff tests are defined in the [`visual-tests`](../test/visual-diff/visual-tests), see file for the configurations of each test. When running, the visual diff test runner does the following for each test case:
+Visual diff tests are defined in the [`visual-tests.jsonc`](../test/visual-diff/visual-tests.jsonc), see file for the configurations of each test. When running, the visual diff test runner does the following for each test case:
 
 -   Navgates to the defined page using a headless Chrome browser
 -   Waits for the page to finish loading, both by verifying idle network connections and lack of loader animations
@@ -283,7 +283,7 @@ Once the environment variable is set up, you can run the AMP visual diff tests. 
 To start, create the page and register it in the configuration file for visual diff tests:
 
 -   Create an AMP document that will be tested under `examples/visual-tests`.
--   Add an entry in the [`test/visual-diff/visual-tests`](../test/visual-diff/visual-tests) JSON5 file. Documentation for the various settings are in that file.
+-   Add an entry in the [`test/visual-diff/visual-tests.jsonc`](../test/visual-diff/visual-tests.jsonc) JSON5 file. Documentation for the various settings are in that file.
     -   Must set fields: `url`, `name`
     -   You will also likely want to set `loading_complete_css` and maybe also `loading_incomplete_css`
     -   Only set `viewport` if your page looks different on mobile vs. desktop, and you intend to create a separate config for each

--- a/test/visual-diff/visual-tests.jsonc
+++ b/test/visual-diff/visual-tests.jsonc
@@ -3,7 +3,7 @@
 /**
  * Particulars of the webpages used in the AMP visual diff tests.
  */
- {
+{
   /**
    * List of webpages used in tests.
    */
@@ -172,7 +172,7 @@
     },
     {
       "url": "examples/visual-tests/css.amp/css.amp.html",
-      "name": "unbuilt css",
+      "name": "unbuilt css"
     },
     {
       "url": "examples/visual-tests/article.amp/article.amp.html",
@@ -189,7 +189,7 @@
       "loading_complete_selectors": [
         "#list1 > div[role='list']",
         "#list2 > div[role='list']",
-        "#list3 > div[role='list']",
+        "#list3 > div[role='list']"
       ],
       "interactive_tests": "examples/visual-tests/amp-list/amp-list.amp.js"
     },
@@ -245,8 +245,8 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-ad.js",
        "loading_complete_selectors": [
         ".i-amphtml-story-ad-badge",
-        "amp-story[ad-showing]",
-      ],
+        "amp-story[ad-showing]"
+      ]
     },
     {
       // TODO(#32685, @ampproject/wg-stories): see https://percy.io/ampproject/amphtml/builds/8876280/changed/503548953
@@ -357,7 +357,7 @@
       "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-info-dialog"
-      ],
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-consent.html",
@@ -447,7 +447,7 @@
       "name": "amp-story: embed mode 2 (desktop)",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-loaded"
       ]
     },
     {
@@ -473,32 +473,32 @@
       "name": "amp-story: desktop one panel desktop default margin",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
-      ],
+        ".i-amphtml-story-loaded"
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-desktop-one-panel.html",
       "name": "amp-story: desktop one panel desktop panel responsive margin",
       "viewport": {"width": 1440, "height": 1300},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
-      ],
+        ".i-amphtml-story-loaded"
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-desktop-one-panel.html",
       "name": "amp-story: desktop one panel short screen no margin",
       "viewport": {"width": 1440, "height": 750},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
-      ],
+        ".i-amphtml-story-loaded"
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-desktop-one-panel.html",
       "name": "amp-story: desktop one panel small square screen",
       "viewport": {"width": 400, "height": 400},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
-      ],
+        ".i-amphtml-story-loaded"
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/basic.rtl.html",
@@ -529,7 +529,7 @@
       "loading_complete_selectors": [
         ".i-amphtml-story-loaded",
         ".i-amphtml-story-info-dialog"
-      ],
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-consent.rtl.html",
@@ -569,8 +569,8 @@
       "name": "AMP Inabox GPT Ad",
       "loading_complete_selectors": [
         ".slot-render-ended",
-        ".slot-onload",
-      ],
+        ".slot-onload"
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-tooltip.html",
@@ -599,7 +599,7 @@
       "name": "amp-story: pagination-buttons desktop",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-loaded"
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-pagination-buttons.js"
     },
@@ -622,7 +622,7 @@
       "name": "amp-story: landscape templates",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-loaded"
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-landscape-templates.js"
     },
@@ -640,7 +640,7 @@
       "name": "amp-story: live story desktop",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-loaded"
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-live-story.js"
     },
@@ -649,7 +649,7 @@
       "name": "amp-story: bot rendering",
       "viewport": {"width": 360, "height": 4500},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-loaded"
       ]
     },
     {
@@ -657,24 +657,24 @@
       "name": "amp-story-interactive-quiz: sizing and positioning",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
-      ],
+        ".i-amphtml-story-loaded"
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-interactive-img-poll.html",
       "name": "amp-story-interactive-img-poll: render 4 image options with default customization options in mobile layout",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
-      ],
+        ".i-amphtml-story-loaded"
+      ]
     },
     {
       "url": "examples/visual-tests/amp-story/amp-story-interactive-img-quiz.html",
       "name": "amp-story-interactive-img-quiz: render 4 image options with default customization options in mobile layout",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
-      ],
+        ".i-amphtml-story-loaded"
+      ]
     },
     {
       "flaky": true, // #34033. See https://percy.io/ampproject/amphtml/builds/10102542/changed/568786603
@@ -700,19 +700,19 @@
       "url": "examples/visual-tests/amp-date-picker/amp-date-picker.amp.html",
       "name": "amp-date-picker",
       "loading_complete_selectors": [
-        ".i-amphtml-date-picker-container",
+        ".i-amphtml-date-picker-container"
       ],
       "interactive_tests": "examples/visual-tests/amp-date-picker/amp-date-picker.js"
     },
     {
       "url": "examples/visual-tests/amp-selector.amp.html",
       "name": "amp-selector",
-      "interactive_tests": "examples/visual-tests/amp-selector.js",
+      "interactive_tests": "examples/visual-tests/amp-selector.js"
     },
     {
       "url": "examples/visual-tests/amp-form/amp-form.amp.html",
       "name": "amp-form",
-      "interactive_tests": "examples/visual-tests/amp-form/amp-form.js",
+      "interactive_tests": "examples/visual-tests/amp-form/amp-form.js"
     },
     {
       "url": "examples/visual-tests/amp-accordion/amp-accordion.html",
@@ -725,14 +725,14 @@
       "name": "amp-user-notification",
       "viewport": {"width": 400, "height": 600},
       "loading_complete_selectors": [
-        "amp-user-notification.amp-active",
+        "amp-user-notification.amp-active"
       ],
       "interactive_tests": "examples/visual-tests/amp-user-notification/amp-user-notification.js"
     },
     {
       "url": "examples/visual-tests/amp-autocomplete/amp-autocomplete.amp.html",
       "name": "amp-autocomplete",
-      "interactive_tests": "examples/visual-tests/amp-autocomplete/amp-autocomplete.js",
+      "interactive_tests": "examples/visual-tests/amp-autocomplete/amp-autocomplete.js"
     },
     {
       "url": "examples/visual-tests/amphtml-ads/amp-fie-adchoices.html",
@@ -839,12 +839,12 @@
     {
       "url": "examples/visual-tests/amp-carousel/amp-carousel.html",
       "name": "amp-carousel",
-      "loading_complete_delay_ms": 2000,
+      "loading_complete_delay_ms": 2000
     },
     {
       "url": "examples/visual-tests/amp-carousel/amp-carousel-slides.html",
       "name": "amp-carousel-slides",
-      "loading_complete_delay_ms": 2000,
+      "loading_complete_delay_ms": 2000
     },
     {
       "url": "examples/visual-tests/amp-story/basic-transformed.html",
@@ -863,7 +863,7 @@
       "name": "amp-story-page-attachment: new inline & outlink CTA buttons",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-loaded"
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment.js"
     },
@@ -872,7 +872,7 @@
       "name": "amp-story-page-attachment: page attachment desktop",
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [
-        ".i-amphtml-story-loaded",
+        ".i-amphtml-story-loaded"
       ],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment.js"
     }


### PR DESCRIPTION
vscode recognizes ".jsonc" files as "JSON with comments", which are slightly different from JSON5 (JSON is parseable as JSONC, which is parseable as JSON5, but not the other way round) - JSON5 isn't yet supported by vscode natively without an extension so it's best to just use jsonc in this case