### PR TITLE
compiler: accept partials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-Ukegl+czEVP2S6Xd48d8vR/yL1bXd2A2ccUDztW29vVOC7XrJjKSa3bIqecYckuUI+mBfJtzHJKzN6rkscz3jw=="
     },
     "@ampproject/bento-compiler": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.10.tgz",
-      "integrity": "sha512-s/uQR3D/bx9q1MoPbAXzLsKXzDwTDJMOVgBH2b7HMPdBwL2rB/1MpOGufkKnAclastjdyJd7CI3LKnq4s79D4A==",
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.11.tgz",
+      "integrity": "sha512-FR6bw/EodR0hHJEw7hwTD+5YhxJQHx43vZxlWYef8Asn1wF5PmRmVV769+ZIMQlSM3leYV4et01YrAyrZL0Keg==",
       "requires": {
         "@ampproject/worker-dom": "0.32.1"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ampproject/animations": "0.2.2",
-    "@ampproject/bento-compiler": "0.0.10",
+    "@ampproject/bento-compiler": "0.0.11",
     "@ampproject/toolbox-cache-url": "2.8.0",
     "@ampproject/viewer-messaging": "1.1.2",
     "@ampproject/worker-dom": "0.32.1",

--- a/src/compiler/compile.js
+++ b/src/compiler/compile.js
@@ -1,0 +1,28 @@
+import * as compiler from '@ampproject/bento-compiler';
+
+import {getBuilders} from './builders';
+
+/**
+ * Returns the AST for an AMP Document with eligible components server-rendered.
+ *
+ * @param {import('./types').CompilerRequest} request
+ * @return {import('./types').CompilerResponse}
+ */
+export function compile(request) {
+  if (!request || (!request.document && !request.nodes)) {
+    throw new Error('Must provide either document or nodes');
+  }
+
+  // TODO(samouri): remove the defaults.
+  const versions = request.versions ?? [
+    {component: 'amp-layout', version: 'v0'},
+  ];
+
+  const {document, nodes} = request;
+  if (document) {
+    return {
+      document: compiler.renderAstDocument(document, getBuilders(versions)),
+    };
+  }
+  return {nodes: compiler.renderAstNodes(nodes, getBuilders(versions))};
+}

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -10,17 +10,22 @@ import {getBuilders} from './builders';
  * @return {import('./types').CompilerResponse}
  */
 function compile(request) {
+  if (!request || (!request.document && !request.nodes)) {
+    throw new Error('Must provide either document or nodes');
+  }
+
   // TODO(samouri): remove the defaults.
-  const document = request.document ?? {
-    root: 0,
-    tree: [{tagid: 92, children: []}],
-    'quirks_mode': false,
-  };
   const versions = request.versions ?? [
     {component: 'amp-layout', version: 'v0'},
   ];
 
-  return {document: compiler.renderAst(document, getBuilders(versions))};
+  const {document, nodes} = request;
+  if (document) {
+    return {
+      document: compiler.renderAstDocument(document, getBuilders(versions)),
+    };
+  }
+  return {nodes: compiler.renderAstNodes(nodes, getBuilders(versions))};
 }
 
 globalThis['compile'] = compile;

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1,31 +1,4 @@
 import './polyfills';
-import * as compiler from '@ampproject/bento-compiler';
-
-import {getBuilders} from './builders';
-
-/**
- * Returns the AST for an AMP Document with eligible components server-rendered.
- *
- * @param {import('./types').CompilerRequest} request
- * @return {import('./types').CompilerResponse}
- */
-function compile(request) {
-  if (!request || (!request.document && !request.nodes)) {
-    throw new Error('Must provide either document or nodes');
-  }
-
-  // TODO(samouri): remove the defaults.
-  const versions = request.versions ?? [
-    {component: 'amp-layout', version: 'v0'},
-  ];
-
-  const {document, nodes} = request;
-  if (document) {
-    return {
-      document: compiler.renderAstDocument(document, getBuilders(versions)),
-    };
-  }
-  return {nodes: compiler.renderAstNodes(nodes, getBuilders(versions))};
-}
+import {compile} from './compile';
 
 globalThis['compile'] = compile;

--- a/src/compiler/types.d.ts
+++ b/src/compiler/types.d.ts
@@ -1,4 +1,4 @@
-import {TreeProto} from '@ampproject/bento-compiler';
+import {TreeProto, NodeProto} from '@ampproject/bento-compiler';
 
 /**
  * AMP Components must implement this "buildDom" function in order to be server-rendered.
@@ -18,8 +18,12 @@ export type BuildDom = (Element) => void;
  */
 export type Versions = Array<{component: string; version: string}>;
 
-export type CompilerRequest = {document: TreeProto; versions: Versions};
+export type CompilerRequest = {
+  document?: TreeProto;
+  nodes?: NodeProto[];
+  versions: Versions;
+};
 
-export type CompilerResponse = {document: TreeProto};
+export type CompilerResponse = {document: TreeProto} | {nodes: NodeProto[]};
 
 export type BuilderMap = {[tagName: string]: BuildDom};

--- a/test/unit/compiler/test-compile.js
+++ b/test/unit/compiler/test-compile.js
@@ -1,12 +1,7 @@
-import '#compiler';
+import {compile} from '#compiler/compile';
 
 describes.sandboxed('compile', {}, () => {
-  it('compile function should be added to global', () => {
-    expect(globalThis['compile']).ok;
-  });
-
   it('should throw if provided invalid input', () => {
-    const compile = globalThis['compile'];
     const errorMsg = /Must provide either document or nodes/;
 
     expect(() => compile()).throw(errorMsg);
@@ -16,7 +11,6 @@ describes.sandboxed('compile', {}, () => {
   });
 
   it('should return compiled document', () => {
-    const compile = globalThis['compile'];
     const document = {
       root: 0,
       tree: [{tagid: 92, children: []}],
@@ -26,7 +20,6 @@ describes.sandboxed('compile', {}, () => {
   });
 
   it('should return compiled nodes', () => {
-    const compile = globalThis['compile'];
     const nodes = [
       {tagid: 1, value: 'a', children: [], attributes: []},
       {tagid: 7, value: 'b', children: [], attributes: []},

--- a/test/unit/compiler/test-index.js
+++ b/test/unit/compiler/test-index.js
@@ -1,0 +1,36 @@
+import '#compiler';
+
+describes.sandboxed('compile', {}, () => {
+  it('compile function should be added to global', () => {
+    expect(globalThis['compile']).ok;
+  });
+
+  it('should throw if provided invalid input', () => {
+    const compile = globalThis['compile'];
+    const errorMsg = /Must provide either document or nodes/;
+
+    expect(() => compile()).throw(errorMsg);
+    expect(() => compile({})).throw(errorMsg);
+    expect(() => compile({unknown: {}})).throw(errorMsg);
+    expect(() => compile({versions: []})).throw(errorMsg);
+  });
+
+  it('should return compiled document', () => {
+    const compile = globalThis['compile'];
+    const document = {
+      root: 0,
+      tree: [{tagid: 92, children: []}],
+      'quirks_mode': false,
+    };
+    expect(compile({document})).to.deep.equal({document});
+  });
+
+  it('should return compiled nodes', () => {
+    const compile = globalThis['compile'];
+    const nodes = [
+      {tagid: 1, value: 'a', children: [], attributes: []},
+      {tagid: 7, value: 'b', children: [], attributes: []},
+    ];
+    expect(compile({nodes})).to.deep.equal({nodes});
+  });
+});


### PR DESCRIPTION
**summary**
- Teaches `compiler.js` how to compile a list of nodes instead of only complete documents.
- Bumps version of bento-compiler (0.11 introduced the compileNodes fn)
- ~Adds tests for the compiler entrypoint~
- Extracts `compile()` function to its own file to make it testable. The global side effects created from the entrypoint unfortunately break our testing infra.