### PR TITLE
Adjust amp-ad sticky doubleclick arguments for parity

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -2329,13 +2329,6 @@ export class AmpA4A extends AMP.BaseElement {
   }
 
   /**
-   * @return {boolean} whether this is a sticky ad unit
-   */
-  isStickyAd() {
-    return false;
-  }
-
-  /**
    * Checks if the given lifecycle event has a corresponding amp-analytics event
    * and fires the analytics trigger if so.
    * @param {string} lifecycleStage

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -693,8 +693,15 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     const {fwSignal, parentWidth, slotWidth} = this.flexibleAdSlotData_;
     // If slotWidth is -1, that means its width must be determined by its
     // parent container, and so should have the same value as parentWidth.
-    msz = `${slotWidth == -1 ? parentWidth : slotWidth}x-1`;
-    psz = `${parentWidth}x-1`;
+
+    // For amp-sticky-ad, it returns 0, so we follow them for amp-ad sticky ads here.
+    if (this.uiHandler.isStickyAd()) {
+      msz = '0x-1';
+      psz = '0x-1';
+    } else {
+      msz = `${slotWidth == -1 ? parentWidth : slotWidth}x-1`;
+      psz = `${parentWidth}x-1`;
+    }
     fws = fwSignal ? fwSignal : '0';
     return {
       'iu': this.element.getAttribute('data-slot'),

--- a/extensions/amp-ad-network-valueimpression-impl/0.1/amp-ad-network-valueimpression-impl.js
+++ b/extensions/amp-ad-network-valueimpression-impl/0.1/amp-ad-network-valueimpression-impl.js
@@ -276,8 +276,13 @@ export class AmpAdNetworkValueimpressionImpl extends AmpA4A {
       const {fwSignal, parentWidth, slotWidth} = this.flexibleAdSlotData_;
       // If slotWidth is -1, that means its width must be determined by its
       // parent container, and so should have the same value as parentWidth.
-      msz = `${slotWidth == -1 ? parentWidth : slotWidth}x-1`;
-      psz = `${parentWidth}x-1`;
+      if (this.uiHandler.isStickyAd()) {
+        msz = '0x-1';
+        psz = '0x-1';
+      } else {
+        msz = `${slotWidth == -1 ? parentWidth : slotWidth}x-1`;
+        psz = `${parentWidth}x-1`;
+      }
       fws = fwSignal ? fwSignal : '0';
 
       const {canonicalUrl, pageViewId} = Services.documentInfoForDoc(ampDoc);

--- a/extensions/amp-ad-network-valueimpression-impl/0.1/test/test-amp-ad-network-valueimpression-impl.js
+++ b/extensions/amp-ad-network-valueimpression-impl/0.1/test/test-amp-ad-network-valueimpression-impl.js
@@ -160,6 +160,7 @@ describes.realWin(
           .returns(Promise.resolve('http://example.com/?foo=bar'));
 
         const impl = new AmpAdNetworkValueimpressionImpl(element);
+        impl.uiHandler = {isStickyAd: () => false};
         return impl
           .getAdUrl(
             {consentString: 'user_consent_string', gdprApplies: true},


### PR DESCRIPTION
It ensures that the ad requests will contain the same psz/msz arugments. @zombifier for approval.

Look like valueimpressions are duplicating the logics here. Changing it for them as well.