### PR TITLE
build-system: lazy preDist and preBuild configuration

### DIFF
--- a/build-system/tasks/default-task.js
+++ b/build-system/tasks/default-task.js
@@ -31,11 +31,14 @@ async function defaultTask() {
   printConfigHelp('amp');
   printDefaultTaskHelp();
   parseExtensionFlags(/* preBuild */ true);
+
+  const options = {fortesting: true, minify: argv.minified, watch: true};
   if (argv.minified) {
-    await runPreDistSteps(/* watch */ true);
+    await runPreDistSteps(options);
   } else {
-    await runPreBuildSteps(/* watch */ true);
+    await runPreBuildSteps(options);
   }
+
   await doServe(/* lazyBuild */ true);
   log(green('JS and extensions will be lazily built when requested...'));
 }


### PR DESCRIPTION
**summary**
We are currently passing a nonsensical argument to `runPreDistSteps` and `runPreBuildSteps`. This PR seeks to fix that.