### PR TITLE
🐛 Fix syntax errors in babel plugin tests (detected by node 16)

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/input.js
@@ -50,6 +50,8 @@ class Static {
   static set 'setter_'(v) {}
 }
 
+var bar_;
+
 foo.bar_;
 foo[bar_];
 foo['bar_'];
@@ -63,5 +65,5 @@ deep.foo?.[bar_];
 deep.foo?.['bar_'];
 
 deep?.foo.bar_;
-deep?.foo.[bar_];
-deep?.foo.['bar_'];
+deep?.foo[bar_];
+deep?.foo['bar_'];

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/test/fixtures/transform/rename-amp-privates/output.mjs
@@ -80,6 +80,7 @@ class Static {
 
 }
 
+var bar_;
 foo.bar_AMP_PRIVATE_;
 foo[bar_];
 foo['bar_'];


### PR DESCRIPTION
Running `amp babel-plugin-tests` with node 16 yields this [syntax error](https://app.circleci.com/pipelines/github/ampproject/amphtml/18164/workflows/69f70afe-4ecb-4afc-970d-01214ef416ec/jobs/338141) that leads to a failure to parse the input file.

![image](https://user-images.githubusercontent.com/26553114/138911424-10f9fa2f-eee6-45bf-8019-0b2fce7373f0.png)

Unblocks #36099