### PR TITLE
✨ Render page level CTA when amp-story-shopping-attachment exists

### DIFF
--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -17,12 +17,20 @@
         publisher="AMP Story Shopping"
         publisher-logo-src="example.com/logo.png"
         poster-portrait-src="example.com/poster.jpg">
-      <amp-story-page id="example">
+      <amp-story-page id="default">
         <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag></amp-story-shopping-tag>
         </amp-story-grid-layer>
         <amp-story-shopping-attachment layout='nodisplay'></amp-story-shopping-attachment>
+      </amp-story-page>
+      
+      <amp-story-page id="dark theme">
+        <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+        <amp-story-shopping-attachment layout='nodisplay' theme="dark"></amp-story-shopping-attachment>
       </amp-story-page>
     </amp-story>
   </body>

--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -25,7 +25,7 @@
         <amp-story-shopping-attachment layout='nodisplay'></amp-story-shopping-attachment>
       </amp-story-page>
       
-      <amp-story-page id="dark theme">
+      <amp-story-page id="dark-theme">
         <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag></amp-story-shopping-tag>

--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -24,7 +24,7 @@
         </amp-story-grid-layer>
         <amp-story-shopping-attachment layout='nodisplay'></amp-story-shopping-attachment>
       </amp-story-page>
-      
+
       <amp-story-page id="dark-theme">
         <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
         <amp-story-grid-layer template="vertical">

--- a/examples/visual-tests/amp-story/amp-story-shopping.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-story-shopping" src="https://cdn.ampproject.org/v0/amp-story-shopping-0.1.js"></script>        
+    <title>AMP Story Shopping</title>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <link rel="canonical" href="index.html">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <style amp-custom>
+      .i-amphtml-story-spinner-container {
+        /* Hide the spinner for loading pages, since this causes flakes */
+        display: none;
+      }
+    </style>
+  </head>
+
+  <body>
+    <amp-story standalone publisher="AMP Team" title="Visual Diff Test"
+        publisher-logo-src="/examples/visual-tests/photos/120.png"
+        poster-portrait-src="/examples/visual-tests/picsum.photos/image981_900x1600.jpg"
+        poster-landscape-src="/examples/visual-tests/picsum.photos/image981_1600x900.jpg"
+        poster-square-src="/examples/visual-tests/picsum.photos/image981_1600x1600.jpg"
+        supports-landscape>
+      <amp-story-page id="default">
+        <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+        <amp-story-shopping-attachment layout='nodisplay'></amp-story-shopping-attachment>
+      </amp-story-page>
+
+      <amp-story-page id="dark-theme">
+        <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+        <amp-story-shopping-attachment layout='nodisplay' theme="dark"></amp-story-shopping-attachment>
+      </amp-story-page>      
+    </amp-story>
+  </body>
+</html>

--- a/examples/visual-tests/amp-story/amp-story-shopping.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
-    <script async custom-element="amp-story-shopping" src="https://cdn.ampproject.org/v0/amp-story-shopping-0.1.js"></script>        
+    <script async custom-element="amp-story-shopping" src="https://cdn.ampproject.org/v0/amp-story-shopping-0.1.js"></script>
     <title>AMP Story Shopping</title>
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <link rel="canonical" href="index.html">
@@ -38,7 +38,7 @@
           <amp-story-shopping-tag></amp-story-shopping-tag>
         </amp-story-grid-layer>
         <amp-story-shopping-attachment layout='nodisplay' theme="dark"></amp-story-shopping-attachment>
-      </amp-story-page>      
+      </amp-story-page>
     </amp-story>
   </body>
 </html>

--- a/examples/visual-tests/amp-story/amp-story-shopping.js
+++ b/examples/visual-tests/amp-story/amp-story-shopping.js
@@ -2,7 +2,7 @@
 
 const {
   verifySelectorsVisible,
-} = require('../../../build-system/tasks/visual-diff/helpers');
+} = require('../../../build-system/tasks/visual-diff/verifiers');
 
 module.exports = {
   'dark theme - shopping CTA UI should display': async (page, name) => {

--- a/examples/visual-tests/amp-story/amp-story-shopping.js
+++ b/examples/visual-tests/amp-story/amp-story-shopping.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const {
+  verifySelectorsVisible,
+} = require('../../../build-system/tasks/visual-diff/helpers');
+
+module.exports = {
+  'default shopping CTA UI should display': async (page, name) => {
+    const pageID = 'default';
+    const url = await page.url();
+    await page.goto(`${url}#page=${pageID}`);
+    await page.waitForSelector(
+      `amp-story-page#${pageID}[active][distance="0"]`
+    );
+    await verifySelectorsVisible(page, name, [
+      '.i-amphtml-story-page-open-attachment[active]',
+    ]);
+  },
+
+  'dark theme - shopping CTA UI should display': async (page, name) => {
+    const pageID = 'dark-theme';
+    const url = await page.url();
+    await page.goto(`${url}#page=${pageID}`);
+    await page.waitForSelector(
+      `amp-story-page#${pageID}[active][distance="0"]`
+    );
+    await verifySelectorsVisible(page, name, [
+      '.i-amphtml-story-page-open-attachment[active]',
+    ]);
+  },
+};

--- a/examples/visual-tests/amp-story/amp-story-shopping.js
+++ b/examples/visual-tests/amp-story/amp-story-shopping.js
@@ -5,18 +5,6 @@ const {
 } = require('../../../build-system/tasks/visual-diff/helpers');
 
 module.exports = {
-  'default shopping CTA UI should display': async (page, name) => {
-    const pageID = 'default';
-    const url = await page.url();
-    await page.goto(`${url}#page=${pageID}`);
-    await page.waitForSelector(
-      `amp-story-page#${pageID}[active][distance="0"]`
-    );
-    await verifySelectorsVisible(page, name, [
-      '.i-amphtml-story-page-open-attachment[active]',
-    ]);
-  },
-
   'dark theme - shopping CTA UI should display': async (page, name) => {
     const pageID = 'dark-theme';
     const url = await page.url();

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1708,7 +1708,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   renderOpenAttachmentUI_() {
     // AttachmentEl can be any component that extends draggable drawer.
     const attachmentEl = this.element.querySelector(
-      '.amp-story-draggable-drawer-root'
+      'amp-story-page-attachment, amp-story-page-outlink, amp-story-shopping-attachment'
     );
     if (!attachmentEl) {
       return;
@@ -1762,7 +1762,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   openAttachment(shouldAnimate = true) {
     const attachmentEl = this.element.querySelector(
-      '.amp-story-draggable-drawer-root'
+      'amp-story-page-attachment, amp-story-page-outlink, amp-story-shopping-attachment'
     );
 
     if (!attachmentEl) {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1708,7 +1708,7 @@ export class AmpStoryPage extends AMP.BaseElement {
   renderOpenAttachmentUI_() {
     // AttachmentEl can be any component that extends draggable drawer.
     const attachmentEl = this.element.querySelector(
-      'amp-story-page-attachment, amp-story-page-outlink, amp-story-shopping-attachment'
+      '.amp-story-draggable-drawer-root'
     );
     if (!attachmentEl) {
       return;
@@ -1762,7 +1762,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   openAttachment(shouldAnimate = true) {
     const attachmentEl = this.element.querySelector(
-      'amp-story-page-attachment, amp-story-page-outlink, amp-story-shopping-attachment'
+      '.amp-story-draggable-drawer-root'
     );
 
     if (!attachmentEl) {

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1706,9 +1706,9 @@ export class AmpStoryPage extends AMP.BaseElement {
    * @private
    */
   renderOpenAttachmentUI_() {
-    // AttachmentEl can be either amp-story-page-attachment or amp-story-page-outlink
+    // AttachmentEl can be any component that extends draggable drawer.
     const attachmentEl = this.element.querySelector(
-      'amp-story-page-attachment, amp-story-page-outlink'
+      'amp-story-page-attachment, amp-story-page-outlink, amp-story-shopping-attachment'
     );
     if (!attachmentEl) {
       return;
@@ -1762,7 +1762,7 @@ export class AmpStoryPage extends AMP.BaseElement {
    */
   openAttachment(shouldAnimate = true) {
     const attachmentEl = this.element.querySelector(
-      'amp-story-page-attachment, amp-story-page-outlink'
+      'amp-story-page-attachment, amp-story-page-outlink, amp-story-shopping-attachment'
     );
 
     if (!attachmentEl) {

--- a/test/visual-diff/visual-tests.jsonc
+++ b/test/visual-diff/visual-tests.jsonc
@@ -809,6 +809,13 @@
       "viewport": {"width": 1440, "height": 900},
       "loading_complete_selectors": [".i-amphtml-story-loaded"],
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment.js"
-    }
+    },
+    {
+      "url": "examples/visual-tests/amp-story/amp-story-shopping.html",
+      "name": "amp-story-shopping UI",
+      "viewport": {"width": 320, "height": 480},
+      "loading_complete_selectors": [".i-amphtml-story-loaded"],
+      "interactive_tests": "examples/visual-tests/amp-story/amp-story-shopping.js"
+    }    
   ]
 }


### PR DESCRIPTION
Adds `amp-story-shopping-attachment` to list of elements that need a CTA button rendered.
Adds visual test for default and dark theme.
Adds example for dark theme.

Fixes #36697