### PR TITLE
test-amp-script: fix stubbing of WorkerDOM

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -1,4 +1,4 @@
-import {upgrade as upgradeImported} from '@ampproject/worker-dom/dist/amp-production/main.mjs';
+import {upgrade} from '@ampproject/worker-dom/dist/amp-production/main.mjs';
 
 import {Deferred} from '#core/data-structures/promise';
 import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
@@ -65,15 +65,15 @@ export const StorageLocation = {
 };
 
 /** @private {*}  */
-let upgrade = upgradeImported;
+let upgradeForTest = null;
 
 /**
- * Set the WorkerDOM Module for stubbing in tests.
+ * Set the WorkerDOM.upgrade function for tests.
  * @param {*} fn the function to use instead of WorkerDOM.upgrade.
  * @visibleForTesting
  */
-export function setWorkerDOMUpgradeForTest(fn) {
-  upgrade = fn;
+export function setUpgradeForTest(fn) {
+  upgradeForTest = fn;
 }
 
 export class AmpScript extends AMP.BaseElement {
@@ -319,7 +319,7 @@ export class AmpScript extends AMP.BaseElement {
     };
 
     // Create worker and hydrate.
-    return upgrade(
+    return (upgradeForTest || upgrade)(
       container || this.element,
       workerAndAuthorScripts,
       config

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -1,4 +1,4 @@
-import * as WorkerDOM from '@ampproject/worker-dom/dist/amp-production/main.mjs';
+import * as WorkerDOMImport from '@ampproject/worker-dom/dist/amp-production/main.mjs';
 
 import {Deferred} from '#core/data-structures/promise';
 import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
@@ -63,6 +63,18 @@ export const StorageLocation = {
   SESSION: 1,
   AMP_STATE: 2,
 };
+
+/** @private {{upgrade: *}}  */
+let WorkerDOM = WorkerDOMImport;
+
+/**
+ * Set the WorkerDOM Module for stubbing in tests.
+ * @param {{upgrade: *}} workerDomModule the module to replace WorkerDOM with.
+ * @visibleForTesting
+ */
+export function setWorkerDOMForTest(workerDomModule) {
+  WorkerDOM = workerDomModule;
+}
 
 export class AmpScript extends AMP.BaseElement {
   /**

--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -1,4 +1,4 @@
-import * as WorkerDOMImport from '@ampproject/worker-dom/dist/amp-production/main.mjs';
+import {upgrade as upgradeImported} from '@ampproject/worker-dom/dist/amp-production/main.mjs';
 
 import {Deferred} from '#core/data-structures/promise';
 import {Layout, applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
@@ -64,16 +64,16 @@ export const StorageLocation = {
   AMP_STATE: 2,
 };
 
-/** @private {{upgrade: *}}  */
-let WorkerDOM = WorkerDOMImport;
+/** @private {*}  */
+let upgrade = upgradeImported;
 
 /**
  * Set the WorkerDOM Module for stubbing in tests.
- * @param {{upgrade: *}} workerDomModule the module to replace WorkerDOM with.
+ * @param {*} fn the function to use instead of WorkerDOM.upgrade.
  * @visibleForTesting
  */
-export function setWorkerDOMForTest(workerDomModule) {
-  WorkerDOM = workerDomModule;
+export function setWorkerDOMUpgradeForTest(fn) {
+  upgrade = fn;
 }
 
 export class AmpScript extends AMP.BaseElement {
@@ -319,7 +319,7 @@ export class AmpScript extends AMP.BaseElement {
     };
 
     // Create worker and hydrate.
-    return WorkerDOM.upgrade(
+    return upgrade(
       container || this.element,
       workerAndAuthorScripts,
       config

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -13,7 +13,7 @@ import {
   AmpScriptService,
   SanitizerImpl,
   StorageLocation,
-  setWorkerDOMForTest,
+  setUpgradeForTest,
 } from '../../amp-script';
 
 describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
@@ -49,7 +49,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     env.sandbox.stub(Services, 'xhrFor').returns(xhr);
 
     // Make @ampproject/worker-dom dependency essentially a noop for these tests.
-    setWorkerDOMForTest({upgrade: (unused, scriptsPromise) => scriptsPromise});
+    setUpgradeForTest((unused, scriptsPromise) => scriptsPromise);
   });
 
   afterEach(() => {

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -23,6 +23,11 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
   let xhr;
 
   beforeEach(() => {
+    registerServiceBuilderForDoc(
+      env.win.document,
+      'amp-script',
+      AmpScriptService
+    );
     element = document.createElement('amp-script');
     env.ampdoc.getBody().appendChild(element);
 
@@ -45,6 +50,10 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
 
     // Make @ampproject/worker-dom dependency essentially a noop for these tests.
     setWorkerDOMForTest({upgrade: (unused, scriptsPromise) => scriptsPromise});
+  });
+
+  afterEach(() => {
+    resetServiceForTesting(env.win, 'amp-script');
   });
 
   function stubFetch(url, headers, text, responseUrl) {
@@ -87,15 +96,9 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     xhr.fetchText
       .withArgs(env.sandbox.match(/amp-script-worker-nodom-0.1.js/))
       .resolves({text: () => Promise.resolve('/* noop */')});
-    registerServiceBuilderForDoc(
-      env.win.document,
-      'amp-script',
-      AmpScriptService
-    );
 
     await script.buildCallback();
     await script.layoutCallback();
-    resetServiceForTesting(env.win, 'amp-script');
   });
 
   it('should work with "text/javascript" content-type for same-origin src', () => {
@@ -228,17 +231,6 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
   });
 
   describe('development mode', () => {
-    beforeEach(() => {
-      registerServiceBuilderForDoc(
-        env.win.document,
-        'amp-script',
-        AmpScriptService
-      );
-    });
-    afterEach(() => {
-      resetServiceForTesting(env.win, 'amp-script');
-    });
-
     it('should not be in dev mode by default', () => {
       script.buildCallback();
       expect(script.development_).false;

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -1,5 +1,3 @@
-import * as WorkerDOM from '@ampproject/worker-dom/dist/amp-production/main.mjs';
-
 import {Services} from '#service';
 
 import {user} from '#utils/log';
@@ -15,6 +13,7 @@ import {
   AmpScriptService,
   SanitizerImpl,
   StorageLocation,
+  setWorkerDOMForTest,
 } from '../../amp-script';
 
 describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
@@ -45,9 +44,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
     env.sandbox.stub(Services, 'xhrFor').returns(xhr);
 
     // Make @ampproject/worker-dom dependency essentially a noop for these tests.
-    env.sandbox
-      .stub(WorkerDOM, 'upgrade')
-      .callsFake((unused, scriptsPromise) => scriptsPromise);
+    setWorkerDOMForTest({upgrade: (unused, scriptsPromise) => scriptsPromise});
   });
 
   function stubFetch(url, headers, text, responseUrl) {

--- a/extensions/amp-script/0.1/test/unit/test-amp-script.js
+++ b/extensions/amp-script/0.1/test/unit/test-amp-script.js
@@ -44,7 +44,7 @@ describes.fakeWin('AmpScript', {amp: {runtimeOn: false}}, (env) => {
       fetchText: env.sandbox.stub(),
     };
     xhr.fetchText
-      .withArgs(env.sandbox.match(/amp-script-worker-0.1.js/))
+      .withArgs(env.sandbox.match(/amp-script-worker/))
       .resolves({text: () => Promise.resolve('/* noop */')});
     env.sandbox.stub(Services, 'xhrFor').returns(xhr);
 


### PR DESCRIPTION
**summary**
Likely since switching to bundling with esbuild for tests (particularly since the esbuild change which _forces_ all .mjs files to be module type), the `amp-script` tests have started emitting errors.

Turns out our stubbing of `WorkerDOM` module was broken as it relies on assigning to an esm namespace.
This PR removes the errors + fixes the stubbing.

As a bonus fix, I also moved service registration / clearing to toplevel, which should help out https://github.com/ampproject/amphtml/pull/36618 💅 

**example error**
![Screen Shot 2021-10-29 at 1 41 29 PM](https://user-images.githubusercontent.com/4656974/139479358-b1ccaa61-9b4f-476e-b005-fd32dacf8402.png)

cc @zshnr