### PR TITLE
🚀♻️ Normalize how locale strings are rendered in `amp-story`

### DIFF
--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -29,6 +29,7 @@ import {isJsonScriptTag} from '#core/dom';
 
 import {parseJson} from '#core/types/object/json';
 import {renderAsElement} from './simple-template';
+import {localize} from './amp-story-localization-service';
 
 /** @const {string} */
 const TAG = 'amp-story-consent';
@@ -45,13 +46,14 @@ const DEFAULT_OPTIONAL_PARAMETERS = {
 // TODO(gmajoulet): switch to `htmlFor` static template helper.
 /**
  * Story consent template.
+ * @param {!Element} element
  * @param {!Object} config
  * @param {string} consentId
  * @param {?string} logoSrc
  * @return {!./simple-template.ElementDef}
  * @private @const
  */
-const getTemplate = (config, consentId, logoSrc) => ({
+const getTemplate = (element, config, consentId, logoSrc) => ({
   tag: 'div',
   attrs: dict({
     'class': 'i-amphtml-story-consent i-amphtml-story-system-reset',
@@ -77,7 +79,6 @@ const getTemplate = (config, consentId, logoSrc) => ({
                       ? `background-image: url('${logoSrc}') !important;`
                       : '',
                   }),
-                  children: [],
                 },
               ],
             },
@@ -87,15 +88,11 @@ const getTemplate = (config, consentId, logoSrc) => ({
               children: [
                 {
                   tag: 'h3',
-                  attrs: dict({}),
-                  children: [],
-                  unlocalizedString: config.title,
+                  children: [config.title],
                 },
                 {
                   tag: 'p',
-                  attrs: dict({}),
-                  children: [],
-                  unlocalizedString: config.message,
+                  children: [config.message],
                 },
                 {
                   tag: 'ul',
@@ -105,8 +102,7 @@ const getTemplate = (config, consentId, logoSrc) => ({
                     config.vendors.map((vendor) => ({
                       tag: 'li',
                       attrs: dict({'class': 'i-amphtml-story-consent-vendor'}),
-                      children: [],
-                      unlocalizedString: vendor,
+                      children: [vendor],
                     })),
                 },
                 {
@@ -121,8 +117,7 @@ const getTemplate = (config, consentId, logoSrc) => ({
                     'target': '_top',
                     'title': config.externalLink.title,
                   }),
-                  children: [],
-                  unlocalizedString: config.externalLink.title,
+                  children: [config.externalLink.title],
                 },
               ],
             },
@@ -141,9 +136,12 @@ const getTemplate = (config, consentId, logoSrc) => ({
                   (config.onlyAccept === true ? ' i-amphtml-hidden' : ''),
                 'on': `tap:${consentId}.reject`,
               }),
-              children: [],
-              localizedStringId:
-                LocalizedStringId.AMP_STORY_CONSENT_DECLINE_BUTTON_LABEL,
+              children: [
+                localize(
+                  element,
+                  LocalizedStringId.AMP_STORY_CONSENT_DECLINE_BUTTON_LABEL
+                ),
+              ],
             },
             {
               tag: 'button',
@@ -153,9 +151,12 @@ const getTemplate = (config, consentId, logoSrc) => ({
                   'i-amphtml-story-consent-action-accept',
                 'on': `tap:${consentId}.accept`,
               }),
-              children: [],
-              localizedStringId:
-                LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL,
+              children: [
+                localize(
+                  element,
+                  LocalizedStringId.AMP_STORY_CONSENT_ACCEPT_BUTTON_LABEL
+                ),
+              ],
             },
           ],
         },
@@ -220,7 +221,7 @@ export class AmpStoryConsent extends AMP.BaseElement {
     if (this.storyConsentConfig_) {
       this.storyConsentEl_ = renderAsElement(
         this.win.document,
-        getTemplate(this.storyConsentConfig_, consentId, logoSrc)
+        getTemplate(this.element, this.storyConsentConfig_, consentId, logoSrc)
       );
       createShadowRootWithStyle(this.element, this.storyConsentEl_, CSS);
 

--- a/extensions/amp-story/1.0/amp-story-draggable-drawer.js
+++ b/extensions/amp-story/1.0/amp-story-draggable-drawer.js
@@ -10,8 +10,8 @@ import {LocalizedStringId} from '#service/localization/strings';
 import {Services} from '#service';
 import {closest} from '#core/dom/query';
 import {createShadowRootWithStyle} from './utils';
-import {dev, devAssert} from '#utils/log';
-import {getLocalizationService} from './amp-story-localization-service';
+import {dev} from '#utils/log';
+import {localize} from './amp-story-localization-service';
 import {htmlFor} from '#core/dom/static-template';
 import {isAmpElement} from '#core/dom/amp-element-helpers';
 import {listen} from '#utils/event-helper';
@@ -142,13 +142,11 @@ export class DraggableDrawer extends AMP.BaseElement {
     spacerEl.classList.add('i-amphtml-story-draggable-drawer-spacer');
     spacerEl.classList.add('i-amphtml-story-system-reset');
     spacerEl.setAttribute('role', 'button');
-    const localizationService = getLocalizationService(devAssert(this.element));
-    if (localizationService) {
-      const localizedCloseString = localizationService.getLocalizedString(
-        LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
-      );
-      spacerEl.setAttribute('aria-label', localizedCloseString);
-    }
+    const localizedCloseString = localize(
+      this.element,
+      LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
+    );
+    spacerEl.setAttribute('aria-label', localizedCloseString);
     this.containerEl.insertBefore(spacerEl, this.contentEl);
     this.contentEl.appendChild(headerShadowRootEl);
 

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -26,7 +26,7 @@ import {
 import {dev, devAssert, user, userAssert} from '#utils/log';
 import {dict} from '#core/types/object';
 import {getAmpdoc} from '../../../src/service-helpers';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {htmlFor, htmlRefs} from '#core/dom/static-template';
 import {isProtocolValid, parseUrlDeprecated} from '../../../src/url';
 
@@ -662,15 +662,10 @@ export class AmpStoryEmbeddedComponent {
         '.i-amphtml-expanded-view-close-button'
       )
     );
-    const localizationService = getLocalizationService(
-      devAssert(this.storyEl_)
+    closeButton.setAttribute(
+      'aria-label',
+      localize(this.storyEl_, LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL)
     );
-    if (localizationService) {
-      const localizedCloseString = localizationService.getLocalizedString(
-        LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
-      );
-      closeButton.setAttribute('aria-label', localizedCloseString);
-    }
     this.mutator_.mutateElement(dev().assertElement(this.componentPage_), () =>
       this.componentPage_.appendChild(this.expandedViewOverlay_)
     );
@@ -1131,9 +1126,7 @@ export class AmpStoryEmbeddedComponent {
   updateTooltipText_(target, embedConfig) {
     const tooltipText =
       target.getAttribute('data-tooltip-text') ||
-      getLocalizationService(this.storyEl_).getLocalizedString(
-        embedConfig.localizedStringId
-      ) ||
+      localize(this.storyEl_, embedConfig.localizedStringId) ||
       getSourceOriginForElement(target, this.getElementHref_(target));
     const existingTooltipText = this.tooltip_.querySelector(
       '.i-amphtml-tooltip-text'

--- a/extensions/amp-story/1.0/amp-story-form.js
+++ b/extensions/amp-story/1.0/amp-story-form.js
@@ -1,9 +1,8 @@
 import {Action, getStoreService} from './amp-story-store-service';
 import {LoadingSpinner} from './loading-spinner';
 import {LocalizedStringId} from '#service/localization/strings';
-import {devAssert} from '#utils/log';
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {htmlFor} from '#core/dom/static-template';
 import {scopedQuerySelector, scopedQuerySelectorAll} from '#core/dom/query';
 
@@ -123,8 +122,8 @@ function createFormResultEl_(win, formEl, isSuccess) {
   resultEl.firstElementChild.appendChild(iconEl);
 
   const textEl = win.document.createElement('div');
-  const localizationService = getLocalizationService(devAssert(win.document));
-  textEl.textContent = localizationService.getLocalizedString(
+  textEl.textContent = localize(
+    win.document,
     isSuccess
       ? LocalizedStringId.AMP_STORY_FORM_SUBMIT_SUCCESS
       : LocalizedStringId.AMP_STORY_FORM_SUBMIT_ERROR

--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -10,9 +10,13 @@ import {Services} from '#service';
 import {createShadowRootWithStyle} from './utils';
 import {dict} from '#core/types/object';
 import {renderAsElement} from './simple-template';
+import {localize} from './amp-story-localization-service';
 
-/** @private @const {!./simple-template.ElementDef} */
-const TEMPLATE = {
+/**
+ * @param {!Element} element
+ * @return {!./simple-template.ElementDef}
+ */
+const getTemplate = (element) => ({
   tag: 'aside',
   attrs: dict({
     'class':
@@ -51,8 +55,12 @@ const TEMPLATE = {
                   attrs: dict({
                     'class': 'i-amphtml-story-hint-tap-button-text',
                   }),
-                  localizedStringId:
-                    LocalizedStringId.AMP_STORY_HINT_UI_PREVIOUS_LABEL,
+                  children: [
+                    localize(
+                      element,
+                      LocalizedStringId.AMP_STORY_HINT_UI_PREVIOUS_LABEL
+                    ),
+                  ],
                 },
               ],
             },
@@ -85,8 +93,12 @@ const TEMPLATE = {
                   attrs: dict({
                     'class': 'i-amphtml-story-hint-tap-button-text',
                   }),
-                  localizedStringId:
-                    LocalizedStringId.AMP_STORY_HINT_UI_NEXT_LABEL,
+                  children: [
+                    localize(
+                      element,
+                      LocalizedStringId.AMP_STORY_HINT_UI_NEXT_LABEL
+                    ),
+                  ],
                 },
               ],
             },
@@ -95,7 +107,7 @@ const TEMPLATE = {
       ],
     },
   ],
-};
+});
 
 /** @type {string} */
 const NAVIGATION_OVERLAY_CLASS = 'show-navigation-overlay';
@@ -157,7 +169,10 @@ export class AmpStoryHint {
     this.isBuilt_ = true;
 
     const root = this.document_.createElement('div');
-    this.hintContainer_ = renderAsElement(this.document_, TEMPLATE);
+    this.hintContainer_ = renderAsElement(
+      this.document_,
+      getTemplate(this.parentEl_)
+    );
     createShadowRootWithStyle(root, this.hintContainer_, CSS);
 
     this.storeService_.subscribe(

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -16,7 +16,7 @@ import {closest, matches} from '#core/dom/query';
 import {createShadowRootWithStyle, triggerClickFromLightDom} from './utils';
 import {dev} from '#utils/log';
 import {getAmpdoc} from '../../../src/service-helpers';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {htmlFor} from '#core/dom/static-template';
 
 /** @const {string} Class to toggle the info dialog. */
@@ -47,9 +47,6 @@ export class InfoDialog {
 
     /** @private {boolean} */
     this.isBuilt_ = false;
-
-    /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = getLocalizationService(parentEl);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(this.win_);
@@ -206,7 +203,8 @@ export class InfoDialog {
    * @return {*} TODO(#23582): Specify return type
    */
   setHeading_() {
-    const label = this.localizationService_.getLocalizedString(
+    const label = localize(
+      this.parentEl_,
       LocalizedStringId.AMP_STORY_DOMAIN_DIALOG_HEADING_LABEL
     );
     const headingEl = dev().assertElement(
@@ -252,7 +250,8 @@ export class InfoDialog {
     );
 
     return this.mutator_.mutateElement(this.moreInfoLinkEl_, () => {
-      const label = this.localizationService_.getLocalizedString(
+      const label = localize(
+        this.parentEl_,
         LocalizedStringId.AMP_STORY_DOMAIN_DIALOG_HEADING_LINK
       );
       this.moreInfoLinkEl_.classList.add(MOREINFO_VISIBLE_CLASS);

--- a/extensions/amp-story/1.0/amp-story-localization-service.js
+++ b/extensions/amp-story/1.0/amp-story-localization-service.js
@@ -1,6 +1,8 @@
 import {LocalizationService} from '#service/localization';
 import {Services} from '#service';
 import {registerServiceBuilderForDoc} from '../../../src/service-helpers';
+// eslint-disable-next-line no-unused-vars
+import {LocalizedStringId} from '#service/localization/strings';
 
 /**
  * Util function to retrieve the localization service. Ensures we can retrieve
@@ -9,7 +11,7 @@ import {registerServiceBuilderForDoc} from '../../../src/service-helpers';
  * @param {!Element} element
  * @return {!../../../src/service/localization.LocalizationService}
  */
-export const getLocalizationService = (element) => {
+export function getLocalizationService(element) {
   let localizationService = Services.localizationForDoc(element);
 
   if (!localizationService) {
@@ -20,4 +22,13 @@ export const getLocalizationService = (element) => {
   }
 
   return localizationService;
-};
+}
+
+/**
+ * @param {!Node} context
+ * @param {LocalizedStringId} key
+ * @return {?string}
+ */
+export function localize(context, key) {
+  return getLocalizationService(context).getLocalizedString(key);
+}

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -5,7 +5,7 @@ import {AttachmentTheme} from './amp-story-page-attachment';
 import {LocalizedStringId} from '#service/localization/strings';
 import {computedStyle, setImportantStyles} from '#core/dom/style';
 import {dev} from '#utils/log';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {
   getRGBFromCssColorValue,
   getTextColorForRGB,
@@ -133,9 +133,7 @@ const renderOutlinkUI = (pageEl, attachmentEl) => {
     attachmentEl.getAttribute('data-cta-text');
   const openLabel = openLabelAttr
     ? openLabelAttr.trim()
-    : getLocalizationService(pageEl).getLocalizedString(
-        LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL
-      );
+    : localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
   ctaLabelEl.textContent = openLabel;
   openAttachmentEl.setAttribute('aria-label', openLabel);
 
@@ -178,9 +176,7 @@ const renderInlineUi = (pageEl, attachmentEl) => {
     attachmentEl.getAttribute('data-cta-text');
   const openLabel =
     (openLabelAttr && openLabelAttr.trim()) ||
-    getLocalizationService(pageEl).getLocalizedString(
-      LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL
-    );
+    localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
   openAttachmentEl.setAttribute('aria-label', openLabel);
 
   if (openLabel !== 'none') {

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -6,9 +6,9 @@ import {Services} from '#service';
 import {StoryAnalyticsEvent, getAnalyticsService} from './story-analytics';
 import {buildOutlinkLinkIconElement} from './amp-story-open-page-attachment';
 import {closest} from '#core/dom/query';
-import {dev, devAssert} from '#utils/log';
+import {dev} from '#utils/log';
 import {getHistoryState} from '#core/window/history';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {getSourceOrigin} from '../../../src/url';
 import {htmlFor, htmlRefs} from '#core/dom/static-template';
 import {
@@ -128,14 +128,10 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
           <button class="i-amphtml-story-page-attachment-close-button" aria-label="close"
               role="button">
           </button>`;
-    const localizationService = getLocalizationService(devAssert(this.element));
-
-    if (localizationService) {
-      const localizedCloseString = localizationService.getLocalizedString(
-        LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
-      );
-      closeButtonEl.setAttribute('aria-label', localizedCloseString);
-    }
+    closeButtonEl.setAttribute(
+      'aria-label',
+      localize(this.element, LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL)
+    );
 
     const titleAndCloseWrapperEl = this.headerEl.appendChild(
       htmlFor(this.element)`
@@ -252,13 +248,11 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     }
 
     // Set url prevew text.
-    const localizationService = getLocalizationService(devAssert(this.element));
-    if (localizationService) {
-      const localizedOpenString = localizationService.getLocalizedString(
-        LocalizedStringId.AMP_STORY_OPEN_OUTLINK_TEXT
-      );
-      openStringEl.textContent = localizedOpenString;
-    }
+    const localizedOpenString = localize(
+      this.element,
+      LocalizedStringId.AMP_STORY_OPEN_OUTLINK_TEXT
+    );
+    openStringEl.textContent = localizedOpenString;
     urlStringEl.textContent = hrefAttr;
 
     this.contentEl.appendChild(link);

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -49,7 +49,7 @@ import {dev} from '#utils/log';
 import {dict} from '#core/types/object';
 import {getAmpdoc} from '../../../src/service-helpers';
 import {getFriendlyIframeEmbedOptional} from '../../../src/iframe-helper';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {getLogEntries} from './logging';
 import {getMediaPerformanceMetricsService} from './media-performance-metrics-service';
 import {getMode} from '../../../src/mode';
@@ -1634,9 +1634,10 @@ export class AmpStoryPage extends AMP.BaseElement {
     const labelEl = this.playMessageEl_.querySelector(
       '.i-amphtml-story-page-play-label'
     );
-    labelEl.textContent = getLocalizationService(
-      this.element
-    ).getLocalizedString(LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO);
+    labelEl.textContent = localize(
+      this.element,
+      LocalizedStringId.AMP_STORY_PAGE_PLAY_VIDEO
+    );
 
     this.playMessageEl_.addEventListener('click', () => {
       this.togglePlayMessage_(false);
@@ -1681,9 +1682,10 @@ export class AmpStoryPage extends AMP.BaseElement {
     const labelEl = this.errorMessageEl_.querySelector(
       '.i-amphtml-story-page-error-label'
     );
-    labelEl.textContent = getLocalizationService(
-      this.element
-    ).getLocalizedString(LocalizedStringId.AMP_STORY_PAGE_ERROR_VIDEO);
+    labelEl.textContent = localize(
+      this.element,
+      LocalizedStringId.AMP_STORY_PAGE_ERROR_VIDEO
+    );
 
     this.mutateElement(() => this.element.appendChild(this.errorMessageEl_));
   }

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -16,9 +16,9 @@ import {Services} from '#service';
 import {ShareWidget} from './amp-story-share';
 import {closest} from '#core/dom/query';
 import {createShadowRootWithStyle} from './utils';
-import {dev, devAssert} from '#utils/log';
+import {dev} from '#utils/log';
 import {getAmpdoc} from '../../../src/service-helpers';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {htmlFor} from '#core/dom/static-template';
 import {setStyles} from '#core/dom/style';
 
@@ -157,15 +157,10 @@ export class ShareMenu {
     this.closeButton_ = dev().assertElement(
       this.element_.querySelector('.i-amphtml-story-share-menu-close-button')
     );
-    const localizationService = getLocalizationService(
-      devAssert(this.parentEl_)
+    this.closeButton_.setAttribute(
+      'aria-label',
+      localize(this.parentEl_, LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL)
     );
-    if (localizationService) {
-      const localizedCloseString = localizationService.getLocalizedString(
-        LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
-      );
-      this.closeButton_.setAttribute('aria-label', localizedCloseString);
-    }
 
     this.initializeListeners_();
 

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -7,11 +7,11 @@ import {
 } from '#core/window/clipboard';
 import {dev, devAssert, user} from '#utils/log';
 import {dict, map} from '#core/types/object';
-import {getLocalizationService} from './amp-story-localization-service';
+import {localize} from './amp-story-localization-service';
 import {getRequestService} from './amp-story-request-service';
 import {isObject} from '#core/types';
 import {listen} from '#utils/event-helper';
-import {renderAsElement, renderSimpleTemplate} from './simple-template';
+import {renderAsElement} from './simple-template';
 
 /**
  * Maps share provider type to visible name.
@@ -81,7 +81,8 @@ function buildLinkShareItemTemplate(el) {
       'class': 'i-amphtml-story-share-icon i-amphtml-story-share-icon-link',
       'tabindex': 0,
       'role': 'button',
-      'aria-label': getLocalizationService(el).getLocalizedString(
+      'aria-label': localize(
+        el,
         LocalizedStringId.AMP_STORY_SHARING_PROVIDER_NAME_LINK
       ),
     }),
@@ -89,8 +90,9 @@ function buildLinkShareItemTemplate(el) {
       {
         tag: 'span',
         attrs: dict({'class': 'i-amphtml-story-share-label'}),
-        localizedStringId:
-          LocalizedStringId.AMP_STORY_SHARING_PROVIDER_NAME_LINK,
+        children: [
+          localize(el, LocalizedStringId.AMP_STORY_SHARING_PROVIDER_NAME_LINK),
+        ],
       },
     ],
   };
@@ -119,7 +121,7 @@ function buildProviderParams(opt_params) {
  * @param {!Document} doc
  * @param {string} shareType
  * @param {!JsonObject=} opt_params
- * @return {!Node}
+ * @return {!Element}
  */
 function buildProvider(doc, shareType, opt_params) {
   const shareProviderLocalizedStringId = devAssert(
@@ -127,32 +129,27 @@ function buildProvider(doc, shareType, opt_params) {
     `No localized string to display name for share type ${shareType}.`
   );
 
-  return renderSimpleTemplate(
-    doc,
-    /** @type {!Array<!./simple-template.ElementDef>} */ ([
+  return renderAsElement(doc, {
+    tag: 'amp-social-share',
+    attrs: /** @type {!JsonObject} */ (
+      Object.assign(
+        dict({
+          'width': 48,
+          'height': 48,
+          'class': 'i-amphtml-story-share-icon',
+          'type': shareType,
+        }),
+        buildProviderParams(opt_params)
+      )
+    ),
+    children: [
       {
-        tag: 'amp-social-share',
-        attrs: /** @type {!JsonObject} */ (
-          Object.assign(
-            dict({
-              'width': 48,
-              'height': 48,
-              'class': 'i-amphtml-story-share-icon',
-              'type': shareType,
-            }),
-            buildProviderParams(opt_params)
-          )
-        ),
-        children: [
-          {
-            tag: 'span',
-            attrs: dict({'class': 'i-amphtml-story-share-label'}),
-            localizedStringId: shareProviderLocalizedStringId,
-          },
-        ],
+        tag: 'span',
+        attrs: dict({'class': 'i-amphtml-story-share-label'}),
+        children: [localize(doc, shareProviderLocalizedStringId)],
       },
-    ])
-  );
+    ],
+  });
 }
 
 /**
@@ -169,13 +166,17 @@ function buildCopySuccessfulToast(doc, url) {
       children: [
         {
           tag: 'div',
-          localizedStringId:
-            LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_SUCCESS_TEXT,
+          children: [
+            localize(
+              doc,
+              LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_SUCCESS_TEXT
+            ),
+          ],
         },
         {
           tag: 'div',
           attrs: dict({'class': 'i-amphtml-story-copy-url'}),
-          unlocalizedString: url,
+          chilren: [url],
         },
       ],
     })
@@ -276,9 +277,8 @@ export class ShareWidget {
     const url = Services.documentInfoForDoc(this.getAmpDoc_()).canonicalUrl;
 
     if (!copyTextToClipboard(this.win, url)) {
-      const localizationService = getLocalizationService(this.storyEl);
-      devAssert(localizationService, 'Could not retrieve LocalizationService.');
-      const failureString = localizationService.getLocalizedString(
+      const failureString = localize(
+        this.storyEl_,
         LocalizedStringId.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT
       );
       Toast.show(this.storyEl, dev().assertString(failureString));

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -150,9 +150,11 @@ const getTemplate = (element) => ({
               attrs: dict({
                 'class': 'i-amphtml-story-has-new-page-text',
               }),
-              children: localize(element, [
-                LocalizedStringId.AMP_STORY_HAS_NEW_PAGE_TEXT,
-              ]),
+              children: [
+                localize(element, [
+                  LocalizedStringId.AMP_STORY_HAS_NEW_PAGE_TEXT,
+                ]),
+              ],
             },
           ],
         },

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -31,6 +31,7 @@ import {renderAsElement} from './simple-template';
 
 import {setImportantStyles} from '#core/dom/style';
 import {toArray} from '#core/types/array';
+import {localize} from './amp-story-localization-service';
 
 /** @private @const {string} */
 const AD_SHOWING_ATTRIBUTE = 'ad-showing';
@@ -86,8 +87,11 @@ const ATTRIBUTION_CLASS = 'i-amphtml-story-attribution';
 /** @private @const {number} */
 const HIDE_MESSAGE_TIMEOUT_MS = 1500;
 
-/** @private @const {!./simple-template.ElementDef} */
-const TEMPLATE = {
+/**
+ * @param {!Element} element
+ * @return {!./simple-template.ElementDef}
+ */
+const getTemplate = (element) => ({
   tag: 'aside',
   attrs: dict({
     'class': 'i-amphtml-story-system-layer i-amphtml-story-system-reset',
@@ -146,7 +150,9 @@ const TEMPLATE = {
               attrs: dict({
                 'class': 'i-amphtml-story-has-new-page-text',
               }),
-              localizedStringId: LocalizedStringId.AMP_STORY_HAS_NEW_PAGE_TEXT,
+              children: localize(element, [
+                LocalizedStringId.AMP_STORY_HAS_NEW_PAGE_TEXT,
+              ]),
             },
           ],
         },
@@ -161,8 +167,11 @@ const TEMPLATE = {
           attrs: dict({
             'role': 'button',
             'class': INFO_CLASS + ' i-amphtml-story-button',
+            'aria-label': localize(
+              element,
+              LocalizedStringId.AMP_STORY_INFO_BUTTON_LABEL
+            ),
           }),
-          localizedLabelId: LocalizedStringId.AMP_STORY_INFO_BUTTON_LABEL,
         },
         {
           tag: 'div',
@@ -182,24 +191,36 @@ const TEMPLATE = {
                   attrs: dict({
                     'class': 'i-amphtml-story-mute-text',
                   }),
-                  localizedStringId:
-                    LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_TEXT,
+                  children: [
+                    localize(
+                      element,
+                      LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_TEXT
+                    ),
+                  ],
                 },
                 {
                   tag: 'div',
                   attrs: dict({
                     'class': 'i-amphtml-story-unmute-sound-text',
                   }),
-                  localizedStringId:
-                    LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_SOUND_TEXT,
+                  children: [
+                    localize(
+                      element,
+                      LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_SOUND_TEXT
+                    ),
+                  ],
                 },
                 {
                   tag: 'div',
                   attrs: dict({
                     'class': 'i-amphtml-story-unmute-no-sound-text',
                   }),
-                  localizedStringId:
-                    LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_NO_SOUND_TEXT,
+                  children: [
+                    localize(
+                      element,
+                      LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_NO_SOUND_TEXT
+                    ),
+                  ],
                 },
               ],
             },
@@ -207,17 +228,21 @@ const TEMPLATE = {
               tag: 'button',
               attrs: dict({
                 'class': UNMUTE_CLASS + ' i-amphtml-story-button',
+                'aria-label': localize(
+                  element,
+                  LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_BUTTON_LABEL
+                ),
               }),
-              localizedLabelId:
-                LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_BUTTON_LABEL,
             },
             {
               tag: 'button',
               attrs: dict({
                 'class': MUTE_CLASS + ' i-amphtml-story-button',
+                'aria-label': localize(
+                  element,
+                  LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_LABEL
+                ),
               }),
-              localizedLabelId:
-                LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_LABEL,
             },
           ],
         },
@@ -231,15 +256,21 @@ const TEMPLATE = {
               tag: 'button',
               attrs: dict({
                 'class': PAUSE_CLASS + ' i-amphtml-story-button',
+                'aria-label': localize(
+                  element,
+                  LocalizedStringId.AMP_STORY_PAUSE_BUTTON_LABEL
+                ),
               }),
-              localizedLabelId: LocalizedStringId.AMP_STORY_PAUSE_BUTTON_LABEL,
             },
             {
               tag: 'button',
               attrs: dict({
                 'class': PLAY_CLASS + ' i-amphtml-story-button',
+                'aria-label': localize(
+                  element,
+                  LocalizedStringId.AMP_STORY_PLAY_BUTTON_LABEL
+                ),
               }),
-              localizedLabelId: LocalizedStringId.AMP_STORY_PLAY_BUTTON_LABEL,
             },
           ],
         },
@@ -249,16 +280,21 @@ const TEMPLATE = {
             'class':
               SKIP_TO_NEXT_CLASS +
               ' i-amphtml-story-ui-hide-button i-amphtml-story-button',
+            'aria-label': localize(
+              element,
+              LocalizedStringId.AMP_STORY_SKIP_TO_NEXT_BUTTON_LABEL
+            ),
           }),
-          localizedLabelId:
-            LocalizedStringId.AMP_STORY_SKIP_TO_NEXT_BUTTON_LABEL,
         },
         {
           tag: 'button',
           attrs: dict({
             'class': SHARE_CLASS + ' i-amphtml-story-button',
+            'aria-label': localize(
+              element,
+              LocalizedStringId.AMP_STORY_SHARE_BUTTON_LABEL
+            ),
           }),
-          localizedLabelId: LocalizedStringId.AMP_STORY_SHARE_BUTTON_LABEL,
         },
         {
           tag: 'button',
@@ -266,8 +302,11 @@ const TEMPLATE = {
             'class':
               CLOSE_CLASS +
               ' i-amphtml-story-ui-hide-button i-amphtml-story-button',
+            'aria-label': localize(
+              element,
+              LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL
+            ),
           }),
-          localizedLabelId: LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL,
         },
       ],
     },
@@ -278,7 +317,7 @@ const TEMPLATE = {
       }),
     },
   ],
-};
+});
 
 /**
  * Contains the event name belonging to the viewer control.
@@ -391,7 +430,10 @@ export class SystemLayer {
 
     this.root_ = this.win_.document.createElement('div');
     this.root_.classList.add('i-amphtml-system-layer-host');
-    this.systemLayerEl_ = renderAsElement(this.win_.document, TEMPLATE);
+    this.systemLayerEl_ = renderAsElement(
+      this.win_.document,
+      getTemplate(this.parentEl_)
+    );
     // Make the share button link to the current document to make sure
     // embedded STAMPs always have a back-link to themselves, and to make
     // gestures like right-clicks work.

--- a/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
@@ -5,14 +5,17 @@ import {createShadowRootWithStyle} from './utils';
 import {dict} from '#core/types/object';
 import {removeElement} from '#core/dom';
 import {renderAsElement} from './simple-template';
+import {localize} from './amp-story-localization-service';
 
 /** @const {string} Class for the continue anyway button */
 const CONTINUE_ANYWAY_BUTTON_CLASS = 'i-amphtml-continue-button';
+
 /**
  * Full viewport black layer indicating browser is not supported.
- * @private @const {!./simple-template.ElementDef}
+ * @param {!Element} element
+ * @return {!./simple-template.ElementDef}
  */
-const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = {
+const renderTemplate = (element) => ({
   tag: 'div',
   attrs: dict({'class': 'i-amphtml-story-unsupported-browser-overlay'}),
   children: [
@@ -27,8 +30,12 @@ const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = {
         {
           tag: 'div',
           attrs: dict({'class': 'i-amphtml-story-overlay-text'}),
-          localizedStringId:
-            LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT,
+          children: [
+            localize(
+              element,
+              LocalizedStringId.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT
+            ),
+          ],
         },
         // The continue button functionality will only be present in the default
         // layer. Publisher provided fallbacks will not provide users with the
@@ -36,13 +43,17 @@ const UNSUPPORTED_BROWSER_LAYER_TEMPLATE = {
         {
           tag: 'button',
           attrs: dict({'class': 'i-amphtml-continue-button'}),
-          localizedStringId:
-            LocalizedStringId.AMP_STORY_CONTINUE_ANYWAY_BUTTON_LABEL,
+          children: [
+            localize(
+              element,
+              LocalizedStringId.AMP_STORY_CONTINUE_ANYWAY_BUTTON_LABEL
+            ),
+          ],
         },
       ],
     },
   ],
-};
+});
 
 /**
  * Unsupported browser layer UI.
@@ -79,7 +90,7 @@ export class UnsupportedBrowserLayer {
     this.root_ = this.win_.document.createElement('div');
     this.element_ = renderAsElement(
       this.win_.document,
-      UNSUPPORTED_BROWSER_LAYER_TEMPLATE
+      renderTemplate(this.win_.document)
     );
     createShadowRootWithStyle(this.root_, this.element_, CSS);
     this.continueButton_ = this.element_./*OK*/ querySelector(

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -77,7 +77,6 @@ import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
 import {findIndex, lastItem, toArray} from '#core/types/array';
 import {getConsentPolicyState} from '../../../src/consent';
 import {getDetail} from '#utils/event-helper';
-// eslint-disable-next-line local/no-forbidden-terms
 import {getLocalizationService} from './amp-story-localization-service';
 import {getMediaQueryService} from './amp-story-media-query-service';
 import {getMode, isModeDevelopment} from '../../../src/mode';
@@ -305,7 +304,6 @@ export class AmpStory extends AMP.BaseElement {
       ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
       : null;
 
-    // eslint-disable-next-line local/no-forbidden-terms
     getLocalizationService(this.element)
       .registerLocalizedStringBundle('default', LocalizedStringsEn)
       .registerLocalizedStringBundle('ar', LocalizedStringsAr)

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -77,6 +77,7 @@ import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
 import {findIndex, lastItem, toArray} from '#core/types/array';
 import {getConsentPolicyState} from '../../../src/consent';
 import {getDetail} from '#utils/event-helper';
+// eslint-disable-next-line local/no-forbidden-terms
 import {getLocalizationService} from './amp-story-localization-service';
 import {getMediaQueryService} from './amp-story-media-query-service';
 import {getMode, isModeDevelopment} from '../../../src/mode';
@@ -279,9 +280,6 @@ export class AmpStory extends AMP.BaseElement {
     /** @private {?AmpStoryViewerMessagingHandler} */
     this.viewerMessagingHandler_ = null;
 
-    /** @private {?../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = null;
-
     /**
      * Store the current paused state, to make sure the story does not play on
      * resume if it was previously paused. null when nothing to restore.
@@ -307,9 +305,8 @@ export class AmpStory extends AMP.BaseElement {
       ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
       : null;
 
-    this.localizationService_ = getLocalizationService(this.element);
-
-    this.localizationService_
+    // eslint-disable-next-line local/no-forbidden-terms
+    getLocalizationService(this.element)
       .registerLocalizedStringBundle('default', LocalizedStringsEn)
       .registerLocalizedStringBundle('ar', LocalizedStringsAr)
       .registerLocalizedStringBundle('de', LocalizedStringsDe)
@@ -331,16 +328,11 @@ export class AmpStory extends AMP.BaseElement {
       .registerLocalizedStringBundle('tr', LocalizedStringsTr)
       .registerLocalizedStringBundle('vi', LocalizedStringsVi)
       .registerLocalizedStringBundle('zh-CN', LocalizedStringsZhCn)
-      .registerLocalizedStringBundle('zh-TW', LocalizedStringsZhTw);
-
-    const enXaPseudoLocaleBundle = createPseudoLocale(
-      LocalizedStringsEn,
-      (s) => `[${s} one two]`
-    );
-    this.localizationService_.registerLocalizedStringBundle(
-      'en-xa',
-      enXaPseudoLocaleBundle
-    );
+      .registerLocalizedStringBundle('zh-TW', LocalizedStringsZhTw)
+      .registerLocalizedStringBundle(
+        'en-xa',
+        createPseudoLocale(LocalizedStringsEn, (s) => `[${s} one two]`)
+      );
 
     if (this.isStandalone_()) {
       this.initializeStandaloneStory_();

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -9,8 +9,8 @@ import {LocalizedStringId} from '#service/localization/strings';
 import {Services} from '#service';
 import {dev, devAssert} from '#utils/log';
 
-import {getLocalizationService} from './amp-story-localization-service';
 import {htmlFor} from '#core/dom/static-template';
+import {localize} from './amp-story-localization-service';
 
 /** @struct @typedef {{className: string, triggers: (string|undefined)}} */
 let ButtonState_1_0_Def; // eslint-disable-line google-camelcase/google-camelcase
@@ -77,15 +77,13 @@ class PaginationButton {
       this.element.querySelector('button')
     );
 
-    /** @private @const {!../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = getLocalizationService(doc);
-
     this.element.classList.add(initialState.className);
-    initialState.label &&
+    if (initialState.label) {
       this.buttonElement_.setAttribute(
         'aria-label',
-        this.localizationService_.getLocalizedString(initialState.label)
+        localize(doc, initialState.label)
       );
+    }
     this.element.addEventListener('click', (e) => this.onClick_(e));
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
@@ -105,7 +103,7 @@ class PaginationButton {
     state.label
       ? this.buttonElement_.setAttribute(
           'aria-label',
-          this.localizationService_.getLocalizedString(state.label)
+          localize(this.element, state.label)
         )
       : this.buttonElement_.removeAttribute('aria-label');
 

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -103,7 +103,7 @@ class PaginationButton {
     state.label
       ? this.buttonElement_.setAttribute(
           'aria-label',
-          localize(this.element, state.label)
+          localize(this.win_.document, state.label)
         )
       : this.buttonElement_.removeAttribute('aria-label');
 

--- a/extensions/amp-story/1.0/simple-template.js
+++ b/extensions/amp-story/1.0/simple-template.js
@@ -1,33 +1,13 @@
-import {LocalizedStringId} from '#service/localization/strings'; // eslint-disable-line no-unused-vars
 import {createElementWithAttributes} from '#core/dom';
-import {devAssert} from '#utils/log';
-import {getLocalizationService} from './amp-story-localization-service';
-import {hasOwn} from '#core/types/object';
-import {isArray} from '#core/types';
 
 /**
  * @typedef {{
  *   tag: string,
  *   attrs: (!JsonObject|undefined),
- *   localizedStringId: (!LocalizedStringId|undefined),
- *   unlocalizedString: (string|undefined),
- *   localizedLabelId: (!LocalizedStringId|undefined),
- *   children: (!Array<!ElementDef>|undefined),
+ *   children: (!Array<!ElementDef|string|null>|undefined),
  * }}
  */
 export let ElementDef;
-
-/**
- * @param {!Document} doc
- * @param {!ElementDef|!Array<!ElementDef>} elementsDef
- * @return {!Node}
- */
-export function renderSimpleTemplate(doc, elementsDef) {
-  if (isArray(elementsDef)) {
-    return renderMulti(doc, /** @type {!Array<!ElementDef>} */ (elementsDef));
-  }
-  return renderSingle(doc, /** @type {!ElementDef} */ (elementsDef));
-}
 
 /**
  * @param {!Document} doc
@@ -35,67 +15,19 @@ export function renderSimpleTemplate(doc, elementsDef) {
  * @return {!Element}
  */
 export function renderAsElement(doc, elementDef) {
-  return renderSingle(doc, elementDef);
-}
-
-/**
- * @param {!Document} doc
- * @param {!Array<!ElementDef>} elementsDef
- * @return {!Node}
- */
-function renderMulti(doc, elementsDef) {
-  const fragment = doc.createDocumentFragment();
-  elementsDef.forEach((elementDef) =>
-    fragment.appendChild(renderSingle(doc, elementDef))
+  const el = createElementWithAttributes(
+    doc,
+    elementDef.tag,
+    /** @type {!JsonObject} */ (elementDef.attrs || {})
   );
-  return fragment;
-}
-
-/**
- * @param {!Document} doc
- * @param {!ElementDef} elementDef
- * @return {!Element}
- */
-function renderSingle(doc, elementDef) {
-  const el = hasOwn(elementDef, 'attrs')
-    ? createElementWithAttributes(
-        doc,
-        elementDef.tag,
-        /** @type {!JsonObject} */ (elementDef.attrs)
-      )
-    : doc.createElement(elementDef.tag);
-
-  const hasLocalizedTextContent = hasOwn(elementDef, 'localizedStringId');
-  const hasLocalizedLabel = hasOwn(elementDef, 'localizedLabelId');
-  if (hasLocalizedTextContent || hasLocalizedLabel) {
-    const localizationService = getLocalizationService(devAssert(doc.body));
-    devAssert(localizationService, 'Could not retrieve LocalizationService.');
-
-    if (hasLocalizedTextContent) {
-      el.textContent = localizationService.getLocalizedString(
-        /** @type {!LocalizedStringId} */ (elementDef.localizedStringId)
+  elementDef.children?.forEach((child) => {
+    if (child) {
+      el.appendChild(
+        typeof child === 'string'
+          ? document.createTextNode(child)
+          : renderAsElement(doc, child)
       );
     }
-
-    if (hasLocalizedLabel) {
-      const labelString = localizationService.getLocalizedString(
-        /** @type {!LocalizedStringId} */ (elementDef.localizedLabelId)
-      );
-      if (labelString) {
-        el.setAttribute('aria-label', labelString);
-      }
-    }
-  }
-
-  if (hasOwn(elementDef, 'unlocalizedString')) {
-    el.textContent = elementDef.unlocalizedString;
-  }
-
-  if (hasOwn(elementDef, 'children')) {
-    el.appendChild(
-      renderMulti(doc, /** @type {!Array<!ElementDef>} */ (elementDef.children))
-    );
-  }
-
+  });
   return el;
 }

--- a/extensions/amp-story/1.0/test/test-simple-template.js
+++ b/extensions/amp-story/1.0/test/test-simple-template.js
@@ -1,0 +1,64 @@
+import {expect} from 'chai';
+import {renderAsElement} from '../simple-template';
+
+describes.realWin('simple-template', {}, (env) => {
+  it('renders tag', () => {
+    const element = renderAsElement(env.win.document, {tag: 'div'});
+    expect(element.outerHTML).to.equal('<div></div>');
+  });
+
+  it('renders attributes', () => {
+    const element = renderAsElement(env.win.document, {
+      tag: 'span',
+      attrs: {'class': 'foo', 'aria-label': 'bar label'},
+    });
+    expect(element.outerHTML).to.equal(
+      '<span class="foo" aria-label="bar label"></span>'
+    );
+  });
+
+  it('renders children', () => {
+    const element = renderAsElement(env.win.document, {
+      tag: 'p',
+      children: [
+        {
+          tag: 'span',
+          children: ['Hello'],
+        },
+        ' ',
+        {
+          tag: 'strong',
+          children: ['World'],
+        },
+      ],
+    });
+    expect(element.outerHTML).to.equal(
+      '<p><span>Hello</span> <strong>World</strong></p>'
+    );
+  });
+
+  it('renders children with attributes', () => {
+    const element = renderAsElement(env.win.document, {
+      tag: 'a',
+      attrs: {href: '#'},
+      children: [
+        {
+          tag: 'span',
+          attrs: {class: 'foo'},
+          children: ['Hello'],
+        },
+      ],
+    });
+    expect(element.outerHTML).to.equal(
+      '<a href="#"><span class="foo">Hello</span></a>'
+    );
+  });
+
+  it('ignores null children', () => {
+    const element = renderAsElement(env.win.document, {
+      tag: 'span',
+      children: [null, 'bar'],
+    });
+    expect(element.outerHTML).to.equal('<span>bar</span>');
+  });
+});


### PR DESCRIPTION
All callsites now use `localize(element, key)`. This attempts zero changes in functionality.

This function compresses better than the alternatives, which we're able remove as well:

- `getLocalizationService(...).getLocalizedString(...)`. Some callsites check for existence of the service even though it's always present, and sometimes they'd store it in a private. `localize()` is briefer.

- On `simple-template`, we remove awkward fields: `unlocalizedString` and `localizedStringId` use `children`, and `localizedLabelId` is moved to an `aria-label` in `attrs`. This allows us to simplify the `simple-template` implementation, and reformats templates so that they'll be more easily converted to JSX in the future.

Together, these changes reduce the module build by ~0.3k compressed:

|        | `amp-story-1.0.mjs` |
| ------ | ------------------: |
| before |             `74346` |
| after  |             `74056` |
