### PR TITLE
🏗 Remove `@babel/plugin-transform-react-constant-elements`

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -32,7 +32,6 @@ function getMinifiedConfig() {
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
     './build-system/babel-plugins/babel-plugin-transform-rename-privates',
-    '@babel/plugin-transform-react-constant-elements',
     reactJsxPlugin,
     (argv.esm || argv.sxg) &&
       './build-system/babel-plugins/babel-plugin-transform-dev-methods',

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -31,7 +31,6 @@ function getPreClosureConfig() {
     './build-system/babel-plugins/babel-plugin-transform-inline-isenumvalue',
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
-    '@babel/plugin-transform-react-constant-elements',
     reactJsxPlugin,
     argv.esm || argv.sxg
       ? './build-system/babel-plugins/babel-plugin-transform-dev-methods'

--- a/build-system/babel-config/test-config.js
+++ b/build-system/babel-config/test-config.js
@@ -52,7 +52,6 @@ function getTestConfig() {
     './build-system/babel-plugins/babel-plugin-transform-json-configuration',
     './build-system/babel-plugins/babel-plugin-transform-jss',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
-    '@babel/plugin-transform-react-constant-elements',
     '@babel/plugin-transform-classes',
     reactJsxPlugin,
   ].filter(Boolean);

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -41,7 +41,6 @@ function getUnminifiedConfig() {
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
     './build-system/babel-plugins/babel-plugin-transform-amp-extension-call',
-    '@babel/plugin-transform-react-constant-elements',
     '@babel/plugin-transform-classes',
     reactJsxPlugin,
   ].filter(Boolean);

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "@babel/plugin-proposal-class-properties": "7.14.5",
         "@babel/plugin-syntax-import-assertions": "7.14.5",
         "@babel/plugin-transform-classes": "7.14.9",
-        "@babel/plugin-transform-react-constant-elements": "7.14.5",
         "@babel/plugin-transform-react-jsx": "7.14.9",
         "@babel/preset-env": "7.15.0",
         "@babel/runtime": "7.15.3",
@@ -1656,20 +1655,6 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.14.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-constant-elements": {
       "version": "7.14.5",
       "dev": true,
       "license": "MIT",
@@ -24272,13 +24257,6 @@
       }
     },
     "@babel/plugin-transform-property-literals": {
-      "version": "7.14.5",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      }
-    },
-    "@babel/plugin-transform-react-constant-elements": {
       "version": "7.14.5",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@babel/plugin-proposal-class-properties": "7.14.5",
     "@babel/plugin-syntax-import-assertions": "7.14.5",
     "@babel/plugin-transform-classes": "7.14.9",
-    "@babel/plugin-transform-react-constant-elements": "7.14.5",
     "@babel/plugin-transform-react-jsx": "7.14.9",
     "@babel/preset-env": "7.15.0",
     "@babel/runtime": "7.15.3",


### PR DESCRIPTION
This transform breaks `#core/dom/jsx`. It does not provide much benefit in our case when using `#preact` either, so we disable it.