### PR TITLE
🐛  Update of CMP Sirdata configuration for <amp-consent>

### DIFF
--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -47,8 +47,8 @@ CMP_CONFIG['iubenda'] = {
 
 CMP_CONFIG['sirdata'] = {
   'consentInstanceId': 'sirdata',
-  'checkConsentHref': 'https://sddan.mgr.consensu.org/api/v1/public/amp/check',
-  'promptUISrc': 'https://ui.sddan.mgr.consensu.org/amp.html',
+  'checkConsentHref': 'https://choices.consentframework.com/api/v1/public/amp/check',
+  'promptUISrc': 'https://ui.consentframework.com/amp/loader.html',
 };
 
 CMP_CONFIG['Marfeel'] = {


### PR DESCRIPTION
Following the deprecation of IAB TCF global scope (*.mgr.consensu.org), this PR updates the checkConsentHref and promptUISrc endpoints for Sirdata CMP.
