### PR TITLE
🏗 Rename bundle's `latestName` to `aliasName`

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -26,7 +26,7 @@ exports.jsBundles = {
       toName: 'bento.max.js',
       minifiedName: 'bento.js',
       // For backwards-compat:
-      latestName: 'custom-elements-polyfill.js',
+      aliasName: 'custom-elements-polyfill.js',
     },
   },
   'alp.max.js': {

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -199,13 +199,13 @@ function buildLoginDone(version) {
   const buildDir = `build/all/amp-access-${version}`;
   const builtName = `amp-login-done-${version}.max.js`;
   const minifiedName = `amp-login-done-${version}.js`;
-  const latestName = 'amp-login-done-latest.js';
+  const aliasName = 'amp-login-done-latest.js';
   return compileJs(`./${buildDir}`, builtName, './dist/v0/', {
     watch: argv.watch,
     includePolyfills: true,
     minify: true,
     minifiedName,
-    latestName,
+    aliasName,
     extraGlobs: [
       `${buildDir}/amp-login-done-0.1.max.js`,
       `${buildDir}/amp-login-done-dialog.js`,

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -697,7 +697,7 @@ function buildBinaries(extDir, binaries, options) {
       ...options,
       toName: maybeToNpmEsmName(`${name}.max.js`),
       minifiedName: maybeToNpmEsmName(`${name}.js`),
-      latestName: '',
+      aliasName: '',
       outputFormat: esm ? 'esm' : 'cjs',
       externalDependencies: external,
       remapDependencies: remap,
@@ -811,7 +811,7 @@ async function buildExtensionJs(dir, name, options) {
     ...options,
     toName: `${name}-${version}.max.js`,
     minifiedName: `${name}-${version}.js`,
-    latestName: isLatest ? `${name}-latest.js` : '',
+    aliasName: isLatest ? `${name}-latest.js` : '',
     wrapper: resolvedWrapper,
   });
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -313,16 +313,16 @@ async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
 
   const destPath = path.join(destDir, minifiedName);
   combineWithCompiledFile(srcFilename, destPath, options);
-  if (options.latestName) {
+  if (options.aliasName) {
     fs.copySync(
       destPath,
-      path.join(destDir, maybeToEsmName(options.latestName))
+      path.join(destDir, maybeToEsmName(options.aliasName))
     );
   }
 
   let name = minifiedName;
-  if (options.latestName) {
-    name += ` → ${maybeToEsmName(options.latestName)}`;
+  if (options.aliasName) {
+    name += ` → ${maybeToEsmName(options.aliasName)}`;
   }
   endBuildStep('Minified', name, timeInfo.startTime);
 }
@@ -359,17 +359,17 @@ function handleBundleError(err, continueOnError, destFilename) {
  */
 async function finishBundle(destDir, destFilename, options, startTime) {
   const logPrefix = options.minify ? 'Minified' : 'Compiled';
-  let {latestName} = options;
-  if (latestName) {
+  let {aliasName} = options;
+  if (aliasName) {
     if (!options.minify) {
-      latestName = latestName.replace(/\.js$/, '.max.js');
+      aliasName = aliasName.replace(/\.js$/, '.max.js');
     }
-    latestName = maybeToEsmName(latestName);
+    aliasName = maybeToEsmName(aliasName);
     fs.copySync(
       path.join(destDir, destFilename),
-      path.join(destDir, latestName)
+      path.join(destDir, aliasName)
     );
-    endBuildStep(logPrefix, `${destFilename} → ${latestName}`, startTime);
+    endBuildStep(logPrefix, `${destFilename} → ${aliasName}`, startTime);
   } else {
     const loggingName =
       options.npm && !destFilename.startsWith('amp-')


### PR DESCRIPTION
Existing `*-latest.js` files are still created, this is just a more general name.