### PR TITLE
🏗 Allow rendering plain DOM using JSX

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -459,11 +459,9 @@ module.exports = {
       'rules': {'local/preact-preferred-props': 2},
     },
     {
+      // Files that use JSX for plain DOM nodes instead of Preact
       'files': ['**/amp-story*/**'],
-      'rules': {
-        // amp-story uses JSX for plain DOM nodes instead of Preact
-        'local/preact': [2, '#core/dom/jsx'],
-      },
+      'rules': {'local/preact': [2, '#core/dom/jsx']},
     },
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -458,5 +458,12 @@ module.exports = {
       'files': ['src/preact/**', 'extensions/**/1.0/**', '**/storybook/**'],
       'rules': {'local/preact-preferred-props': 2},
     },
+    {
+      'files': ['**/amp-story*/**'],
+      'rules': {
+        // amp-story uses JSX for plain DOM nodes instead of Preact
+        'local/preact': [2, '#core/dom/jsx'],
+      },
+    },
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -460,7 +460,12 @@ module.exports = {
     },
     {
       // Files that use JSX for plain DOM nodes instead of Preact
-      'files': ['**/amp-story*/**'],
+      'files': [
+        'extensions/amp-story/**',
+        'extensions/amp-story-*/**',
+        // Extensions whose version is lower than 1.0 do not use Preact
+        'extensions/*/0.*/**',
+      ],
       'rules': {'local/preact': [2, '#core/dom/jsx']},
     },
   ],

--- a/build-system/eslint-rules/preact.js
+++ b/build-system/eslint-rules/preact.js
@@ -1,18 +1,16 @@
 'use strict';
 
-const path = require('path');
-
 // Enforces importing a Preact namespace specifier if using JSX
 //
 // Good
-// import * as Preact from 'path/to/preact';
+// import * as Preact from '#preact';
 // <div />
 //
 // Bad
 // <div />
 //
 // Bad
-// import { createElement } from 'path/to/preact';
+// import { createElement } from '#preact';
 // <div />
 module.exports = {
   meta: {
@@ -32,19 +30,16 @@ module.exports = {
       }
       warned = true;
 
+      const [packageName = '#preact'] = context.options;
+
       context.report({
         node,
         message: [
           'Using JSX requires importing the Preact namespace',
-          "Eg, `import * as Preact from 'src/preact'`",
+          `Eg, \`import * as Preact from '${packageName}'\``,
         ].join('\n\t'),
 
         fix(fixer) {
-          const fileName = context.getFilename();
-          const absolutePath = path
-            .relative(path.dirname(fileName), './src/preact')
-            .replace(/\.js$/, '');
-
           const ancestors = context.getAncestors();
           const program = ancestors[0];
           let firstImport = program.body.find(
@@ -56,7 +51,7 @@ module.exports = {
 
           return fixer.insertTextBefore(
             firstImport,
-            `import * as Preact from '${absolutePath}';\n`
+            `import * as Preact from '${packageName}';\n`
           );
         },
       });

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -1,3 +1,4 @@
+import * as Preact from '#core/dom/jsx';
 import {
   Action,
   StateProperty,
@@ -8,10 +9,8 @@ import {closest} from '#core/dom/query';
 import {copyChildren, removeChildren} from '#core/dom';
 import {dev, user} from '#utils/log';
 import {getStoryAttributeSrc} from './utils';
-import {htmlFor} from '#core/dom/static-template';
 import {isArray, isObject} from '#core/types';
 import {parseJson} from '#core/types/object/json';
-import {setImportantStyles} from '#core/dom/style';
 
 /** @const {string} */
 const TAG = 'amp-story-access';
@@ -26,38 +25,42 @@ export const Type = {
 
 /**
  * Story access blocking type template.
- * @param {!Element} element
+ * @param {{logoSrc: ?string|undefined}} props
  * @return {!Element}
  */
-const getBlockingTemplate = (element) => {
-  return htmlFor(element)`
-      <div class="i-amphtml-story-access-overflow">
-        <div class="i-amphtml-story-access-container">
-          <div class="i-amphtml-story-access-header">
-            <div class="i-amphtml-story-access-logo"></div>
-          </div>
-          <div class="i-amphtml-story-access-content"></div>
+function BlockingNotification({logoSrc}) {
+  return (
+    <div class="i-amphtml-story-access-overflow">
+      <div class="i-amphtml-story-access-container">
+        <div class="i-amphtml-story-access-header">
+          <div
+            class="i-amphtml-story-access-logo"
+            style={logoSrc ? `background-image: url(${logoSrc});` : null}
+          ></div>
         </div>
-      </div>`;
-};
+        <div class="i-amphtml-story-access-content"></div>
+      </div>
+    </div>
+  );
+}
 
 /**
  * Story access notification type template.
- * @param {!Element} element
  * @return {!Element}
  */
-const getNotificationTemplate = (element) => {
-  return htmlFor(element)`
-      <div class="i-amphtml-story-access-overflow">
-        <div class="i-amphtml-story-access-container">
-          <div class="i-amphtml-story-access-content">
-            <span class="i-amphtml-story-access-close-button" role="button">
-              &times;
-            </span>
-          </div>
+function renderNotificationElement() {
+  return (
+    <div class="i-amphtml-story-access-overflow">
+      <div class="i-amphtml-story-access-container">
+        <div class="i-amphtml-story-access-content">
+          <span class="i-amphtml-story-access-close-button" role="button">
+            &times;
+          </span>
         </div>
-      </div>`;
-};
+      </div>
+    </div>
+  );
+}
 
 /**
  * The <amp-story-access> custom element.
@@ -198,25 +201,15 @@ export class AmpStoryAccess extends AMP.BaseElement {
   renderDrawerEl_() {
     switch (this.getType_()) {
       case Type.BLOCKING:
-        const drawerEl = getBlockingTemplate(this.element);
-
         const logoSrc = getStoryAttributeSrc(
           this.element,
           'publisher-logo-src',
           /* warn */ true
         );
-
-        if (logoSrc) {
-          const logoEl = dev().assertElement(
-            drawerEl.querySelector('.i-amphtml-story-access-logo')
-          );
-          setImportantStyles(logoEl, {'background-image': `url(${logoSrc})`});
-        }
-
-        return drawerEl;
+        return <BlockingNotification logoSrc={logoSrc} />;
         break;
       case Type.NOTIFICATION:
-        return getNotificationTemplate(this.element);
+        return renderNotificationElement();
         break;
       default:
         user().error(

--- a/extensions/amp-story/1.0/amp-story-access.js
+++ b/extensions/amp-story/1.0/amp-story-access.js
@@ -25,7 +25,7 @@ export const Type = {
 
 /**
  * Story access blocking type template.
- * @param {{logoSrc: ?string|undefined}} props
+ * @param {{logoSrc: (?string|undefined)}} props
  * @return {!Element}
  */
 function BlockingNotification({logoSrc}) {

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -23,27 +23,34 @@
  *
  * 🚫 No dangerouslySetInnerHTML
  *   - You should not do this anyway.
+ *
+ * TODO(https://go.amp.dev/issue/36679): Lint these unsupported features.
  */
 import {devAssert} from '#core/assert';
 
 /**
+ * @typedef {Node|Object|string|number|bigint|boolean|null|undefined}
+ */
+let ChildDef;
+
+/**
  * @param {!Element} parent
- * @param {*} child
+ * @param {!ChildDef|Array<!ChildDef>} child
  */
 function appendChild(parent, child) {
-  if (child === false || child == null) {
+  if (!!child === child || child == null) {
     return;
   }
   if (Array.isArray(child)) {
-    child.forEach((child) => {
+    const children = /** @type {!Array<!ChildDef>} */ (child);
+    children.forEach((child) => {
       appendChild(parent, child);
     });
     return;
   }
+  const maybeNode = /** @type {!Node} */ (child);
   parent.appendChild(
-    child?.nodeType
-      ? /** @type {!Node} */ (child)
-      : self.document.createTextNode(String(child))
+    maybeNode.nodeType ? maybeNode : self.document.createTextNode(String(child))
   );
 }
 

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -56,7 +56,7 @@ function setAttribute(element, name, value) {
   if (value === false || value == null) {
     return;
   }
-  if (typeof value == 'function' && name[0] === 'o' && name[1] === 'n') {
+  if (typeof value === 'function' && name[0] === 'o' && name[1] === 'n') {
     const eventName = name.toLowerCase().substr(2);
     element.addEventListener(eventName, value);
     return;

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -56,7 +56,7 @@ function appendChild(parent, child) {
  */
 export function createElement(tag, props, ...children) {
   if (typeof tag !== 'string') {
-    return tag(children.length ? {...props, children} : props);
+    return tag({...props, children});
   }
 
   const element = self.document.createElement(tag);

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -31,7 +31,7 @@ import {devAssert} from '#core/assert';
  * @param {*} child
  */
 function appendChild(parent, child) {
-  if (!child && child !== 0) {
+  if (child === false || child == null) {
     return;
   }
   if (Array.isArray(child)) {

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -35,16 +35,33 @@ function appendChild(parent, child) {
     return;
   }
   if (Array.isArray(child)) {
-    child.forEach((nestedChild) => {
-      appendChild(parent, nestedChild);
+    child.forEach((child) => {
+      appendChild(parent, child);
     });
-  } else {
-    parent.appendChild(
-      child?.nodeType
-        ? /** @type {!Node} */ (child)
-        : self.document.createTextNode(String(child))
-    );
+    return;
   }
+  parent.appendChild(
+    child?.nodeType
+      ? /** @type {!Node} */ (child)
+      : self.document.createTextNode(String(child))
+  );
+}
+
+/**
+ * @param {!Element} element
+ * @param {string} name
+ * @param {*} value
+ */
+function setAttribute(element, name, value) {
+  if (value === false || value == null) {
+    return;
+  }
+  if (typeof value == 'function' && name[0] === 'o' && name[1] === 'n') {
+    const eventName = name.toLowerCase().substr(2);
+    element.addEventListener(eventName, value);
+    return;
+  }
+  element.setAttribute(name, value === true ? '' : String(value));
 }
 
 /**
@@ -60,21 +77,12 @@ export function createElement(tag, props, ...children) {
   }
 
   const element = self.document.createElement(tag);
-  children.forEach((child) => {
-    appendChild(element, child);
-  });
+
+  appendChild(element, children);
 
   if (props) {
     Object.keys(props).forEach((name) => {
-      const value = props[name];
-      if (value === false || value == null) {
-        return;
-      }
-      if (name.startsWith('on') && name.length > 2) {
-        element.addEventListener(name.toLowerCase().substr(2), value);
-        return;
-      }
-      element.setAttribute(name, value === true ? '' : String(value));
+      setAttribute(element, name, props[name]);
     });
   }
 

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -75,17 +75,13 @@ export function createElement(tag, props, ...children) {
   if (typeof tag !== 'string') {
     return tag({...props, children});
   }
-
   const element = self.document.createElement(tag);
-
   appendChild(element, children);
-
   if (props) {
     Object.keys(props).forEach((name) => {
       setAttribute(element, name, props[name]);
     });
   }
-
   return element;
 }
 

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview
+ * Minimal implementation of JSX that outputs DOM nodes.
+ *
+ * Usage:
+ *   import * as Preact from '#core/dom/jsx';
+ *
+ * This library is nicer than templates in bundles that do not include Preact,
+ * but it does not attempt to implement JSX fully.
+ *
+ * These features are omitted for the sake of bundle size:
+ *
+ * 🚫 Attribute names are not re-mapped.
+ *   - Use standard HTML attribute names on elements (`class`, not `className`).
+ *   - Dashes are ok, like `data-foo="bar"`.
+ *
+ * 🚫 No objects in attribute values, like `style={{width: 40}}`
+ *   - For `style`, use strings instead.
+ *   - For `class`, call `objstr()` or use strings instead.
+ *
+ * 🚫 No Fragments
+ *   - Instead use a root node, or split into an array of nodes.
+ *
+ * 🚫 No dangerouslySetInnerHTML
+ *   - You should not do this anyway.
+ */
+import {devAssert} from '#core/assert';
+
+/**
+ * @param {!Element} parent
+ * @param {*} child
+ */
+function appendChild(parent, child) {
+  if (!child && child !== 0) {
+    return;
+  }
+  if (Array.isArray(child)) {
+    child.forEach((nestedChild) => {
+      appendChild(parent, nestedChild);
+    });
+  } else {
+    parent.appendChild(
+      child.nodeType ? child : self.document.createTextNode(child)
+    );
+  }
+}
+
+/**
+ * @param {string|function(T):!Element} tag
+ * @param {T} props
+ * @param {...*} children
+ * @return {!Element}
+ * @template T
+ */
+export function createElement(tag, props, ...children) {
+  if (typeof tag !== 'string') {
+    return tag(children?.length ? {...props, children} : props);
+  }
+
+  const element = self.document.createElement(tag);
+  children.forEach((child) => {
+    appendChild(element, child);
+  });
+
+  if (props) {
+    Object.keys(props).forEach((name) => {
+      const value = props[name];
+      if (name.startsWith('on') && name.length > 2) {
+        element.addEventListener(name.toLowerCase().substr(2), value);
+        return;
+      }
+      if (value !== false && value != null) {
+        element.setAttribute(name, value === true ? '' : value.toString());
+      }
+    });
+  }
+
+  return element;
+}
+
+/** */
+export function Fragment() {
+  devAssert(
+    false,
+    "Don't use Fragment (<></>) with jsx-dom. " +
+      'Use a root node or an array of nodes instead.'
+  );
+}

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -31,18 +31,18 @@ import {devAssert} from '#core/assert';
 /**
  * @typedef {Node|Object|string|number|bigint|boolean|null|undefined}
  */
-let ChildDef;
+let DomJsxChildDef;
 
 /**
  * @param {!Element} parent
- * @param {!ChildDef|Array<!ChildDef>} child
+ * @param {!DomJsxChildDef|Array<!DomJsxChildDef>} child
  */
 function appendChild(parent, child) {
   if (!!child === child || child == null) {
     return;
   }
   if (Array.isArray(child)) {
-    const children = /** @type {!Array<!ChildDef>} */ (child);
+    const children = /** @type {!Array<!DomJsxChildDef>} */ (child);
     children.forEach((child) => {
       appendChild(parent, child);
     });

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -40,7 +40,9 @@ function appendChild(parent, child) {
     });
   } else {
     parent.appendChild(
-      child.nodeType ? child : self.document.createTextNode(child)
+      child?.nodeType
+        ? /** @type {!Node} */ (child)
+        : self.document.createTextNode(String(child))
     );
   }
 }
@@ -54,7 +56,7 @@ function appendChild(parent, child) {
  */
 export function createElement(tag, props, ...children) {
   if (typeof tag !== 'string') {
-    return tag(children?.length ? {...props, children} : props);
+    return tag(children.length ? {...props, children} : props);
   }
 
   const element = self.document.createElement(tag);
@@ -65,24 +67,27 @@ export function createElement(tag, props, ...children) {
   if (props) {
     Object.keys(props).forEach((name) => {
       const value = props[name];
+      if (value === false || value == null) {
+        return;
+      }
       if (name.startsWith('on') && name.length > 2) {
         element.addEventListener(name.toLowerCase().substr(2), value);
         return;
       }
-      if (value !== false && value != null) {
-        element.setAttribute(name, value === true ? '' : value.toString());
-      }
+      element.setAttribute(name, value === true ? '' : String(value));
     });
   }
 
   return element;
 }
 
-/** */
+/**
+ * @return {null}
+ */
 export function Fragment() {
-  devAssert(
-    false,
-    "Don't use Fragment (<></>) with jsx-dom. " +
+  return devAssert(
+    null,
+    "Don't use Fragment (<></>) with #core/dom/jsx. " +
       'Use a root node or an array of nodes instead.'
   );
 }

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -125,10 +125,10 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
     expect(onFooBar).to.have.been.calledOnce;
   });
 
-  it('`on` attribute is not treated like an event handler function', () => {
-    const element = <button on="tap:lightbox.open" />;
+  it('non-function `on` attribute is not treated like an event handler function', () => {
+    const element = <button on="tap:lightbox.open" onClick="foo()" />;
     expect(element.outerHTML).to.equal(
-      '<button on="tap:lightbox.open"></button>'
+      '<button on="tap:lightbox.open" onclick="foo()"></button>'
     );
   });
 

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -1,65 +1,75 @@
 import {dispatchCustomEvent} from '#core/dom/index';
-import {Fragment, createElement as h} from '#core/dom/jsx';
+import * as Preact from '#core/dom/jsx';
+
+const {createElement} = Preact;
 
 describes.sandboxed('#core/dom/jsx', {}, (env) => {
   it('renders without attributes', () => {
-    const element = h('div');
+    const element = <div />;
     expect(element.outerHTML).to.equal('<div></div>');
   });
 
   it('renders attributes', () => {
-    const element = h('div', {'data-foo': 'bar', 'data-count': 0});
+    const element = <div data-foo="bar" data-count={0} />;
     expect(element.outerHTML).to.equal(
       '<div data-foo="bar" data-count="0"></div>'
     );
   });
 
   it('boolean `true` implies empty attribute', () => {
-    const element = h('video', {autoplay: true});
+    const element = <video autoplay={true} />;
     expect(element.outerHTML).to.equal('<video autoplay=""></video>');
   });
 
   it('boolean `false` implies no attribute', () => {
-    const element = h('video', {autoplay: false});
+    const element = <video autoplay={false} />;
     expect(element.outerHTML).to.equal('<video></video>');
   });
 
   it('nullish implies no attribute', () => {
-    const element = h('video', {autoplay: null});
+    const element = <video autoplay={null} />;
     expect(element.outerHTML).to.equal('<video></video>');
   });
 
   it('includes string child', () => {
-    const element = h('div', null, 'foo');
+    const element = <div>foo</div>;
     expect(element.outerHTML).to.equal('<div>foo</div>');
   });
 
   it('includes string children', () => {
-    const element = h('div', null, ['foo']);
+    const element = <div>{['foo']}</div>;
     expect(element.outerHTML).to.equal('<div>foo</div>');
   });
 
   it('includes DOM node child', () => {
-    const element = h('div', null, h('span', null, ['foo']));
+    const element = (
+      <div>
+        <span>{['foo']}</span>
+      </div>
+    );
     expect(element.outerHTML).to.equal('<div><span>foo</span></div>');
   });
 
   it('includes DOM node children', () => {
-    const element = h('div', null, [
-      h('a', {href: '#'}, h('span', null, ['click'])),
-    ]);
+    const element = (
+      <div>
+        <a href="#">
+          <span>{['click']}</span>
+        </a>
+      </div>
+    );
     expect(element.outerHTML).to.equal(
       '<div><a href="#"><span>click</span></a></div>'
     );
   });
 
   it('includes children var args', () => {
-    const element = h(
+    const element = createElement(
       'ul',
       null,
-      h('li', null, 'one'),
-      h('li', {class: 'even'}, 'two'),
-      h('li', null, 'three')
+      <li>one</li>,
+      <li class="even">two</li>,
+      <li>three</li>
     );
     expect(element.outerHTML).to.equal(
       '<ul><li>one</li><li class="even">two</li><li>three</li></ul>'
@@ -67,25 +77,39 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
   });
 
   it('ignores falsy children', () => {
-    const element = h('div', null, [null, false]);
+    const element = (
+      <div>
+        {null}
+        {false}
+      </div>
+    );
     expect(element.outerHTML).to.equal('<div></div>');
   });
 
   it('ignores nested falsy children', () => {
-    const element = h('div', null, [null, [false, [null]]]);
+    const element = (
+      <div>
+        {null}
+        {[false, [null]]}
+      </div>
+    );
     expect(element.outerHTML).to.equal('<div></div>');
   });
 
   it('renders child of value `0`', () => {
-    const element = h('div', null, 0);
+    const element = <div>0</div>;
     expect(element.outerHTML).to.equal('<div>0</div>');
   });
 
   it('renders functions', () => {
     function Component({children, 'class': className}) {
-      return h('div', {'class': `component ${className}`}, children);
+      return <div class={`component ${className}`}>{children}</div>;
     }
-    const element = h(Component, {'class': 'composed'}, h('p', null, 'foo'));
+    const element = (
+      <Component class="composed">
+        <p>foo</p>
+      </Component>
+    );
     expect(element.outerHTML).to.equal(
       '<div class="component composed"><p>foo</p></div>'
     );
@@ -93,18 +117,27 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
 
   it('attaches event handlers from attributes', () => {
     const onFooBar = env.sandbox.spy();
-    const element = h('div', {onFooBar});
+    const element = <div onFooBar={onFooBar} />;
+    expect(element).to.not.have.attribute('onfoobar');
+    expect(onFooBar).to.not.have.been.called;
     dispatchCustomEvent(element, 'foobar');
     expect(onFooBar).to.have.been.calledOnce;
   });
 
+  it('`on` attribute is not treated like an event handler function', () => {
+    const element = <button on="tap:lightbox.open" />;
+    expect(element.outerHTML).to.equal(
+      '<button on="tap:lightbox.open"></button>'
+    );
+  });
+
   it('text content is safe', () => {
-    const element = h('div', null, '<script dangerous>');
+    const element = <div>{'<script dangerous>'}</div>;
     expect(element.outerHTML).to.equal('<div>&lt;script dangerous&gt;</div>');
   });
 
   it('attributes are safe', () => {
-    const element = h('div', {'data-dangerous': '"><script src="foo.js'});
+    const element = <div data-dangerous={'"><script src="foo.js'} />;
     expect(element.outerHTML).to.equal(
       '<div data-dangerous="&quot;><script src=&quot;foo.js"></div>'
     );
@@ -113,24 +146,21 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
   describe('unsupported JSX features', () => {
     it('does not support Fragments', () => {
       allowConsoleError(() => {
-        expect(() => h(Fragment)).to.throw();
+        expect(() => <></>).to.throw();
       });
     });
 
     it('does not support objects as attribute values', () => {
-      const element = h('div', {
-        style: {width: 400},
-        class: {foo: true, bar: false},
-      });
+      const element = (
+        <div style={{width: 400}} class={{foo: true, bar: false}} />
+      );
       expect(element.outerHTML).to.equal(
         '<div style="[object Object]" class="[object Object]"></div>'
       );
     });
 
     it('does not support dangerouslySetInnerHTML', () => {
-      const element = h('div', {
-        dangerouslySetInnerHTML: {__html: '<script>'},
-      });
+      const element = <div dangerouslySetInnerHTML={{__html: '<script>'}} />;
       expect(element.outerHTML).to.equal(
         '<div dangerouslysetinnerhtml="[object Object]"></div>'
       );

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -37,8 +37,8 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
   });
 
   it('includes string children', () => {
-    const element = <div>{['foo']}</div>;
-    expect(element.outerHTML).to.equal('<div>foo</div>');
+    const element = <div>{['foo', 'bar']}</div>;
+    expect(element.outerHTML).to.equal('<div>foobar</div>');
   });
 
   it('includes DOM node child', () => {
@@ -76,10 +76,11 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
     );
   });
 
-  it('ignores falsy children', () => {
+  it('ignores nullish and false children', () => {
     const element = (
       <div>
         {null}
+        {undefined}
         {false}
       </div>
     );
@@ -97,7 +98,7 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
   });
 
   it('renders child of value `0`', () => {
-    const element = <div>0</div>;
+    const element = <div>{0}</div>;
     expect(element.outerHTML).to.equal('<div>0</div>');
   });
 

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -87,11 +87,11 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
     expect(element.outerHTML).to.equal('<div></div>');
   });
 
-  it('ignores nested falsy children', () => {
+  it('ignores nested nullish and false children', () => {
     const element = (
       <div>
         {null}
-        {[false, [null]]}
+        {[false, [undefined]]}
       </div>
     );
     expect(element.outerHTML).to.equal('<div></div>');

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -1,0 +1,139 @@
+import {dispatchCustomEvent} from '#core/dom/index';
+import {Fragment, createElement as h} from '#core/dom/jsx';
+
+describes.sandboxed('#core/dom/jsx', {}, (env) => {
+  it('renders without attributes', () => {
+    const element = h('div');
+    expect(element.outerHTML).to.equal('<div></div>');
+  });
+
+  it('renders attributes', () => {
+    const element = h('div', {'data-foo': 'bar', 'data-count': 0});
+    expect(element.outerHTML).to.equal(
+      '<div data-foo="bar" data-count="0"></div>'
+    );
+  });
+
+  it('boolean `true` implies empty attribute', () => {
+    const element = h('video', {autoplay: true});
+    expect(element.outerHTML).to.equal('<video autoplay=""></video>');
+  });
+
+  it('boolean `false` implies no attribute', () => {
+    const element = h('video', {autoplay: false});
+    expect(element.outerHTML).to.equal('<video></video>');
+  });
+
+  it('nullish implies no attribute', () => {
+    const element = h('video', {autoplay: null});
+    expect(element.outerHTML).to.equal('<video></video>');
+  });
+
+  it('includes string child', () => {
+    const element = h('div', null, 'foo');
+    expect(element.outerHTML).to.equal('<div>foo</div>');
+  });
+
+  it('includes string children', () => {
+    const element = h('div', null, ['foo']);
+    expect(element.outerHTML).to.equal('<div>foo</div>');
+  });
+
+  it('includes DOM node child', () => {
+    const element = h('div', null, h('span', null, ['foo']));
+    expect(element.outerHTML).to.equal('<div><span>foo</span></div>');
+  });
+
+  it('includes DOM node children', () => {
+    const element = h('div', null, [
+      h('a', {href: '#'}, h('span', null, ['click'])),
+    ]);
+    expect(element.outerHTML).to.equal(
+      '<div><a href="#"><span>click</span></a></div>'
+    );
+  });
+
+  it('includes children var args', () => {
+    const element = h(
+      'ul',
+      null,
+      h('li', null, 'one'),
+      h('li', {class: 'even'}, 'two'),
+      h('li', null, 'three')
+    );
+    expect(element.outerHTML).to.equal(
+      '<ul><li>one</li><li class="even">two</li><li>three</li></ul>'
+    );
+  });
+
+  it('ignores falsy children', () => {
+    const element = h('div', null, [null, false]);
+    expect(element.outerHTML).to.equal('<div></div>');
+  });
+
+  it('ignores nested falsy children', () => {
+    const element = h('div', null, [null, [false, [null]]]);
+    expect(element.outerHTML).to.equal('<div></div>');
+  });
+
+  it('renders child of value `0`', () => {
+    const element = h('div', null, 0);
+    expect(element.outerHTML).to.equal('<div>0</div>');
+  });
+
+  it('renders functions', () => {
+    function Component({children, 'class': className}) {
+      return h('div', {'class': `component ${className}`}, children);
+    }
+    const element = h(Component, {'class': 'composed'}, h('p', null, 'foo'));
+    expect(element.outerHTML).to.equal(
+      '<div class="component composed"><p>foo</p></div>'
+    );
+  });
+
+  it('attaches event handlers from attributes', () => {
+    const onFooBar = env.sandbox.spy();
+    const element = h('div', {onFooBar});
+    dispatchCustomEvent(element, 'foobar');
+    expect(onFooBar).to.have.been.calledOnce;
+  });
+
+  it('text content is safe', () => {
+    const element = h('div', null, '<script dangerous>');
+    expect(element.outerHTML).to.equal('<div>&lt;script dangerous&gt;</div>');
+  });
+
+  it('attributes are safe', () => {
+    const element = h('div', {'data-dangerous': '"><script src="foo.js'});
+    expect(element.outerHTML).to.equal(
+      '<div data-dangerous="&quot;><script src=&quot;foo.js"></div>'
+    );
+  });
+
+  describe('unsupported JSX features', () => {
+    it('does not support Fragments', () => {
+      allowConsoleError(() => {
+        expect(() => h(Fragment)).to.throw();
+      });
+    });
+
+    it('does not support objects as attribute values', () => {
+      const element = h('div', {
+        style: {width: 400},
+        class: {foo: true, bar: false},
+      });
+      expect(element.outerHTML).to.equal(
+        '<div style="[object Object]" class="[object Object]"></div>'
+      );
+    });
+
+    it('does not support dangerouslySetInnerHTML', () => {
+      const element = h('div', {
+        dangerouslySetInnerHTML: {__html: '<script>'},
+      });
+      expect(element.outerHTML).to.equal(
+        '<div dangerouslysetinnerhtml="[object Object]"></div>'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Related to #36459

Provides a replacement for existing rendering methods that's more powerful and convenient:

|                  | JSX | imperative DOM | `htmlFor` | `simple-template` (Stories) |
| ---------------- | --- | -------------- | --------- | --------------------------- |
| like HTML        | ✅  | 🚫             | ✅        | 🚫                          |
| dynamic attrs    | ✅  | ✅             | 🚫        | ✅                          |
| dynamic children | ✅  | 🚫             | 🚫        | sort-of                     |
| event handlers   | ✅  | 🚫             | 🚫        | 🚫                          |
| nesting          | ✅  | 🚫             | 🚫        | 🚫                          |

A minimal implementation of JSX is included as `#core/dom/jsx`.

This library adds ~0.22K of size to any given bundle. By replacing callsites of previous rendering methods, the overall size of a bundle is roughly neutral or smaller.

This change does not change any implementation code. A migration of existing templates and renderers will follow-up.
