### PR TITLE
🚀♻️ Use common public names in `amp-story`

### DIFF
--- a/extensions/amp-story/1.0/amp-story-affiliate-link.js
+++ b/extensions/amp-story/1.0/amp-story-affiliate-link.js
@@ -26,11 +26,11 @@ export class AmpStoryAffiliateLink {
    * @param {!Element} element
    */
   constructor(win, element) {
-    /** @private {!Window} */
-    this.win_ = win;
+    /** @public {!Window} */
+    this.win = win;
 
-    /** @private {!Element} */
-    this.element_ = element;
+    /** @public {!Element} */
+    this.element = element;
 
     /** @private {?Element} */
     this.textEl_ = null;
@@ -39,29 +39,29 @@ export class AmpStoryAffiliateLink {
     this.launchEl_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
 
     /** @private {string} */
-    this.text_ = this.element_.textContent;
+    this.text_ = this.element.textContent;
 
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
-    this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win_.document));
+    this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win.document));
 
     /** @private @const {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, element);
+    this.analyticsService_ = getAnalyticsService(this.win, element);
   }
 
   /**
    * Builds affiliate link.
    */
   build() {
-    if (this.element_[AFFILIATE_LINK_BUILT]) {
+    if (this.element[AFFILIATE_LINK_BUILT]) {
       return;
     }
 
-    this.mutator_.mutateElement(this.element_, () => {
-      this.element_.textContent = '';
-      this.element_.setAttribute('pristine', '');
+    this.mutator_.mutateElement(this.element, () => {
+      this.element.textContent = '';
+      this.element.setAttribute('pristine', '');
       this.addPulseElement_();
       this.addIconElement_();
       this.addText_();
@@ -69,7 +69,7 @@ export class AmpStoryAffiliateLink {
     });
 
     this.initializeListeners_();
-    this.element_[AFFILIATE_LINK_BUILT] = true;
+    this.element[AFFILIATE_LINK_BUILT] = true;
   }
 
   /**
@@ -80,32 +80,32 @@ export class AmpStoryAffiliateLink {
     this.storeService_.subscribe(
       StateProperty.AFFILIATE_LINK_STATE,
       (elementToToggleExpand) => {
-        const expand = this.element_ === elementToToggleExpand;
+        const expand = this.element === elementToToggleExpand;
         if (expand) {
-          this.element_.setAttribute('expanded', '');
+          this.element.setAttribute('expanded', '');
           this.textEl_.removeAttribute('hidden');
           this.launchEl_.removeAttribute('hidden');
         } else {
-          this.element_.removeAttribute('expanded');
+          this.element.removeAttribute('expanded');
           this.textEl_.setAttribute('hidden', '');
           this.launchEl_.setAttribute('hidden', '');
         }
         if (expand) {
-          this.element_.removeAttribute('pristine');
+          this.element.removeAttribute('pristine');
           this.analyticsService_.triggerEvent(
             StoryAnalyticsEvent.FOCUS,
-            this.element_
+            this.element
           );
         }
       }
     );
 
-    this.element_.addEventListener('click', (event) => {
-      if (this.element_.hasAttribute('expanded')) {
+    this.element.addEventListener('click', (event) => {
+      if (this.element.hasAttribute('expanded')) {
         event.stopPropagation();
         this.analyticsService_.triggerEvent(
           StoryAnalyticsEvent.CLICK_THROUGH,
-          this.element_
+          this.element
         );
       }
     });
@@ -116,7 +116,7 @@ export class AmpStoryAffiliateLink {
    * @private
    */
   addIconElement_() {
-    const iconEl = htmlFor(this.element_)`
+    const iconEl = htmlFor(this.element)`
       <div class="i-amphtml-story-affiliate-link-circle">
         <i class="i-amphtml-story-affiliate-link-icon"></i>
         <div class="i-amphtml-story-reset i-amphtml-hidden">
@@ -124,7 +124,7 @@ export class AmpStoryAffiliateLink {
           <i class="i-amphtml-story-affiliate-link-launch" hidden></i>
         </div>
       </div>`;
-    this.element_.appendChild(iconEl);
+    this.element.appendChild(iconEl);
   }
 
   /**
@@ -132,7 +132,7 @@ export class AmpStoryAffiliateLink {
    * @private
    */
   addText_() {
-    this.textEl_ = this.element_.querySelector(
+    this.textEl_ = this.element.querySelector(
       '.i-amphtml-story-affiliate-link-text'
     );
 
@@ -145,7 +145,7 @@ export class AmpStoryAffiliateLink {
    * @private
    */
   addLaunchElement_() {
-    this.launchEl_ = this.element_.querySelector(
+    this.launchEl_ = this.element.querySelector(
       '.i-amphtml-story-affiliate-link-launch'
     );
 
@@ -157,8 +157,8 @@ export class AmpStoryAffiliateLink {
    * @private
    */
   addPulseElement_() {
-    const pulseEl = htmlFor(this.element_)`
+    const pulseEl = htmlFor(this.element)`
       <div class="i-amphtml-story-affiliate-link-pulse"></div>`;
-    this.element_.appendChild(pulseEl);
+    this.element.appendChild(pulseEl);
   }
 }

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -441,8 +441,8 @@ export class AmpStoryEmbeddedComponent {
    * @param {!Element} storyEl
    */
   constructor(win, storyEl) {
-    /** @private {!Window} */
-    this.win_ = win;
+    /** @public {!Window} */
+    this.win = win;
 
     /** @private {!Element} */
     this.storyEl_ = storyEl;
@@ -460,19 +460,19 @@ export class AmpStoryEmbeddedComponent {
     this.tooltipArrow_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
 
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
-    this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win_.document));
+    this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win.document));
 
     /** @private @const {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, storyEl);
+    this.analyticsService_ = getAnalyticsService(this.win, storyEl);
 
     /** @private @const {!../../../src/service/owners-interface.OwnersInterface} */
-    this.owners_ = Services.ownersForDoc(getAmpdoc(this.win_.document));
+    this.owners_ = Services.ownersForDoc(getAmpdoc(this.win.document));
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
-    this.timer_ = Services.timerFor(this.win_);
+    this.timer_ = Services.timerFor(this.win);
 
     /** @private {?Element} */
     this.expandedViewOverlay_ = null;
@@ -504,9 +504,7 @@ export class AmpStoryEmbeddedComponent {
     );
 
     /** @type {!../../../src/service/history-impl.History} */
-    this.historyService_ = Services.historyForDoc(
-      getAmpdoc(this.win_.document)
-    );
+    this.historyService_ = Services.historyForDoc(getAmpdoc(this.win.document));
 
     /** @private {EmbeddedComponentState} */
     this.state_ = EmbeddedComponentState.HIDDEN;
@@ -702,10 +700,10 @@ export class AmpStoryEmbeddedComponent {
    * @return {Node}
    */
   buildFocusedState_() {
-    this.shadowRoot_ = this.win_.document.createElement('div');
+    this.shadowRoot_ = this.win.document.createElement('div');
 
     this.focusedStateOverlay_ = devAssert(
-      this.buildFocusedStateTemplate_(this.win_.document)
+      this.buildFocusedStateTemplate_(this.win.document)
     );
     createShadowRootWithStyle(this.shadowRoot_, this.focusedStateOverlay_, CSS);
 
@@ -846,7 +844,7 @@ export class AmpStoryEmbeddedComponent {
       }
     });
 
-    this.win_.addEventListener('keyup', (event) => {
+    this.win.addEventListener('keyup', (event) => {
       if (
         event.key === Keys.ESCAPE &&
         this.state_ === EmbeddedComponentState.EXPANDED
@@ -1443,7 +1441,7 @@ export class AmpStoryEmbeddedComponent {
       AdvancementMode.MANUAL_ADVANCE
     );
     dispatch(
-      this.win_,
+      this.win,
       dev().assertElement(this.shadowRoot_),
       direction,
       undefined,

--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -118,20 +118,20 @@ export class AmpStoryHint {
    * @param {!Element} parentEl Element where to append the component
    */
   constructor(win, parentEl) {
-    /** @private {!Window} */
-    this.win_ = win;
+    /** @public {!Window} */
+    this.win = win;
 
     /** @private {boolean} Whether the component is built. */
     this.isBuilt_ = false;
 
     /** @private {!Document} */
-    this.document_ = this.win_.document;
+    this.document_ = this.win.document;
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(this.win_);
+    this.vsync_ = Services.vsyncFor(this.win);
 
     /** @const @private {!../../../src/service/timer-impl.Timer} */
-    this.timer_ = Services.timerFor(this.win_);
+    this.timer_ = Services.timerFor(this.win);
 
     /** @private {?Element} */
     this.hintContainer_ = null;
@@ -140,7 +140,7 @@ export class AmpStoryHint {
     this.hintTimeout_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -36,11 +36,11 @@ export class InfoDialog {
    * @param {!Element} parentEl Element where to append the component
    */
   constructor(win, parentEl) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
-    /** @private {?Element} */
-    this.element_ = null;
+    /** @public {?Element} */
+    this.element = null;
 
     /** @private {?Element} */
     this.innerContainerEl_ = null;
@@ -52,16 +52,16 @@ export class InfoDialog {
     this.localizationService_ = getLocalizationService(parentEl);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
 
     /** @private {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, parentEl);
+    this.analyticsService_ = getAnalyticsService(this.win, parentEl);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;
 
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
-    this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win_.document));
+    this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win.document));
 
     /** @private {?Element} */
     this.moreInfoLinkEl_ = null;
@@ -81,9 +81,9 @@ export class InfoDialog {
     }
 
     this.isBuilt_ = true;
-    const root = this.win_.document.createElement('div');
+    const root = this.win.document.createElement('div');
     const html = htmlFor(this.parentEl_);
-    this.element_ = html`
+    this.element = html`
       <div class="i-amphtml-story-info-dialog i-amphtml-story-system-reset">
         <div class="i-amphtml-story-info-dialog-container">
           <h1 class="i-amphtml-story-info-heading"></h1>
@@ -93,10 +93,10 @@ export class InfoDialog {
       </div>
     `;
 
-    createShadowRootWithStyle(root, this.element_, CSS);
+    createShadowRootWithStyle(root, this.element, CSS);
     this.initializeListeners_();
 
-    this.innerContainerEl_ = this.element_.querySelector(
+    this.innerContainerEl_ = this.element.querySelector(
       '.i-amphtml-story-info-dialog-container'
     );
 
@@ -134,7 +134,7 @@ export class InfoDialog {
       this.onInfoDialogStateUpdated_(isOpen);
     });
 
-    this.element_.addEventListener('click', (event) =>
+    this.element.addEventListener('click', (event) =>
       this.onInfoDialogClick_(event)
     );
   }
@@ -146,14 +146,14 @@ export class InfoDialog {
    * @private
    */
   onInfoDialogStateUpdated_(isOpen) {
-    this.mutator_.mutateElement(dev().assertElement(this.element_), () => {
-      this.element_.classList.toggle(DIALOG_VISIBLE_CLASS, isOpen);
+    this.mutator_.mutateElement(dev().assertElement(this.element), () => {
+      this.element.classList.toggle(DIALOG_VISIBLE_CLASS, isOpen);
     });
 
-    this.element_[ANALYTICS_TAG_NAME] = 'amp-story-info-dialog';
+    this.element[ANALYTICS_TAG_NAME] = 'amp-story-info-dialog';
     this.analyticsService_.triggerEvent(
       isOpen ? StoryAnalyticsEvent.OPEN : StoryAnalyticsEvent.CLOSE,
-      this.element_
+      this.element
     );
   }
 
@@ -164,7 +164,7 @@ export class InfoDialog {
   onInfoDialogClick_(event) {
     const el = dev().assertElement(event.target);
     // Closes the dialog if click happened outside of the dialog main container.
-    if (!closest(el, (el) => el === this.innerContainerEl_, this.element_)) {
+    if (!closest(el, (el) => el === this.innerContainerEl_, this.element)) {
       this.close_();
     }
     const anchorClicked = closest(event.target, (e) => matches(e, 'a[href]'));
@@ -210,7 +210,7 @@ export class InfoDialog {
       LocalizedStringId.AMP_STORY_DOMAIN_DIALOG_HEADING_LABEL
     );
     const headingEl = dev().assertElement(
-      this.element_.querySelector('.i-amphtml-story-info-heading')
+      this.element.querySelector('.i-amphtml-story-info-heading')
     );
 
     return this.mutator_.mutateElement(headingEl, () => {
@@ -225,7 +225,7 @@ export class InfoDialog {
    */
   setPageLink_(pageUrl) {
     const linkEl = dev().assertElement(
-      this.element_.querySelector('.i-amphtml-story-info-link')
+      this.element.querySelector('.i-amphtml-story-info-link')
     );
 
     return this.mutator_.mutateElement(linkEl, () => {
@@ -248,7 +248,7 @@ export class InfoDialog {
     }
 
     this.moreInfoLinkEl_ = dev().assertElement(
-      this.element_.querySelector('.i-amphtml-story-info-moreinfo')
+      this.element.querySelector('.i-amphtml-story-info-moreinfo')
     );
 
     return this.mutator_.mutateElement(this.moreInfoLinkEl_, () => {

--- a/extensions/amp-story/1.0/amp-story-media-query-service.js
+++ b/extensions/amp-story/1.0/amp-story-media-query-service.js
@@ -30,8 +30,8 @@ export class AmpStoryMediaQueryService {
    * @param {!Window} win
    */
   constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @private {?Promise} */
     this.initializePromise_ = null;
@@ -41,7 +41,7 @@ export class AmpStoryMediaQueryService {
 
     /** @private @const {!Element} */
     this.storyEl_ = dev().assertElement(
-      this.win_.document.querySelector('amp-story')
+      this.win.document.querySelector('amp-story')
     );
   }
 
@@ -72,7 +72,7 @@ export class AmpStoryMediaQueryService {
     }
 
     this.initializePromise_ = new Promise((resolve) => {
-      this.matcher_ = this.win_.document.createElement('iframe');
+      this.matcher_ = this.win.document.createElement('iframe');
       this.matcher_.classList.add('i-amphtml-story-media-query-matcher');
       this.matcher_.onload = resolve;
       this.storyEl_.appendChild(this.matcher_);

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -59,11 +59,11 @@ export class ShareMenu {
    * @param {!Element} storyEl Element where to append the component
    */
   constructor(win, storyEl) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
-    /** @private {?Element} */
-    this.element_ = null;
+    /** @public {?Element} */
+    this.element = null;
 
     /** @private {?Element} */
     this.closeButton_ = null;
@@ -78,19 +78,19 @@ export class ShareMenu {
     this.isSystemShareSupported_ = false;
 
     /** @private @const {!ShareWidget} */
-    this.shareWidget_ = ShareWidget.create(this.win_, storyEl);
+    this.shareWidget_ = ShareWidget.create(this.win, storyEl);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
 
     /** @private {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, storyEl);
+    this.analyticsService_ = getAnalyticsService(this.win, storyEl);
 
     /** @private @const {!Element} */
     this.parentEl_ = storyEl;
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(this.win_);
+    this.vsync_ = Services.vsyncFor(this.win);
   }
 
   /**
@@ -129,17 +129,17 @@ export class ShareMenu {
    */
   buildForSystemSharing_() {
     this.shareWidget_.loadRequiredExtensions(getAmpdoc(this.parentEl_));
-    this.element_ = getAmpSocialSystemShareTemplate(this.parentEl_);
+    this.element = getAmpSocialSystemShareTemplate(this.parentEl_);
 
     this.initializeListeners_();
 
     this.vsync_.mutate(() => {
-      setStyles(dev().assertElement(this.element_), {
+      setStyles(dev().assertElement(this.element), {
         'visibility': 'hidden',
         'pointer-events': 'none',
         'z-index': -1,
       });
-      this.parentEl_.appendChild(this.element_);
+      this.parentEl_.appendChild(this.element);
     });
   }
 
@@ -148,14 +148,14 @@ export class ShareMenu {
    * @private
    */
   buildForFallbackSharing_() {
-    const root = this.win_.document.createElement('div');
+    const root = this.win.document.createElement('div');
     root.classList.add('i-amphtml-story-share-menu-host');
 
-    this.element_ = getTemplate(this.parentEl_);
-    createShadowRootWithStyle(root, this.element_, CSS);
+    this.element = getTemplate(this.parentEl_);
+    createShadowRootWithStyle(root, this.element, CSS);
 
     this.closeButton_ = dev().assertElement(
-      this.element_.querySelector('.i-amphtml-story-share-menu-close-button')
+      this.element.querySelector('.i-amphtml-story-share-menu-close-button')
     );
     const localizationService = getLocalizationService(
       devAssert(this.parentEl_)
@@ -171,7 +171,7 @@ export class ShareMenu {
 
     this.vsync_.run({
       measure: () => {
-        this.innerContainerEl_ = this.element_./*OK*/ querySelector(
+        this.innerContainerEl_ = this.element./*OK*/ querySelector(
           '.i-amphtml-story-share-menu-container'
         );
       },
@@ -203,11 +203,11 @@ export class ShareMenu {
     // Don't listen to click events if the system share is supported, since the
     // native layer handles all the UI interactions.
     if (!this.isSystemShareSupported_) {
-      this.element_.addEventListener('click', (event) =>
+      this.element.addEventListener('click', (event) =>
         this.onShareMenuClick_(event)
       );
 
-      this.win_.addEventListener('keyup', (event) => {
+      this.win.addEventListener('keyup', (event) => {
         if (event.key == Keys.ESCAPE) {
           event.preventDefault();
           this.close_();
@@ -226,7 +226,7 @@ export class ShareMenu {
     if (this.isSystemShareSupported_ && isOpen) {
       // Dispatches a click event on the amp-social-share button to trigger the
       // native system sharing UI. This has to be done upon user interaction.
-      this.element_.dispatchEvent(new Event('click'));
+      this.element.dispatchEvent(new Event('click'));
 
       // There is no way to know when the user dismisses the native system share
       // menu, so we pretend it is closed on the story end, and let the native
@@ -236,14 +236,14 @@ export class ShareMenu {
 
     if (!this.isSystemShareSupported_) {
       this.vsync_.mutate(() => {
-        this.element_.classList.toggle(VISIBLE_CLASS, isOpen);
-        this.element_.setAttribute('aria-hidden', !isOpen);
+        this.element.classList.toggle(VISIBLE_CLASS, isOpen);
+        this.element.setAttribute('aria-hidden', !isOpen);
       });
     }
-    this.element_[ANALYTICS_TAG_NAME] = 'amp-story-share-menu';
+    this.element[ANALYTICS_TAG_NAME] = 'amp-story-share-menu';
     this.analyticsService_.triggerEvent(
       isOpen ? StoryAnalyticsEvent.OPEN : StoryAnalyticsEvent.CLOSE,
-      this.element_
+      this.element
     );
   }
 
@@ -259,7 +259,7 @@ export class ShareMenu {
     }
 
     // Closes the menu if click happened outside of the menu main container.
-    if (!closest(el, (el) => el === this.innerContainerEl_, this.element_)) {
+    if (!closest(el, (el) => el === this.innerContainerEl_, this.element)) {
       this.close_();
     }
   }
@@ -272,8 +272,8 @@ export class ShareMenu {
   onUIStateUpdate_(uiState) {
     this.vsync_.mutate(() => {
       uiState !== UIType.MOBILE
-        ? this.element_.setAttribute('desktop', '')
-        : this.element_.removeAttribute('desktop');
+        ? this.element.setAttribute('desktop', '')
+        : this.element.removeAttribute('desktop');
     });
   }
 

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -194,7 +194,7 @@ export class ShareWidget {
     /** @private {?../../../src/service/ampdoc-impl.AmpDoc} */
     this.ampdoc_ = null;
 
-    /** @protected @const {!Window} */
+    /** @public @const {!Window} */
     this.win = win;
 
     /** @protected @const {!Element} */

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -458,8 +458,8 @@ export class AmpStoryStoreService {
    * @param {!Window} win
    */
   constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @private {!Object<string, !Observable>} */
     this.listeners_ = {};
@@ -594,7 +594,7 @@ export class AmpStoryStoreService {
    * @protected
    */
   getEmbedOverrides_() {
-    const embedMode = parseEmbedMode(this.win_.location.hash);
+    const embedMode = parseEmbedMode(this.win.location.hash);
     switch (embedMode) {
       case EmbedMode.NAME_TBD:
         return {

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -326,8 +326,8 @@ export class SystemLayer {
    * @param {!Element} parentEl
    */
   constructor(win, parentEl) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @protected @const {!Element} */
     this.parentEl_ = parentEl;
@@ -360,13 +360,13 @@ export class SystemLayer {
     this.developerButtons_ = DevelopmentModeLogButtonSet.create(win);
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
 
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
-    this.vsync_ = Services.vsyncFor(this.win_);
+    this.vsync_ = Services.vsyncFor(this.win);
 
     /** @const @private {!../../../src/service/timer-impl.Timer} */
-    this.timer_ = Services.timerFor(this.win_);
+    this.timer_ = Services.timerFor(this.win);
 
     /** @private {?number|?string} */
     this.timeoutId_ = null;
@@ -389,9 +389,9 @@ export class SystemLayer {
 
     this.isBuilt_ = true;
 
-    this.root_ = this.win_.document.createElement('div');
+    this.root_ = this.win.document.createElement('div');
     this.root_.classList.add('i-amphtml-system-layer-host');
-    this.systemLayerEl_ = renderAsElement(this.win_.document, TEMPLATE);
+    this.systemLayerEl_ = renderAsElement(this.win.document, TEMPLATE);
     // Make the share button link to the current document to make sure
     // embedded STAMPs always have a back-link to themselves, and to make
     // gestures like right-clicks work.
@@ -424,13 +424,13 @@ export class SystemLayer {
       true /* callToInitialize */
     );
 
-    if (Services.platformFor(this.win_).isIos()) {
+    if (Services.platformFor(this.win).isIos()) {
       this.systemLayerEl_.setAttribute('ios', '');
     }
 
-    this.viewer_ = Services.viewerForDoc(this.win_.document.documentElement);
+    this.viewer_ = Services.viewerForDoc(this.win.document.documentElement);
     this.viewerMessagingHandler_ = this.viewer_.isEmbedded()
-      ? new AmpStoryViewerMessagingHandler(this.win_, this.viewer_)
+      ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
       : null;
 
     if (shouldShowStoryUrlInfo(this.viewer_, this.storeService_)) {
@@ -1010,7 +1010,7 @@ export class SystemLayer {
           defaultConfig.selector
         );
       } else {
-        element = this.win_.document.createElement('button');
+        element = this.win.document.createElement('button');
         this.vsync_.mutate(() => {
           element.classList.add('i-amphtml-story-button');
           this.buttonsContainer_.appendChild(element);

--- a/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
@@ -52,20 +52,20 @@ export class UnsupportedBrowserLayer {
    * @param {!Window} win
    */
   constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @private {?Element} */
     this.root_ = null;
 
-    /** @private {?Element} */
-    this.element_ = null;
+    /** @public {?Element} */
+    this.element = null;
 
     /** @private {?Element} */
     this.continueButton_ = null;
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
   }
 
   /**
@@ -76,13 +76,13 @@ export class UnsupportedBrowserLayer {
     if (this.root_) {
       return this.root_;
     }
-    this.root_ = this.win_.document.createElement('div');
-    this.element_ = renderAsElement(
-      this.win_.document,
+    this.root_ = this.win.document.createElement('div');
+    this.element = renderAsElement(
+      this.win.document,
       UNSUPPORTED_BROWSER_LAYER_TEMPLATE
     );
-    createShadowRootWithStyle(this.root_, this.element_, CSS);
-    this.continueButton_ = this.element_./*OK*/ querySelector(
+    createShadowRootWithStyle(this.root_, this.element, CSS);
+    this.continueButton_ = this.element./*OK*/ querySelector(
       `.${CONTINUE_ANYWAY_BUTTON_CLASS}`
     );
     this.continueButton_.addEventListener('click', () => {

--- a/extensions/amp-story/1.0/background-blur.js
+++ b/extensions/amp-story/1.0/background-blur.js
@@ -25,11 +25,11 @@ export class BackgroundBlur {
    * @param {!Element} element
    */
   constructor(win, element) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
-    /** @private @const {!Element} */
-    this.element_ = element;
+    /** @public @const {!Element} */
+    this.element = element;
 
     /** @private @const {!Array<Element>} */
     this.mediaElements_ = null;
@@ -38,7 +38,7 @@ export class BackgroundBlur {
     this.canvas_ = null;
 
     /** @private @const {Element} */
-    this.offscreenCanvas_ = this.win_.document.createElement('canvas');
+    this.offscreenCanvas_ = this.win.document.createElement('canvas');
     this.offscreenCanvas_.width = this.offscreenCanvas_.height = CANVAS_SIZE;
 
     /**  @private {?number} */
@@ -52,7 +52,7 @@ export class BackgroundBlur {
    * Setup canvas and attach it to the document.
    */
   attach() {
-    this.canvas_ = this.win_.document.createElement('canvas');
+    this.canvas_ = this.win.document.createElement('canvas');
     this.canvas_.width = this.canvas_.height = CANVAS_SIZE;
     setImportantStyles(this.canvas_, {
       width: '100%',
@@ -61,14 +61,14 @@ export class BackgroundBlur {
       left: 0,
       top: 0,
     });
-    this.element_.appendChild(this.canvas_);
+    this.element.appendChild(this.canvas_);
   }
 
   /**
    * Remove canvas from the document and cancel the RAF.
    */
   detach() {
-    this.element_.removeChild(this.canvas_);
+    this.element.removeChild(this.canvas_);
     cancelAnimationFrame(this.currentRAF_);
   }
 
@@ -137,7 +137,7 @@ export class BackgroundBlur {
       return false;
     }
     const imgEl = mediaEl.querySelector('img');
-    const canvas = this.win_.document.createElement('canvas');
+    const canvas = this.win.document.createElement('canvas');
     canvas.width = canvas.height = CANVAS_SIZE;
     const context = canvas.getContext('2d');
     context.drawImage(imgEl, 0, 0, CANVAS_SIZE, CANVAS_SIZE);

--- a/extensions/amp-story/1.0/development-ui.js
+++ b/extensions/amp-story/1.0/development-ui.js
@@ -43,8 +43,8 @@ export class DevelopmentModeLogButtonSet {
    * @param {!Window} win
    */
   constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @private {?Element} */
     this.root_ = null;
@@ -75,24 +75,24 @@ export class DevelopmentModeLogButtonSet {
    */
   build(logButtonActionFn) {
     this.errorButton_ = createButton(
-      this.win_,
+      this.win,
       ['i-amphtml-story-error-button', 'i-amphtml-story-dev-logs-button'],
       () => logButtonActionFn()
     );
 
     this.warningButton_ = createButton(
-      this.win_,
+      this.win,
       ['i-amphtml-story-warning-button', 'i-amphtml-story-dev-logs-button'],
       () => logButtonActionFn()
     );
 
     this.successButton_ = createButton(
-      this.win_,
+      this.win,
       ['i-amphtml-story-success-button', 'i-amphtml-story-dev-logs-button'],
       () => logButtonActionFn()
     );
 
-    this.root_ = this.win_.document.createElement('div');
+    this.root_ = this.win.document.createElement('div');
     this.root_.appendChild(this.errorButton_);
     this.root_.appendChild(this.warningButton_);
     this.root_.appendChild(this.successButton_);
@@ -155,8 +155,8 @@ export class DevelopmentModeLog {
    * @param {!Window} win
    */
   constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @private {?Element} */
     this.root_ = null;
@@ -181,29 +181,29 @@ export class DevelopmentModeLog {
    * @return {?Element}
    */
   build() {
-    this.contextStringEl_ = this.win_.document.createElement('span');
+    this.contextStringEl_ = this.win.document.createElement('span');
     this.contextStringEl_.classList.add(
       'i-amphtml-story-developer-log-context'
     );
-    const titleEl = this.win_.document.createElement('div');
+    const titleEl = this.win.document.createElement('div');
     titleEl.textContent = 'Developer logs for page ';
     titleEl.appendChild(this.contextStringEl_);
 
     const closeDeveloperLogEl = createButton(
-      this.win_,
+      this.win,
       'i-amphtml-story-developer-log-close',
       () => this.hide()
     );
 
-    const headerEl = this.win_.document.createElement('div');
+    const headerEl = this.win.document.createElement('div');
     headerEl.classList.add('i-amphtml-story-developer-log-header');
     headerEl.appendChild(titleEl);
     headerEl.appendChild(closeDeveloperLogEl);
 
-    this.entriesEl_ = this.win_.document.createElement('ul');
+    this.entriesEl_ = this.win.document.createElement('ul');
     this.entriesEl_.classList.add('i-amphtml-story-developer-log-entries');
 
-    this.root_ = this.win_.document.createElement('div');
+    this.root_ = this.win.document.createElement('div');
     this.root_.classList.add('i-amphtml-story-developer-log');
     toggle(this.root_, false);
     this.root_.appendChild(headerEl);
@@ -253,7 +253,7 @@ export class DevelopmentModeLog {
     const logLevelClass = this.getCssLogLevelClass_(logEntry.level);
     const conformanceClass = this.getCssConformanceClass_(logEntry.conforms);
 
-    const logEntryUi = this.win_.document.createElement('li');
+    const logEntryUi = this.win.document.createElement('li');
     logEntryUi.classList.add('i-amphtml-story-developer-log-entry');
 
     if (logLevelClass) {
@@ -272,7 +272,7 @@ export class DevelopmentModeLog {
    * Clears all entries from the developer logs.
    */
   clear() {
-    Services.vsyncFor(this.win_).mutate(() => {
+    Services.vsyncFor(this.win).mutate(() => {
       removeChildren(dev().assertElement(this.entriesEl_));
     });
   }
@@ -292,7 +292,7 @@ export class DevelopmentModeLog {
   toggle() {
     const newHiddenState = !this.root_.hasAttribute('hidden');
     toggleHiddenAttribute(
-      Services.vsyncFor(this.win_),
+      Services.vsyncFor(this.win),
       dev().assertElement(this.root_),
       newHiddenState
     );
@@ -303,7 +303,7 @@ export class DevelopmentModeLog {
    */
   hide() {
     toggleHiddenAttribute(
-      Services.vsyncFor(this.win_),
+      Services.vsyncFor(this.win),
       dev().assertElement(this.root_),
       /* isHidden */ true
     );

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -124,8 +124,8 @@ export class MediaPool {
    *     dependant, as long as it is consistent between invocations.
    */
   constructor(win, maxCounts, distanceFn) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(win);
@@ -183,7 +183,7 @@ export class MediaPool {
     /** @const {!Object<string, (function(): !PoolBoundElementDef)>} */
     this.mediaFactory_ = {
       [MediaType.AUDIO]: () => {
-        const audioEl = this.win_.document.createElement('audio');
+        const audioEl = this.win.document.createElement('audio');
         audioEl.setAttribute('muted', '');
         audioEl.muted = true;
         audioEl.classList.add('i-amphtml-pool-media');
@@ -191,7 +191,7 @@ export class MediaPool {
         return audioEl;
       },
       [MediaType.VIDEO]: () => {
-        const videoEl = this.win_.document.createElement('video');
+        const videoEl = this.win.document.createElement('video');
         videoEl.setAttribute('muted', '');
         videoEl.muted = true;
         videoEl.setAttribute('playsinline', '');
@@ -509,7 +509,7 @@ export class MediaPool {
       .then(() =>
         this.enqueueMediaElementTask_(
           poolMediaEl,
-          new UpdateSourcesTask(this.win_, sources)
+          new UpdateSourcesTask(this.win, sources)
         )
       )
       .then(() => this.enqueueMediaElementTask_(poolMediaEl, new LoadTask()))
@@ -551,7 +551,7 @@ export class MediaPool {
 
     return this.enqueueMediaElementTask_(
       poolMediaEl,
-      new UpdateSourcesTask(this.win_, defaultSources)
+      new UpdateSourcesTask(this.win, defaultSources)
     ).then(() => this.enqueueMediaElementTask_(poolMediaEl, new LoadTask()));
   }
 
@@ -715,7 +715,7 @@ export class MediaPool {
 
     // This media element has not yet been registered.
     placeholderEl.id = id;
-    const sources = Sources.removeFrom(this.win_, placeholderEl);
+    const sources = Sources.removeFrom(this.win, placeholderEl);
     this.sources_[id] = sources;
     this.placeholderEls_[id] = placeholderEl;
 

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -351,8 +351,8 @@ export class UpdateSourcesTask extends MediaTask {
   constructor(win, newSources) {
     super('update-src');
 
-    /** @private {!Window} */
-    this.win_ = win;
+    /** @public {!Window} */
+    this.win = win;
 
     /** @private @const {!Sources} */
     this.newSources_ = newSources;
@@ -360,8 +360,8 @@ export class UpdateSourcesTask extends MediaTask {
 
   /** @override */
   executeInternal(mediaEl) {
-    Sources.removeFrom(this.win_, mediaEl);
-    this.newSources_.applyToElement(this.win_, mediaEl);
+    Sources.removeFrom(this.win, mediaEl);
+    this.newSources_.applyToElement(this.win, mediaEl);
     return Promise.resolve();
   }
 

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -254,8 +254,8 @@ export class ManualAdvancement extends AdvancementConfig {
   constructor(win, element) {
     super();
 
-    /** @private @const {!Element} */
-    this.element_ = element;
+    /** @public @const {!Element} */
+    this.element = element;
 
     /** @private {number|string|null} */
     this.timeoutId_ = null;
@@ -312,17 +312,17 @@ export class ManualAdvancement extends AdvancementConfig {
    * @private
    */
   startListening_() {
-    this.element_.addEventListener(
+    this.element.addEventListener(
       'touchstart',
       this.onTouchstart_.bind(this),
       true
     );
-    this.element_.addEventListener(
+    this.element.addEventListener(
       'touchend',
       this.onTouchend_.bind(this),
       true
     );
-    this.element_.addEventListener(
+    this.element.addEventListener(
       'click',
       this.maybePerformNavigation_.bind(this),
       true
@@ -420,7 +420,7 @@ export class ManualAdvancement extends AdvancementConfig {
       (el) => {
         return hasTapAction(el);
       },
-      /* opt_stopAt */ this.element_
+      /* opt_stopAt */ this.element
     );
   }
 
@@ -442,7 +442,7 @@ export class ManualAdvancement extends AdvancementConfig {
         }
         return false;
       },
-      /* opt_stopAt */ this.element_
+      /* opt_stopAt */ this.element
     );
   }
 
@@ -496,7 +496,7 @@ export class ManualAdvancement extends AdvancementConfig {
 
         return false;
       },
-      /* opt_stopAt */ this.element_
+      /* opt_stopAt */ this.element
     );
 
     return shouldHandleEvent;
@@ -536,7 +536,7 @@ export class ManualAdvancement extends AdvancementConfig {
 
         return tagName === 'amp-story-page' && valid;
       },
-      /* opt_stopAt */ this.element_
+      /* opt_stopAt */ this.element
     );
 
     if (
@@ -753,9 +753,9 @@ export class ManualAdvancement extends AdvancementConfig {
   getStoryPageRect_() {
     const uiState = this.storeService_.get(StateProperty.UI_STATE);
     if (uiState !== UIType.DESKTOP_ONE_PANEL) {
-      return this.element_.getLayoutBox();
+      return this.element.getLayoutBox();
     } else {
-      return this.element_
+      return this.element
         .querySelector('amp-story-page[active]')
         ./*OK*/ getBoundingClientRect();
     }
@@ -975,8 +975,8 @@ export class MediaBasedAdvancement extends AdvancementConfig {
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(win);
 
-    /** @private {!Element} */
-    this.element_ = element;
+    /** @public {!Element} */
+    this.element = element;
 
     /** @private {?Element} */
     this.mediaElement_ = null;
@@ -1005,7 +1005,7 @@ export class MediaBasedAdvancement extends AdvancementConfig {
    * @private
    */
   isVideoInterfaceVideo_() {
-    return this.element_.classList.contains('i-amphtml-video-interface');
+    return this.element.classList.contains('i-amphtml-video-interface');
   }
 
   /**
@@ -1014,17 +1014,17 @@ export class MediaBasedAdvancement extends AdvancementConfig {
    * @private
    */
   getMediaElement_() {
-    const tagName = this.element_.tagName.toLowerCase();
+    const tagName = this.element.tagName.toLowerCase();
 
-    if (this.element_ instanceof HTMLMediaElement) {
-      return this.element_;
+    if (this.element instanceof HTMLMediaElement) {
+      return this.element;
     } else if (
-      this.element_.hasAttribute('background-audio') &&
+      this.element.hasAttribute('background-audio') &&
       tagName === 'amp-story-page'
     ) {
-      return this.element_.querySelector('.i-amphtml-story-background-audio');
+      return this.element.querySelector('.i-amphtml-story-background-audio');
     } else if (tagName === 'amp-audio') {
-      return this.element_.querySelector('audio');
+      return this.element.querySelector('audio');
     }
 
     return null;
@@ -1035,7 +1035,7 @@ export class MediaBasedAdvancement extends AdvancementConfig {
     super.start();
 
     // Prevents race condition when checking for video interface classname.
-    (this.element_.build ? this.element_.build() : Promise.resolve()).then(() =>
+    (this.element.build ? this.element.build() : Promise.resolve()).then(() =>
       this.startWhenBuilt_()
     );
   }
@@ -1058,7 +1058,7 @@ export class MediaBasedAdvancement extends AdvancementConfig {
 
     user().error(
       'AMP-STORY-PAGE',
-      `Element with ID ${this.element_.id} is not a media element ` +
+      `Element with ID ${this.element.id} is not a media element ` +
         'supported for automatic advancement.'
     );
   }
@@ -1087,15 +1087,15 @@ export class MediaBasedAdvancement extends AdvancementConfig {
 
   /** @private */
   startVideoInterfaceElement_() {
-    this.element_.getImpl().then((video) => {
+    this.element.getImpl().then((video) => {
       this.video_ = video;
     });
 
     // Removes [loop] attribute if specified, so the 'ended' event can trigger.
-    this.element_.querySelector('video').removeAttribute('loop');
+    this.element.querySelector('video').removeAttribute('loop');
 
     this.unlistenFns_.push(
-      listenOnce(this.element_, VideoEvents.ENDED, () => this.onAdvance(), {
+      listenOnce(this.element, VideoEvents.ENDED, () => this.onAdvance(), {
         capture: true,
       })
     );

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -91,8 +91,8 @@ class PaginationButton {
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = storeService;
 
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
   }
 
   /** @param {!ButtonState_1_0_Def} state */
@@ -133,7 +133,7 @@ class PaginationButton {
 
     if (this.state_.triggers) {
       dispatch(
-        this.win_,
+        this.win,
         this.element,
         devAssert(this.state_.triggers),
         /* payload */ undefined,

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -67,8 +67,8 @@ export class ProgressBar {
    * @param {!Element} storyEl
    */
   constructor(win, storyEl) {
-    /** @private @const {!Window} */
-    this.win_ = win;
+    /** @public @const {!Window} */
+    this.win = win;
 
     /** @private {boolean} */
     this.isBuilt_ = false;
@@ -86,7 +86,7 @@ export class ProgressBar {
     this.activeSegmentProgress_ = 1;
 
     /** @private {!../../../src/service/ampdoc-impl.AmpDoc} */
-    this.ampdoc_ = Services.ampdocServiceFor(this.win_).getSingleDoc();
+    this.ampdoc_ = Services.ampdocServiceFor(this.win).getSingleDoc();
 
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
     this.mutator_ = Services.mutatorForDoc(this.ampdoc_);
@@ -95,7 +95,7 @@ export class ProgressBar {
     this.segmentIdMap_ = map();
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
+    this.storeService_ = getStoreService(this.win);
 
     /** @private {string} */
     this.activeSegmentId_ = '';
@@ -139,7 +139,7 @@ export class ProgressBar {
       return this.getRoot();
     }
 
-    this.root_ = this.win_.document.createElement('ol');
+    this.root_ = this.win.document.createElement('ol');
     this.root_.setAttribute('aria-hidden', true);
     this.root_.classList.add('i-amphtml-story-progress-bar');
     this.storyEl_.addEventListener(EventType.REPLAY, () => {
@@ -196,7 +196,7 @@ export class ProgressBar {
     });
 
     Services.viewportForDoc(this.ampdoc_).onResize(
-      debounce(this.win_, () => this.onResize_(), 300)
+      debounce(this.win, () => this.onResize_(), 300)
     );
 
     this.segmentsAddedPromise_.then(() => {
@@ -423,7 +423,7 @@ export class ProgressBar {
    */
   onAdStateUpdate_(adState) {
     const segmentExpBranch = getExperimentBranch(
-      this.win_,
+      this.win,
       StoryAdSegmentExp.ID
     );
     if (
@@ -458,7 +458,7 @@ export class ProgressBar {
         index + 2
       )})`
     );
-    const adSegment = this.win_.document.createElement('div');
+    const adSegment = this.win.document.createElement('div');
     adSegment.className = 'i-amphtml-story-ad-progress-value';
     setStyle(adSegment, 'animationDuration', animationDuration);
     this.currentAdSegment_ = adSegment;
@@ -479,9 +479,9 @@ export class ProgressBar {
    * @private
    */
   buildSegmentEl_() {
-    const segmentProgressBar = this.win_.document.createElement('li');
+    const segmentProgressBar = this.win.document.createElement('li');
     segmentProgressBar.classList.add('i-amphtml-story-page-progress-bar');
-    const segmentProgressValue = this.win_.document.createElement('div');
+    const segmentProgressValue = this.win.document.createElement('div');
     segmentProgressValue.classList.add('i-amphtml-story-page-progress-value');
     segmentProgressBar.appendChild(segmentProgressValue);
     this.getRoot().appendChild(segmentProgressBar);

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -74,7 +74,7 @@ export class StoryAnalyticsService {
    * @param {!Element} element
    */
   constructor(win, element) {
-    /** @protected @const {!Window} */
+    /** @public @const {!Window} */
     this.win = win;
 
     /** @public @const {!Element} */

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -75,10 +75,10 @@ export class StoryAnalyticsService {
    */
   constructor(win, element) {
     /** @protected @const {!Window} */
-    this.win_ = win;
+    this.win = win;
 
-    /** @private @const {!Element} */
-    this.element_ = element;
+    /** @public @const {!Element} */
+    this.element = element;
 
     /** @const @private {!./variable-service.AmpStoryVariableService} */
     this.variableService_ = getVariableService(win);
@@ -124,7 +124,7 @@ export class StoryAnalyticsService {
     this.incrementPageEventCount_(eventType);
 
     triggerAnalyticsEvent(
-      this.element_,
+      this.element,
       eventType,
       this.updateDetails(eventType, element)
     );

--- a/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-info-dialog.js
@@ -62,14 +62,14 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
   it('should build the info dialog', async () => {
     await infoDialog.build();
     expect(infoDialog.isBuilt()).to.be.true;
-    expect(infoDialog.element_).to.exist;
+    expect(infoDialog.element).to.exist;
   });
 
   it('should hide more info link when there is no viewer messaging', async () => {
     embedded = false;
 
     await infoDialog.build();
-    expect(infoDialog.element_.querySelector(MOREINFO_CLASS)).not.to.have.class(
+    expect(infoDialog.element.querySelector(MOREINFO_CLASS)).not.to.have.class(
       MOREINFO_VISIBLE_CLASS
     );
   });
@@ -78,7 +78,7 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
     moreInfoLinkUrl = null;
 
     await infoDialog.build();
-    expect(infoDialog.element_.querySelector(MOREINFO_CLASS)).not.to.have.class(
+    expect(infoDialog.element.querySelector(MOREINFO_CLASS)).not.to.have.class(
       MOREINFO_VISIBLE_CLASS
     );
   });
@@ -87,7 +87,7 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
     moreInfoLinkUrl = 'https://example.com/more-info.html';
 
     await infoDialog.build();
-    expect(infoDialog.element_.querySelector(MOREINFO_CLASS)).to.have.class(
+    expect(infoDialog.element.querySelector(MOREINFO_CLASS)).to.have.class(
       MOREINFO_VISIBLE_CLASS
     );
   });
@@ -100,15 +100,15 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
   it('should show the info dialog on store property update', async () => {
     await infoDialog.build();
     storeService.dispatch(Action.TOGGLE_INFO_DIALOG, true);
-    expect(infoDialog.element_).to.have.class(DIALOG_VISIBLE_CLASS);
+    expect(infoDialog.element).to.have.class(DIALOG_VISIBLE_CLASS);
   });
 
   it('should hide the info dialog on click on the overlay', async () => {
     await infoDialog.build();
     storeService.dispatch(Action.TOGGLE_INFO_DIALOG, true);
-    infoDialog.element_.dispatchEvent(new Event('click'));
+    infoDialog.element.dispatchEvent(new Event('click'));
 
-    expect(infoDialog.element_).not.to.have.class(DIALOG_VISIBLE_CLASS);
+    expect(infoDialog.element).not.to.have.class(DIALOG_VISIBLE_CLASS);
     expect(storeService.get(StateProperty.INFO_DIALOG_STATE)).to.be.false;
   });
 
@@ -117,7 +117,7 @@ describes.realWin('amp-story-info-dialog', {amp: true}, (env) => {
     storeService.dispatch(Action.TOGGLE_INFO_DIALOG, true);
     infoDialog.innerContainerEl_.dispatchEvent(new Event('click'));
 
-    expect(infoDialog.element_).to.have.class(DIALOG_VISIBLE_CLASS);
+    expect(infoDialog.element).to.have.class(DIALOG_VISIBLE_CLASS);
     expect(storeService.get(StateProperty.INFO_DIALOG_STATE)).to.be.true;
   });
 });

--- a/extensions/amp-story/1.0/test/test-amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-share-menu.js
@@ -53,7 +53,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
     shareMenu.build();
 
     expect(shareMenu.isBuilt()).to.be.true;
-    expect(shareMenu.element_).to.exist;
+    expect(shareMenu.element).to.exist;
   });
 
   it('should append the sharing menu in the parentEl on build', () => {
@@ -83,7 +83,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
 
     shareMenu.build();
 
-    expect(shareMenu.element_.querySelector('.foo')).to.exist;
+    expect(shareMenu.element.querySelector('.foo')).to.exist;
     shareWidgetMock.verify();
   });
 
@@ -92,16 +92,16 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
 
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
 
-    expect(shareMenu.element_).to.have.class(VISIBLE_CLASS);
+    expect(shareMenu.element).to.have.class(VISIBLE_CLASS);
   });
 
   it('should hide the share menu on click on the overlay', () => {
     shareMenu.build();
 
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
-    shareMenu.element_.dispatchEvent(new Event('click'));
+    shareMenu.element.dispatchEvent(new Event('click'));
 
-    expect(shareMenu.element_).not.to.have.class(VISIBLE_CLASS);
+    expect(shareMenu.element).not.to.have.class(VISIBLE_CLASS);
     expect(storeService.get(StateProperty.SHARE_MENU_STATE)).to.be.false;
   });
 
@@ -111,7 +111,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
     storeService.dispatch(Action.TOGGLE_SHARE_MENU, true);
     shareMenu.innerContainerEl_.dispatchEvent(new Event('click'));
 
-    expect(shareMenu.element_).to.have.class(VISIBLE_CLASS);
+    expect(shareMenu.element).to.have.class(VISIBLE_CLASS);
   });
 
   it('should hide the share menu on escape key press', () => {
@@ -134,7 +134,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
 
     shareMenu.build();
 
-    expect(shareMenu.element_.tagName).to.equal('AMP-SOCIAL-SHARE');
+    expect(shareMenu.element.tagName).to.equal('AMP-SOCIAL-SHARE');
   });
 
   it('should hide the amp-social-share button if system share', () => {
@@ -142,7 +142,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
 
     shareMenu.build();
 
-    expect(getStyle(shareMenu.element_, 'visibility')).to.equal('hidden');
+    expect(getStyle(shareMenu.element, 'visibility')).to.equal('hidden');
   });
 
   it('should load the amp-social-share extension if system share', () => {
@@ -160,7 +160,7 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
     shareMenu.build();
 
     const clickCallbackSpy = env.sandbox.spy();
-    shareMenu.element_.addEventListener('click', clickCallbackSpy);
+    shareMenu.element.addEventListener('click', clickCallbackSpy);
 
     // Toggling the share menu dispatches a click event on the amp-social-share
     // button, which triggers the native sharing menu.

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1150,7 +1150,7 @@ describes.realWin(
 
           await story.layoutCallback();
           const clickEvent = new MouseEvent('click', {clientX: 200});
-          story.shareMenu_.element_.dispatchEvent(clickEvent);
+          story.shareMenu_.element.dispatchEvent(clickEvent);
 
           expect(story.activePage_.element.id).to.equal('cover');
         });


### PR DESCRIPTION
Classes attached to a node, like an Element implementation, typically expose `.element` and `.win` properties. These are safe to share since their values are still accessible by circumventing the properties.

Even though public names like `win` or `element` are not mangled so they're longer _uncompressed_, they should be present in the file's compression table if they're commonly used. Thus, this change reduces _compressed_ bundle size by ~0.16k:

|        | `amp-story-1.0.mjs` |
| ------ | ------------------: |
| before |             `74346` |
| after  |             `74186` |

Note that this change only targets `element_` and `win_` for convenience and safety. A followup could go further by replacing less standard, but equivalent names like `.root_`.