### PR TITLE
babel strip assertions fix

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/input.js
@@ -1,5 +1,6 @@
-(dev().assertElement(dev()));
+/** @type {x} */ (dev().assertElement(dev()));
 
 function hello() {
-  return (dev().assertElement(dev()));
+    return /** @type {x} */ (
+        dev().assertElement(dev()));
 }

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
@@ -1,3 +1,5 @@
+/** @type {x} */
+
 /** @type {!Element} */
 (dev());
 

--- a/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
+++ b/build-system/babel-plugins/babel-plugin-transform-amp-asserts/test/fixtures/transform-assertions/preserve-parens/output.js
@@ -1,11 +1,13 @@
 /** @type {x} */
-
+(
 /** @type {!Element} */
-(dev());
+(dev()));
 
 function hello() {
   return (
+    /** @type {x} */
+    (
     /** @type {!Element} */
-    (dev())
+    (dev()))
   );
 }


### PR DESCRIPTION
**summary**
The code in this PR does not work.
So this is essentially a GH issue.

**input**
```js
/** @type {x} */ (dev().assertElement(dev()));
````
**expected output**
```js
/** @type {x} */ (
  /** @type {!Element} */ (dev())
);
```

**current output**
```js
/** @type {!Element} */
(dev());
```