### PR TITLE
🐛 [amp-script] skip sha384 check for cross-origin scripts in sandboxed mode

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -437,8 +437,8 @@ export class AmpScript extends AMP.BaseElement {
           return response.text();
         } else {
           // For cross-origin, verify hash of script itself (skip in
-          // development mode).
-          if (this.development_) {
+          // development and sandboxed mode).
+          if (this.development_ || this.sandboxed_) {
             return response.text();
           } else {
             return response.text().then((text) => {

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -135,15 +135,13 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     element.setAttribute('src', 'https://bar.example/bar.js')
     element.setAttribute('sandboxed', '')
 
-    script.buildCallback()
-
     stubFetch(
       'https://bar.example/bar.js',
       { 'Content-Type': 'application/javascript; charset=UTF-8' },
       'alert(1)'
     )
 
-    service.checkSha384.withArgs('alert(1)').resolves()
+    await script.buildCallback()
     await script.layoutCallback()
     expect(service.checkSha384).not.to.be.called
   });

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -131,19 +131,19 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
   });
 
   it('should skip the check for sha384(author_js) for cross-origin src in sandboxed mode', async () => {
-    env.sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/')
-    element.setAttribute('src', 'https://bar.example/bar.js')
-    element.setAttribute('sandboxed', '')
+    env.sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/');
+    element.setAttribute('src', 'https://bar.example/bar.js');
+    element.setAttribute('sandboxed', '');
 
     stubFetch(
       'https://bar.example/bar.js',
-      { 'Content-Type': 'application/javascript; charset=UTF-8' },
+      {'Content-Type': 'application/javascript; charset=UTF-8'},
       'alert(1)'
-    )
+    );
 
-    await script.buildCallback()
-    await script.layoutCallback()
-    expect(service.checkSha384).not.to.be.called
+    await script.buildCallback();
+    await script.layoutCallback();
+    expect(service.checkSha384).not.to.be.called;
   });
 
   it('callFunction waits for initialization to complete before returning', async () => {

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -130,6 +130,24 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     expect(service.checkSha384).to.be.called;
   });
 
+  it('should skip the check for sha384(author_js) for cross-origin src in sandboxed mode', async () => {
+    env.sandbox.stub(env.ampdoc, 'getUrl').returns('https://foo.example/')
+    element.setAttribute('src', 'https://bar.example/bar.js')
+    element.setAttribute('sandboxed', '')
+
+    script.buildCallback()
+
+    stubFetch(
+      'https://bar.example/bar.js',
+      { 'Content-Type': 'application/javascript; charset=UTF-8' },
+      'alert(1)'
+    )
+
+    service.checkSha384.withArgs('alert(1)').resolves()
+    await script.layoutCallback()
+    expect(service.checkSha384).not.to.be.called
+  });
+
   it('callFunction waits for initialization to complete before returning', async () => {
     element.setAttribute('script', 'local-script');
     script.workerDom_ = {callFunction: env.sandbox.spy()};


### PR DESCRIPTION
**Summary**

Skips the CSP hash check for a cross-origin source passed to `amp-script` since this is one of the features of `sandboxed` mode introduced in PR #33643.


Fixes #36614 