### PR TITLE
[amp story page outlink] Add `cta-text` to validation

### DIFF
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -914,6 +914,9 @@ tags: {
   mandatory_ancestor: "AMP-STORY-PAGE"
   mandatory_last_child: true
   attrs: {
+    name: "cta-text"
+  }  
+  attrs: {
     name: "cta-accent-color"
   }
   attrs: {


### PR DESCRIPTION
`cta-text` is an accepted attribute of `amp-story-page-outlink` and is communicated in the docs. 
It needs to be added to validation.