### PR TITLE
update package names to use `bentoproject` scope and drop `amp-` prefix

### DIFF
--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -6,6 +6,7 @@
 const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
 const fastGlob = require('fast-glob');
 const path = require('path');
+const {getNameWithoutComponentPrefix} = require('../tasks/bento-helpers');
 const {getSemver} = require('./utils');
 const {log} = require('../common/logging');
 const {stat, writeFile} = require('fs/promises');
@@ -78,7 +79,7 @@ async function writePackageJson() {
   }
 
   const json = {
-    name: `@ampproject/${extension}`,
+    name: `@bentoproject/${getNameWithoutComponentPrefix(extension)}`,
     version,
     description: `AMP HTML ${extension} Component`,
     author: 'The AMP HTML Authors',

--- a/build-system/tasks/bento-helpers.js
+++ b/build-system/tasks/bento-helpers.js
@@ -6,4 +6,12 @@ function getBentoName(name) {
   return name.replace(/^amp-/, 'bento-');
 }
 
-module.exports = {getBentoName};
+/**
+ * @param {string} name
+ * @return {string} name without `amp-` or `bento-` prefix
+ */
+function getNameWithoutComponentPrefix(name) {
+  return name.replace(/^(amp|bento)-/, '');
+}
+
+module.exports = {getBentoName, getNameWithoutComponentPrefix};


### PR DESCRIPTION
In preparation for the Bento release: this changes the package name of the published Bento components to `@bentoproject/foo` (instead of `@amppproject/amp-foo`).  We'll also need to deprecate the existing npm packages so that consumers use the new packages.
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
