### PR TITLE
🏗 Add dev-mode for `amp visual-diff` and split code into modules

### DIFF
--- a/build-system/tasks/visual-diff/browser.js
+++ b/build-system/tasks/visual-diff/browser.js
@@ -1,0 +1,196 @@
+'use strict';
+
+const argv = require('minimist')(process.argv.slice(2));
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+const PuppeteerExtraPluginUserPreferences = require('puppeteer-extra-plugin-user-preferences');
+const {addExtra} = require('puppeteer-extra');
+const {cyan, yellow} = require('kleur/colors');
+const {HOST} = require('./consts');
+const {log} = require('./log');
+
+// REPEATING TODO(@ampproject/wg-infra): Update this whenever the Percy backend
+// starts using a new version of Chrome to render DOM snapshots.
+//
+// Steps:
+// 1. Open a recent Percy build, and click the “ⓘ” icon
+// 2. Note the Chrome major version at the bottom
+// 3. Look up the full version at https://en.wikipedia.org/wiki/Google_Chrome_version_history
+// 4. Open https://omahaproxy.appspot.com in a browser
+// 5. Go to "Tools" -> "Version information"
+// 6. Paste the full version (add ".0" at the end) in the "Version" field and click "Lookup"
+// 7. Copy the value next to "Branch Base Position" and update the line below
+const PUPPETEER_CHROMIUM_REVISION = '870763'; // 91.0.4472.0
+
+const VIEWPORT_WIDTH = 1400;
+const VIEWPORT_HEIGHT = 100000;
+
+/**
+ * Launches a Puppeteer controlled browser.
+ *
+ * Waits until the browser is up and reachable, and ties its lifecycle to this
+ * process's lifecycle.
+ *
+ * @param {!puppeteer.BrowserFetcher} browserFetcher Puppeteer browser binaries
+ *     manager.
+ * @return {Promise<!puppeteer.Browser>} a Puppeteer controlled browser.
+ */
+async function launchBrowser(browserFetcher) {
+  const browserOptions = {
+    args: [
+      '--disable-background-media-suspend',
+      '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-extensions',
+      '--disable-gpu',
+      '--disable-renderer-backgrounding',
+      '--no-sandbox',
+      '--no-startup-window',
+    ],
+    dumpio: argv.chrome_debug,
+    headless: !argv.dev,
+    executablePath: browserFetcher.revisionInfo(PUPPETEER_CHROMIUM_REVISION)
+      .executablePath,
+    waitForInitialPage: false,
+  };
+
+  // @ts-ignore type mismatch in puppeteer-extra.
+  const puppeteerExtra = addExtra(puppeteer);
+  puppeteerExtra.use(
+    PuppeteerExtraPluginUserPreferences({
+      userPrefs: {
+        devtools: {
+          preferences: {
+            currentDockState: '"undocked"',
+          },
+        },
+      },
+    })
+  );
+  return await puppeteerExtra.launch(browserOptions);
+}
+
+/**
+ * Opens a new browser tab, resizes its viewport, and returns a Page handler.
+ *
+ * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
+ * @param {?puppeteer.Viewport} viewport optional viewport size object with
+ *     numeric fields `width` and `height`.
+ * @return {Promise<!puppeteer.Page>}
+ */
+async function newPage(browser, viewport = null) {
+  log('verbose', 'Creating new tab');
+
+  const context = await browser.createIncognitoBrowserContext();
+  const page = await context.newPage();
+  page.setDefaultNavigationTimeout(0);
+  await page.setJavaScriptEnabled(true);
+  await page.setRequestInterception(true);
+  page.on('request', (interceptedRequest) => {
+    const requestUrl = new URL(interceptedRequest.url());
+    const mockedFilepath = path.join(
+      path.dirname(__filename),
+      'network-mocks',
+      requestUrl.hostname,
+      encodeURIComponent(
+        `${requestUrl.pathname.substr(1)}${requestUrl.search}`
+      ).replace(/%2F/g, '/')
+    );
+
+    if (
+      requestUrl.protocol === 'data:' ||
+      requestUrl.hostname === HOST ||
+      requestUrl.hostname.endsWith(`.${HOST}`)
+    ) {
+      return interceptedRequest.continue();
+    } else if (fs.existsSync(mockedFilepath)) {
+      log(
+        'verbose',
+        'Mocked network request for',
+        yellow(requestUrl.href),
+        'with file',
+        cyan(mockedFilepath)
+      );
+      return interceptedRequest.respond({
+        status: 200,
+        body: fs.readFileSync(mockedFilepath),
+      });
+    } else {
+      log(
+        'verbose',
+        'Blocked external network request for',
+        yellow(requestUrl.href)
+      );
+      return interceptedRequest.abort('blockedbyclient');
+    }
+  });
+  await resetPage(page, viewport);
+  return page;
+}
+
+/**
+ * Resets the size of a tab and loads about:blank.
+ *
+ * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
+ * @param {?puppeteer.Viewport} viewport optional viewport size object with
+ *     numeric fields `width` and `height`.
+ * @return {Promise<void>}
+ */
+async function resetPage(page, viewport = null) {
+  const width = viewport ? viewport.width : VIEWPORT_WIDTH;
+  const height = viewport ? viewport.height : VIEWPORT_HEIGHT;
+
+  log(
+    'verbose',
+    'Resetting tab to',
+    yellow('about:blank'),
+    'with size',
+    yellow(`${width}×${height}`)
+  );
+
+  await page.goto('about:blank');
+  await page.setViewport({width, height});
+}
+
+/**
+ * Loads task-specific dependencies are returns an instance of BrowserFetcher.
+ *
+ * @return {Promise<!puppeteer.BrowserFetcher>}
+ */
+async function loadBrowserFetcher() {
+  // @ts-ignore Valid method in Puppeteer's nodejs interface.
+  // https://github.com/puppeteer/puppeteer/blob/main/src/node/Puppeteer.ts
+  const browserFetcher = puppeteer.createBrowserFetcher();
+  const chromiumRevisions = await browserFetcher.localRevisions();
+  if (chromiumRevisions.includes(PUPPETEER_CHROMIUM_REVISION)) {
+    log(
+      'info',
+      'Using Percy-compatible version of Chromium',
+      cyan(PUPPETEER_CHROMIUM_REVISION)
+    );
+  } else {
+    log(
+      'info',
+      'Percy-compatible version of Chromium',
+      cyan(PUPPETEER_CHROMIUM_REVISION),
+      'was not found. Downloading...'
+    );
+    await browserFetcher.download(
+      PUPPETEER_CHROMIUM_REVISION,
+      (/* downloadedBytes, totalBytes */) => {
+        // TODO(@ampproject/wg-infra): display download progress.
+        // Logging every call is too verbose.
+      }
+    );
+  }
+  return browserFetcher;
+}
+
+module.exports = {
+  PUPPETEER_CHROMIUM_REVISION,
+  launchBrowser,
+  loadBrowserFetcher,
+  newPage,
+  resetPage,
+};

--- a/build-system/tasks/visual-diff/consts.js
+++ b/build-system/tasks/visual-diff/consts.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const {PORT} = require('../serve');
+
+const HOST = 'localhost';
+
+// Base tests do not run any special code other than loading the page. Use this
+// no-op function instead of null for easier type checking.
+const BASE_TEST_FUNCTION = async () => {};
+
+module.exports = {
+  BASE_TEST_FUNCTION,
+  HOST,
+  PORT,
+};

--- a/build-system/tasks/visual-diff/dev-mode.js
+++ b/build-system/tasks/visual-diff/dev-mode.js
@@ -143,10 +143,12 @@ async function inquireForWebpage_(webpages) {
             ' (use ' +
             cyan('--grep') +
             ' to filter this list):',
-          choices: webpages.map((webpage) => ({
-            name: webpage.name,
-            value: webpage,
-          })),
+          choices: webpages
+            .map((webpage) => ({
+              name: webpage.name,
+              value: webpage,
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name)),
         },
       ])
     ).webpage;

--- a/build-system/tasks/visual-diff/dev-mode.js
+++ b/build-system/tasks/visual-diff/dev-mode.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const inquirer = require('inquirer');
+const puppeteer = require('puppeteer'); // eslint-disable-line no-unused-vars
+const {
+  verifySelectorsInvisible,
+  verifySelectorsVisible,
+  waitForPageLoad,
+} = require('./verifiers');
+const {BASE_TEST_FUNCTION} = require('./consts');
+const {cyan, yellow} = require('kleur/colors');
+const {HOST, PORT} = require('./consts');
+const {log} = require('./log');
+const {newPage} = require('./browser');
+const {sleep} = require('./helpers');
+const {WebpageDef} = require('./types');
+
+/**
+ * Runs a development mode.
+ *
+ * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
+ * @param {!Array<!WebpageDef>} webpages an array of JSON objects containing
+ *     details about the webpages to snapshot.
+ * @return {Promise<void>}
+ */
+async function devMode(browser, webpages) {
+  /** @type {WebpageDef} */
+  let webpage;
+  if (webpages.length > 1) {
+    webpage = (
+      await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'webpage',
+          message:
+            'Select test name from ' +
+            cyan('visual-diff.jsonc') +
+            ' (use ' +
+            cyan('--grep') +
+            ' to filter this list):',
+          choices: webpages.map((webpage) => ({
+            name: webpage.name,
+            value: webpage,
+          })),
+        },
+      ])
+    ).webpage;
+  } else {
+    webpage = webpages[0];
+    log(
+      'info',
+      'Using test',
+      yellow(webpage.name),
+      '(Only one test matches the',
+      cyan('--grep'),
+      'value)'
+    );
+  }
+
+  let testName = '';
+  let testFunction = Object.values(webpage.tests_)[0];
+  if (Object.entries(webpage.tests_).length > 1) {
+    [testName, testFunction] = (
+      await inquirer.prompt([
+        {
+          type: 'list',
+          name: 'test_',
+          message:
+            'Select which interactive test from ' +
+            cyan(webpage.interactive_tests) +
+            ' to run:',
+          choices: Object.entries(webpage.tests_).map(
+            ([testName, testFunction]) => ({
+              name: testName || '(base test)',
+              value: [testName, testFunction],
+            })
+          ),
+        },
+      ])
+    ).test_;
+  }
+
+  log('info', 'The test will now run in a browser window...');
+  const page = await newPage(browser, webpage.viewport);
+  await page.goto(`http://${HOST}:${PORT}/${webpage.url}`, {
+    waitUntil: 'networkidle0',
+  });
+
+  while (true) {
+    try {
+      await waitForPageLoad(page, webpage.name);
+    } catch {
+      log('warning', 'Page did not finish loading all AMP components');
+    }
+
+    // Based on test configuration, wait for a specific amount of time.
+    if (webpage.loading_complete_delay_ms) {
+      log(
+        'info',
+        'Waiting',
+        cyan(`${webpage.loading_complete_delay_ms}ms`),
+        'for loading to complete'
+      );
+      await sleep(webpage.loading_complete_delay_ms);
+    }
+
+    if (testFunction !== BASE_TEST_FUNCTION) {
+      log('info', 'Executing custom test function', cyan(testName));
+      try {
+        await testFunction(page, webpage.name);
+      } catch (e) {
+        log('warning', 'Custom test function did not execute correctly:', e);
+      }
+    }
+
+    log('info', '- Type', cyan('CSS selector'), 'to verify that it is visible');
+    log('info', '- Start with', cyan('!'), 'to verify invisibility');
+    log('info', '- Press enter on', cyan('empty prompt'), 'to reload the page');
+    log('info', '-', cyan('Ctrl + C'), 'to quit.');
+    while (true) {
+      /** @type {string} */
+      let cssSelector = (
+        await inquirer.prompt({
+          type: 'input',
+          name: 'cssSelector',
+          message: '>',
+          prefix: '',
+        })
+      ).cssSelector.trim();
+
+      if (!cssSelector) {
+        break;
+      }
+
+      const verifySelectors = cssSelector.startsWith('!')
+        ? verifySelectorsInvisible
+        : verifySelectorsVisible;
+      const verifyingText = cssSelector.startsWith('!')
+        ? 'invisible'
+        : 'visible';
+      if (cssSelector.startsWith('!')) {
+        cssSelector = cssSelector.slice(1);
+      }
+
+      try {
+        await verifySelectors(page, webpage.name, [cssSelector], 0);
+        log(
+          'info',
+          'CSS selector',
+          cyan(cssSelector),
+          'is',
+          cyan(verifyingText),
+          'on the page as expected'
+        );
+      } catch (e) {
+        log(
+          'warning',
+          'CSS selector',
+          cyan(cssSelector),
+          'is not',
+          cyan(verifyingText),
+          'on the page'
+        );
+      }
+    }
+
+    log('info', 'Reloading the page...');
+    await page.reload({waitUntil: 'networkidle0'});
+  }
+}
+
+module.exports = {
+  devMode,
+};

--- a/build-system/tasks/visual-diff/helpers.js
+++ b/build-system/tasks/visual-diff/helpers.js
@@ -1,15 +1,5 @@
 'use strict';
 
-const argv = require('minimist')(process.argv.slice(2));
-const puppeteer = require('puppeteer'); // eslint-disable-line no-unused-vars
-const {cyan, green, red, yellow} = require('kleur/colors');
-const {log: logBase} = require('../../common/logging');
-
-const CSS_SELECTOR_RETRY_MS = 200;
-const CSS_SELECTOR_RETRY_ATTEMPTS = 50;
-const CSS_SELECTOR_TIMEOUT_MS =
-  CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS;
-
 const HTML_ESCAPE_CHARS = {
   '&': '&amp;',
   '<': '&lt;',
@@ -21,14 +11,6 @@ const HTML_ESCAPE_CHARS = {
 const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
 
 /**
- * @typedef {{
- *  visible?: boolean,
- *  hidden?: boolean,
- * }}
- */
-let VisibilityDef;
-
-/**
  * Escapes a string of HTML elements to HTML entities.
  *
  * @param {string} html HTML as string to escape.
@@ -36,218 +18,6 @@ let VisibilityDef;
  */
 function escapeHtml(html) {
   return html.replace(HTML_ESCAPE_REGEX, (c) => HTML_ESCAPE_CHARS[c]);
-}
-
-/**
- * Logs a message to the console.
- *
- * @param {string} mode
- * @param {!Array<*>} messages
- */
-function log(mode, ...messages) {
-  switch (mode) {
-    case 'verbose':
-      if (argv.verbose) {
-        logBase(green('VERBOSE:'), ...messages);
-      }
-      break;
-    case 'info':
-      logBase(green('INFO:'), ...messages);
-      break;
-    case 'warning':
-      logBase(yellow('WARNING:'), ...messages);
-      break;
-    case 'error':
-      logBase(red('ERROR:'), ...messages);
-      break;
-    case 'fatal':
-      process.exitCode = 1;
-      logBase(red('FATAL:'), ...messages);
-      throw new Error(messages.join(' '));
-  }
-}
-
-/**
- * Verifies that all CSS elements are as expected before taking a snapshot.
- *
- * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
- * @param {string} testName the full name of the test.
- * @param {!Array<string>} selectors Array of CSS selector that must eventually
- *     be removed from the page.
- * @return {Promise<void>}
- * @throws {Error} an encountered error.
- */
-async function verifySelectorsInvisible(page, testName, selectors) {
-  log(
-    'verbose',
-    'Waiting for invisibility of all:',
-    cyan(selectors.join(', '))
-  );
-  try {
-    await Promise.all(
-      selectors.map((selector) =>
-        waitForElementVisibility(page, selector, {hidden: true})
-      )
-    );
-  } catch (e) {
-    throw new Error(
-      `${cyan(testName)} | An element with the CSS ` +
-        `selector ${cyan(e.message)} is still visible after ` +
-        `${CSS_SELECTOR_TIMEOUT_MS} ms`
-    );
-  }
-}
-
-/**
- * Verifies that all CSS elements are as expected before taking a snapshot.
- *
- * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
- * @param {string} testName the full name of the test.
- * @param {!Array<string>} selectors Array of CSS selectors that must
- *     eventually appear on the page.
- * @return {Promise<void>}
- * @throws {Error} an encountered error.
- */
-async function verifySelectorsVisible(page, testName, selectors) {
-  log('verbose', 'Waiting for existence of all:', cyan(selectors.join(', ')));
-  try {
-    await Promise.all(
-      selectors.map((selector) => waitForSelectorExistence(page, selector))
-    );
-  } catch (e) {
-    throw new Error(
-      `${cyan(testName)} | The CSS selector ` +
-        `${cyan(e.message)} does not match any elements in the page`
-    );
-  }
-
-  log('verbose', 'Waiting for visibility of all:', cyan(selectors.join(', ')));
-  try {
-    await Promise.all(
-      selectors.map((selector) =>
-        waitForElementVisibility(page, selector, {visible: true})
-      )
-    );
-  } catch (e) {
-    throw new Error(
-      `${cyan(testName)} | An element with the CSS ` +
-        `selector ${cyan(e.message)} is still invisible after ` +
-        `${CSS_SELECTOR_TIMEOUT_MS} ms`
-    );
-  }
-}
-
-/**
- * Wait for all AMP loader indicators to disappear.
- *
- * @param {!puppeteer.Page} page page to wait on.
- * @param {string} testName the full name of the test.
- * @return {Promise<void>}
- * @throws {Error} an encountered error.
- */
-async function waitForPageLoad(page, testName) {
-  const allLoadersGone = await waitForElementVisibility(
-    page,
-    '[class~="i-amphtml-loader"], [class~="i-amphtml-loading"]',
-    {hidden: true}
-  );
-  if (!allLoadersGone) {
-    throw new Error(
-      `${cyan(testName)} still has the AMP loader dot ` +
-        `after ${CSS_SELECTOR_TIMEOUT_MS} ms`
-    );
-  }
-}
-
-/**
- * Wait until the element is either hidden or visible or until timed out.
- *
- * Timeout is set to CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS ms.
- *
- * @param {!puppeteer.Page} page page to check the visibility of elements in.
- * @param {string} selector CSS selector for elements to wait on.
- * @param {!VisibilityDef} options with key 'visible' OR 'hidden' set to true.
- * @return {Promise<boolean>} true if the expectation is met before the timeout.
- * @throws {Error} if the expectation is not met before the timeout, throws an
- *    error with the message value set to the CSS selector.
- */
-async function waitForElementVisibility(page, selector, options) {
-  const waitForVisible = Boolean(options['visible']);
-  const waitForHidden = Boolean(options['hidden']);
-  if (waitForVisible == waitForHidden) {
-    log(
-      'fatal',
-      'waitForElementVisibility must be called with exactly one of',
-      "'visible' or 'hidden' set to true."
-    );
-  }
-
-  let attempt = 0;
-  do {
-    const elementsAreVisible = [];
-
-    for (const elementHandle of await page.$$(selector)) {
-      const boundingBox = await elementHandle.boundingBox();
-      const elementIsVisible =
-        boundingBox != null && boundingBox.height > 0 && boundingBox.width > 0;
-      elementsAreVisible.push(elementIsVisible);
-    }
-
-    if (elementsAreVisible.length) {
-      log(
-        'verbose',
-        'Found',
-        cyan(elementsAreVisible.length),
-        'element(s) matching the CSS selector',
-        cyan(selector)
-      );
-      log(
-        'verbose',
-        'Expecting all element visibilities to be',
-        cyan(waitForVisible),
-        '; they are:',
-        cyan(elementsAreVisible.join(', '))
-      );
-    } else {
-      log('verbose', 'No', cyan(selector), 'matches found');
-    }
-    // Since we assert that waitForVisible == !waitForHidden, there is no need
-    // to check equality to both waitForVisible and waitForHidden.
-    if (
-      elementsAreVisible.every(
-        (elementIsVisible) => elementIsVisible == waitForVisible
-      )
-    ) {
-      return true;
-    }
-
-    await sleep(CSS_SELECTOR_RETRY_MS);
-    attempt++;
-  } while (attempt < CSS_SELECTOR_RETRY_ATTEMPTS);
-  throw new Error(selector);
-}
-
-/**
- * Wait until the CSS selector exists in the page or until timed out.
- *
- * Timeout is set to CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS ms.
- *
- * @param {!puppeteer.Page} page page to check the existence of the selector in.
- * @param {string} selector CSS selector.
- * @return {Promise<boolean>} true if the element exists before the timeout.
- * @throws {Error} if the element does not exist before the timeout, throws an
- *    error with the message value set to the CSS selector.
- */
-async function waitForSelectorExistence(page, selector) {
-  let attempt = 0;
-  do {
-    if ((await page.$(selector)) !== null) {
-      return true;
-    }
-    await sleep(CSS_SELECTOR_RETRY_MS);
-    attempt++;
-  } while (attempt < CSS_SELECTOR_RETRY_ATTEMPTS);
-  throw new Error(selector);
 }
 
 /**
@@ -261,9 +31,5 @@ async function sleep(ms) {
 
 module.exports = {
   escapeHtml,
-  log,
   sleep,
-  waitForPageLoad,
-  verifySelectorsInvisible,
-  verifySelectorsVisible,
 };

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -8,29 +8,38 @@ const os = require('os');
 const path = require('path');
 const Percy = require('@percy/core');
 const percySnapshot = require('@percy/puppeteer');
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer'); // eslint-disable-line no-unused-vars
 const {
   createCtrlcHandler,
   exitCtrlcHandler,
 } = require('../../common/ctrlcHandler');
-const {
-  escapeHtml,
-  log,
-  sleep,
-  verifySelectorsInvisible,
-  verifySelectorsVisible,
-  waitForPageLoad,
-} = require('./helpers');
 const {
   gitBranchName,
   gitCiMainBaseline,
   gitCommitterEmail,
   shortSha,
 } = require('../../common/git');
+const {
+  PUPPETEER_CHROMIUM_REVISION,
+  launchBrowser,
+  loadBrowserFetcher,
+  newPage,
+  resetPage,
+} = require('./browser');
+const {
+  verifySelectorsInvisible,
+  verifySelectorsVisible,
+  waitForPageLoad,
+} = require('./verifiers');
+const {BASE_TEST_FUNCTION, HOST, PORT} = require('./consts');
 const {cyan, green, red, yellow} = require('kleur/colors');
+const {devMode} = require('./dev-mode');
+const {drawBoxes, log} = require('./log');
+const {escapeHtml, sleep} = require('./helpers');
 const {isCiBuild} = require('../../common/ci');
 const {isPercyEnabled} = require('@percy/sdk-utils');
 const {startServer, stopServer} = require('../serve');
+const {TestErrorDef, WebpageDef} = require('./types');
 
 // CSS injected in every page tested.
 // Normally, as in https://docs.percy.io/docs/percy-specific-css
@@ -41,26 +50,9 @@ const percyCss = [
   '.i-amphtml-new-loader * { animation: none !important; }',
 ].join('\n');
 
-// REPEATING TODO(@ampproject/wg-infra): Update this whenever the Percy backend
-// starts using a new version of Chrome to render DOM snapshots.
-//
-// Steps:
-// 1. Open a recent Percy build, and click the “ⓘ” icon
-// 2. Note the Chrome major version at the bottom
-// 3. Look up the full version at https://en.wikipedia.org/wiki/Google_Chrome_version_history
-// 4. Open https://omahaproxy.appspot.com in a browser
-// 5. Go to "Tools" -> "Version information"
-// 6. Paste the full version (add ".0" at the end) in the "Version" field and click "Lookup"
-// 7. Copy the value next to "Branch Base Position" and update the line below
-const PUPPETEER_CHROMIUM_REVISION = '870763'; // 91.0.4472.0
-
 const SNAPSHOT_SINGLE_BUILD_OPTIONS = {
   widths: [375],
 };
-const VIEWPORT_WIDTH = 1400;
-const VIEWPORT_HEIGHT = 100000;
-const HOST = 'localhost';
-const PORT = 8000;
 const PERCY_AGENT_PORT = 5338;
 const WAIT_FOR_TABS_MS = 1000;
 const WAIT_FOR_AGENT_MS = 5000;
@@ -92,36 +84,6 @@ const SNAPSHOT_ERROR_SNIPPET = fs.readFileSync(
   path.resolve(__dirname, 'snippets/snapshot-error.html'),
   'utf8'
 );
-
-/**
- * @typedef {{
- *  name: string,
- *  message: string,
- *  error: Error,
- *  consoleMessages: puppeteer.ConsoleMessage[],
- * }}
- */
-let TestErrorDef;
-
-/**
- * @typedef {{
- *  url: string,
- *  name: string,
- *  viewport: {
- *    width: number,
- *    height: number,
- *  },
- *  loading_incomplete_selectors: string[],
- *  loading_complete_selectors: string[],
- *  loading_complete_delay_ms: number,
- *  enable_percy_javascript: boolean,
- *  interactive_tests: string,
- *  no_base_test: boolean,
- *  flaky: boolean,
- *  tests_: Object<string, Function>,
- * }}
- */
-let WebpageDef;
 
 /**
  * Decode the write-only Percy token during CI builds.
@@ -177,7 +139,7 @@ function setPercyTargetCommit() {
  *
  * @param {!puppeteer.BrowserFetcher} browserFetcher Puppeteer browser binaries
  *     manager.
- * @return {!Promise<Percy|undefined>} percy agent instance.
+ * @return {Promise<Percy|undefined>} percy agent instance.
  */
 async function launchPercyAgent(browserFetcher) {
   if (argv.percy_disabled) {
@@ -233,131 +195,6 @@ async function launchPercyAgent(browserFetcher) {
 }
 
 /**
- * Launches an AMP webserver for minified js.
- * @return {Promise<void>}
- */
-async function launchWebServer() {
-  await startServer(
-    {host: HOST, port: PORT},
-    {quiet: !argv.webserver_debug},
-    {minified: true}
-  );
-}
-
-/**
- * Launches a Puppeteer controlled browser.
- *
- * Waits until the browser is up and reachable, and ties its lifecycle to this
- * process's lifecycle.
- *
- * @param {!puppeteer.BrowserFetcher} browserFetcher Puppeteer browser binaries
- *     manager.
- * @return {!Promise<!puppeteer.Browser>} a Puppeteer controlled browser.
- */
-async function launchBrowser(browserFetcher) {
-  const browserOptions = {
-    args: [
-      '--disable-background-media-suspend',
-      '--disable-background-timer-throttling',
-      '--disable-backgrounding-occluded-windows',
-      '--disable-extensions',
-      '--disable-gpu',
-      '--disable-renderer-backgrounding',
-      '--no-sandbox',
-      '--no-startup-window',
-    ],
-    dumpio: argv.chrome_debug,
-    headless: true,
-    executablePath: browserFetcher.revisionInfo(PUPPETEER_CHROMIUM_REVISION)
-      .executablePath,
-    waitForInitialPage: false,
-  };
-  return await puppeteer.launch(browserOptions);
-}
-
-/**
- * Opens a new browser tab, resizes its viewport, and returns a Page handler.
- *
- * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
- * @param {?{height: number, width: number}} viewport optional viewport size
- *     object with numeric fields `width` and `height`.
- * @return {!Promise<!puppeteer.Page>}
- */
-async function newPage(browser, viewport = null) {
-  log('verbose', 'Creating new tab');
-
-  const context = await browser.createIncognitoBrowserContext();
-  const page = await context.newPage();
-  page.setDefaultNavigationTimeout(0);
-  await page.setJavaScriptEnabled(true);
-  await page.setRequestInterception(true);
-  page.on('request', (interceptedRequest) => {
-    const requestUrl = new URL(interceptedRequest.url());
-    const mockedFilepath = path.join(
-      path.dirname(__filename),
-      'network-mocks',
-      requestUrl.hostname,
-      encodeURIComponent(
-        `${requestUrl.pathname.substr(1)}${requestUrl.search}`
-      ).replace(/%2F/g, '/')
-    );
-
-    if (
-      requestUrl.protocol === 'data:' ||
-      requestUrl.hostname === HOST ||
-      requestUrl.hostname.endsWith(`.${HOST}`)
-    ) {
-      return interceptedRequest.continue();
-    } else if (fs.existsSync(mockedFilepath)) {
-      log(
-        'verbose',
-        'Mocked network request for',
-        yellow(requestUrl.href),
-        'with file',
-        cyan(mockedFilepath)
-      );
-      return interceptedRequest.respond({
-        status: 200,
-        body: fs.readFileSync(mockedFilepath),
-      });
-    } else {
-      log(
-        'verbose',
-        'Blocked external network request for',
-        yellow(requestUrl.href)
-      );
-      return interceptedRequest.abort('blockedbyclient');
-    }
-  });
-  await resetPage(page, viewport);
-  return page;
-}
-
-/**
- * Resets the size of a tab and loads about:blank.
- *
- * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
- * @param {?{height: number, width: number}} viewport optional viewport size
- *     object with numeric fields `width` and `height`.
- * @return {Promise<void>}
- */
-async function resetPage(page, viewport = null) {
-  const width = viewport ? viewport.width : VIEWPORT_WIDTH;
-  const height = viewport ? viewport.height : VIEWPORT_HEIGHT;
-
-  log(
-    'verbose',
-    'Resetting tab to',
-    yellow('about:blank'),
-    'with size',
-    yellow(`${width}×${height}`)
-  );
-
-  await page.goto('about:blank');
-  await page.setViewport({width, height});
-}
-
-/**
  * Adds a test error and logs it if running locally (not as part of CI).
  *
  * @param {!Array<!TestErrorDef>} testErrors array of testError objects.
@@ -407,7 +244,7 @@ function logTestError(testError) {
  * set of given webpages.
  *
  * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
- * @param {!Array<WebpageDef>} webpages details about the pages to snapshot.
+ * @param {!Array<!WebpageDef>} webpages details about the pages to snapshot.
  * @return {Promise<void>}
  */
 async function runVisualTests(browser, webpages) {
@@ -438,7 +275,7 @@ async function runVisualTests(browser, webpages) {
   for (const webpage of webpages) {
     webpage.tests_ = {};
     if (!webpage.no_base_test) {
-      webpage.tests_[''] = async () => {};
+      webpage.tests_[''] = BASE_TEST_FUNCTION;
     }
     if (webpage.interactive_tests) {
       try {
@@ -479,43 +316,20 @@ async function runVisualTests(browser, webpages) {
 
   if (argv.main) {
     const page = await newPage(browser);
-    await page.goto(
-      `http://${HOST}:${PORT}/examples/visual-tests/blank-page/blank.html`
-    );
+    await page.goto('about:blank');
     // @ts-ignore Type mismatch in library
     await percySnapshot(page, 'Blank page', SNAPSHOT_SINGLE_BUILD_OPTIONS);
   }
 
-  log('info', 'Generating snapshots...');
-  if (!(await snapshotWebpages(browser, webpages))) {
-    log('fatal', 'Some tests have failed locally.');
+  if (argv.dev) {
+    log('info', 'Running development mode...');
+    await devMode(browser, webpages);
+  } else {
+    log('info', 'Generating snapshots...');
+    if (!(await snapshotWebpages(browser, webpages))) {
+      log('fatal', 'Some tests have failed locally.');
+    }
   }
-}
-
-/**
- * Pretty-prints the current test status of each page.
- * @param {!Array<!puppeteer.Page>} allPages
- * @param {!Array<!puppeteer.Page>} availablePages
- * @param {!puppeteer.Page} thisPage
- * @param {string} thisPageText
- * @return {string}
- */
-function drawBoxes(allPages, availablePages, thisPage, thisPageText) {
-  return (
-    '[' +
-    allPages
-      .map((page) => {
-        if (page === thisPage) {
-          return thisPageText;
-        } else if (availablePages.includes(page)) {
-          return ' ';
-        } else {
-          return yellow('█');
-        }
-      })
-      .join(' ') +
-    ']'
-  );
 }
 
 /**
@@ -524,7 +338,7 @@ function drawBoxes(allPages, availablePages, thisPage, thisPageText) {
  * @param {!puppeteer.Browser} browser a Puppeteer controlled browser.
  * @param {!Array<!WebpageDef>} webpages an array of JSON objects containing
  *     details about the webpages to snapshot.
- * @return {!Promise<boolean>} true if all tests passed locally (does not
+ * @return {Promise<boolean>} true if all tests passed locally (does not
  *     indicate whether the tests passed on Percy).
  */
 async function snapshotWebpages(browser, webpages) {
@@ -759,9 +573,7 @@ async function createEmptyBuild(browser) {
   const page = await newPage(browser);
 
   try {
-    await page.goto(
-      `http://${HOST}:${PORT}/examples/visual-tests/blank-page/blank.html`
-    );
+    await page.goto('about:blank');
   } catch {
     // Ignore failures
   }
@@ -772,12 +584,12 @@ async function createEmptyBuild(browser) {
 
 /**
  * Runs the AMP visual diff tests.
- * @return {!Promise<void>}
+ * @return {Promise<void>}
  */
 async function visualDiff() {
   const handlerProcess = createCtrlcHandler('visual-diff');
   await ensureOrBuildAmpRuntimeInTestMode_();
-  const browserFetcher = await loadBrowserFetcher_();
+  const browserFetcher = await loadBrowserFetcher();
   decodePercyTokenForCi();
   maybeOverridePercyEnvironmentVariables();
   setPercyBranch();
@@ -785,6 +597,10 @@ async function visualDiff() {
 
   if (argv.grep) {
     argv.grep = RegExp(argv.grep);
+  }
+
+  if (argv.dev) {
+    argv['percy_disabled'] = true;
   }
 
   if (!argv.percy_disabled && !process.env.PERCY_TOKEN) {
@@ -813,10 +629,14 @@ async function performVisualTests(browserFetcher) {
 
   const browser = await launchBrowser(browserFetcher);
   const handlerProcess = createCtrlcHandler(
-    'visual-diff:headless-browser',
+    'visual-diff:browser',
     browser.process()?.pid
   );
-  await launchWebServer();
+  await startServer(
+    {host: HOST, port: PORT},
+    {quiet: !argv.webserver_debug},
+    {minified: true}
+  );
 
   try {
     if (argv.empty) {
@@ -864,40 +684,6 @@ async function ensureOrBuildAmpRuntimeInTestMode_() {
   }
 }
 
-/**
- * Loads task-specific dependencies are returns an instance of BrowserFetcher.
- *
- * @return {!Promise<!puppeteer.BrowserFetcher>}
- */
-async function loadBrowserFetcher_() {
-  // @ts-ignore Valid method in Puppeteer's nodejs interface.
-  // https://github.com/puppeteer/puppeteer/blob/main/src/node/Puppeteer.ts
-  const browserFetcher = puppeteer.createBrowserFetcher();
-  const chromiumRevisions = await browserFetcher.localRevisions();
-  if (chromiumRevisions.includes(PUPPETEER_CHROMIUM_REVISION)) {
-    log(
-      'info',
-      'Using Percy-compatible version of Chromium',
-      cyan(PUPPETEER_CHROMIUM_REVISION)
-    );
-  } else {
-    log(
-      'info',
-      'Percy-compatible version of Chromium',
-      cyan(PUPPETEER_CHROMIUM_REVISION),
-      'was not found. Downloading...'
-    );
-    await browserFetcher.download(
-      PUPPETEER_CHROMIUM_REVISION,
-      (/* downloadedBytes, totalBytes */) => {
-        // TODO(@ampproject/wg-infra): display download progress.
-        // Logging every call is too verbose.
-      }
-    );
-  }
-  return browserFetcher;
-}
-
 module.exports = {
   visualDiff,
 };
@@ -916,4 +702,5 @@ visualDiff.flags = {
   'percy_branch': 'Override the PERCY_BRANCH environment variable',
   'percy_disabled':
     'Disable Percy integration (for testing local changes only)',
+  'dev': 'Developer mode for creating and debugging tests',
 };

--- a/build-system/tasks/visual-diff/log.js
+++ b/build-system/tasks/visual-diff/log.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const argv = require('minimist')(process.argv.slice(2));
+const puppeteer = require('puppeteer'); // eslint-disable-line no-unused-vars
+const {green, red, yellow} = require('kleur/colors');
+const {log: logBase} = require('../../common/logging');
+
+/**
+ * Logs a message to the console.
+ *
+ * @param {string} mode
+ * @param {!Array<*>} messages
+ */
+function log(mode, ...messages) {
+  switch (mode) {
+    case 'verbose':
+      if (argv.verbose) {
+        logBase(green('VERBOSE:'), ...messages);
+      }
+      break;
+    case 'info':
+      logBase(green('INFO:'), ...messages);
+      break;
+    case 'warning':
+      logBase(yellow('WARNING:'), ...messages);
+      break;
+    case 'error':
+      logBase(red('ERROR:'), ...messages);
+      break;
+    case 'fatal':
+      process.exitCode = 1;
+      logBase(red('FATAL:'), ...messages);
+      throw new Error(messages.join(' '));
+  }
+}
+
+/**
+ * Pretty-prints the current test status of each page.
+ * @param {!Array<!puppeteer.Page>} allPages
+ * @param {!Array<!puppeteer.Page>} availablePages
+ * @param {!puppeteer.Page} thisPage
+ * @param {string} thisPageText
+ * @return {string}
+ */
+function drawBoxes(allPages, availablePages, thisPage, thisPageText) {
+  return (
+    '[' +
+    allPages
+      .map((page) => {
+        if (page === thisPage) {
+          return thisPageText;
+        } else if (availablePages.includes(page)) {
+          return ' ';
+        } else {
+          return yellow('█');
+        }
+      })
+      .join(' ') +
+    ']'
+  );
+}
+
+module.exports = {
+  drawBoxes,
+  log,
+};

--- a/build-system/tasks/visual-diff/package-lock.json
+++ b/build-system/tasks/visual-diff/package-lock.json
@@ -11,8 +11,12 @@
         "@percy/core": "1.0.0-beta.70",
         "@percy/puppeteer": "2.0.0",
         "@percy/sdk-utils": "1.0.0-beta.70",
+        "@types/inquirer": "8.1.3",
         "@types/puppeteer": "5.4.4",
-        "puppeteer": "10.4.0"
+        "inquirer": "8.2.0",
+        "puppeteer": "10.4.0",
+        "puppeteer-extra": "3.2.3",
+        "puppeteer-extra-plugin-user-preferences": "2.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -149,6 +153,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/inquirer": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.1.3.tgz",
+      "integrity": "sha512-AayK4ZL5ssPzR1OtnOLGAwpT0Dda3Xi/h1G0l1oJDNrowp7T1423q4Zb8/emr7tzRlCy4ssEri0LWVexAqHyKQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "14.11.8",
       "dev": true,
@@ -164,6 +193,15 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.4.tgz",
       "integrity": "sha512-3Nau+qi69CN55VwZb0ATtdUAlYlqOOQ3OfQfq0Hqgc4JMFXiQT/XInlwQ9g6LbicDslE6loIFsXFklGh5XmI6Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -206,6 +244,15 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -216,6 +263,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -318,11 +374,75 @@
         "node": ">=4"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+      "dev": true,
+      "dependencies": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -417,10 +537,34 @@
         }
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
+    },
     "node_modules/devtools-protocol": {
       "version": "0.0.901419",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
       "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "node_modules/end-of-stream": {
@@ -447,6 +591,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/extract-zip": {
@@ -482,6 +640,21 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -495,11 +668,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "dependencies": {
+        "for-in": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -539,6 +747,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "dev": true
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -559,6 +773,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -612,16 +838,192 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/inquirer": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.2.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -641,6 +1043,39 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -657,6 +1092,121 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "dev": true,
+      "dependencies": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/minimatch": {
@@ -676,6 +1226,28 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "node_modules/mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "dev": true,
+      "dependencies": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-object/node_modules/for-in": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+      "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -693,6 +1265,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "node_modules/node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -708,6 +1286,123 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -876,6 +1571,70 @@
         "node": ">=10.18.1"
       }
     },
+    "node_modules/puppeteer-extra": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.2.3.tgz",
+      "integrity": "sha512-CnSN9yIedbAbS8WmRybaDHJLf6goRk+VYM/kbH6i/+EMadCaAeh2O+1/mFUMN2LbkbDNAp2Vd/UwrTVCHjTxyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "@types/puppeteer": "*",
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "puppeteer": "*"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.0.tgz",
+      "integrity": "sha512-wbiw12USE3b+maMk/IMaroYsz7rusVI9G+ml6pCFCnFFh91Z9BAEiVzhCpOHuquVXEiCCsDTWhDUgvdNxQHOyw==",
+      "dev": true,
+      "dependencies": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=9.11.2"
+      },
+      "peerDependencies": {
+        "puppeteer-extra": "*"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.3.1.tgz",
+      "integrity": "sha512-yhaYMaNFdfQ1LbA94ZElW1zU8rh+MFmO+GZA0gtQ8BXc+UZ6aRrWS9flIZvlXDzk+ZsXhCbTEohEwZ8lEDLRVA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "puppeteer-extra-plugin": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer-extra-plugin-user-preferences": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.3.1.tgz",
+      "integrity": "sha512-t/FyGQj2aqtHOROqL02z+k2kNQe0cjT0Hd9pG5FJ7x0JXx1722PhOuK7FeJLQMJ+BLl2YvCUgaWSC8Zohjts5A==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.2.0",
+        "puppeteer-extra-plugin-user-data-dir": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/puppeteer/node_modules/ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
@@ -929,6 +1688,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "dev": true,
@@ -941,6 +1713,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "~2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -963,6 +1753,54 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/kind-of": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+      "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shallow-clone/node_modules/lazy-cache": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+      "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
+      "dev": true
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -970,6 +1808,32 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -1018,6 +1882,36 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unbzip2-stream": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
@@ -1026,6 +1920,15 @@
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/uri-js": {
@@ -1042,6 +1945,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1203,6 +2115,31 @@
         "@percy/logger": "1.0.0-beta.70"
       }
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
+    "@types/inquirer": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-8.1.3.tgz",
+      "integrity": "sha512-AayK4ZL5ssPzR1OtnOLGAwpT0Dda3Xi/h1G0l1oJDNrowp7T1423q4Zb8/emr7tzRlCy4ssEri0LWVexAqHyKQ==",
+      "dev": true,
+      "requires": {
+        "@types/through": "*",
+        "rxjs": "^7.2.0"
+      }
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.11.8",
       "dev": true
@@ -1217,6 +2154,15 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.4.tgz",
       "integrity": "sha512-3Nau+qi69CN55VwZb0ATtdUAlYlqOOQ3OfQfq0Hqgc4JMFXiQT/XInlwQ9g6LbicDslE6loIFsXFklGh5XmI6Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/through": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+      "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1251,6 +2197,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -1259,6 +2211,12 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1320,11 +2278,57 @@
         "supports-color": "^5.3.0"
       }
     },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
+    },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true
+    },
+    "clone-deep": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+      "dev": true,
+      "requires": {
+        "for-own": "^0.1.3",
+        "is-plain-object": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "lazy-cache": "^1.0.3",
+        "shallow-clone": "^0.1.2"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -1393,10 +2397,31 @@
         "ms": "2.1.2"
       }
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "devtools-protocol": {
       "version": "0.0.901419",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
       "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "end-of-stream": {
@@ -1421,6 +2446,17 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
     "extract-zip": {
       "version": "2.0.1",
       "dev": true,
@@ -1444,6 +2480,15 @@
         "pend": "~1.2.0"
       }
     },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1454,11 +2499,37 @@
         "path-exists": "^4.0.0"
       }
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1483,6 +2554,12 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1497,6 +2574,15 @@
       "requires": {
         "agent-base": "6",
         "debug": "4"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -1529,14 +2615,141 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "inquirer": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.2.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+          "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.21.3"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "js-tokens": {
@@ -1557,6 +2770,31 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -1572,6 +2810,90 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "merge-deep": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
+      "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "clone-deep": "^0.2.4",
+        "kind-of": "^3.0.2"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "dev": true,
@@ -1584,6 +2906,24 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "mixin-object": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^0.1.3",
+        "is-extendable": "^0.1.1"
+      },
+      "dependencies": {
+        "for-in": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+          "dev": true
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -1598,6 +2938,12 @@
       "version": "2.1.2",
       "dev": true
     },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
     "node-fetch": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
@@ -1610,6 +2956,89 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -1740,6 +3169,52 @@
         }
       }
     },
+    "puppeteer-extra": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.2.3.tgz",
+      "integrity": "sha512-CnSN9yIedbAbS8WmRybaDHJLf6goRk+VYM/kbH6i/+EMadCaAeh2O+1/mFUMN2LbkbDNAp2Vd/UwrTVCHjTxyg==",
+      "dev": true,
+      "requires": {
+        "@types/debug": "^4.1.0",
+        "@types/puppeteer": "*",
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "puppeteer-extra-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.0.tgz",
+      "integrity": "sha512-wbiw12USE3b+maMk/IMaroYsz7rusVI9G+ml6pCFCnFFh91Z9BAEiVzhCpOHuquVXEiCCsDTWhDUgvdNxQHOyw==",
+      "dev": true,
+      "requires": {
+        "@types/debug": "^4.1.0",
+        "debug": "^4.1.1",
+        "merge-deep": "^3.0.1"
+      }
+    },
+    "puppeteer-extra-plugin-user-data-dir": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.3.1.tgz",
+      "integrity": "sha512-yhaYMaNFdfQ1LbA94ZElW1zU8rh+MFmO+GZA0gtQ8BXc+UZ6aRrWS9flIZvlXDzk+ZsXhCbTEohEwZ8lEDLRVA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^10.0.0",
+        "puppeteer-extra-plugin": "^3.2.0"
+      }
+    },
+    "puppeteer-extra-plugin-user-preferences": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.3.1.tgz",
+      "integrity": "sha512-t/FyGQj2aqtHOROqL02z+k2kNQe0cjT0Hd9pG5FJ7x0JXx1722PhOuK7FeJLQMJ+BLl2YvCUgaWSC8Zohjts5A==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "deepmerge": "^4.2.2",
+        "puppeteer-extra-plugin": "^3.2.0",
+        "puppeteer-extra-plugin-user-data-dir": "^2.3.1"
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -1763,6 +3238,16 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "rimraf": {
       "version": "3.0.2",
       "dev": true,
@@ -1770,10 +3255,66 @@
         "glob": "^7.1.3"
       }
     },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "rxjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "dev": true,
+      "requires": {
+        "tslib": "~2.1.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "shallow-clone": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.1",
+        "kind-of": "^2.0.1",
+        "lazy-cache": "^0.2.3",
+        "mixin-object": "^2.0.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.0.2"
+          }
+        },
+        "lazy-cache": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+          "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+          "dev": true
+        }
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
     },
     "string_decoder": {
@@ -1783,6 +3324,26 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
       }
     },
     "supports-color": {
@@ -1825,6 +3386,27 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true
+    },
     "unbzip2-stream": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
@@ -1834,6 +3416,12 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",
@@ -1849,6 +3437,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/build-system/tasks/visual-diff/package.json
+++ b/build-system/tasks/visual-diff/package.json
@@ -7,7 +7,11 @@
     "@percy/core": "1.0.0-beta.70",
     "@percy/puppeteer": "2.0.0",
     "@percy/sdk-utils": "1.0.0-beta.70",
+    "@types/inquirer": "8.1.3",
     "@types/puppeteer": "5.4.4",
-    "puppeteer": "10.4.0"
+    "inquirer": "8.2.0",
+    "puppeteer": "10.4.0",
+    "puppeteer-extra": "3.2.3",
+    "puppeteer-extra-plugin-user-preferences": "2.3.1"
   }
 }

--- a/build-system/tasks/visual-diff/types.js
+++ b/build-system/tasks/visual-diff/types.js
@@ -1,0 +1,45 @@
+const {ConsoleMessage} = require('puppeteer'); // eslint-disable-line no-unused-vars
+
+/**
+ * @typedef {{
+ *   url: string;
+ *   name: string;
+ *   viewport: {
+ *     width: number,
+ *     height: number,
+ *   };
+ *   loading_incomplete_selectors: string[];
+ *   loading_complete_selectors: string[];
+ *   loading_complete_delay_ms: number;
+ *   enable_percy_javascript: boolean;
+ *   interactive_tests: string;
+ *   no_base_test: boolean;
+ *   flaky: boolean;
+ *   tests_: Record<string, Function>;
+ * }}
+ */
+let WebpageDef;
+
+/**
+ * @typedef {{
+ *   name: string;
+ *   message: string;
+ *   error: Error;
+ *   consoleMessages: ConsoleMessage[];
+ * }}
+ */
+let TestErrorDef;
+
+/**
+ * @typedef {{
+ *   visible?: boolean,
+ *   hidden?: boolean,
+ * }}
+ */
+let VisibilityDef;
+
+module.exports = {
+  TestErrorDef,
+  VisibilityDef,
+  WebpageDef,
+};

--- a/build-system/tasks/visual-diff/verifiers.js
+++ b/build-system/tasks/visual-diff/verifiers.js
@@ -1,0 +1,224 @@
+'use strict';
+
+const puppeteer = require('puppeteer'); // eslint-disable-line no-unused-vars
+const {cyan} = require('kleur/colors');
+const {log} = require('./log');
+const {sleep} = require('./helpers');
+const {VisibilityDef} = require('./types');
+
+const CSS_SELECTOR_RETRY_MS = 200;
+const CSS_SELECTOR_TIMEOUT_MS = 10000;
+
+/**
+ * Verifies that all CSS elements are as expected before taking a snapshot.
+ *
+ * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
+ * @param {string} testName the full name of the test.
+ * @param {!Array<string>} selectors Array of CSS selector that must eventually
+ *     be removed from the page.
+ * @param {number} timeoutMillis how long to retry.
+ * @return {Promise<void>}
+ * @throws {Error} an encountered error.
+ */
+async function verifySelectorsInvisible(
+  page,
+  testName,
+  selectors,
+  timeoutMillis = CSS_SELECTOR_TIMEOUT_MS
+) {
+  log(
+    'verbose',
+    'Waiting for invisibility of all:',
+    cyan(selectors.join(', '))
+  );
+  try {
+    await Promise.all(
+      selectors.map((selector) =>
+        waitForElementVisibility(page, selector, {hidden: true}, timeoutMillis)
+      )
+    );
+  } catch (e) {
+    throw new Error(
+      `${cyan(testName)} | An element with the CSS ` +
+        `selector ${cyan(e.message)} is still visible after ` +
+        `${CSS_SELECTOR_TIMEOUT_MS} ms`
+    );
+  }
+}
+
+/**
+ * Verifies that all CSS elements are as expected before taking a snapshot.
+ *
+ * @param {!puppeteer.Page} page a Puppeteer control browser tab/page.
+ * @param {string} testName the full name of the test.
+ * @param {!Array<string>} selectors Array of CSS selectors that must
+ *     eventually appear on the page.
+ * @param {number} timeoutMillis how long to retry.
+ * @return {Promise<void>}
+ * @throws {Error} an encountered error.
+ */
+async function verifySelectorsVisible(
+  page,
+  testName,
+  selectors,
+  timeoutMillis = CSS_SELECTOR_TIMEOUT_MS
+) {
+  log('verbose', 'Waiting for existence of all:', cyan(selectors.join(', ')));
+  try {
+    await Promise.all(
+      selectors.map((selector) =>
+        waitForSelectorExistence(page, selector, timeoutMillis)
+      )
+    );
+  } catch (e) {
+    throw new Error(
+      `${cyan(testName)} | The CSS selector ` +
+        `${cyan(e.message)} does not match any elements in the page`
+    );
+  }
+
+  log('verbose', 'Waiting for visibility of all:', cyan(selectors.join(', ')));
+  try {
+    await Promise.all(
+      selectors.map((selector) =>
+        waitForElementVisibility(page, selector, {visible: true}, timeoutMillis)
+      )
+    );
+  } catch (e) {
+    throw new Error(
+      `${cyan(testName)} | An element with the CSS ` +
+        `selector ${cyan(e.message)} is still invisible after ` +
+        `${CSS_SELECTOR_TIMEOUT_MS} ms`
+    );
+  }
+}
+
+/**
+ * Wait for all AMP loader indicators to disappear.
+ *
+ * @param {!puppeteer.Page} page page to wait on.
+ * @param {string} testName the full name of the test.
+ * @param {number} timeoutMillis how long to retry.
+ * @return {Promise<void>}
+ * @throws {Error} an encountered error.
+ */
+async function waitForPageLoad(
+  page,
+  testName,
+  timeoutMillis = CSS_SELECTOR_TIMEOUT_MS
+) {
+  const allLoadersGone = await waitForElementVisibility(
+    page,
+    '[class~="i-amphtml-loader"], [class~="i-amphtml-loading"]',
+    {hidden: true},
+    timeoutMillis
+  );
+  if (!allLoadersGone) {
+    throw new Error(
+      `${cyan(testName)} still has the AMP loader dot ` +
+        `after ${CSS_SELECTOR_TIMEOUT_MS} ms`
+    );
+  }
+}
+
+/**
+ * Wait until the element is either hidden or visible or until timed out.
+ *
+ * Timeout is set to CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS ms.
+ *
+ * @param {!puppeteer.Page} page page to check the visibility of elements in.
+ * @param {string} selector CSS selector for elements to wait on.
+ * @param {!VisibilityDef} options with key 'visible' OR 'hidden' set to true.
+ * @param {number} timeoutMillis how long to retry.
+ * @return {Promise<boolean>} true if the expectation is met before the timeout.
+ * @throws {Error} if the expectation is not met before the timeout, throws an
+ *      error with the message value set to the CSS selector.
+ */
+async function waitForElementVisibility(
+  page,
+  selector,
+  options,
+  timeoutMillis
+) {
+  const waitForVisible = Boolean(options['visible']);
+  const waitForHidden = Boolean(options['hidden']);
+  if (waitForVisible == waitForHidden) {
+    log(
+      'fatal',
+      'waitForElementVisibility must be called with exactly one of',
+      "'visible' or 'hidden' set to true."
+    );
+  }
+
+  const startTime = Date.now();
+  do {
+    const elementsAreVisible = [];
+
+    for (const elementHandle of await page.$$(selector)) {
+      const boundingBox = await elementHandle.boundingBox();
+      const elementIsVisible =
+        boundingBox != null && boundingBox.height > 0 && boundingBox.width > 0;
+      elementsAreVisible.push(elementIsVisible);
+    }
+
+    if (elementsAreVisible.length) {
+      log(
+        'verbose',
+        'Found',
+        cyan(elementsAreVisible.length),
+        'element(s) matching the CSS selector',
+        cyan(selector)
+      );
+      log(
+        'verbose',
+        'Expecting all element visibilities to be',
+        cyan(waitForVisible),
+        '; they are:',
+        cyan(elementsAreVisible.join(', '))
+      );
+    } else {
+      log('verbose', 'No', cyan(selector), 'matches found');
+    }
+    // Since we assert that waitForVisible == !waitForHidden, there is no need
+    // to check equality to both waitForVisible and waitForHidden.
+    if (
+      elementsAreVisible.every(
+        (elementIsVisible) => elementIsVisible == waitForVisible
+      )
+    ) {
+      return true;
+    }
+
+    await sleep(CSS_SELECTOR_RETRY_MS);
+  } while (Date.now() < startTime + timeoutMillis);
+  throw new Error(selector);
+}
+
+/**
+ * Wait until the CSS selector exists in the page or until timed out.
+ *
+ * Timeout is set to CSS_SELECTOR_RETRY_MS * CSS_SELECTOR_RETRY_ATTEMPTS ms.
+ *
+ * @param {!puppeteer.Page} page page to check the existence of the selector in.
+ * @param {string} selector CSS selector.
+ * @param {number} timeoutMillis how long to retry.
+ * @return {Promise<boolean>} true if the element exists before the timeout.
+ * @throws {Error} if the element does not exist before the timeout, throws an
+ *    error with the message value set to the CSS selector.
+ */
+async function waitForSelectorExistence(page, selector, timeoutMillis) {
+  const startTime = Date.now();
+  do {
+    if ((await page.$(selector)) !== null) {
+      return true;
+    }
+    await sleep(CSS_SELECTOR_RETRY_MS);
+  } while (Date.now() < startTime + timeoutMillis);
+  throw new Error(selector);
+}
+
+module.exports = {
+  waitForPageLoad,
+  verifySelectorsInvisible,
+  verifySelectorsVisible,
+};

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -230,7 +230,7 @@ Additionally, the following query parameters can be provided:
 
 For testing documents on arbitrary URLs with your current local version of the AMP runtime we created a [Chrome extension](../testing/local-amp-chrome-extension/README.md).
 
-## Visual Diff Tests
+## <a name="visual-diff-tests"></a> Visual Diff Tests
 
 In addition to building the AMP runtime and running `amp [unit|integration]`, the automatic test run on CircleCI includes a set of visual diff tests to make sure a new commit to `main` does not result in unintended changes to how pages are rendered. The tests load a few well-known pages in a browser and compare the results with known good versions of the same pages.
 
@@ -268,48 +268,7 @@ Percy DOES NOT by default run JavaScript, so the same DOM snapshot will be used 
 
 ### Adding and Modifying Visual Diff Tests
 
-#### One-time Setup
-
-First create a [free BrowserStack account](https://www.browserstack.com/), use it to log into [https://percy.io](https://percy.io), create a project, and set the `PERCY_TOKEN` environment variable using the unique value you find at `https://percy.io/<org>/<project>/integrations`:
-
-```sh
-export PERCY_TOKEN="<unique-percy-token>"
-```
-
-Once the environment variable is set up, you can run the AMP visual diff tests. You can also pass this token directly to `amp visual-diff --percy_token="<unique-percy-token>"`
-
-#### Writing the Test
-
-To start, create the page and register it in the configuration file for visual diff tests:
-
--   Create an AMP document that will be tested under `examples/visual-tests`.
--   Add an entry in the [`test/visual-diff/visual-tests.jsonc`](../test/visual-diff/visual-tests.jsonc) JSON5 file. Documentation for the various settings are in that file.
-    -   Must set fields: `url`, `name`
-    -   You will also likely want to set `loading_complete_css` and maybe also `loading_incomplete_css`
-    -   Only set `viewport` if your page looks different on mobile vs. desktop, and you intend to create a separate config for each
-        -   The `viewport` setting wraps the entire DOM snapshot inside an `<iframe>` before uploading to Percy. Beware of weird iframe behaviors! 🐉
-    -   Do not set `enable_percy_javascript` without consulting `@ampproject/wg-infra`
-    -   Point `interactive_tests` to a JavaScript file if you would like to add interactions to the page. See examples of existing interactive tests to learn how to write those
--   (For past examples of pull requests that add visual diff tests, see [#17047](https://github.com/ampproject/amphtml/pull/17047), [#17110](https://github.com/ampproject/amphtml/pull/17110))
-
-Now, verify your test by executing it:
-
--   Build the AMP runtime in minified mode:
-    ```sh
-    amp dist --fortesting
-    ```
-    -   You can verify that your page looks as intented by running `amp serve --minified` and opening it in a browser
--   Execute the visual diff tests:
-    ```sh
-    amp visual-diff
-    ```
-    -   Add `--grep="<regular expression>"` to the command to execute a subset of the tests. e.g., `amp visual-diff --grep="amp-[a-f]"` will execute on tests that have an AMP component name between `<amp-a...>` through `<amp-f...>`.
-    -   To see debugging info during Percy runs, you can add `--chrome_debug`, `--webserver_debug`, or `--debug` for both.
--   When the test finishes executing it will print a URL to Percy where you can inspect the results. It should take about a minute to finish processing.
--   Inspect the build on Percy. If you are not happy with the results, fix your page or code, and repeat. If all is well, approve it. This creates a new baseline on Percy, against which all following builds will be compared.
--   After approving your test, repeat the `amp visual-diff` command at least 5 more times. If any of the subsequent runs fails with a visual changes, this means that your test is flaky.
-    -   Flakiness is usually caused by bad `loading_complete_css` configurations
-    -   To find what CSS selector appear _exclusively_ after the page settles into the expected result, download the _baseline_ and _new_ source for the snapshots that Percy used in the build that flaked, and compare them using a text diff application
+See [Adding and Modifying Visual Diff Tests](./writing-visual-diff-tests.md).
 
 ## Isolated Component Testing
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,7 +19,7 @@ This document provides details for testing and building your AMP code.
     -   [A4A envelope (/a4a/, /a4a-3p/)](#a4a-envelope-a4a-a4a-3p)
     -   [In-a-box envelope (/inabox/)](#in-a-box-envelope-inabox)
     -   [Chrome extension](#chrome-extension)
--   [Visual Diff Tests](#visual-diff-tests)
+-   [Visual Diff Tests](#-visual-diff-tests)
     -   [Failing Tests](#failing-tests)
     -   [Flaky Tests](#flaky-tests)
     -   [How Are Tests Executed](#how-are-tests-executed)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,8 +24,6 @@ This document provides details for testing and building your AMP code.
     -   [Flaky Tests](#flaky-tests)
     -   [How Are Tests Executed](#how-are-tests-executed)
     -   [Adding and Modifying Visual Diff Tests](#adding-and-modifying-visual-diff-tests)
-        -   [One-time Setup](#one-time-setup)
-        -   [Writing the Test](#writing-the-test)
 -   [Isolated Component Testing](#isolated-component-testing)
     -   [Launching Storybook](#launching-storybook)
     -   [Writing test scenarios](#writing-test-scenarios)

--- a/docs/writing-visual-diff-tests.md
+++ b/docs/writing-visual-diff-tests.md
@@ -1,0 +1,55 @@
+# Adding and Modifying Visual Diff Tests
+
+This document provides details for creating new visual diff tests. For other information about visual diff tests see [testing.md](./testing.md#visual-diff-tests).
+
+## One-time Setup
+
+First create a [free BrowserStack account](https://www.browserstack.com/), use it to log into [https://percy.io](https://percy.io), create a project, and set the `PERCY_TOKEN` environment variable using the unique value you find at `https://percy.io/<org>/<project>/integrations`:
+
+```sh
+export PERCY_TOKEN="<unique-percy-token>"
+```
+
+Once the environment variable is set up, you can run the AMP visual diff tests. You can also pass this token directly to `amp visual-diff --percy_token="<unique-percy-token>"`
+
+## Writing the Test
+
+### Create and register your test
+
+-   Create an AMP document that will be tested under `examples/visual-tests`.
+-   Add an entry in the [`test/visual-diff/visual-tests.jsonc`](../test/visual-diff/visual-tests.jsonc) JSON file. Documentation for the various settings are in that file.
+    -   Must set fields: `url`, `name`
+    -   You will also likely want to set `loading_complete_css` and maybe also `loading_incomplete_css`
+    -   Only set `viewport` if your page looks different on mobile vs. desktop, and you intend to create a separate config for each
+        -   The `viewport` setting wraps the entire DOM snapshot inside an `<iframe>` before uploading to Percy. Beware of weird iframe behaviors! 🐉
+    -   Do not set `enable_percy_javascript` without consulting `@ampproject/wg-infra`
+    -   Point `interactive_tests` to a JavaScript file if you would like to add interactions to the page. See examples of existing interactive tests to learn how to write those
+-   (For past examples of pull requests that add visual diff tests, see [#17047](https://github.com/ampproject/amphtml/pull/17047), [#17110](https://github.com/ampproject/amphtml/pull/17110))
+
+### Iterate on the test
+
+Now, execute the test in development mode. Use `--grep` to filter down the list of available web pages. The value is a regular expression. e.g., `amp visual-diff --grep="amp-[a-f]"` will execute on tests that have an AMP component name between `<amp-a...>` through `<amp-f...>`.
+
+```sh
+amp visual-diff --dev --grep="<regular expression>"
+```
+
+Follow the development mode instructions and iterate on the test until you are satisfied.
+
+### Validate the test
+
+Finally, verify that your test display as expected by executing it on Percy:
+
+```sh
+amp visual-diff --grep="<regular expression>"
+```
+
+-   When the test finishes executing it will print a URL to Percy where you can inspect the results. It should take about a minute to finish processing.
+-   Inspect the build on Percy. If you are not happy with the results, fix your page or code, and repeat. If all is well, approve it. This creates a new baseline on Percy, against which all following builds will be compared.
+
+After approving your test, repeat the `amp visual-diff` command at least 5 more times. If any of the subsequent runs fails with a visual changes, this means that your test is flaky.
+
+### Things to note
+
+-   Flakiness is usually caused by bad `loading_complete_css` configurations. You can repeat `--dev` mode until you find the right mix of complete and incomplete CSS selectors.
+-   To see debugging info during Percy runs, you can add `--chrome_debug`, `--webserver_debug`, or `--debug` for both.

--- a/docs/writing-visual-diff-tests.md
+++ b/docs/writing-visual-diff-tests.md
@@ -38,14 +38,15 @@ Follow the development mode instructions and iterate on the test until you are s
 
 ### Validate the test
 
-Finally, verify that your test display as expected by executing it on Percy:
+Finally, verify that your test displays as expected by executing it on Percy:
 
 ```sh
 amp visual-diff --grep="<regular expression>"
 ```
 
 -   When the test finishes executing it will print a URL to Percy where you can inspect the results. It should take about a minute to finish processing.
--   Inspect the build on Percy. If you are not happy with the results, fix your page or code, and repeat. If all is well, approve it. This creates a new baseline on Percy, against which all following builds will be compared.
+-   Inspect the build on Percy. If you are not happy with the results, fix your page or code, and repeat.
+-   If all is well, approve it. This creates a new baseline on Percy, against which all following builds will be compared.
 
 After approving your test, repeat the `amp visual-diff` command at least 5 more times. If any of the subsequent runs fails with a visual changes, this means that your test is flaky.
 

--- a/examples/visual-tests/amp-accordion/amp-accordion.js
+++ b/examples/visual-tests/amp-accordion/amp-accordion.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'click section one': async (page, name) => {

--- a/examples/visual-tests/amp-autocomplete/amp-autocomplete.js
+++ b/examples/visual-tests/amp-autocomplete/amp-autocomplete.js
@@ -3,7 +3,7 @@
 const {
   verifySelectorsInvisible,
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'tap input1 to focus and display results': async (page, name) => {

--- a/examples/visual-tests/amp-date-picker/amp-date-picker.js
+++ b/examples/visual-tests/amp-date-picker/amp-date-picker.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'select a different date': async (page, name) => {

--- a/examples/visual-tests/amp-form/amp-form.js
+++ b/examples/visual-tests/amp-form/amp-form.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'try to submit without input': async (page, name) => {

--- a/examples/visual-tests/amp-list/amp-list.amp.js
+++ b/examples/visual-tests/amp-list/amp-list.amp.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsInvisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'tap "see more" button': async (page, name) => {

--- a/examples/visual-tests/amp-mega-menu/amp-mega-menu.js
+++ b/examples/visual-tests/amp-mega-menu/amp-mega-menu.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'click menu item one': async (page, name) => {

--- a/examples/visual-tests/amp-selector.js
+++ b/examples/visual-tests/amp-selector.js
@@ -3,7 +3,7 @@
 const {
   verifySelectorsInvisible,
   verifySelectorsVisible,
-} = require('../../build-system/tasks/visual-diff/helpers');
+} = require('../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'single selector select option 2': async (page, name) => {

--- a/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar-toolbar.js
@@ -6,7 +6,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'open sidebar toolbar': async (page, name) => {

--- a/examples/visual-tests/amp-sidebar/amp-sidebar.js
+++ b/examples/visual-tests/amp-sidebar/amp-sidebar.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'open sidebar': async (page, name) => {

--- a/examples/visual-tests/amp-story/amp-story-ad.js
+++ b/examples/visual-tests/amp-story/amp-story-ad.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'Test story ad system layer property correctness': async (page, name) => {

--- a/examples/visual-tests/amp-story/amp-story-page-attachment.js
+++ b/examples/visual-tests/amp-story/amp-story-page-attachment.js
@@ -3,7 +3,7 @@
 const {
   verifySelectorsInvisible,
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'custom text - inline CTA pre-tap UI should display': async (page, name) => {

--- a/examples/visual-tests/amp-story/amp-story-pagination-buttons.js
+++ b/examples/visual-tests/amp-story/amp-story-pagination-buttons.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'shows corresponding buttons for first page': async (page, name) => {

--- a/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip-desktop.js
@@ -3,7 +3,7 @@
 const {
   verifySelectorsInvisible,
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'tapping on a clickable anchor should show the tooltip': async (

--- a/examples/visual-tests/amp-story/amp-story-tooltip.js
+++ b/examples/visual-tests/amp-story/amp-story-tooltip.js
@@ -3,7 +3,7 @@
 const {
   verifySelectorsInvisible,
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'tapping on a clickable anchor should show the tooltip': async (

--- a/examples/visual-tests/amp-video-docking/amp-video-docking.js
+++ b/examples/visual-tests/amp-video-docking/amp-video-docking.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 function toggleScrollable(page, toggle) {
   return page.evaluate((toggle) => {


### PR DESCRIPTION
This PR adds a "development mode" for `amp visual-diff` to help iterate on new visual diff tests faster. It's triggered by calling `amp visual-diff --dev` (preferably with `--grep <test-name>` to make it easier):

![image](https://user-images.githubusercontent.com/1839738/139736902-360f6ec8-8401-4064-ae8a-351ae09bc9b7.png)

Then the user selects the test file and an interactive test if they exist:

![image](https://user-images.githubusercontent.com/1839738/139737003-b3ec2d2e-42db-4347-9a48-3e8ad6755c82.png)

And the task opens a browser window with the test, runs any interactivity code embedded in it, and then prompts the user for actions:

![image](https://user-images.githubusercontent.com/1839738/139737244-5c60328c-4927-4fba-ab7d-7016812fb5d1.png)

The actions are to immediately test whether a CSS selector is visible/invisible on the page or to reload the page.

![image](https://user-images.githubusercontent.com/1839738/139737597-66ab67b3-f16b-4ff3-9e79-0a823a94e838.png)

Reloading the page by pressing enter on an empty prompt will reload any new changes to the HTML and interactive JS files