### PR TITLE
♻️[amp story page advancement] handle clicks on drawer

### DIFF
--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -462,10 +462,7 @@ export class ManualAdvancement extends AdvancementConfig {
       (el) => {
         tagName = el.tagName.toLowerCase();
 
-        if (
-          tagName === 'amp-story-page-attachment' ||
-          tagName === 'amp-story-page-outlink'
-        ) {
+        if (el.classList.contains('amp-story-draggable-drawer-root')) {
           shouldHandleEvent = false;
           return true;
         }


### PR DESCRIPTION
This simplifies the handle event check when a click is inside a draggable drawer.

This checks if the element is a draggable drawer rather than checking the tag name of elements that extend the draggable drawer.

This will be helpful in the future - when other elements extend draggable drawer (such as `amp-story-shopping-attachment`), we will not need to add another tag to this list.