### PR TITLE
🏗 Remove the --nobuild flag from visual diff tests

### DIFF
--- a/build-system/pr-check/visual-diff-tests.js
+++ b/build-system/pr-check/visual-diff-tests.js
@@ -14,7 +14,7 @@ const jobName = 'visual-diff-tests.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp visual-diff --nobuild --main');
+  timedExecOrDie('amp visual-diff --main');
 }
 
 /**
@@ -22,7 +22,7 @@ function pushBuildWorkflow() {
  */
 function prBuildWorkflow() {
   if (buildTargetsInclude(Targets.RUNTIME, Targets.VISUAL_DIFF)) {
-    timedExecOrDie('amp visual-diff --nobuild');
+    timedExecOrDie('amp visual-diff');
   } else {
     timedExecOrDie('amp visual-diff --empty');
     skipDependentJobs(

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -27,7 +27,6 @@ const {
   gitCommitterEmail,
   shortSha,
 } = require('../../common/git');
-const {buildRuntime} = require('../../common/utils');
 const {cyan, green, red, yellow} = require('kleur/colors');
 const {isCiBuild} = require('../../common/ci');
 const {startServer, stopServer} = require('../serve');
@@ -826,22 +825,18 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
     return;
   }
 
-  if (argv.nobuild) {
-    const isInTestMode = /AMP_CONFIG=\{(?:.+,)?"test":(!0|true)\b/.test(
+  const isBuiltInTestMode =
+    fs.existsSync('dist/v0.js') &&
+    /AMP_CONFIG=\{(?:.+,)?"test":(!0|true)\b/.test(
       fs.readFileSync('dist/v0.js', 'utf8')
     );
-    if (!isInTestMode) {
-      log(
-        'fatal',
-        'The AMP runtime was not built in test mode. Run',
-        cyan('amp dist --fortesting'),
-        'or remove the',
-        cyan('--nobuild'),
-        'option from this command'
-      );
-    }
-  } else {
-    await buildRuntime(/* opt_compiled */ true);
+  if (!isBuiltInTestMode) {
+    log(
+      'fatal',
+      'The AMP runtime was not built or not build in test mode. Run',
+      cyan('amp dist --fortesting'),
+      'before executing visual diff tests.'
+    );
   }
 }
 
@@ -899,5 +894,4 @@ visualDiff.flags = {
   'percy_branch': 'Override the PERCY_BRANCH environment variable',
   'percy_disabled':
     'Disable Percy integration (for testing local changes only)',
-  'nobuild': 'Skip build',
 };

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -301,10 +301,9 @@ Now, verify your test by executing it:
     -   You can verify that your page looks as intented by running `amp serve --minified` and opening it in a browser
 -   Execute the visual diff tests:
     ```sh
-    amp visual-diff --nobuild
+    amp visual-diff
     ```
     -   Add `--grep="<regular expression>"` to the command to execute a subset of the tests. e.g., `amp visual-diff --grep="amp-[a-f]"` will execute on tests that have an AMP component name between `<amp-a...>` through `<amp-f...>`.
-    -   Note that if you drop the `--nobuild` flag, `amp visual-diff` will run `amp dist --fortesting` on each execution. This is time consuming, so only drop it if you are changing the runtime/extension code and not just the test files
     -   To see debugging info during Percy runs, you can add `--chrome_debug`, `--webserver_debug`, or `--debug` for both.
 -   When the test finishes executing it will print a URL to Percy where you can inspect the results. It should take about a minute to finish processing.
 -   Inspect the build on Percy. If you are not happy with the results, fix your page or code, and repeat. If all is well, approve it. This creates a new baseline on Percy, against which all following builds will be compared.


### PR DESCRIPTION
It's more trouble than it's worth, a forgotten flag shouldn't cost me 10 minutes 😅