### PR TITLE
🏗  Set node to 16 on github workflows

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           check-latest: true
           registry-url: https://registry.npmjs.org
-          node-version: lts/*
+          node-version: '16'
       - name: Get latest scripts
         run: |
           wget -q "https://raw.githubusercontent.com/ampproject/amphtml/main/build-system/npm-publish/utils.js" -O ./build-system/npm-publish/utils.js

--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: '16'
       - uses: actions/checkout@v2
       - name: Add progress comment to cherry-pick issue for Stable and LTS
         if: github.event_name == 'issues' && github.event.action == 'opened'

--- a/.github/workflows/sweep-experiments.yml
+++ b/.github/workflows/sweep-experiments.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
-          node-version: lts/*
+          node-version: '16'
 
       - name: Set Up Environment
         run: sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}


### PR DESCRIPTION
Currently set to `lts/*` which resolves to a cached v14