### PR TITLE
🐛 Fix bug in babel test for parens (detected by Node 16)

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/input.js
@@ -1,6 +1,5 @@
-/** @type {x} */ (dev().assertElement(dev()));
+(dev().assertElement(dev()));
 
 function hello() {
-    return /** @type {x} */ (
-        dev().assertElement(dev()));
+  return (dev().assertElement(dev()));
 }

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
@@ -1,5 +1,3 @@
-/** @type {x} */
-
 /** @type {!Element} */
 (dev());
 


### PR DESCRIPTION
Running `amp babel-plugin-tests` with node 16 yields this [error](https://app.circleci.com/pipelines/github/ampproject/amphtml/18164/workflows/69f70afe-4ecb-4afc-970d-01214ef416ec/jobs/338141?invite=true#step-116-231) in the plugin that preserves parens.

![image](https://user-images.githubusercontent.com/26553114/138921727-92d2c6cf-1ebf-4eb5-9304-7d897c14eac1.png)

Unblocks #36099