### PR TITLE
🐛 [Attachment Forms] Prevent desktop one panel stylings from taking effect on mobile devices when the soft keyboard is open

### DIFF
--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -13,7 +13,7 @@ amp-story[standalone] {
 
 @media(min-aspect-ratio: 3/4) {
   /** Variables shared between page, system layer and pagination buttons. */
-  :root:not([data-story-supports-landscape]):not([mobile-story]) {
+  :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {
     --i-amphtml-story-desktop-one-panel-ratio: 69 / 116;
     --i-amphtml-story-desktop-one-panel-responsive-margin: max(74px, 8.25vh);
     /** Calculates panel height by subtracting responsive vertical margin. */
@@ -25,7 +25,7 @@ amp-story[standalone] {
   }
 
   @media(max-height: 756px) {
-    :root:not([data-story-supports-landscape]):not([mobile-story]) {
+    :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {
       --i-amphtml-story-desktop-one-panel-responsive-margin: 0px;
       --i-amphtml-story-desktop-one-panel-width: calc(100vh * var(--i-amphtml-story-desktop-one-panel-ratio));
       --i-amphtml-story-desktop-one-panel-border-radius: 0;
@@ -33,12 +33,12 @@ amp-story[standalone] {
   }
 
   @media(max-height: 538px) {
-    :root:not([data-story-supports-landscape]):not([mobile-story]) {
+    :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {
       /** If changing this, also change amp-story-player-shadow.css **/
       --i-amphtml-story-desktop-one-panel-ratio: 36 / 53;
     }
   }
-  :root:not([mobile-story]) amp-story:not([supports-landscape]) amp-story-page {
+  :root:not([i-amphtml-story-mobile]) amp-story:not([supports-landscape]) amp-story-page {
     width: var(--i-amphtml-story-desktop-one-panel-width) !important;
     height: var(--i-amphtml-story-desktop-one-panel-height) !important;
     border-radius: var(--i-amphtml-story-desktop-one-panel-border-radius) !important;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1648,7 +1648,10 @@ export class AmpStory extends AMP.BaseElement {
     switch (uiState) {
       case UIType.MOBILE:
         this.vsync_.mutate(() => {
-          this.win.document.documentElement.setAttribute('mobile-story', '');
+          this.win.document.documentElement.setAttribute(
+            'i-amphtml-story-mobile',
+            ''
+          );
           this.element.removeAttribute('desktop');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-one-panel');
@@ -1663,7 +1666,9 @@ export class AmpStory extends AMP.BaseElement {
           }
         }
         this.vsync_.mutate(() => {
-          this.win.document.documentElement.removeAttribute('mobile-story');
+          this.win.document.documentElement.removeAttribute(
+            'i-amphtml-story-mobile'
+          );
           this.element.removeAttribute('desktop');
           this.element.classList.add('i-amphtml-story-desktop-one-panel');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
@@ -1671,7 +1676,9 @@ export class AmpStory extends AMP.BaseElement {
         break;
       case UIType.DESKTOP_FULLBLEED:
         this.vsync_.mutate(() => {
-          this.win.document.documentElement.removeAttribute('mobile-story');
+          this.win.document.documentElement.removeAttribute(
+            'i-amphtml-story-mobile'
+          );
           this.element.setAttribute('desktop', '');
           this.element.classList.add('i-amphtml-story-desktop-fullbleed');
           this.element.classList.remove('i-amphtml-story-desktop-one-panel');
@@ -1691,7 +1698,9 @@ export class AmpStory extends AMP.BaseElement {
             'i-amphtml-story-vertical'
           );
           setImportantStyles(this.win.document.body, {height: 'auto'});
-          this.win.document.documentElement.removeAttribute('mobile-story');
+          this.win.document.documentElement.removeAttribute(
+            'i-amphtml-story-mobile'
+          );
           this.element.removeAttribute('desktop');
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
           for (let i = 0; i < pageAttachments.length; i++) {


### PR DESCRIPTION
Stories that do not have the `supports-landscape` attribute set are unintentionally triggering desktop one panel CSS stylings whenever the Android soft keyboard alters the aspect ratio by opening up. This PR sets a new `'mobile-story'` attribute on the `<html>` element whenever the UI type is determined to be `MOBILE`, and prevents desktop one panel stylings from taking effect on documents with this attribute.

I have confirmed that the desktop one panel UI still appears as expected on desktop, and also that desktop one panel styles trigger neither on Android nor iOS.