### PR TITLE
🏗 Add release tagger hook to handle 404s and fix CP logic

### DIFF
--- a/build-system/release-tagger/index.js
+++ b/build-system/release-tagger/index.js
@@ -14,8 +14,9 @@ const dedent = require('dedent');
 const {addLabels, removeLabels} = require('./label-pull-requests');
 const {createOrUpdateTracker} = require('./update-issue-tracker');
 const {cyan, magenta} = require('kleur/colors');
+const {getRelease} = require('./utils');
 const {log} = require('../common/logging');
-const {makeRelease, maybeGetRelease} = require('./make-release');
+const {makeRelease} = require('./make-release');
 const {publishRelease, rollbackRelease} = require('./update-release');
 
 const {action, base, channel, head, sha, time} = argv;
@@ -40,7 +41,7 @@ async function _promote() {
     return;
   }
 
-  const release = await maybeGetRelease(head);
+  const release = await getRelease(head);
   if (!release) {
     const {'html_url': url} = await makeRelease(head, base, channel, sha);
     log('Created release', magenta(head), 'at', cyan(url));

--- a/build-system/release-tagger/make-release.js
+++ b/build-system/release-tagger/make-release.js
@@ -9,7 +9,6 @@ const {
   createTag,
   getPullRequestsBetweenCommits,
   getRef,
-  getRelease,
 } = require('./utils');
 const {getExtensions, getSemver} = require('../npm-publish/utils');
 const {GraphQlQueryResponseData} = require('@octokit/graphql'); //eslint-disable-line no-unused-vars
@@ -193,17 +192,6 @@ function _createBody(head, base, prs) {
 }
 
 /**
- * Get release if exists
- * @param {string} head
- * @return {!Promise}
- */
-async function maybeGetRelease(head) {
-  try {
-    return await getRelease(head);
-  } catch {}
-}
-
-/**
  * Make release
  * @param {string} head
  * @param {string} base
@@ -225,4 +213,4 @@ async function makeRelease(head, base, channel, sha) {
   return await createRelease(head, headRef.sha, body, prerelease);
 }
 
-module.exports = {maybeGetRelease, makeRelease};
+module.exports = {makeRelease};

--- a/build-system/release-tagger/test/update-issue-tracker.test.js
+++ b/build-system/release-tagger/test/update-issue-tracker.test.js
@@ -149,6 +149,22 @@ test('add cherrypick tasks', async (t) => {
       '',
       '{"query":"query {' +
         'search(query:\\"repo:ampproject/amphtml ' +
+        'in:title Release 2109080123002\\", type: ISSUE, first: 1) ' +
+        '{ nodes { ... on Issue { number title body }}}}"}'
+    )
+    .reply(200, {data: {search: {}}})
+    .post(
+      '',
+      '{"query":"query {' +
+        'search(query:\\"repo:ampproject/amphtml ' +
+        'in:title Release 2109080123001\\", type: ISSUE, first: 1) ' +
+        '{ nodes { ... on Issue { number title body }}}}"}'
+    )
+    .reply(200, {data: {search: {}}})
+    .post(
+      '',
+      '{"query":"query {' +
+        'search(query:\\"repo:ampproject/amphtml ' +
         'in:title Release 2109080123000\\", type: ISSUE, first: 1) ' +
         '{ nodes { ... on Issue { number title body }}}}"}'
     )
@@ -181,10 +197,10 @@ test('add cherrypick tasks', async (t) => {
   const rest = nock('https://api.github.com')
     // https://docs.github.com/en/rest/reference/issues#update-an-issue
     .patch('/repos/ampproject/amphtml/issues/1', {
-      title: '🚄 Release 2109080123001',
+      title: '🚄 Release 2109080123002',
       body:
-        '### AMP Version\n\n[2109080123001]' +
-        '(https://github.com/ampproject/amphtml/releases/tag/2109080123001)\n\n' +
+        '### AMP Version\n\n[2109080123002]' +
+        '(https://github.com/ampproject/amphtml/releases/tag/2109080123002)\n\n' +
         '### Promotions\n\n' +
         '- [x] <!-- amp-version=2109080123000 channel=beta-opt-in -->' +
         '2109080123000 promoted to Experimental and Beta (opt-in) channels (optintime)\n' +
@@ -192,18 +208,18 @@ test('add cherrypick tasks', async (t) => {
         '2109080123000 promoted to Experimental and Beta (1% traffic) channels (percenttime)\n' +
         '- [x] <!-- amp-version=2109080123000 channel=stable -->' +
         '2109080123000 promoted to Stable channel (stabletime)\n' +
-        '🌸 2109080123000 was cherry-picked to create 2109080123001\n' +
-        '- [x] <!-- amp-version=2109080123001 channel=stable -->' +
-        '2109080123001 promoted to Stable channel (9/15/2021, 5:34:56 AM PT)\n' +
-        '- [ ] <!-- amp-version=2109080123001 channel=lts -->' +
-        '2109080123001 promoted to LTS channel <!-- promote-time -->\n\n' +
+        '🌸 2109080123000 was cherry-picked to create 2109080123002\n' +
+        '- [x] <!-- amp-version=2109080123002 channel=stable -->' +
+        '2109080123002 promoted to Stable channel (9/15/2021, 5:34:56 AM PT)\n' +
+        '- [ ] <!-- amp-version=2109080123002 channel=lts -->' +
+        '2109080123002 promoted to LTS channel <!-- promote-time -->\n\n' +
         '/cc @ampproject/release-on-duty',
       state: 'open',
     })
     .reply(200);
 
   await createOrUpdateTracker(
-    '2109080123001',
+    '2109080123002',
     '2109080123000',
     'stable',
     '2021-09-15 12:34:56'

--- a/build-system/release-tagger/update-issue-tracker.js
+++ b/build-system/release-tagger/update-issue-tracker.js
@@ -94,6 +94,18 @@ class IssueTracker {
 }
 
 /**
+ * Get issue if it exists and whether it's a cherrypick
+ * @param {string} head
+ * @return {!Promise}
+ */
+async function setup(head) {
+  const issue = await getIssue(head);
+  return issue
+    ? {isCherrypick: false, issue}
+    : {isCherrypick: !head.endsWith('000'), issue: undefined};
+}
+
+/**
  * Create or update issue tracker
  * @param {string} head
  * @param {string} base
@@ -106,10 +118,7 @@ async function createOrUpdateTracker(head, base, channel, time) {
     new Date(`${time} UTC`).toLocaleString('en-US', {
       timeZone: 'America/Los_Angeles',
     }) + ' PT';
-  const isCherrypick = Number(head) - Number(base) < 1000;
-  const issue = isCherrypick
-    ? await getIssue(`Release ${base}`)
-    : await getIssue(`Release ${head}`);
+  const {isCherrypick, issue} = await setup(head);
 
   // create new tracker
   if (!issue) {

--- a/build-system/release-tagger/update-issue-tracker.js
+++ b/build-system/release-tagger/update-issue-tracker.js
@@ -106,7 +106,7 @@ async function setup(head) {
 
   // is cherrypick, so find base issue tracker
   let version = Number(head) - 1;
-  while (version % 1000 !== 1000) {
+  while (version % 1000 !== 0) {
     issue = await getIssue(`Release ${version}`);
     if (issue) {
       break;

--- a/build-system/release-tagger/update-issue-tracker.js
+++ b/build-system/release-tagger/update-issue-tracker.js
@@ -99,10 +99,21 @@ class IssueTracker {
  * @return {!Promise}
  */
 async function setup(head) {
-  const issue = await getIssue(head);
-  return issue
-    ? {isCherrypick: false, issue}
-    : {isCherrypick: !head.endsWith('000'), issue: undefined};
+  let issue = await getIssue(`Release ${head}`);
+  if (issue || head.endsWith('000')) {
+    return {isCherrypick: false, issue};
+  }
+
+  // is cherrypick, so find base issue tracker
+  let version = Number(head) - 1;
+  while (version % 1000 !== 1000) {
+    issue = await getIssue(`Release ${version}`);
+    if (issue) {
+      break;
+    }
+    version--;
+  }
+  return {isCherrypick: true, issue};
 }
 
 /**

--- a/build-system/release-tagger/update-issue-tracker.js
+++ b/build-system/release-tagger/update-issue-tracker.js
@@ -105,13 +105,13 @@ async function setup(head) {
   }
 
   // is cherrypick, so find base issue tracker
-  let version = Number(head) - 1;
+  let version = Number(head);
   while (version % 1000 !== 0) {
+    version--;
     issue = await getIssue(`Release ${version}`);
     if (issue) {
       break;
     }
-    version--;
   }
   return {isCherrypick: true, issue};
 }


### PR DESCRIPTION
1. Fix CP logic: 
Release tagger assumed that any version not ending with `000` was a new CP, so it would try to update the issue tracker with new tasks.  When actually, versions not ending in `000` can be a previously CP'ed version.

2. Handle 404s:
Add an octokit hook that returns undefined instead of throwing error when a github resource is not found. This lets the release tagger do a quick null check instead of try/catch clauses everywhere.