### PR TITLE
compiler: create buildDom for amp-carousel 0.1

### DIFF
--- a/extensions/amp-carousel/0.1/amp-carousel.js
+++ b/extensions/amp-carousel/0.1/amp-carousel.js
@@ -1,15 +1,15 @@
 import {AmpScrollableCarousel} from './scrollable-carousel';
 import {AmpSlideScroll} from './slidescroll';
 import {CSS} from '../../../build/amp-carousel-0.1.css';
-import {getType} from './build-dom';
+import {isScrollable} from './build-dom';
 
 class CarouselSelector extends AMP.BaseElement {
   /** @override */
   upgradeCallback() {
-    if (getType(this.element) == 'slides') {
-      return new AmpSlideScroll(this.element);
+    if (isScrollable(this.element)) {
+      return new AmpScrollableCarousel(this.element);
     }
-    return new AmpScrollableCarousel(this.element);
+    return new AmpSlideScroll(this.element);
   }
 }
 

--- a/extensions/amp-carousel/0.1/amp-carousel.js
+++ b/extensions/amp-carousel/0.1/amp-carousel.js
@@ -1,11 +1,12 @@
 import {AmpScrollableCarousel} from './scrollable-carousel';
 import {AmpSlideScroll} from './slidescroll';
 import {CSS} from '../../../build/amp-carousel-0.1.css';
+import {getType} from './build-dom';
 
 class CarouselSelector extends AMP.BaseElement {
   /** @override */
   upgradeCallback() {
-    if (this.element.getAttribute('type') == 'slides') {
+    if (getType(this.element) == 'slides') {
       return new AmpSlideScroll(this.element);
     }
     return new AmpScrollableCarousel(this.element);

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -294,13 +294,15 @@ export function buildDom(element) {
  * @return {string} The default title to use for the next button.
  * @param {{index?: string, total?: string}} options - The default title to use for the pevious button.
  */
-export function getNextButtonTitle(element, {index, total} = {}) {
+export function getNextButtonTitle(element, options = {}) {
   const prefix =
     element.getAttribute('data-next-button-aria-label') ||
     'Next item in carousel';
   if (getType(element) === 'scroll') {
     return prefix;
   }
+
+  const {index, total} = options;
   return getVerboseButtonTitle(element, {prefix, index, total});
 }
 
@@ -309,13 +311,15 @@ export function getNextButtonTitle(element, {index, total} = {}) {
  * @param {{index?: string, total?: string}} options - The default title to use for the pevious button.
  * @return {string} The default title to use for the pevious button.
  */
-export function getPrevButtonTitle(element, {index, total} = {}) {
+export function getPrevButtonTitle(element, options) {
   const prefix =
     element.getAttribute('data-prev-button-aria-label') ||
     'Previous item in carousel';
   if (getType(element) === 'scroll') {
     return prefix;
   }
+
+  const {index, total} = options;
   return getVerboseButtonTitle(element, {prefix, index, total});
 }
 

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -1,4 +1,5 @@
 import {isAmp4Email} from '#core/document/format';
+import {isServerRendered} from '#core/dom';
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
 import {realChildElements} from '#core/dom/query';
 
@@ -10,6 +11,10 @@ export const _HAS_CONTROL_CLASS = 'i-amphtml-carousel-has-controls';
 const ClassNames = {
   PREV_BUTTON: 'amp-carousel-button-prev',
   NEXT_BUTTON: 'amp-carousel-button-next',
+  SLIDES_CONTAINER: 'i-amphtml-slides-container',
+  SCROLLABLE_CONTAINER: 'i-amphtml-scrollable-carousel-container',
+  SLIDE: 'amp-carousel-slide',
+  SLIDE_WRAPPER: 'i-amphtml-slide-item',
 };
 
 /**
@@ -24,11 +29,20 @@ function buildButton(element, type) {
   const title =
     type === 'prev' ? getPrevButtonTitle(element) : getNextButtonTitle(element);
 
+  /**
+   * In scrollable carousel, the next/previous buttons add no functionality
+   * for screen readers as scrollable carousel is just a horizontally
+   * scrollable div which ATs navigate just like any other content.
+   * To avoid confusion, we therefore set the role to presentation for the
+   * controls in this case.
+   */
+  const ariaRole = getType(element) === 'slides' ? 'button' : 'presentation';
+
   const button = element.ownerDocument.createElement('div');
   button.setAttribute('tabindex', '0');
   button.classList.add('amp-carousel-button');
   button.classList.add(className);
-  button.setAttribute('role', this.ariaRole_);
+  button.setAttribute('role', ariaRole);
   button.setAttribute('title', title);
   element.appendChild(button);
 
@@ -40,47 +54,181 @@ function buildButton(element, type) {
  * @param {!Element} element
  * @return {{
  *   prevButton: !HTMLDivElement,
- *   nextButton: !HTMLDivElement,
- *   container?: !HTMLDivElement
- *   cells?: !HTMLDivElement[]
+ *   nextButton: !HTMLDivElement
  * }}
  */
-export function buildDom(element) {
+export function buildCarouselControls(element) {
+  if (isServerRendered(element)) {
+    return queryCarouselControlsDom(element);
+  }
+
   const doc = element.ownerDocument;
   if (isAmp4Email(doc) || element.hasAttribute('controls')) {
-    this.element_.classList.add(_HAS_CONTROL_CLASS);
+    element.classList.add(_HAS_CONTROL_CLASS);
   }
 
   const prevButton = buildButton(element, 'prev');
   const nextButton = buildButton(element, 'next');
 
-  return {prevButton, nextButton, ...buildScrollableCarousel(element)};
+  return {prevButton, nextButton};
 }
 
+/**
+ * Builds the DOM necessary for scrollable carousel.
+ * @param {!Element} element
+ * @return {{
+ *   container: !HTMLDivElement
+ *   cells: !HTMLDivElement[]
+ * }}
+ */
 function buildScrollableCarousel(element) {
+  if (isServerRendered(element)) {
+    return queryScrollableCarousel(element);
+  }
+
   const doc = element.ownerDocument;
   const cells = realChildElements(element);
   const container = doc.createElement('div');
 
-  container.classList.add('i-amphtml-scrollable-carousel-container');
+  container.classList.add(ClassNames.SCROLLABLE_CONTAINER);
   // Focusable container makes it possible to fully consume Arrow key events.
   container.setAttribute('tabindex', '-1');
   element.appendChild(container);
   cells.forEach((cell) => {
-    cell.classList.add('amp-carousel-slide');
+    cell.classList.add(ClassNames.SLIDE);
     cell.classList.add('amp-scrollable-carousel-slide');
-    this.container_.appendChild(cell);
+    container.appendChild(cell);
   });
 
   return {cells, container};
 }
 
 /**
+ * Queries for ivars for scrollable carousel.
+ * @param {!Element} element
+ * @return {{
+ *   container: !HTMLDivElement
+ *   cells: !HTMLDivElement[]
+ * }}
+ */
+function queryScrollableCarousel(element) {
+  const container = /** @type {!HTMLDivElement} */ (
+    element.querySelector(
+      `./${escapeCssSelectorIdent(ClassNames.SCROLLABLE_CONTAINER)}`
+    )
+  );
+  const cells = /** @type {!HTMLDivElement[]} */ (
+    Array.from(
+      element.querySelectorAll(`./${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
+    )
+  );
+  return {container, cells};
+}
+
+/**
+ * Builds the DOM necessary for slidescroll carousel.
+ * @param {!Element} element
+ * @return {{
+ *   slides: !HTMLDivElement[]
+ *   slidesContainer: !HTMLDivElement
+ *   slideWrappers: !HTMLDivElement[]
+ * }}
+ */
+function buildSlideScroll(element) {
+  if (isServerRendered(element)) {
+    return querySlideScrollCarousel(element);
+  }
+  const doc = element.ownerDocument;
+  const slides = realChildElements(element);
+  element.classList.add('i-amphtml-slidescroll');
+
+  const slidesContainer = doc.createElement('div');
+  // Focusable container makes it possible to fully consume Arrow key events.
+  slidesContainer.setAttribute('tabindex', '-1');
+  slidesContainer.classList.add(ClassNames.SLIDES_CONTAINER);
+  // Let screen reader know that this is a live area and changes
+  // to it (such after pressing next) should be announced to the
+  // user.
+  slidesContainer.setAttribute('aria-live', 'polite');
+  element.appendChild(slidesContainer);
+
+  const slideWrappers = [];
+  slides.forEach((slide) => {
+    slide.classList.add(ClassNames.SLIDE);
+
+    const slideWrapper = doc.createElement('div');
+    slideWrapper.classList.add(ClassNames.SLIDE_WRAPPER);
+    slideWrapper.appendChild(slide);
+    slidesContainer.appendChild(slideWrapper);
+    slideWrappers.push(slideWrapper);
+  });
+
+  return {slidesContainer, slides, slideWrappers};
+}
+
+/**
+ * Queries for ivars for slidescroll.
+ * @param {!Element} element
+ * @return {{
+ *   slides: !HTMLDivElement[]
+ *   slidesContainer: !HTMLDivElement
+ *   slideWrappers: !HTMLDivElement[]
+ * }}
+ */
+function querySlideScrollCarousel(element) {
+  const slidesContainer = /** @type {!HTMLDivElement} */ (
+    element.querySelector(
+      `./${escapeCssSelectorIdent(ClassNames.SLIDES_CONTAINER)}`
+    )
+  );
+  const slideWrappers = /** @type {!HTMLDivElement[]} */ (
+    Array.from(
+      element.querySelectorAll(
+        `./${escapeCssSelectorIdent(ClassNames.SLIDE_WRAPPER)}`
+      )
+    )
+  );
+  const slides = /** @type {!HTMLDivElement[]} */ (
+    Array.from(
+      element.querySelectorAll(`./${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
+    )
+  );
+  return {slides, slidesContainer, slideWrappers};
+}
+
+/**
+ * Builds the DOM necessary for slidescroll carousel.
+ * @param {!Element} element
+ * @return {{
+ *   prevButton: !HTMLDivElement,
+ *   nextButton: !HTMLDivElement
+ *   container?: !HTMLDivElement
+ *   cells?: !HTMLDivElement[]
+ *   slides?: !HTMLDivElement[]
+ *   slidesContainer?: !HTMLDivElement
+ *   slideWrappers?: !HTMLDivElement[]
+ * }}
+ */
+export function buildDom(element) {
+  const type = getType(element);
+  const specificDom =
+    type == 'slides'
+      ? buildSlideScroll(element)
+      : buildScrollableCarousel(element);
+  const controlsDom = buildCarouselControls(element);
+
+  return {...controlsDom, ...specificDom};
+}
+
+/**
  * Queries for all of the necessary DOM Elements to assign to ivars
  * @param {!Element} element
- * @return {{prevButton: !HTMLDivElement, nextButton: !HTMLDivElement}}
+ * @return {{
+ *   prevButton: !HTMLDivElement,
+ *   nextButton: !HTMLDivElement
+ * }}
  */
-export function queryDom(element) {
+export function queryCarouselControlsDom(element) {
   const prevButton = /** @type {!HTMLDivElement} */ (
     element.querySelector(`./${escapeCssSelectorIdent(ClassNames.PREV_BUTTON)}`)
   );
@@ -111,4 +259,15 @@ export function getPrevButtonTitle(element) {
     element.getAttribute('data-prev-button-aria-label') ||
     'Previous item in carousel'
   );
+}
+
+/**
+ * @param {!Element} element
+ * @return {'slides' | 'scroll'}
+ */
+export function getType(element) {
+  if (element.getAttribute('type') == 'slides') {
+    return 'slides';
+  }
+  return 'scroll';
 }

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -289,46 +289,44 @@ export function buildDom(element) {
 /**
  * @param {!Element} element
  * @return {string} The default title to use for the next button.
- * @param {{index?: string, total?: string}} options - The default title to use for the pevious button.
+ * @param {{index?: string, total?: string}} options - The default title to use for the previous button.
  */
 export function getNextButtonTitle(element, options = {}) {
   const prefix =
     element.getAttribute('data-next-button-aria-label') ||
     'Next item in carousel';
-  if (isScrollable(element)) {
-    return prefix;
-  }
-
   const {index, total} = options;
-  return getVerboseButtonTitle(element, {prefix, index, total});
+  return getButtonTitle(element, {prefix, index, total});
 }
 
 /**
  * @param {!Element} element
- * @param {{index?: string, total?: string}} options - The default title to use for the pevious button.
- * @return {string} The default title to use for the pevious button.
+ * @param {{index?: string, total?: string}} options - The default title to use for the previous button.
+ * @return {string} The default title to use for the previous button.
  */
-export function getPrevButtonTitle(element, options) {
+export function getPrevButtonTitle(element, options = {}) {
   const prefix =
     element.getAttribute('data-prev-button-aria-label') ||
     'Previous item in carousel';
-  if (isScrollable(element)) {
-    return prefix;
-  }
-
   const {index, total} = options;
-  return getVerboseButtonTitle(element, {prefix, index, total});
+  return getButtonTitle(element, {prefix, index, total});
 }
 
 /**
  * Returns the title for a next or prev button.
- * Format: "Next item in carousel (X of Y)".
+ * Format:
+ * - Scrollable: "Next item in carousel"
+ * - Slides    : "Next item in carousel (X of Y)"
  *
  * @param {*} element
  * @param {{prefix: string, index: string, total:string}} param1
  * @return {string}
  */
-function getVerboseButtonTitle(element, {index, prefix, total}) {
+function getButtonTitle(element, {index, prefix, total}) {
+  if (isScrollable(element)) {
+    return prefix;
+  }
+
   /**
    * A format string for the button label. Should be a string, containing two
    * placeholders of "%s", where the index and total count will go.
@@ -342,7 +340,7 @@ function getVerboseButtonTitle(element, {index, prefix, total}) {
 }
 
 /**
- * Returns true if the carousel is a Scrollable.  *
+ * Returns true if the carousel is a Scrollable Carousel.
  * @param {!Element} element
  * @return {boolean}
  */

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -1,5 +1,6 @@
 import {isAmp4Email} from '#core/document/format';
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
+import {realChildElements} from '#core/dom/query';
 
 export const _HAS_CONTROL_CLASS = 'i-amphtml-carousel-has-controls';
 
@@ -37,7 +38,12 @@ function buildButton(element, type) {
 /**
  * Builds the DOM necessary for amp-carousel.
  * @param {!Element} element
- * @return {{prevButton: !HTMLDivElement, nextButton: !HTMLDivElement}}
+ * @return {{
+ *   prevButton: !HTMLDivElement,
+ *   nextButton: !HTMLDivElement,
+ *   container?: !HTMLDivElement
+ *   cells?: !HTMLDivElement[]
+ * }}
  */
 export function buildDom(element) {
   const doc = element.ownerDocument;
@@ -48,7 +54,25 @@ export function buildDom(element) {
   const prevButton = buildButton(element, 'prev');
   const nextButton = buildButton(element, 'next');
 
-  return {prevButton, nextButton};
+  return {prevButton, nextButton, ...buildScrollableCarousel(element)};
+}
+
+function buildScrollableCarousel(element) {
+  const doc = element.ownerDocument;
+  const cells = realChildElements(element);
+  const container = doc.createElement('div');
+
+  container.classList.add('i-amphtml-scrollable-carousel-container');
+  // Focusable container makes it possible to fully consume Arrow key events.
+  container.setAttribute('tabindex', '-1');
+  element.appendChild(container);
+  cells.forEach((cell) => {
+    cell.classList.add('amp-carousel-slide');
+    cell.classList.add('amp-scrollable-carousel-slide');
+    this.container_.appendChild(cell);
+  });
+
+  return {cells, container};
 }
 
 /**

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -128,10 +128,10 @@ export function buildCarouselControls(element, slideCount) {
  */
 export function queryCarouselControlsDom(element) {
   const prevButton = /** @type {!HTMLDivElement} */ (
-    element.querySelector(`./${escapeCssSelectorIdent(ClassNames.PREV_BUTTON)}`)
+    element.querySelector(`.${escapeCssSelectorIdent(ClassNames.PREV_BUTTON)}`)
   );
   const nextButton = /** @type {!HTMLDivElement} */ (
-    element.querySelector(`./${escapeCssSelectorIdent(ClassNames.NEXT_BUTTON)}`)
+    element.querySelector(`.${escapeCssSelectorIdent(ClassNames.NEXT_BUTTON)}`)
   );
   assertDomQueryResults(prevButton, nextButton);
   return {prevButton, nextButton};
@@ -177,12 +177,12 @@ function buildScrollableCarousel(element) {
 function queryScrollableCarousel(element) {
   const container = /** @type {!HTMLDivElement} */ (
     element.querySelector(
-      `./${escapeCssSelectorIdent(ClassNames.SCROLLABLE_CONTAINER)}`
+      `.${escapeCssSelectorIdent(ClassNames.SCROLLABLE_CONTAINER)}`
     )
   );
   const cells = /** @type {!HTMLDivElement[]} */ (
     Array.from(
-      element.querySelectorAll(`./${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
+      element.querySelectorAll(`.${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
     )
   );
   assertDomQueryResults(container, cells);
@@ -245,19 +245,19 @@ function buildSlideScroll(element) {
 function querySlideScrollCarousel(element) {
   const slidesContainer = /** @type {!HTMLDivElement} */ (
     element.querySelector(
-      `./${escapeCssSelectorIdent(ClassNames.SLIDES_CONTAINER)}`
+      `.${escapeCssSelectorIdent(ClassNames.SLIDES_CONTAINER)}`
     )
   );
   const slideWrappers = /** @type {!HTMLDivElement[]} */ (
     Array.from(
       element.querySelectorAll(
-        `./${escapeCssSelectorIdent(ClassNames.SLIDE_WRAPPER)}`
+        `.${escapeCssSelectorIdent(ClassNames.SLIDE_WRAPPER)}`
       )
     )
   );
   const slides = /** @type {!HTMLDivElement[]} */ (
     Array.from(
-      element.querySelectorAll(`./${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
+      element.querySelectorAll(`.${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
     )
   );
   assertDomQueryResults(slidesContainer, slideWrappers, slides);

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -30,11 +30,10 @@ export const ClassNames = {
 
 /**
  * Throws if any provided param is not truthy.
- * @param  {...any} elements
  */
-function assertDomQueryResults(...elements) {
-  for (let i = 0; i < elements.length; i++) {
-    if (!elements[i]) {
+function assertDomQueryResults() {
+  for (let i = 0; i < arguments.length; i++) {
+    if (!arguments[i]) {
       throw new Error('Invalid server render');
     }
   }
@@ -47,14 +46,14 @@ function assertDomQueryResults(...elements) {
  * @return {?HTMLDivElement}
  */
 function buildButton(element, {className, enabled, title}) {
-  /**
+  /*
    * In scrollable carousel, the next/previous buttons add no functionality
    * for screen readers as scrollable carousel is just a horizontally
    * scrollable div which ATs navigate just like any other content.
    * To avoid confusion, we therefore set the role to presentation for the
    * controls in this case.
    */
-  const ariaRole = getType(element) === 'scroll' ? 'presentation' : 'button';
+  const ariaRole = isScrollable(element) ? 'presentation' : 'button';
 
   const button = element.ownerDocument.createElement('div');
   button.setAttribute('tabindex', '0');
@@ -278,12 +277,10 @@ function querySlideScrollCarousel(element) {
  * }}
  */
 export function buildDom(element) {
-  const type = getType(element);
   const slideCount = realChildElements(element).length;
-  const slidesDom =
-    type == 'slides'
-      ? buildSlideScrollCarousel(element)
-      : buildScrollableCarousel(element);
+  const slidesDom = isScrollable(element)
+    ? buildScrollableCarousel(element)
+    : buildSlideScrollCarousel(element);
   const controlsDom = buildCarouselControls(element, slideCount);
 
   return {...controlsDom, ...slidesDom};
@@ -298,7 +295,7 @@ export function getNextButtonTitle(element, options = {}) {
   const prefix =
     element.getAttribute('data-next-button-aria-label') ||
     'Next item in carousel';
-  if (getType(element) === 'scroll') {
+  if (isScrollable(element)) {
     return prefix;
   }
 
@@ -315,7 +312,7 @@ export function getPrevButtonTitle(element, options) {
   const prefix =
     element.getAttribute('data-prev-button-aria-label') ||
     'Previous item in carousel';
-  if (getType(element) === 'scroll') {
+  if (isScrollable(element)) {
     return prefix;
   }
 
@@ -345,12 +342,10 @@ function getVerboseButtonTitle(element, {index, prefix, total}) {
 }
 
 /**
+ * Returns true if the carousel is a Scrollable.  *
  * @param {!Element} element
- * @return {'slides' | 'scroll'}
+ * @return {boolean}
  */
-export function getType(element) {
-  if (element.getAttribute('type') == 'slides') {
-    return 'slides';
-  }
-  return 'scroll';
+export function isScrollable(element) {
+  return element.getAttribute('type') !== 'slides';
 }

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -17,7 +17,7 @@ export const ClassNames = {
   // Generic
   SLIDE: 'amp-carousel-slide',
 
-  // Slide Scroll
+  // SlideScroll Carousel
   SLIDESCROLL_CAROUSEL: 'i-amphtml-slidescroll',
   SLIDE_WRAPPER: 'i-amphtml-slide-item',
   SLIDES_CONTAINER: 'i-amphtml-slides-container',
@@ -88,7 +88,7 @@ export function setButtonState(button, enabled) {
  */
 export function buildCarouselControls(element, slideCount) {
   if (isServerRendered(element)) {
-    return queryCarouselControlsDom(element);
+    return queryCarouselControls(element);
   }
 
   const doc = element.ownerDocument;
@@ -126,7 +126,7 @@ export function buildCarouselControls(element, slideCount) {
  *   nextButton: !HTMLDivElement
  * }}
  */
-export function queryCarouselControlsDom(element) {
+export function queryCarouselControls(element) {
   const prevButton = /** @type {!HTMLDivElement} */ (
     element.querySelector(`.${escapeCssSelectorIdent(ClassNames.PREV_BUTTON)}`)
   );
@@ -198,7 +198,7 @@ function queryScrollableCarousel(element) {
  *   slideWrappers: !HTMLDivElement[]
  * }}
  */
-function buildSlideScroll(element) {
+function buildSlideScrollCarousel(element) {
   if (isServerRendered(element)) {
     return querySlideScrollCarousel(element);
   }
@@ -282,7 +282,7 @@ export function buildDom(element) {
   const slideCount = realChildElements(element).length;
   const slidesDom =
     type == 'slides'
-      ? buildSlideScroll(element)
+      ? buildSlideScrollCarousel(element)
       : buildScrollableCarousel(element);
   const controlsDom = buildCarouselControls(element, slideCount);
 

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -1,0 +1,90 @@
+import {isAmp4Email} from '#core/document/format';
+import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
+
+export const _HAS_CONTROL_CLASS = 'i-amphtml-carousel-has-controls';
+
+/**
+ * @enum {string}
+ */
+const ClassNames = {
+  PREV_BUTTON: 'amp-carousel-button-prev',
+  NEXT_BUTTON: 'amp-carousel-button-next',
+};
+
+/**
+ * Builds a carousel button for next/prev.
+ * @param {!Element} element
+ * @param {'prev' | 'next'} type
+ * @return {?HTMLDivElement}
+ */
+function buildButton(element, type) {
+  const className =
+    type === 'prev' ? ClassNames.PREV_BUTTON : ClassNames.NEXT_BUTTON;
+  const title =
+    type === 'prev' ? getPrevButtonTitle(element) : getNextButtonTitle(element);
+
+  const button = element.ownerDocument.createElement('div');
+  button.setAttribute('tabindex', '0');
+  button.classList.add('amp-carousel-button');
+  button.classList.add(className);
+  button.setAttribute('role', this.ariaRole_);
+  button.setAttribute('title', title);
+  element.appendChild(button);
+
+  return button;
+}
+
+/**
+ * Builds the DOM necessary for amp-carousel.
+ * @param {!Element} element
+ * @return {{prevButton: !HTMLDivElement, nextButton: !HTMLDivElement}}
+ */
+export function buildDom(element) {
+  const doc = element.ownerDocument;
+  if (isAmp4Email(doc) || element.hasAttribute('controls')) {
+    this.element_.classList.add(_HAS_CONTROL_CLASS);
+  }
+
+  const prevButton = buildButton(element, 'prev');
+  const nextButton = buildButton(element, 'next');
+
+  return {prevButton, nextButton};
+}
+
+/**
+ * Queries for all of the necessary DOM Elements to assign to ivars
+ * @param {!Element} element
+ * @return {{prevButton: !HTMLDivElement, nextButton: !HTMLDivElement}}
+ */
+export function queryDom(element) {
+  const prevButton = /** @type {!HTMLDivElement} */ (
+    element.querySelector(`./${escapeCssSelectorIdent(ClassNames.PREV_BUTTON)}`)
+  );
+  const nextButton = /** @type {!HTMLDivElement} */ (
+    element.querySelector(`./${escapeCssSelectorIdent(ClassNames.NEXT_BUTTON)}`)
+  );
+
+  return {prevButton, nextButton};
+}
+
+/**
+ * @param {!Element} element
+ * @return {string} The default title to use for the next button.
+ */
+export function getNextButtonTitle(element) {
+  return (
+    element.getAttribute('data-next-button-aria-label') ||
+    'Next item in carousel'
+  );
+}
+
+/**
+ * @param {!Element} element
+ * @return {string} The default title to use for the pevious button.
+ */
+export function getPrevButtonTitle(element) {
+  return (
+    element.getAttribute('data-prev-button-aria-label') ||
+    'Previous item in carousel'
+  );
+}

--- a/extensions/amp-carousel/0.1/carousel-controls.js
+++ b/extensions/amp-carousel/0.1/carousel-controls.js
@@ -2,7 +2,7 @@ import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {toggleAttribute} from '#core/dom';
 import {getWin} from '#core/window';
-import {ClassNames} from './build-dom';
+import {ClassNames, setButtonState} from './build-dom';
 
 /**
  * @type {(dir:-1|1, animate: boolean, opt_autoplay?:boolean) => void}
@@ -14,13 +14,11 @@ export class CarouselControls {
    * @param {{
    *  element: !AmpElement,
    *  go: !GoFunctionDef,
-   *  hasPrev: () => boolean,
-   *  hasNext: () => boolean,
    *  prevButton: !HTMLDivElement,
    *  nextButton: !HTMLDivElement,
    * }} param0
    */
-  constructor({element, go, hasNext, hasPrev, nextButton, prevButton}) {
+  constructor({element, go, nextButton, prevButton}) {
     /** @private @type {!AmpElement} */
     this.element_ = element;
 
@@ -39,21 +37,14 @@ export class CarouselControls {
     /** @private {boolean} */
     this.showControls_ = false;
 
-    /** @private {() => boolean} */
-    this.hasNext_ = hasNext;
-
-    /** @private {() => boolean} */
-    this.hasPrev_ = hasPrev;
-
-    this.initialize_();
+    this.setupBehaviors_();
   }
 
   /**
    * Runs side effects to initialize controls.
    * Meant to be called during carousel's buildCallback().
    */
-  initialize_() {
-    this.setControlsState();
+  setupBehaviors_() {
     this.setupButtonInteraction(this.prevButton_, () => this.handlePrev());
     this.setupButtonInteraction(this.nextButton_, () => this.handleNext());
 
@@ -94,14 +85,11 @@ export class CarouselControls {
 
   /**
    * Sets the previous and next button visual states.
+   * @param {{prev: boolean, next: boolean}} param0
    */
-  setControlsState() {
-    this.prevButton_.classList.toggle('amp-disabled', !this.hasPrev_());
-    this.prevButton_.setAttribute('aria-disabled', String(!this.hasPrev_()));
-    this.nextButton_.classList.toggle('amp-disabled', !this.hasNext_());
-    this.nextButton_.setAttribute('aria-disabled', String(!this.hasNext_()));
-    this.prevButton_.tabIndex = this.hasPrev_() ? 0 : -1;
-    this.nextButton_.tabIndex = this.hasNext_() ? 0 : -1;
+  setControlsState({next, prev}) {
+    setButtonState(this.prevButton_, prev);
+    setButtonState(this.nextButton_, next);
   }
 
   /**

--- a/extensions/amp-carousel/0.1/carousel-controls.js
+++ b/extensions/amp-carousel/0.1/carousel-controls.js
@@ -2,9 +2,7 @@ import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {toggleAttribute} from '#core/dom';
 import {getWin} from '#core/window';
-
-const _CONTROL_HIDE_ATTRIBUTE = 'i-amphtml-carousel-hide-buttons';
-const _HAS_CONTROL_CLASS = 'i-amphtml-carousel-has-controls';
+import {ClassNames} from './build-dom';
 
 /**
  * @type {(dir:-1|1, animate: boolean, opt_autoplay?:boolean) => void}
@@ -70,10 +68,10 @@ export class CarouselControls {
         this.showControls_ = true;
         toggleAttribute(
           this.element_,
-          _CONTROL_HIDE_ATTRIBUTE,
+          ClassNames.CONTROL_HIDE_ATTRIBUTE,
           !this.showControls_
         );
-        this.element_.classList.add(_HAS_CONTROL_CLASS);
+        this.element_.classList.add(ClassNames.HAS_CONTROL);
       }
     }, true);
   }

--- a/extensions/amp-carousel/0.1/carousel-controls.js
+++ b/extensions/amp-carousel/0.1/carousel-controls.js
@@ -1,6 +1,5 @@
 import {Keys} from '#core/constants/key-codes';
 import {Services} from '#service';
-import {isAmp4Email} from '#core/document/format';
 import {toggleAttribute} from '#core/dom';
 import {getWin} from '#core/window';
 
@@ -17,30 +16,18 @@ export class CarouselControls {
    * @param {{
    *  element: !AmpElement,
    *  go: !GoFunctionDef,
-   *  ariaRole: 'button' | 'presentation',
    *  hasPrev: () => boolean,
    *  hasNext: () => boolean,
    *  prevButton: !HTMLDivElement,
    *  nextButton: !HTMLDivElement,
    * }} param0
    */
-  constructor({
-    ariaRole,
-    element,
-    go,
-    hasNext,
-    hasPrev,
-    nextButton,
-    prevButton,
-  }) {
+  constructor({element, go, hasNext, hasPrev, nextButton, prevButton}) {
     /** @private @type {!AmpElement} */
     this.element_ = element;
 
     /** @private @type {!GoFunctionDef} */
     this.go_ = go;
-
-    /** @private @type {'button' | 'presentation'} */
-    this.ariaRole_ = ariaRole;
 
     /** @private @type {!Window} */
     this.win_ = getWin(element);
@@ -68,7 +55,6 @@ export class CarouselControls {
    * Meant to be called during carousel's buildCallback().
    */
   initialize_() {
-    this.updateButtonTitles();
     this.setControlsState();
     this.setupButtonInteraction(this.prevButton_, () => this.handlePrev());
     this.setupButtonInteraction(this.nextButton_, () => this.handleNext());
@@ -146,32 +132,12 @@ export class CarouselControls {
    * Updates the titles for the next/previous buttons.
    * Uses given params if provided, otherwise uses sensible defaults.
    *
-   * @param {string=} prevTitle
-   * @param {string=} nextTitle
+   * @param {string} prevTitle
+   * @param {string} nextTitle
    */
   updateButtonTitles(prevTitle, nextTitle) {
-    this.prevButton_.title = prevTitle ?? this.getPrevButtonTitle();
-    this.nextButton_.title = nextTitle ?? this.getNextButtonTitle();
-  }
-
-  /**
-   * @return {string} The default title to use for the next button.
-   */
-  getNextButtonTitle() {
-    return (
-      this.element_.getAttribute('data-next-button-aria-label') ||
-      'Next item in carousel'
-    );
-  }
-
-  /**
-   * @return {string} The default title to use for the pevious button.
-   */
-  getPrevButtonTitle() {
-    return (
-      this.element_.getAttribute('data-prev-button-aria-label') ||
-      'Previous item in carousel'
-    );
+    this.prevButton_.title = prevTitle;
+    this.nextButton_.title = nextTitle;
   }
 
   /**
@@ -188,9 +154,9 @@ export class CarouselControls {
    * Called on user interaction to proceed to the next position.
    */
   handleNext() {
-    const isEnabled = !this.prevButton_.classList.contains('amp-disabled');
+    const isEnabled = !this.nextButton_.classList.contains('amp-disabled');
     if (isEnabled) {
-      this.go_(/* dir */ -1, /* animate */ true, /* autoplay */ false);
+      this.go_(/* dir */ 1, /* animate */ true, /* autoplay */ false);
     }
   }
 }

--- a/extensions/amp-carousel/0.1/carousel-controls.js
+++ b/extensions/amp-carousel/0.1/carousel-controls.js
@@ -59,13 +59,20 @@ export class CarouselControls {
 
     /** @private {() => boolean} */
     this.hasPrev_ = hasPrev;
+
+    this.initialize_();
   }
 
   /**
    * Runs side effects to initialize controls.
    * Meant to be called during carousel's buildCallback().
    */
-  initialize() {
+  initialize_() {
+    this.updateButtonTitles();
+    this.setControlsState();
+    this.setupButtonInteraction(this.prevButton_, () => this.handlePrev());
+    this.setupButtonInteraction(this.nextButton_, () => this.handleNext());
+
     if (this.element_.hasAttribute('controls')) {
       this.showControls_ = true;
       return;
@@ -83,17 +90,6 @@ export class CarouselControls {
         this.element_.classList.add(_HAS_CONTROL_CLASS);
       }
     }, true);
-  }
-
-  /**
-   * Meant to be called as part of carousel's buildCallback().
-   * TODO(samouri): extract to build-dom.js file.
-   */
-  buildDom() {
-    this.updateButtonTitles();
-    this.setupButtonInteraction(this.prevButton_, () => this.handlePrev());
-    this.setupButtonInteraction(this.nextButton_, () => this.handleNext());
-    this.setControlsState();
   }
 
   /**

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -9,6 +9,7 @@ import {listen} from '#utils/event-helper';
 import {numeric} from '#core/dom/transition';
 import {observeIntersections} from '#core/dom/layout/viewport-observer';
 import {realChildElements} from '#core/dom/query';
+import {buildDom} from './build-dom';
 
 /** @const {string} */
 const TAG = 'amp-scrollable-carousel';
@@ -37,21 +38,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     this.unobserveIntersections_ = null;
 
     /** @private {CarouselControls} */
-    this.controls_ = new CarouselControls({
-      element,
-      go: this.go.bind(this),
-      hasPrev: () => this.hasPrev(),
-      hasNext: () => this.hasNext(),
-
-      /**
-       * In scrollable carousel, the next/previous buttons add no functionality
-       * for screen readers as scrollable carousel is just a horizontally
-       * scrollable div which ATs navigate just like any other content.
-       * To avoid confusion, we therefore set the role to presentation for the
-       * controls in this case.
-       */
-      ariaRole: 'presentation',
-    });
+    this.controls_ = null;
   }
 
   /** @override */
@@ -64,23 +51,11 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     return true;
   }
 
-  /** Build carousel elements */
-  buildCarousel() {
-    this.cells_ = realChildElements(this.element);
-
-    this.container_ = this.element.ownerDocument.createElement('div');
-    this.container_.classList.add('i-amphtml-scrollable-carousel-container');
-    // Focusable container makes it possible to fully consume Arrow key events.
-    this.container_.setAttribute('tabindex', '-1');
-    this.element.appendChild(this.container_);
-
-    this.cells_.forEach((cell) => {
-      Services.ownersForDoc(this.element).setOwner(cell, this.element);
-      cell.classList.add('amp-carousel-slide');
-      cell.classList.add('amp-scrollable-carousel-slide');
-      this.container_.appendChild(cell);
-    });
-
+  /**
+   * Attaches event handlers.
+   * @private
+   */
+  setupBehavior_() {
     this.cancelTouchEvents_();
 
     this.container_.addEventListener('scroll', this.scrollHandler_.bind(this));
@@ -88,6 +63,10 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
       'keydown',
       this.keydownHandler_.bind(this)
     );
+
+    this.cells_.forEach((cell) => {
+      Services.ownersForDoc(this.element).setOwner(cell, this.element);
+    });
 
     this.registerAction(
       'goToSlide',
@@ -110,9 +89,29 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    this.buildCarousel();
-    this.controls_.buildDom();
-    this.controls_.initialize();
+    const {prevButton, nextButton, container, cells} = buildDom(this.element);
+    this.container_ = container;
+    this.cells_ = cells;
+
+    this.controls_ = new CarouselControls({
+      element: this.element,
+      prevButton,
+      nextButton,
+      go: this.go.bind(this),
+      hasPrev: this.hasPrev.bind(this),
+      hasNext: this.hasNext.bind(this),
+
+      /**
+       * In scrollable carousel, the next/previous buttons add no functionality
+       * for screen readers as scrollable carousel is just a horizontally
+       * scrollable div which ATs navigate just like any other content.
+       * To avoid confusion, we therefore set the role to presentation for the
+       * controls in this case.
+       */
+      ariaRole: 'presentation',
+    });
+
+    this.setupBehavior_();
   }
 
   /** @override */
@@ -151,9 +150,8 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
    * desired direction.
    * @param {number} dir -1 or 1
    * @param {boolean} animate
-   * @param {boolean=} opt_autoplay
    */
-  go(dir, animate, opt_autoplay) {
+  go(dir, animate) {
     const newPos = this.nextPos_(this.pos_, dir);
     const oldPos = this.pos_;
 

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -8,7 +8,6 @@ import {isLayoutSizeFixed} from '#core/dom/layout';
 import {listen} from '#utils/event-helper';
 import {numeric} from '#core/dom/transition';
 import {observeIntersections} from '#core/dom/layout/viewport-observer';
-import {realChildElements} from '#core/dom/query';
 import {buildDom} from './build-dom';
 
 /** @const {string} */
@@ -89,7 +88,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    const {prevButton, nextButton, container, cells} = buildDom(this.element);
+    const {cells, container, nextButton, prevButton} = buildDom(this.element);
     this.container_ = container;
     this.cells_ = cells;
 
@@ -100,17 +99,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
       go: this.go.bind(this),
       hasPrev: this.hasPrev.bind(this),
       hasNext: this.hasNext.bind(this),
-
-      /**
-       * In scrollable carousel, the next/previous buttons add no functionality
-       * for screen readers as scrollable carousel is just a horizontally
-       * scrollable div which ATs navigate just like any other content.
-       * To avoid confusion, we therefore set the role to presentation for the
-       * controls in this case.
-       */
-      ariaRole: 'presentation',
     });
-
     this.setupBehavior_();
   }
 

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -111,8 +111,8 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     this.doLayout_(this.pos_);
     this.preloadNext_(this.pos_, 1);
     this.controls_.setControlsState({
-      prev: this.hasPrev(),
-      next: this.hasNext(),
+      prev: this.hasPrev_(),
+      next: this.hasNext_(),
     });
     return Promise.resolve();
   }
@@ -296,8 +296,8 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     this.oldPos_ = pos;
     this.pos_ = pos;
     this.controls_.setControlsState({
-      prev: this.hasPrev(),
-      next: this.hasNext(),
+      prev: this.hasPrev_(),
+      next: this.hasNext_(),
     });
   }
 
@@ -382,13 +382,19 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     }
   }
 
-  /** @return  {boolean} */
-  hasPrev() {
+  /**
+   * @return {boolean}
+   * @private
+   */
+  hasPrev_() {
     return this.pos_ != 0;
   }
 
-  /** @return  {boolean} */
-  hasNext() {
+  /**
+   * @return {boolean}
+   * @private
+   */
+  hasNext_() {
     const containerWidth = this.element./*OK*/ offsetWidth;
     const scrollWidth = this.container_./*OK*/ scrollWidth;
     const maxPos = Math.max(scrollWidth - containerWidth, 0);

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -97,8 +97,6 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
       prevButton,
       nextButton,
       go: this.go.bind(this),
-      hasPrev: this.hasPrev.bind(this),
-      hasNext: this.hasNext.bind(this),
     });
     this.setupBehavior_();
   }
@@ -112,7 +110,10 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
 
     this.doLayout_(this.pos_);
     this.preloadNext_(this.pos_, 1);
-    this.controls_.setControlsState();
+    this.controls_.setControlsState({
+      prev: this.hasPrev(),
+      next: this.hasNext(),
+    });
     return Promise.resolve();
   }
 
@@ -294,7 +295,10 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     this.preloadNext_(pos, Math.sign(pos - this.oldPos_));
     this.oldPos_ = pos;
     this.pos_ = pos;
-    this.controls_.setControlsState();
+    this.controls_.setControlsState({
+      prev: this.hasPrev(),
+      next: this.hasNext(),
+    });
   }
 
   /**
@@ -304,7 +308,6 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
    * @private
    */
   nextPos_(pos, dir) {
-    // TODO(jridgewell): this could be using cached values from Layers.
     const containerWidth = this.element./*OK*/ offsetWidth;
     const fullWidth = this.container_./*OK*/ scrollWidth;
     const newPos = pos + dir * containerWidth;

--- a/extensions/amp-carousel/0.1/shame.d.ts
+++ b/extensions/amp-carousel/0.1/shame.d.ts
@@ -25,6 +25,10 @@ declare module '#utils/analytics' {
   export var triggerAnalyticsEvent: any;
 }
 
+declare module '#core/dom/css-selectors' {
+  export var escapeCssSelectorIdent: (s: string) => string;
+}
+
 // TODO: everything below are core stubs, which we can remove once Core has been
 // converted to TS.
 declare module '#core/constants/key-codes' {
@@ -42,6 +46,7 @@ declare module '#core/dom/layout/viewport-observer' {
 declare module '#core/dom' {
   export var toggleAttribute: any;
   export var dispatchCustomEvent: any;
+  export var isServerRendered: (el: Element) => boolean;
 }
 
 declare module '#core/window' {

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -185,6 +185,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
   setupBehavior_() {
     this.hasLoop_ = this.element.hasAttribute('loop');
     this.hasAutoplay_ = this.element.hasAttribute('autoplay');
+    this.noOfSlides_ = this.slides_.length;
     this.shouldLoop_ = this.hasLoop_ && this.isLoopingEligible();
     this.shouldAutoplay_ = this.hasAutoplay_ && this.isLoopingEligible();
 
@@ -227,8 +228,6 @@ export class AmpSlideScroll extends AMP.BaseElement {
     if (this.shouldDisableCssSnap_) {
       this.hasNativeSnapPoints_ = false;
     }
-
-    this.noOfSlides_ = this.slides_.length;
 
     // Snap point is buggy in IOS 10.3 (beta), so it is disabled in beta.
     // https://bugs.webkit.org/show_bug.cgi?id=169800
@@ -331,7 +330,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
   viewportCallback(inViewport) {
     if (inViewport) {
       this.autoplay_();
-      this.controls_.hintControls();
+      this.controls_?.hintControls();
     } else {
       this.clearAutoplayTimer_();
     }
@@ -855,8 +854,8 @@ export class AmpSlideScroll extends AMP.BaseElement {
       }
     }
     this.hideRestOfTheSlides_(showIndexArr);
-    this.controls_.setControlsState();
-    this.controls_.updateButtonTitles(
+    this.controls_?.setControlsState();
+    this.controls_?.updateButtonTitles(
       this.getPrevButtonTitle(),
       this.getNextButtonTitle()
     );

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -186,8 +186,11 @@ export class AmpSlideScroll extends AMP.BaseElement {
     return true;
   }
 
-  /** Build carousel elements */
-  buildCarousel() {
+  /**
+   * Attaches event handlers
+   * @private
+   */
+  setupBehavior_() {
     this.hasLoop_ = this.element.hasAttribute('loop');
 
     this.hasAutoplay_ = this.element.hasAttribute('autoplay');

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -188,11 +188,6 @@ export class AmpSlideScroll extends AMP.BaseElement {
    * @private
    */
   setupBehavior_() {
-    this.hasLoop_ = this.element.hasAttribute('loop');
-    this.hasAutoplay_ = this.element.hasAttribute('autoplay');
-    this.shouldLoop_ = this.hasLoop_ && this.isLoopingEligible();
-    this.shouldAutoplay_ = this.hasAutoplay_ && this.isLoopingEligible();
-
     const autoplayVal = this.element.getAttribute('autoplay');
     if (autoplayVal) {
       this.autoplayLoops_ = parseInt(autoplayVal, 10);
@@ -417,6 +412,10 @@ export class AmpSlideScroll extends AMP.BaseElement {
     this.slidesContainer_ = slidesContainer;
     this.slideWrappers_ = slideWrappers;
     this.noOfSlides_ = this.slides_.length;
+    this.hasLoop_ = this.element.hasAttribute('loop');
+    this.hasAutoplay_ = this.element.hasAttribute('autoplay');
+    this.shouldLoop_ = this.hasLoop_ && this.isLoopingEligible();
+    this.shouldAutoplay_ = this.hasAutoplay_ && this.isLoopingEligible();
 
     this.controls_ = new CarouselControls({
       element: this.element,
@@ -487,13 +486,19 @@ export class AmpSlideScroll extends AMP.BaseElement {
     return true;
   }
 
-  /** @return  {boolean} */
-  hasPrev() {
+  /**
+   * @return  {boolean}
+   * @private
+   */
+  hasPrev_() {
     return this.shouldLoop_ || this.slideIndex_ > 0;
   }
 
-  /** @return {boolean} */
-  hasNext() {
+  /**
+   * @return  {boolean}
+   * @private
+   */
+  hasNext_() {
     return this.shouldLoop_ || this.slideIndex_ < this.slides_.length - 1;
   }
 
@@ -505,8 +510,8 @@ export class AmpSlideScroll extends AMP.BaseElement {
    */
   moveSlide(dir, animate, trust) {
     if (this.slideIndex_ !== null) {
-      const hasNext = this.hasNext();
-      const hasPrev = this.hasPrev();
+      const hasNext = this.hasNext_();
+      const hasPrev = this.hasPrev_();
       if ((dir == 1 && hasNext) || (dir == -1 && hasPrev)) {
         let newIndex = dev().assertNumber(this.slideIndex_) + dir;
         if (newIndex == -1) {
@@ -607,7 +612,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
     const newIndex = this.getNextSlideIndex_(currentScrollLeft);
     // Default behavior should be stays on current slide
     let diff = newIndex - this.slideIndex_;
-    const hasPrev = this.hasPrev();
+    const hasPrev = this.hasPrev_();
     let toScrollLeft = hasPrev ? this.slideWidth_ : 0;
 
     if (diff == 0 && (opt_forceDir == 1 || opt_forceDir == -1)) {
@@ -645,8 +650,8 @@ export class AmpSlideScroll extends AMP.BaseElement {
     // shown slide.
     let updateValue = 0;
 
-    const hasPrev = this.hasPrev();
-    const hasNext = this.hasNext();
+    const hasPrev = this.hasPrev_();
+    const hasNext = this.hasNext_();
 
     if (hasPrev && hasNext) {
       updateValue = scrolledSlideIndex - 1;
@@ -840,8 +845,8 @@ export class AmpSlideScroll extends AMP.BaseElement {
     }
     this.hideRestOfTheSlides_(showIndexArr);
     this.controls_?.setControlsState({
-      prev: this.hasPrev(),
-      next: this.hasNext(),
+      prev: this.hasPrev_(),
+      next: this.hasNext_(),
     });
     this.controls_?.updateButtonTitles(
       this.getPrevButtonTitle(),

--- a/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
@@ -4,9 +4,6 @@ import {CarouselControls} from '../carousel-controls';
 describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
   let win, doc;
   let viewportCallbackSpy;
-  let hasPrevSpy;
-  let hasNextSpy;
-
   let setupAutoplaySpy;
   let hintControlsSpy;
   let autoplaySpy;
@@ -16,8 +13,6 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     win = env.win;
     doc = win.document;
     viewportCallbackSpy = env.sandbox.spy();
-    hasPrevSpy = env.sandbox.spy();
-    hasNextSpy = env.sandbox.spy();
     setupAutoplaySpy = env.sandbox.spy(
       AmpSlideScroll.prototype,
       'setupAutoplay_'
@@ -64,16 +59,6 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     /** @override */
     isLoopingEligible() {
       return true;
-    }
-
-    /** @override */
-    hasPrev() {
-      hasPrevSpy();
-    }
-
-    /** @override */
-    hasNext() {
-      hasNextSpy();
     }
   }
 

--- a/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
@@ -8,7 +8,6 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
   let hasNextSpy;
 
   let setupAutoplaySpy;
-  let setControlsStateSpy;
   let hintControlsSpy;
   let autoplaySpy;
   let clearAutoplaySpy;
@@ -22,10 +21,6 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     setupAutoplaySpy = env.sandbox.spy(
       AmpSlideScroll.prototype,
       'setupAutoplay_'
-    );
-    setControlsStateSpy = env.sandbox.spy(
-      CarouselControls.prototype,
-      'setControlsState'
     );
     hintControlsSpy = env.sandbox.spy(
       CarouselControls.prototype,
@@ -90,10 +85,8 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     );
 
     carouselLoopOnly.buildCallback();
-
     expect(carouselLoopOnly.shouldLoop_).to.be.true;
     expect(carouselLoopOnly.shouldAutoplay_).to.be.false;
-    expect(setControlsStateSpy).to.be.calledOnce;
 
     const carouselAutoplayOnly = new TestCarousel(
       getElement({
@@ -106,7 +99,6 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     expect(carouselAutoplayOnly.shouldLoop_).to.be.true;
     expect(carouselAutoplayOnly.shouldAutoplay_).to.be.true;
     expect(setupAutoplaySpy).to.have.been.called;
-    expect(setControlsStateSpy).to.have.callCount(2);
 
     const carouselAutoplayWithLoop = new TestCarousel(
       getElement({
@@ -120,7 +112,6 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     expect(carouselAutoplayWithLoop.shouldLoop_).to.be.true;
     expect(carouselAutoplayWithLoop.shouldAutoplay_).to.be.true;
     expect(setupAutoplaySpy).to.have.callCount(2);
-    expect(setControlsStateSpy).to.have.callCount(3);
   });
 
   it('should handle viewportCallback when in viewport', () => {
@@ -338,13 +329,5 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
       satisfiesTrust: () => true,
     });
     expect(carousel.shouldAutoplay_).to.be.true;
-  });
-
-  describe('buildDom', () => {
-    it('buildDom and buildCallback should result in the same outerHTML', async () => {});
-    it('buildCallback should assign ivars even when server rendered', async () => {});
-
-    it('buildDom should throw if invalid server rendered dom', async () => {});
-    it('buildDom should not modify dom for server rendered element', async () => {});
   });
 });

--- a/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
@@ -3,14 +3,11 @@ import {CarouselControls} from '../carousel-controls';
 
 describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
   let win, doc;
-  let buildSlidesSpy;
   let viewportCallbackSpy;
   let hasPrevSpy;
   let hasNextSpy;
-  let goCallbackSpy;
 
   let setupAutoplaySpy;
-  let buildButtonsSpy;
   let setControlsStateSpy;
   let hintControlsSpy;
   let autoplaySpy;
@@ -19,18 +16,12 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
   beforeEach(() => {
     win = env.win;
     doc = win.document;
-    buildSlidesSpy = env.sandbox.spy();
     viewportCallbackSpy = env.sandbox.spy();
     hasPrevSpy = env.sandbox.spy();
     hasNextSpy = env.sandbox.spy();
-    goCallbackSpy = env.sandbox.spy();
     setupAutoplaySpy = env.sandbox.spy(
       AmpSlideScroll.prototype,
       'setupAutoplay_'
-    );
-    buildButtonsSpy = env.sandbox.spy(
-      CarouselControls.prototype,
-      'buildButtons'
     );
     setControlsStateSpy = env.sandbox.spy(
       CarouselControls.prototype,
@@ -51,8 +42,9 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     );
   });
 
-  function setElement(options) {
+  function getElement(options) {
     const element = doc.createElement('div');
+    element.setAttribute('type', 'slides');
     if (options.loop) {
       element.setAttribute('loop', '');
     }
@@ -72,9 +64,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   class TestCarousel extends AmpSlideScroll {
     /** @override */
-    buildSlides() {
-      buildSlidesSpy();
-    }
+    setupSlideBehavior_() {}
 
     /** @override */
     isLoopingEligible() {
@@ -90,44 +80,36 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     hasNext() {
       hasNextSpy();
     }
-
-    /** @override */
-    goCallback() {
-      goCallbackSpy();
-    }
   }
 
   it('should do the right buildCallback processing', () => {
     const carouselLoopOnly = new TestCarousel(
-      setElement({
+      getElement({
         loop: true,
       })
     );
 
     carouselLoopOnly.buildCallback();
 
-    expect(carouselLoopOnly.shouldLoop).to.be.true;
+    expect(carouselLoopOnly.shouldLoop_).to.be.true;
     expect(carouselLoopOnly.shouldAutoplay_).to.be.false;
-    expect(setupAutoplaySpy).to.not.have.been.called;
-    expect(buildButtonsSpy).to.be.calledOnce;
     expect(setControlsStateSpy).to.be.calledOnce;
 
     const carouselAutoplayOnly = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
       })
     );
 
     carouselAutoplayOnly.buildCallback();
 
-    expect(carouselAutoplayOnly.shouldLoop).to.be.true;
+    expect(carouselAutoplayOnly.shouldLoop_).to.be.true;
     expect(carouselAutoplayOnly.shouldAutoplay_).to.be.true;
     expect(setupAutoplaySpy).to.have.been.called;
-    expect(buildButtonsSpy).to.have.callCount(2);
     expect(setControlsStateSpy).to.have.callCount(2);
 
     const carouselAutoplayWithLoop = new TestCarousel(
-      setElement({
+      getElement({
         loop: true,
         autoplay: true,
       })
@@ -135,21 +117,20 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
     carouselAutoplayWithLoop.buildCallback();
 
-    expect(carouselAutoplayWithLoop.shouldLoop).to.be.true;
+    expect(carouselAutoplayWithLoop.shouldLoop_).to.be.true;
     expect(carouselAutoplayWithLoop.shouldAutoplay_).to.be.true;
     expect(setupAutoplaySpy).to.have.callCount(2);
-    expect(buildButtonsSpy).to.have.callCount(3);
     expect(setControlsStateSpy).to.have.callCount(3);
   });
 
   it('should handle viewportCallback when in viewport', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         loop: true,
-        autoplay: true,
+        autoplay: false,
       })
     );
-
+    carousel.buildCallback();
     carousel.viewportCallback(true);
     expect(viewportCallbackSpy).to.have.been.calledWith(true);
     expect(hintControlsSpy).to.have.been.called;
@@ -159,7 +140,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   it('should handle viewportCallback when not in viewport', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         loop: true,
         autoplay: true,
       })
@@ -174,7 +155,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   it('should setup autoplay with no delay set', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
       })
     );
@@ -184,12 +165,12 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     expect(carousel.autoplayDelay_).to.equal(5000);
     expect(carousel.element.hasAttribute('loop')).to.be.true;
     expect(carousel.hasLoop_).to.be.true;
-    expect(carousel.shouldLoop).to.be.true;
+    expect(carousel.shouldLoop_).to.be.true;
   });
 
   it('should setup autoplay with specified number of loops', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
         autoplayLoops: 5,
       })
@@ -199,12 +180,12 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     expect(carousel.element.hasAttribute('loop')).to.be.true;
     expect(carousel.autoplayLoops_).to.equal(5);
     expect(carousel.hasLoop_).to.be.true;
-    expect(carousel.shouldLoop).to.be.true;
+    expect(carousel.shouldLoop_).to.be.true;
   });
 
   it('should setup autoplay with delay set', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
         delay: 3000,
       })
@@ -215,12 +196,12 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     expect(carousel.autoplayDelay_).to.equal(3000);
     expect(carousel.element.hasAttribute('loop')).to.be.true;
     expect(carousel.hasLoop_).to.be.true;
-    expect(carousel.shouldLoop).to.be.true;
+    expect(carousel.shouldLoop_).to.be.true;
   });
 
   it('should setup autoplay with delay set lower', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
         delay: 300,
       })
@@ -231,12 +212,12 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     expect(carousel.autoplayDelay_).to.equal(1000);
     expect(carousel.element.hasAttribute('loop')).to.be.true;
     expect(carousel.hasLoop_).to.be.true;
-    expect(carousel.shouldLoop).to.be.true;
+    expect(carousel.shouldLoop_).to.be.true;
   });
 
   it('should start timer on autoplay', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
         delay: 300,
       })
@@ -250,7 +231,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   it('should not start timer on when there is no autoplay', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         delay: 300,
       })
     );
@@ -263,7 +244,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   it('should clear timeout', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
         delay: 300,
       })
@@ -280,7 +261,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   it('toggle autoPlay status using speficied value & autoplay=true', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
         delay: 300,
       })
@@ -309,7 +290,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   it('toggle autoPlay status using speficied value & autoplay=false', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         delay: 300,
       })
     );
@@ -336,7 +317,7 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
 
   it('toggle autoPlay status without speficied value & autoplay=true', () => {
     const carousel = new TestCarousel(
-      setElement({
+      getElement({
         autoplay: true,
         delay: 300,
       })

--- a/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll-slides.js
@@ -339,4 +339,12 @@ describes.fakeWin('AmpSlideScroll', {amp: true}, (env) => {
     });
     expect(carousel.shouldAutoplay_).to.be.true;
   });
+
+  describe('buildDom', () => {
+    it('buildDom and buildCallback should result in the same outerHTML', async () => {});
+    it('buildCallback should assign ivars even when server rendered', async () => {});
+
+    it('buildDom should throw if invalid server rendered dom', async () => {});
+    it('buildDom should not modify dom for server rendered element', async () => {});
+  });
 });

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -1489,12 +1489,14 @@ describes.realWin(
           /* attachToDom */ false
         );
         const el2 = el1.cloneNode(/* deep */ true);
-        doc.body.appendChild(el1)
-        doc.body.appendChild(el2)
-        await new AmpSlideScroll(el1).buildCallback();
+        // doc.body.appendChild(el1);
+        const impl = new AmpSlideScroll(el1);
+        impl.setupSlideBehavior_ = () => {}
+        await impl.buildCallback();
         buildDom(el2);
 
-        expect(el1.outerHTML).equal(el2.outerHTML);
+        const oldHTML = `<amp-carousel type="slides" width="400" height="300" controls="" loop="" class="i-amphtml-carousel-has-controls i-amphtml-slidescroll" style="position: relative;"><div tabindex="-1" class="i-amphtml-slides-container i-amphtml-slidescroll-no-snap" aria-live="polite"><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" data-slide-id="slide-id" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div></div><div tabindex="0" class="amp-carousel-button amp-carousel-button-prev" role="button" title="Previous item in carousel (5 of 5)" aria-disabled="false"></div><div tabindex="0" class="amp-carousel-button amp-carousel-button-next" role="button" title="Next item in carousel (2 of 5)" aria-disabled="false"></div></amp-carousel>`
+        expect(el2.outerHTML).equal(oldHTML);
       });
       it('buildCallback should assign ivars even when server rendered', async () => {});
       it('buildDom should throw if invalid server rendered dom', async () => {});

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -6,6 +6,8 @@ import {createElementWithAttributes} from '#core/dom';
 import {installResizeObserverStub} from '#testing/resize-observer-stub';
 import {user} from '#utils/log';
 import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
+import {AmpSlideScroll} from '../slidescroll';
+import {buildDom} from '../build-dom';
 
 describes.realWin(
   'SlideScroll',
@@ -27,6 +29,14 @@ describes.realWin(
       resizeObserverStub = installResizeObserverStub(env.sandbox, win);
     });
 
+    /**
+     * @param {boolean=} opt_hasLooping
+     * @param {number=} opt_slideCount
+     * @param {boolean=} opt_attachToDom
+     * @param {boolean=} opt_hasAutoplay
+     * @param {boolean=} opt_autoplayLoops
+     * @return {!Element}
+     */
     function getAmpSlideScroll(
       opt_hasLooping,
       opt_slideCount = 5,
@@ -1469,6 +1479,26 @@ describes.realWin(
           expect(getNextTitle(el)).to.equal('Next item in carousel (1 of 3)');
         });
       });
+    });
+
+    describe('buildDom', () => {
+      it.only('buildDom and buildCallback should result in the same outerHTML', async () => {
+        const el1 = await getAmpSlideScroll(
+          /* hasLooping */ true,
+          /* slideCount */ undefined,
+          /* attachToDom */ false
+        );
+        const el2 = el1.cloneNode(/* deep */ true);
+        doc.body.appendChild(el1)
+        doc.body.appendChild(el2)
+        await new AmpSlideScroll(el1).buildCallback();
+        buildDom(el2);
+
+        expect(el1.outerHTML).equal(el2.outerHTML);
+      });
+      it('buildCallback should assign ivars even when server rendered', async () => {});
+      it('buildDom should throw if invalid server rendered dom', async () => {});
+      it('buildDom should not modify dom for server rendered element', async () => {});
     });
   }
 );

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -367,20 +367,14 @@ describes.realWin(
       const {nextButton_: nextBtn, prevButton_: prevBtn} = controls;
 
       impl.showSlide_(1);
-      expect(controls.hasNext_()).to.be.true;
-      expect(controls.hasPrev_()).to.be.true;
       expect(nextBtn.classList.contains('amp-disabled')).to.be.false;
       expect(prevBtn.classList.contains('amp-disabled')).to.be.false;
 
       impl.showSlide_(0);
-      expect(controls.hasNext_()).to.be.true;
-      expect(controls.hasPrev_()).to.be.false;
       expect(nextBtn.classList.contains('amp-disabled')).to.be.false;
       expect(prevBtn.classList.contains('amp-disabled')).to.be.true;
 
       impl.showSlide_(4);
-      expect(controls.hasNext_()).to.be.false;
-      expect(controls.hasPrev_()).to.be.true;
       expect(nextBtn.classList.contains('amp-disabled')).to.be.true;
       expect(prevBtn.classList.contains('amp-disabled')).to.be.false;
 
@@ -1063,20 +1057,14 @@ describes.realWin(
         const {nextButton_: nextBtn, prevButton_: prevBtn} = controls;
 
         impl.showSlide_(1);
-        expect(controls.hasNext_()).to.be.true;
-        expect(controls.hasPrev_()).to.be.true;
         expect(nextBtn.classList.contains('amp-disabled')).to.be.false;
         expect(prevBtn.classList.contains('amp-disabled')).to.be.false;
 
         impl.showSlide_(0);
-        expect(controls.hasNext_()).to.be.true;
-        expect(controls.hasPrev_()).to.be.true;
         expect(nextBtn.classList.contains('amp-disabled')).to.be.false;
         expect(prevBtn.classList.contains('amp-disabled')).to.be.false;
 
         impl.showSlide_(4);
-        expect(controls.hasNext_()).to.be.true;
-        expect(controls.hasPrev_()).to.be.true;
         expect(nextBtn.classList.contains('amp-disabled')).to.be.false;
         expect(prevBtn.classList.contains('amp-disabled')).to.be.false;
       });
@@ -1482,25 +1470,63 @@ describes.realWin(
     });
 
     describe('buildDom', () => {
-      it.only('buildDom and buildCallback should result in the same outerHTML', async () => {
+      it('buildDom and buildCallback should result in the same outerHTML', async () => {
         const el1 = await getAmpSlideScroll(
           /* hasLooping */ true,
           /* slideCount */ undefined,
           /* attachToDom */ false
         );
         const el2 = el1.cloneNode(/* deep */ true);
-        // doc.body.appendChild(el1);
         const impl = new AmpSlideScroll(el1);
-        impl.setupSlideBehavior_ = () => {}
+        impl.setupSlideBehavior_ = () => {};
         await impl.buildCallback();
         buildDom(el2);
 
-        const oldHTML = `<amp-carousel type="slides" width="400" height="300" controls="" loop="" class="i-amphtml-carousel-has-controls i-amphtml-slidescroll" style="position: relative;"><div tabindex="-1" class="i-amphtml-slides-container i-amphtml-slidescroll-no-snap" aria-live="polite"><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" data-slide-id="slide-id" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div><div class="i-amphtml-slide-item"><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w300-h200-no" width="400" height="300" class="amp-carousel-slide" style="display: inline;"></amp-img></div></div><div tabindex="0" class="amp-carousel-button amp-carousel-button-prev" role="button" title="Previous item in carousel (5 of 5)" aria-disabled="false"></div><div tabindex="0" class="amp-carousel-button amp-carousel-button-next" role="button" title="Next item in carousel (2 of 5)" aria-disabled="false"></div></amp-carousel>`
-        expect(el2.outerHTML).equal(oldHTML);
+        expect(el2.outerHTML).equal(el1.outerHTML);
       });
-      it('buildCallback should assign ivars even when server rendered', async () => {});
-      it('buildDom should throw if invalid server rendered dom', async () => {});
-      it('buildDom should not modify dom for server rendered element', async () => {});
+
+      it('buildCallback should assign ivars even when server rendered', async () => {
+        const el1 = await getAmpSlideScroll(
+          /* hasLooping */ true,
+          /* slideCount */ undefined,
+          /* attachToDom */ false
+        );
+        buildDom(el1);
+        el1.setAttribute('i-amphtml-ssr', '');
+        const impl = new AmpSlideScroll(el1);
+        impl.setupSlideBehavior_ = () => {};
+        await impl.buildCallback();
+
+        expect(impl.slides_).length(5);
+        expect(impl.slideWrappers_).length(5);
+        expect(impl.slidesContainer_).ok;
+      });
+
+      it('buildDom should throw if invalid server rendered dom', async () => {
+        const carousel = await getAmpSlideScroll(
+          /* hasLooping */ true,
+          /* slideCount */ undefined,
+          /* attachToDom */ false
+        );
+        carousel.setAttribute('i-amphtml-ssr', '');
+        expect(() => buildDom(carousel)).throws(/Invalid server render/);
+      });
+
+      it('buildDom should not modify dom for server rendered element', async () => {
+        const carousel = await getAmpSlideScroll(
+          /* hasLooping */ true,
+          /* slideCount */ undefined,
+          /* attachToDom */ false
+        );
+        buildDom(carousel);
+        carousel.setAttribute('i-amphtml-ssr', '');
+
+        const before = carousel.outerHTML;
+        buildDom(carousel);
+        const after = carousel.outerHTML;
+
+        expect(before).equal(after);
+      });
     });
   }
 );

--- a/test/integration/test-amp-carousel.js
+++ b/test/integration/test-amp-carousel.js
@@ -358,11 +358,11 @@ t.run('amp-carousel', {}, function () {
           'able to get past the first and last item',
         () => {
           document.body.classList.add('amp-mode-mouse');
-          const amp = document.querySelector('#carousel-1');
-          const prevBtn = amp.querySelector('.amp-carousel-button-prev');
-          const nextBtn = amp.querySelector('.amp-carousel-button-next');
-          expect(amp.hasAttribute('loop')).to.be.true;
-          expect(amp.hasAttribute('controls')).to.be.true;
+          const carousel = document.querySelector('#carousel-1');
+          const prevBtn = carousel.querySelector('.amp-carousel-button-prev');
+          const nextBtn = carousel.querySelector('.amp-carousel-button-next');
+          expect(carousel.hasAttribute('loop')).to.be.true;
+          expect(carousel.hasAttribute('controls')).to.be.true;
           expect(prevBtn).to.not.be.null;
           expect(nextBtn).to.not.be.null;
           expect(prevBtn).to.be.visible;


### PR DESCRIPTION
**summary**
Final piece for server-rendering amp-carouse-0.1 (https://github.com/ampproject/amphtml/issues/36299).
Implements both `buildDom` and hydration within the `build-dom.js` file.

- The primary `buildDom` has been split into 3 sub-builders. `buildCarouselControls`, `buildSlideScrollCarousel`, `buildScrollableCarousel`. Each of these sub-builders has an associated `queryXYZ` function for implementing hydration.
- All side effects for each of these files have moved to a `setupBehavior` function. 
- All properties were converted to attributes.

**testing**
- [x] Basic manual testing of both slidescroll and scrollable carousel
- [x] Confirmed basic `buildCallback` results from prior to any of these PRs is identical  to the new `buildDom` outerHTML.
- [x] Added two new suites of `buildDom` tests for ensuring our primary invariants.
- [x] Extensive manual testing 