### PR TITLE
🐛[story-ads] use `target=_top`

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
@@ -210,7 +210,7 @@ function createPageOutlink_(doc, uiMetadata, container) {
     'a',
     dict({
       'class': 'i-amphtml-story-ad-link',
-      'target': '_blank',
+      'target': '_top',
       'href': uiMetadata[A4AVarNames.CTA_URL],
     })
   );

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-ui.js
@@ -268,7 +268,7 @@ describes.realWin('story-ad-ui', {amp: true}, (env) => {
           'https://www.cats.com/'
         );
         expect(containerElem.children[0].textContent).to.equal('SHOP');
-        expect(containerElem.children[0].target).to.equal('_blank');
+        expect(containerElem.children[0].target).to.equal('_top');
         expect(containerElem.children[0].tagName).to.equal('A');
       });
     });


### PR DESCRIPTION
Webkit does not count swipes as a trusted interaction, therefore causing the landing page not to open if `target=_blank`.