### PR TITLE
🏗  Remove dupe install step from release tagger

### DIFF
--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -31,14 +31,12 @@ jobs:
       - uses: actions/checkout@v2
       - run: bash ./.github/workflows/install_dependencies.sh
       - name: Run tagger
-        run: |
-          npm ci
-          node ./build-system/release-tagger/index.js \
-            ${{ github.event.inputs.action }} \
-            ${{ github.event.inputs.head }} \
-            ${{ github.event.inputs.base }} \
-            ${{ github.event.inputs.channel }} \
-            ${{ github.event.inputs.time }} \
-            ${{ github.event.inputs.sha }}
+        run: node ./build-system/release-tagger/index.js \
+          ${{ github.event.inputs.action }} \
+          ${{ github.event.inputs.head }} \
+          ${{ github.event.inputs.base }} \
+          ${{ github.event.inputs.channel }} \
+          ${{ github.event.inputs.time }} \
+          ${{ github.event.inputs.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.AMPPROJECTBOT }}


### PR DESCRIPTION
Now that release tagger runs `install_dependencies.sh` we don't need another `npm ci` in the following job.

It looks like `npm ci` will quit the job if it detects the amp runner, so that the following `index.js` script isn't run at all.