### PR TITLE
📖 Remove nonstandard Markdown from components README

### DIFF
--- a/extensions/amp-accordion/1.0/README.md
+++ b/extensions/amp-accordion/1.0/README.md
@@ -29,8 +29,6 @@ The examples below demonstrate use of the `<bento-accordion>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -41,14 +39,10 @@ npm install @ampproject/bento-accordion
 import '@ampproject/bento-accordion';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
 
 The example below contains an `bento-accordion` with three sections. The
 `expanded` attribute on the third section expands it on page load.
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -57,7 +51,7 @@ The example below contains an `bento-accordion` with three sections. The
   <link rel="stylesheet" type="text/css" href="https://cdn.ampproject.org/v0/amp-accordion-1.0.css">
 </head>
 <body>
-  <bento-accordion id="my-accordion"{% if not format=='email'%} disable-session-states{% endif %}>
+  <bento-accordion id="my-accordion" disable-session-states>
     <section>
       <h2>Section 1</h2>
       <p>Content in section 1.</p>
@@ -85,8 +79,6 @@ The example below contains an `bento-accordion` with three sections. The
   </script>
 </body>
 ```
-
-[/example]
 
 #### Interactivity and API usage
 
@@ -287,8 +279,6 @@ animation when the content is expanded and "roll up" animation when collapsed.
 
 This attribute can be configured to based on a [media query](./../../../docs/spec/amp-html-responsive-attributes.md).
 
-[example preview="top-frame" playground="true" imports="bento-accordion:1.0"]
-
 ```html
 <bento-accordion animate>
   <section>
@@ -306,13 +296,9 @@ This attribute can be configured to based on a [media query](./../../../docs/spe
 </bento-accordion>
 ```
 
-[/example]
-
 ##### expanded
 
 Apply the `expanded` attribute to a nested `<section>` to expand that section when the page loads.
-
-[example preview="top-frame" playground="true" imports="bento-accordion:1.0"]
 
 ```html
 <bento-accordion>
@@ -331,13 +317,9 @@ Apply the `expanded` attribute to a nested `<section>` to expand that section wh
 </bento-accordion>
 ```
 
-[/example]
-
 ##### expand-single-section
 
 Allow only one section to expand at a time by applying the `expand-single-section` attribute to the `<bento-accordion>` element. This means if a user taps on a collapsed `<section>`, it will expand and collapse other expanded `<section>`'s.
-
-[example preview="top-frame" playground="true" imports="bento-accordion:1.0"]
 
 ```html
 <bento-accordion expand-single-section>
@@ -351,16 +333,14 @@ Allow only one section to expand at a time by applying the `expand-single-sectio
   </section>
   <section>
     <h2>Section 3</h2>
-    <amp-img
-      src="{{server_for_email}}/static/inline-examples/images/squirrel.jpg"
+    <img
+      src="https://source.unsplash.com/random/320x256"
       width="320"
       height="256"
-    ></amp-img>
+    />
   </section>
 </bento-accordion>
 ```
-
-[/example]
 
 #### Styling
 
@@ -384,8 +364,6 @@ Keep the following points in mind when you style an amp-accordion:
 The examples below demonstrates use of the `<BentoAccordion>` as a functional component usable with the Preact or React libraries.
 
 #### Example: Import via npm
-
-[example preview="top-frame" playground="false"]
 
 Install via npm:
 
@@ -419,8 +397,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Interactivity and API usage
 

--- a/extensions/amp-base-carousel/1.0/README.md
+++ b/extensions/amp-base-carousel/1.0/README.md
@@ -21,8 +21,6 @@ The examples below demonstrate use of the `<bento-base-carousel>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -33,11 +31,7 @@ npm install @ampproject/bento-base-carousel
 import '@ampproject/bento-base-carousel';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -96,8 +90,6 @@ import '@ampproject/bento-base-carousel';
   })();
 </script>
 ```
-
-[/example]
 
 #### Interactivity and API usage
 
@@ -385,8 +377,6 @@ The examples below demonstrate use of the `<BentoBaseCarousel>` as a functional 
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -408,8 +398,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Interactivity and API usage
 

--- a/extensions/amp-date-countdown/1.0/README.md
+++ b/extensions/amp-date-countdown/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-date-countdown>` web component
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,14 +22,10 @@ npm install @ampproject/bento-date-countdown
 import '@ampproject/bento-date-countdown';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
 
 The example below contains an `bento-date-countdown` with three sections. The
 `expanded` attribute on the third section expands it on page load.
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -55,8 +49,6 @@ The example below contains an `bento-date-countdown` with three sections. The
   </bento-date-countdown>
 </body>
 ```
-
-[/example]
 
 #### Interactivity and API usage
 
@@ -167,8 +159,6 @@ The examples below demonstrates use of the `<BentoDateCountdown>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -200,8 +190,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Interactivity and API usage
 

--- a/extensions/amp-date-display/1.0/README.md
+++ b/extensions/amp-date-display/1.0/README.md
@@ -17,8 +17,6 @@ The examples below demonstrate use of the `<bento-date-display>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -29,14 +27,10 @@ npm install @ampproject/bento-date-display
 import '@ampproject/bento-date-display';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
 
 The example below contains an `bento-date-display` with three sections. The
 `expanded` attribute on the third section expands it on page load.
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -56,8 +50,6 @@ The example below contains an `bento-date-display` with three sections. The
   </bento-date-display>
 </body>
 ```
-
-[/example]
 
 #### Interactivity and API usage
 
@@ -136,8 +128,6 @@ The examples below demonstrates use of the `<BentoDateDisplay>` as a functional 
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -162,8 +152,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Interactivity and API usage
 

--- a/extensions/amp-embedly-card/1.0/README.md
+++ b/extensions/amp-embedly-card/1.0/README.md
@@ -17,8 +17,6 @@ The examples below demonstrate use of the `<bento-embedly-card>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -29,11 +27,7 @@ npm install @ampproject/bento-embedly-card
 import '@ampproject/bento-embedly-card';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -87,8 +81,6 @@ import '@ampproject/bento-embedly-card';
   </script>
 </body>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -184,8 +176,6 @@ The examples below demonstrate use of the `<BentoEmbedlyCard>` as a functional c
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -206,8 +196,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-facebook/1.0/README.md
+++ b/extensions/amp-facebook/1.0/README.md
@@ -10,8 +10,6 @@ You must include each Bento component's required CSS library before adding custo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -22,11 +20,7 @@ npm install @ampproject/bento-facebook
 import '@ampproject/bento-facebook';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -125,8 +119,6 @@ import '@ampproject/bento-facebook';
     data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185">
 </bento-facebook>
 ```
-
-[/example]
 
 #### Layout and Style
 
@@ -289,8 +281,6 @@ The examples below demonstrate use of the `<BentoFacebook>` as a functional comp
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -311,8 +301,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Props
 

--- a/extensions/amp-fit-text/1.0/README.md
+++ b/extensions/amp-fit-text/1.0/README.md
@@ -14,8 +14,6 @@ The examples below demonstrate use of the `<bento-fit-text>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -26,11 +24,7 @@ npm install @ampproject/bento-fit-text
 import '@ampproject/bento-fit-text';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -66,16 +60,12 @@ import '@ampproject/bento-fit-text';
 </script>
 ```
 
-[/example]
-
 #### Overflowing content
 
 If the content of the `bento-fit-text` overflows the available space, even with a
 `min-font-size` specified, the overflowing content is cut off and hidden. WebKit and Blink-based browsers show ellipsis for overflowing content.
 
 In the following example, we specified a `min-font-size` of `40`, and added more content inside the `bento-fit-text` element. This causes the content to exceed the size of its fixed block parent, so the text is truncated to fit the container.
-
-[example preview="inline" playground="true" imports="bento-fit-text:1.0"]
 
 ```html
 <div style="width: 300px; height: 300px; background: #005AF0; color: #FFF;">
@@ -86,8 +76,6 @@ In the following example, we specified a `min-font-size` of `40`, and added more
   </bento-fit-text>
 </div>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -145,8 +133,6 @@ The examples below demonstrate use of the `<BentoFitText>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -167,8 +153,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-iframe/1.0/README.md
+++ b/extensions/amp-iframe/1.0/README.md
@@ -14,8 +14,6 @@ The examples below demonstrate use of the `<bento-iframe>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -26,11 +24,7 @@ npm install @ampproject/bento-iframe
 import '@ampproject/bento-iframe';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -66,8 +60,6 @@ import '@ampproject/bento-iframe';
   })();
 </script>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -143,8 +135,6 @@ The examples below demonstrates use of the `<BentoIframe>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -166,8 +156,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Props
 

--- a/extensions/amp-inline-gallery/1.0/README.md
+++ b/extensions/amp-inline-gallery/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-inline-gallery>` web component
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,13 +22,9 @@ npm install @ampproject/bento-inline-gallery
 import '@ampproject/bento-inline-gallery';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
 
 The example below contains a `bento-inline-gallery` consisting of three slides with thumbnails and a pagination indicator.
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -52,8 +46,6 @@ The example below contains a `bento-inline-gallery` consisting of three slides w
 
 </body>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -117,8 +109,6 @@ The examples below demonstrates use of the `<BentoInlineGallery>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -143,8 +133,6 @@ function App() {
     </BentoInlineGallery>
   }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-instagram/1.0/README.md
+++ b/extensions/amp-instagram/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-instagram>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,11 +22,7 @@ npm install @ampproject/bento-instagram
 import '@ampproject/bento-instagram';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -59,8 +53,6 @@ import '@ampproject/bento-instagram';
   })();
 </script>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -113,8 +105,6 @@ The examples below demonstrates use of the `<BentoInstagram>` as a functional co
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -134,8 +124,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-jwplayer/1.0/README.md
+++ b/extensions/amp-jwplayer/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-jwplayer>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,14 +22,10 @@ npm install @ampproject/bento-jwplayer
 import '@ampproject/bento-jwplayer';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
 
 The example below contains an `bento-jwplayer` with three sections. The
 `expanded` attribute on the third section expands it on page load.
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -63,8 +57,6 @@ The example below contains an `bento-jwplayer` with three sections. The
 
 </body>
 ```
-
-[/example]
 
 #### Interactivity and API usage
 
@@ -216,8 +208,6 @@ The examples below demonstrates use of the `<BentoMathml>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -240,8 +230,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-lightbox-gallery/1.0/README.md
+++ b/extensions/amp-lightbox-gallery/1.0/README.md
@@ -14,8 +14,6 @@ The examples below demonstrate use of the `<bento-lightbox-gallery>` web compone
 
 ### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -26,11 +24,7 @@ npm install @ampproject/bento-lightbox-gallery
 import '@ampproject/bento-lightbox-gallery';
 ```
 
-[/example]
-
 ### Example: Import via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -71,8 +65,6 @@ import '@ampproject/bento-lightbox-gallery';
     })();
   </script>
 ```
-
-[/example]
 
 ### Usage
 
@@ -162,8 +154,6 @@ The preact/react version of the bentolightboxgallery functions differently than 
 
 ### Example: Import Via npm
 
-[example preview="top-frame" playground="false"]
-
 ```sh
 npm install @ampproject/bento-lightbox-gallery
 ```
@@ -187,13 +177,9 @@ function App() {
 
 ```
 
-[/example]
-
 #### Example Using BentoBaseCarousel
 
 `<BentoLightboxGallery>` can be used with a `<BentoBaseCarousel>` child in order to lightbox all of the carousel's children. As you navigate throught the carousel items in the lightbox, the original carousel slides are synchronised so that when the lightbox is closed, the user ends up on the same slide as they were originally on.
-
-[example preview="top-frame" playground="false"]
 
 ```javascript
 import React from 'react';
@@ -216,8 +202,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 For further examples of how to use the BentoLightboxGallery please check the storybook example found in (Basic.js)[./storybook/Basic.js].
 

--- a/extensions/amp-lightbox/1.0/README.md
+++ b/extensions/amp-lightbox/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-lightbox>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,11 +22,7 @@ npm install @ampproject/bento-lightbox
 import '@ampproject/bento-lightbox';
 ```
 
-[/example]
-
 #### Example: Import via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -52,8 +46,6 @@ import '@ampproject/bento-lightbox';
   })();
 </script>
 ```
-
-[/example]
 
 #### Interactivity and API usage
 
@@ -149,8 +141,6 @@ The examples below demonstrates use of the `<BentoLightbox>` as a functional com
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -176,8 +166,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-mathml/1.0/README.md
+++ b/extensions/amp-mathml/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-mathml>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,14 +22,10 @@ npm install @ampproject/bento-mathml
 import '@ampproject/bento-mathml';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
 
 The example below contains an `bento-mathml` with three sections. The
 `expanded` attribute on the third section expands it on page load.
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -57,8 +51,6 @@ The example below contains an `bento-mathml` with three sections. The
     </p>
 </body>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -104,8 +96,6 @@ The examples below demonstrates use of the `<BentoMathml>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -136,8 +126,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-selector/1.0/README.md
+++ b/extensions/amp-selector/1.0/README.md
@@ -10,8 +10,6 @@ You must include each Bento component's required CSS library before adding custo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -22,11 +20,7 @@ npm install @ampproject/bento-selector
 import '@ampproject/bento-selector';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -49,8 +43,6 @@ import '@ampproject/bento-selector';
   </ul>
 </bento-selector>
 ```
-
-[/example]
 
 #### Usage notes
 
@@ -157,8 +149,6 @@ The examples below demonstrate use of the `<BentoSelector>` as a functional comp
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -181,8 +171,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and Style
 

--- a/extensions/amp-sidebar/1.0/README.md
+++ b/extensions/amp-sidebar/1.0/README.md
@@ -14,8 +14,6 @@ The examples below demonstrate use of the `<bento-sidebar>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -26,11 +24,7 @@ npm install @ampproject/bento-sidebar
 import '@ampproject/bento-sidebar';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -72,8 +66,6 @@ import '@ampproject/bento-sidebar';
   </script>
 </body>
 ```
-
-[/example]
 
 #### Bento Toolbar
 
@@ -215,8 +207,6 @@ The examples below demonstrate use of the `<BentoSidebar>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -243,8 +233,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Bento Toolbar
 

--- a/extensions/amp-social-share/1.0/README.md
+++ b/extensions/amp-social-share/1.0/README.md
@@ -14,8 +14,6 @@ The examples below demonstrate use of the `<bento-social-share>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -26,11 +24,7 @@ npm install @ampproject/bento-social-share
 import '@ampproject/bento-social-share';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -78,8 +72,6 @@ import '@ampproject/bento-social-share';
   })();
 </script>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -330,8 +322,6 @@ The examples below demonstrate use of the `<BentoSocialShare>` as a functional c
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -352,8 +342,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-soundcloud/1.0/README.md
+++ b/extensions/amp-soundcloud/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-soundcloud>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,11 +22,7 @@ npm install @ampproject/bento-soundcloud
 import '@ampproject/bento-soundcloud';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -73,8 +67,6 @@ import '@ampproject/bento-soundcloud';
   })();
 </script>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -140,8 +132,6 @@ The examples below demonstrate use of the `<BentoSoundcloud>` as a functional co
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -160,8 +150,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-stream-gallery/1.0/README.md
+++ b/extensions/amp-stream-gallery/1.0/README.md
@@ -15,8 +15,6 @@ The examples below demonstrate use of the `<bento-stream-gallery>` web component
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -27,14 +25,10 @@ npm install @ampproject/bento-stream-gallery
 import '@ampproject/bento-stream-gallery';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
 
 The example below contains an `bento-stream-gallery` with three sections. The
 `expanded` attribute on the third section expands it on page load.
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -69,8 +63,6 @@ The example below contains an `bento-stream-gallery` with three sections. The
   </script>
 </body>
 ```
-
-[/example]
 
 #### Interactivity and API usage
 
@@ -216,8 +208,6 @@ The examples below demonstrates use of the `<BentoStreamGallery>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -243,8 +233,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Interactivity and API usage
 

--- a/extensions/amp-timeago/1.0/README.md
+++ b/extensions/amp-timeago/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-timeago>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,11 +22,7 @@ npm install @ampproject/bento-timeago
 import '@ampproject/bento-timeago';
 ```
 
-[/example]
-
 #### Example: Import via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -151,8 +145,6 @@ The examples below demonstrates use of the `<BentoTimeago>` as a functional comp
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -175,8 +167,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-twitter/1.0/README.md
+++ b/extensions/amp-twitter/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-twitter>` web component.
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,11 +22,7 @@ npm install @ampproject/bento-twitter
 import '@ampproject/bento-twitter';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -70,8 +64,6 @@ import '@ampproject/bento-twitter';
   })();
 </script>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -136,8 +128,6 @@ The examples below demonstrate use of the `<BentoTwitter>` as a functional compo
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -156,8 +146,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -12,8 +12,6 @@ The examples below demonstrate use of the `<bento-wordpress-embed>` web componen
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -24,11 +22,7 @@ npm install @ampproject/bento-wordpress-embed
 import '@ampproject/bento-wordpress-embed';
 ```
 
-[/example]
-
 #### Example: Include via `<script>`
-
-[example preview="top-frame" playground="false"]
 
 ```html
 <head>
@@ -60,8 +54,6 @@ import '@ampproject/bento-wordpress-embed';
   })();
 </script>
 ```
-
-[/example]
 
 #### Layout and style
 
@@ -106,8 +98,6 @@ The examples below demonstrate use of the `<BentoWordPressEmbed>` as a functiona
 
 #### Example: Import via npm
 
-[example preview="top-frame" playground="false"]
-
 Install via npm:
 
 ```sh
@@ -126,8 +116,6 @@ function App() {
   );
 }
 ```
-
-[/example]
 
 #### Layout and style
 


### PR DESCRIPTION
This removes special text that is otherwise interpreted by the `amp.dev` builder.

Component `README.md` files are consumed by `npm`, which only renders standard Markdown. This removes noise like:

![image](https://user-images.githubusercontent.com/254946/139113235-fe7fa919-da37-46ea-a404-9113478ae766.png)
