### PR TITLE
🐛 fix standalone inline-gallery - expose thumbnail/pagination elements

### DIFF
--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -61,7 +61,10 @@ async function writePackageJson() {
   }
 
   const exports = {
-    '.': './web-component',
+    '.': {
+      import: './dist/web-component.module.js',
+      require: './dist/web-component.js',
+    },
     './web-component': {
       import: './dist/web-component.module.js',
       require: './dist/web-component.js',

--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery-pagination.js
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery-pagination.js
@@ -1,15 +1,16 @@
-import {CSS} from './pagination.jss';
-import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
-import {BentoInlineGalleryPagination} from './pagination';
-import {PreactBaseElement} from '#preact/base-element';
 import {isExperimentOn} from '#experiments';
 import {userAssert} from '#utils/log';
+import {
+  TAG as BENTO_TAG,
+  PaginationBaseElement,
+} from './pagination-base-element';
+import {getAmpName} from './utils';
 
 /** @const {string} */
-export const TAG = 'amp-inline-gallery-pagination';
+const TAG = getAmpName(BENTO_TAG);
+export {TAG};
 
-/** @extends {PreactBaseElement<BaseCarouselDef.CarouselApi>} */
-export class AmpInlineGalleryPagination extends PreactBaseElement {
+export class AmpInlineGalleryPagination extends PaginationBaseElement {
   /** @override */
   isLayoutSupported(layout) {
     userAssert(
@@ -22,23 +23,3 @@ export class AmpInlineGalleryPagination extends PreactBaseElement {
     return super.isLayoutSupported(layout);
   }
 }
-
-/** @override */
-AmpInlineGalleryPagination['Component'] = BentoInlineGalleryPagination;
-
-/** @override */
-AmpInlineGalleryPagination['props'] = {
-  'inset': {attr: 'inset', type: 'boolean', media: true},
-};
-
-/** @override */
-AmpInlineGalleryPagination['layoutSizeDefined'] = true;
-
-/** @override */
-AmpInlineGalleryPagination['shadowCss'] = CSS;
-
-/** @override */
-AmpInlineGalleryPagination['usesShadowDom'] = true;
-
-/** @override */
-AmpInlineGalleryPagination['useContexts'] = [CarouselContextProp];

--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery-thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery-thumbnails.js
@@ -1,16 +1,16 @@
-import {CSS as CAROUSEL_CSS} from '../../amp-base-carousel/1.0/component.jss';
-import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
-import {PreactBaseElement} from '#preact/base-element';
-import {CSS as THUMBNAIL_CSS} from './thumbnails.jss';
-import {BentoInlineGalleryThumbnails} from './thumbnails';
 import {isExperimentOn} from '#experiments';
 import {userAssert} from '#utils/log';
+import {
+  TAG as BENTO_TAG,
+  ThumbnailsBaseElement,
+} from './thumbnails-base-element';
+import {getAmpName} from './utils';
 
 /** @const {string} */
-export const TAG = 'amp-inline-gallery-thumbnails';
+const TAG = getAmpName(BENTO_TAG);
+export {TAG};
 
-/** @extends {PreactBaseElement<BaseCarouselDef.CarouselApi>} */
-export class AmpInlineGalleryThumbnails extends PreactBaseElement {
+export class AmpInlineGalleryThumbnails extends ThumbnailsBaseElement {
   /** @override */
   isLayoutSupported(layout) {
     userAssert(
@@ -23,25 +23,3 @@ export class AmpInlineGalleryThumbnails extends PreactBaseElement {
     return super.isLayoutSupported(layout);
   }
 }
-
-/** @override */
-AmpInlineGalleryThumbnails['Component'] = BentoInlineGalleryThumbnails;
-
-/** @override */
-AmpInlineGalleryThumbnails['props'] = {
-  'aspectRatio': {attr: 'aspect-ratio', type: 'number', media: true},
-  'children': {passthroughNonEmpty: true},
-  'loop': {attr: 'loop', type: 'boolean', media: true},
-};
-
-/** @override */
-AmpInlineGalleryThumbnails['layoutSizeDefined'] = true;
-
-/** @override */
-AmpInlineGalleryThumbnails['usesShadowDom'] = true;
-
-/** @override */
-AmpInlineGalleryThumbnails['shadowCss'] = CAROUSEL_CSS + THUMBNAIL_CSS;
-
-/** @override */
-AmpInlineGalleryThumbnails['useContexts'] = [CarouselContextProp];

--- a/extensions/amp-inline-gallery/1.0/amp-inline-gallery.js
+++ b/extensions/amp-inline-gallery/1.0/amp-inline-gallery.js
@@ -6,14 +6,15 @@ import {
   AmpInlineGalleryThumbnails,
   TAG as THUMBNAILS_TAG,
 } from './amp-inline-gallery-thumbnails';
-import {BaseElement} from './base-element';
+import {TAG as BENTO_TAG, BaseElement} from './base-element';
 import {Layout} from '#core/dom/layout';
 import {CSS as PAGINATION_CSS} from '../../../build/amp-inline-gallery-pagination-1.0.css';
 import {isExperimentOn} from '#experiments';
 import {userAssert} from '#utils/log';
+import {getAmpName} from './utils';
 
 /** @const {string} */
-const TAG = 'amp-inline-gallery';
+const TAG = getAmpName(BENTO_TAG);
 
 class AmpInlineGallery extends BaseElement {
   /** @override */

--- a/extensions/amp-inline-gallery/1.0/base-element.js
+++ b/extensions/amp-inline-gallery/1.0/base-element.js
@@ -6,6 +6,8 @@ import {dict} from '#core/types/object';
 import {setProp} from '#core/context';
 import {useContext, useLayoutEffect} from '#preact';
 
+export const TAG = 'bento-inline-gallery';
+
 export class BaseElement extends PreactBaseElement {
   /** @override */
   init() {

--- a/extensions/amp-inline-gallery/1.0/bento-inline-gallery.js
+++ b/extensions/amp-inline-gallery/1.0/bento-inline-gallery.js
@@ -1,0 +1,2 @@
+import {defineElement} from './web-component';
+defineElement();

--- a/extensions/amp-inline-gallery/1.0/pagination-base-element.js
+++ b/extensions/amp-inline-gallery/1.0/pagination-base-element.js
@@ -1,0 +1,29 @@
+import {CSS} from './pagination.jss';
+import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
+import {BentoInlineGalleryPagination} from './pagination';
+import {PreactBaseElement} from '#preact/base-element';
+
+export const TAG = 'bento-inline-gallery-pagination';
+
+/** @extends {PreactBaseElement<BaseCarouselDef.CarouselApi>} */
+export class PaginationBaseElement extends PreactBaseElement {}
+
+/** @override */
+PaginationBaseElement['Component'] = BentoInlineGalleryPagination;
+
+/** @override */
+PaginationBaseElement['props'] = {
+  'inset': {attr: 'inset', type: 'boolean', media: true},
+};
+
+/** @override */
+PaginationBaseElement['layoutSizeDefined'] = true;
+
+/** @override */
+PaginationBaseElement['shadowCss'] = CSS;
+
+/** @override */
+PaginationBaseElement['usesShadowDom'] = true;
+
+/** @override */
+PaginationBaseElement['useContexts'] = [CarouselContextProp];

--- a/extensions/amp-inline-gallery/1.0/thumbnails-base-element.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails-base-element.js
@@ -1,0 +1,32 @@
+import {CSS as CAROUSEL_CSS} from '../../amp-base-carousel/1.0/component.jss';
+import {CarouselContextProp} from '../../amp-base-carousel/1.0/carousel-props';
+import {PreactBaseElement} from '#preact/base-element';
+import {CSS as THUMBNAIL_CSS} from './thumbnails.jss';
+import {BentoInlineGalleryThumbnails} from './thumbnails';
+
+export const TAG = 'bento-inline-gallery-thumbnails';
+
+/** @extends {PreactBaseElement<BaseCarouselDef.CarouselApi>} */
+export class ThumbnailsBaseElement extends PreactBaseElement {}
+
+/** @override */
+ThumbnailsBaseElement['Component'] = BentoInlineGalleryThumbnails;
+
+/** @override */
+ThumbnailsBaseElement['props'] = {
+  'aspectRatio': {attr: 'aspect-ratio', type: 'number', media: true},
+  'children': {passthroughNonEmpty: true},
+  'loop': {attr: 'loop', type: 'boolean', media: true},
+};
+
+/** @override */
+ThumbnailsBaseElement['layoutSizeDefined'] = true;
+
+/** @override */
+ThumbnailsBaseElement['usesShadowDom'] = true;
+
+/** @override */
+ThumbnailsBaseElement['shadowCss'] = CAROUSEL_CSS + THUMBNAIL_CSS;
+
+/** @override */
+ThumbnailsBaseElement['useContexts'] = [CarouselContextProp];

--- a/extensions/amp-inline-gallery/1.0/utils.js
+++ b/extensions/amp-inline-gallery/1.0/utils.js
@@ -1,0 +1,7 @@
+/**
+ * @param {string} bentoName
+ * @return {string} `amp-` prefixed component name
+ */
+export function getAmpName(bentoName) {
+  return bentoName.replace(/^bento-/, 'amp-');
+}

--- a/extensions/amp-inline-gallery/1.0/web-component.js
+++ b/extensions/amp-inline-gallery/1.0/web-component.js
@@ -1,0 +1,38 @@
+import {BaseElement, TAG} from './base-element';
+import {
+  TAG as THUMBNAIL_TAG,
+  ThumbnailsBaseElement,
+} from './thumbnails-base-element';
+import {
+  TAG as PAGINATION_TAG,
+  PaginationBaseElement,
+} from './pagination-base-element';
+
+/**
+ * Registers `<bento-inline-gallery> component to CustomElements registry
+ */
+export function defineElement() {
+  customElements.define(TAG, BaseElement.CustomElement(BaseElement));
+  defineThumbnailsElement();
+  definePaginationElement();
+}
+
+/**
+ * Registers `<bento-inline-gallery-pagination> component to CustomElements registry
+ */
+export function definePaginationElement() {
+  customElements.define(
+    PAGINATION_TAG,
+    PaginationBaseElement.CustomElement(PaginationBaseElement)
+  );
+}
+
+/**
+ * Registers `<bento-inline-gallery-thumbnails> component to CustomElements registry
+ */
+export function defineThumbnailsElement() {
+  customElements.define(
+    THUMBNAIL_TAG,
+    ThumbnailsBaseElement.CustomElement(ThumbnailsBaseElement)
+  );
+}

--- a/test/fixtures/e2e/bento/bento-inline-gallery.html
+++ b/test/fixtures/e2e/bento/bento-inline-gallery.html
@@ -1,0 +1,87 @@
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-inline-gallery,
+      bento-inline-gallery-pagination,
+      bento-inline-gallery-thumbnails,
+      bento-base-carousel {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+      bento-inline-gallery-thumbnails {
+        height: 100px;
+      }
+      bento-inline-gallery-pagination {
+        height: 20px;
+      }
+
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-inline-gallery-1.0.js"
+    ></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.js"
+    ></script>
+    <script>
+
+    </script>
+    <style>
+      bento-base-carousel,
+      bento-base-carousel > div {
+        aspect-ratio: 4/1;
+      }
+      .red-gradient {
+        background: brown;
+      }
+      .blue-gradient {
+        background: steelblue;
+      }
+      .green-gradient {
+        background: seagreen;
+      }
+    </style>
+  <body>
+    <bento-inline-gallery id="inline-gallery">
+      <bento-inline-gallery-thumbnails></bento-inline-gallery-thumbnails>
+      <bento-base-carousel snap-align="center" visible-count="3" loop>
+        <img
+          style="width:360px; height:240px"
+          src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1498&q=80"
+          data-thumbnail-src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=120&q=80"
+        ></img>
+        <img
+          style="width:360px; height:240px"
+          src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+          data-thumbnail-src="https://images.unsplash.com/photo-1583511666407-5f06533f2113?ixlib=rb-1.2.1&auto=format&fit=crop&w=120&q=80"
+        ></img>
+        <img
+          style="width:360px; height:240px"
+          src="https://images.unsplash.com/photo-1599839575945-a9e5af0c3fa5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjQwMzA0fQ&auto=format&fit=crop&w=1498&q=80"
+          data-thumbnail-src="https://images.unsplash.com/photo-1599839575945-a9e5af0c3fa5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjQwMzA0fQ&auto=format&fit=crop&w=1498&q=80"
+        ></img>
+        <img
+          style="width:360px; height:240px"
+          src="https://images.unsplash.com/photo-1583512603806-077998240c7a?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+          data-thumbnail-src="https://images.unsplash.com/photo-1583512603806-077998240c7a?ixlib=rb-1.2.1&auto=format&fit=crop&w=120&q=80"
+        ></img>
+        <img
+          style="width:360px; height:240px"
+          src="https://images.unsplash.com/photo-1598133893773-de3574464ef0?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+          data-thumbnail-src="https://images.unsplash.com/photo-1598133893773-de3574464ef0?ixlib=rb-1.2.1&auto=format&fit=crop&w=120&q=80"
+        ></img>
+        <img
+          style="width:360px; height:240px"
+          src="https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80"
+          data-thumbnail-src="https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=120&q=80"
+        ></img>
+
+      </bento-base-carousel>
+      <bento-inline-gallery-pagination inset></bento-inline-gallery-pagination>
+    </bento-inline-gallery>
+  </body>
+</html>


### PR DESCRIPTION
creates `web-component.js` file for npm build and `bento-inline-gallery.js` file for CDN build to correctly expose all elements in the inline-gallery extension. these files are used as entry points in the standalone bento component build process for npm/cdn respectively (instead of generating them).

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
