### PR TITLE
🏗 Force `amp visual-diff` to wait for the Percy agent to be reachable

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -29,6 +29,7 @@ const {
 } = require('../../common/git');
 const {cyan, green, red, yellow} = require('kleur/colors');
 const {isCiBuild} = require('../../common/ci');
+const {isPercyEnabled} = require('@percy/sdk-utils');
 const {startServer, stopServer} = require('../serve');
 
 // CSS injected in every page tested.
@@ -62,6 +63,7 @@ const HOST = 'localhost';
 const PORT = 8000;
 const PERCY_AGENT_PORT = 5338;
 const WAIT_FOR_TABS_MS = 1000;
+const WAIT_FOR_AGENT_MS = 5000;
 
 // Multiple tabs speed up the performance of the visual diff tests.
 const MAX_PARALLEL_TABS = os.cpus().length;
@@ -196,7 +198,29 @@ async function launchPercyAgent(browserFetcher) {
     },
   });
 
-  log('info', 'Percy agent is reachable on port', PERCY_AGENT_PORT);
+  await new Promise((resolve, reject) => {
+    const percyIsEnabledTimeout = setTimeout(() => {
+      log('fatal', 'Percy agent is unreachable after', WAIT_FOR_AGENT_MS, 'ms');
+      reject(false);
+    }, WAIT_FOR_AGENT_MS);
+
+    while (true) {
+      try {
+        if (isPercyEnabled()) {
+          clearTimeout(percyIsEnabledTimeout);
+          log(
+            'info',
+            'Percy agent is enabled and reachable on port',
+            PERCY_AGENT_PORT
+          );
+          resolve(true);
+        }
+      } catch {
+        // Ignore transient errors. Promise will reject after WAIT_FOR_AGENT_MS.
+      }
+    }
+  });
+
   if (process.env['PERCY_TARGET_COMMIT']) {
     log(
       'info',

--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -213,7 +213,7 @@ async function launchPercyAgent(browserFetcher) {
             'Percy agent is enabled and reachable on port',
             PERCY_AGENT_PORT
           );
-          resolve(true);
+          return resolve(true);
         }
       } catch {
         // Ignore transient errors. Promise will reject after WAIT_FOR_AGENT_MS.

--- a/build-system/tasks/visual-diff/package-lock.json
+++ b/build-system/tasks/visual-diff/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@percy/core": "1.0.0-beta.70",
         "@percy/puppeteer": "2.0.0",
+        "@percy/sdk-utils": "1.0.0-beta.70",
         "@types/puppeteer": "5.4.4",
         "puppeteer": "10.4.0"
       }

--- a/build-system/tasks/visual-diff/package.json
+++ b/build-system/tasks/visual-diff/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@percy/core": "1.0.0-beta.70",
     "@percy/puppeteer": "2.0.0",
+    "@percy/sdk-utils": "1.0.0-beta.70",
     "@types/puppeteer": "5.4.4",
     "puppeteer": "10.4.0"
   }


### PR DESCRIPTION
Attempt at fixing the issue found by @alanorozco: https://app.circleci.com/pipelines/github/ampproject/amphtml/18737/workflows/5c398bd7-f6e6-448c-a10c-8ebe0548cc9c/jobs/349250?invite=true#step-113-90