### PR TITLE
🐛 Added back JS for vh

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -59,7 +59,7 @@ import {isPrerenderActivePage} from './prerender-active-page';
 import {listen, listenOnce} from '#utils/event-helper';
 import {CSS as pageAttachmentCSS} from '../../../build/amp-story-open-page-attachment-0.1.css';
 import {propagateAttributes} from '#core/dom/propagate-attributes';
-import {toggle} from '#core/dom/style';
+import {px, toggle} from '#core/dom/style';
 import {renderPageAttachmentUI} from './amp-story-open-page-attachment';
 import {renderPageDescription} from './semantic-render';
 import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
@@ -212,6 +212,9 @@ export class AmpStoryPage extends AMP.BaseElement {
 
     /** @private {?AdvancementConfig} */
     this.advancement_ = null;
+
+    /** @private {?Element} */
+    this.cssVariablesStyleEl_ = null;
 
     /** @const @private {!function(boolean)} */
     this.debounceToggleLoadingSpinner_ = debounce(
@@ -622,6 +625,7 @@ export class AmpStoryPage extends AMP.BaseElement {
           const {height, width} = layoutBox;
           state.height = height;
           state.width = width;
+          state.vh = height / 100;
         },
         mutate: (state) => {
           const {height, width} = state;
@@ -629,6 +633,15 @@ export class AmpStoryPage extends AMP.BaseElement {
             return;
           }
           this.storeService_.dispatch(Action.SET_PAGE_SIZE, {height, width});
+          if (!this.cssVariablesStyleEl_) {
+            const doc = this.win.document;
+            this.cssVariablesStyleEl_ = doc.createElement('style');
+            this.cssVariablesStyleEl_.setAttribute('type', 'text/css');
+            doc.head.appendChild(this.cssVariablesStyleEl_);
+          }
+          this.cssVariablesStyleEl_.textContent = `:root {--story-page-vh: ${px(
+            state.vh
+          )} !important}`;
         },
       },
       {}


### PR DESCRIPTION
Fixes #36711

Reverts removing the JS units calculation from #36033

Before / After (URLs match the [original story](https://stories.nws.ai/1288496525/new-omnichannel-customer-experiences/) and the [demo story with change](https://stories-demos-matias.web.app/examples/amp-story/nws.html))
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/22420856/139943747-9afcd71b-c386-438b-a07b-50c128418a56.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/22420856/139943771-8c666d8b-e298-4dbd-a49c-e0fc80c0e2a9.png">
</td>
</tr>
</table>

Also tested, and the styles for the desktop one-panel are not affected by the bug, and are also not affected by this fix (those styles are overriden). Also, the desktop one-panel is not shown on mobile UIs.