### PR TITLE
🏗 Add lazy-build support for Bento and ESM modes

### DIFF
--- a/build-system/server/lazy-build.js
+++ b/build-system/server/lazy-build.js
@@ -20,13 +20,15 @@ maybeInitializeExtensions(extensionBundles, /* includeLatest */ true);
 const vendorBundles = generateBundles();
 
 /**
- * Gets the unminified name of the bundle if it can be lazily built.
+ * Normalizes bento extension names and gets the unminified name of the bundle
+ * if it can be lazily built.
  *
  * @param {!Object} bundles
  * @param {string} name
  * @return {string}
  */
 function maybeGetUnminifiedName(bundles, name) {
+  name = name.replace('bento-', 'amp-');
   if (argv.minified) {
     for (const key of Object.keys(bundles)) {
       if (
@@ -105,7 +107,9 @@ async function build(bundles, name, buildFunc) {
  */
 async function lazyBuildExtensions(req, _res, next) {
   const matcher = argv.minified
-    ? /\/dist\/v0\/([^\/]*)\.js/ // '/dist/v0/*.js'
+    ? argv.esm
+      ? /\/dist\/v0\/([^\/]*)\.mjs/ // '/dist/v0/*.mjs'
+      : /\/dist\/v0\/([^\/]*)\.js/ // '/dist/v0/*.js'
     : /\/dist\/v0\/([^\/]*)\.max\.js/; // '/dist/v0/*.max.js'
   await lazyBuild(req.url, matcher, extensionBundles, doBuildExtension, next);
 }
@@ -119,7 +123,7 @@ async function lazyBuildExtensions(req, _res, next) {
  * @return {Promise<void>}
  */
 async function lazyBuildJs(req, _res, next) {
-  const matcher = /\/.*\/([^\/]*\.js)/;
+  const matcher = argv.esm ? /\/.*\/([^\/]*\.mjs)/ : /\/.*\/([^\/]*\.js)/;
   await lazyBuild(req.url, matcher, jsBundles, doBuildJs, next);
 }
 
@@ -133,7 +137,9 @@ async function lazyBuildJs(req, _res, next) {
  */
 async function lazyBuild3pVendor(req, _res, next) {
   const matcher = argv.minified
-    ? new RegExp(`\\/dist\\.3p\\/${VERSION}\\/vendor\\/([^\/]*)\\.js`) // '/dist.3p/21900000/vendor/*.js'
+    ? argv.esm
+      ? new RegExp(`\\/dist\\.3p\\/${VERSION}\\/vendor\\/([^\/]*)\\.mjs`) // '/dist.3p/21900000/vendor/*.mjs'
+      : new RegExp(`\\/dist\\.3p\\/${VERSION}\\/vendor\\/([^\/]*)\\.js`) // '/dist.3p/21900000/vendor/*.js'
     : /\/dist\.3p\/current\/vendor\/([^\/]*)\.max\.js/; // '/dist.3p/current/vendor/*.max.js'
   await lazyBuild(req.url, matcher, vendorBundles, doBuild3pVendor, next);
 }

--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -50,6 +50,7 @@ defaultTask.description =
   'Start the dev server, lazily build JS when requested, and watch for changes';
 defaultTask.flags = {
   minified: 'Compile and serve minified binaries',
+  esm: 'Compile and serve minified ESM binaries',
   pseudo_names:
     'Compile with readable names (useful while profiling / debugging production code)',
   pretty_print:


### PR DESCRIPTION
Fixes #36403

**Screenshots:**

**Bento:**

![image](https://user-images.githubusercontent.com/26553114/138720326-3ad5aa77-1e81-4ca5-89b8-1befd95a72fe.png)

**ESM:**

![image](https://user-images.githubusercontent.com/26553114/138720709-39e860ac-a287-47eb-b958-373255f84090.png)

