### PR TITLE
🖍 [Attachment Forms] Remove the 'www.' prefix from the displayed publisher domain in the page attachment header

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -509,7 +509,8 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    * @private
    */
   getPublisherOrigin_() {
-    const publisherOrigin = getSourceOrigin(this.getAmpDoc().getUrl());
-    return publisherOrigin.replace(/https?:\/\//, '');
+    let publisherOrigin = getSourceOrigin(this.getAmpDoc().getUrl());
+    publisherOrigin = publisherOrigin.replace(/https?:\/\//, '');
+    return publisherOrigin.replace(/^www./, '');
   }
 }

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -509,8 +509,7 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    * @private
    */
   getPublisherOrigin_() {
-    let publisherOrigin = getSourceOrigin(this.getAmpDoc().getUrl());
-    publisherOrigin = publisherOrigin.replace(/https?:\/\//, '');
-    return publisherOrigin.replace(/^www./, '');
+    const publisherOrigin = getSourceOrigin(this.getAmpDoc().getUrl());
+    return publisherOrigin.replace(/^http(s)?:\/\/(www.)?/, '');
   }
 }


### PR DESCRIPTION
#35569