### PR TITLE
✨ Allow `media` attribute on `meta` tag in validator spec

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -731,6 +731,7 @@ tags: {
         "viewport"
         ")(\\s|$)"
   }
+  attrs: { name: "media" } # For varying theme-color.
   attrs: { name: "property" }  # property is non-standard, but commonly seen.
   # scheme is used by Dublin Core, see issue #13993
   attrs: { name: "scheme" }


### PR DESCRIPTION
In reviewing the [New WebKit Features in Safari 15](https://webkit.org/blog/11989/new-webkit-features-in-safari-15/), I noticed:

> In the HTML meta tag, developers can specify separate colors for Dark Mode and light appearance with the `media` attribute.
> ```html
> <meta name="theme-color" 
>       content="#ecd96f" 
>       media="(prefers-color-scheme: light)">
> <meta name="theme-color" 
>       content="#0b3e05" 
>       media="(prefers-color-scheme: dark)">
> ```

I thought this was a Safari-specific thing, but turns out it isn't. It's [documented on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color):
 <!--

> You can provide a media type or query inside the `media` attribute; the color will then only be set if the media condition is true. For example:
> 
> ```html
> <meta name="theme-color" media="(prefers-color-scheme: light)" content="white">
> <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black">
> ```

So this PR allows the `media` attribute on the `meta` tag, which is not currently allowed:

> ![image](https://user-images.githubusercontent.com/134745/139311764-916c3bcb-9674-4be6-81be-accb89995e73.png)