### PR TITLE
🏗🐛 Annotate JSX SVG namespace during build-time

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -32,6 +32,7 @@ function getMinifiedConfig() {
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
     './build-system/babel-plugins/babel-plugin-transform-rename-privates',
+    './build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace',
     reactJsxPlugin,
     (argv.esm || argv.sxg) &&
       './build-system/babel-plugins/babel-plugin-transform-dev-methods',

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -31,6 +31,7 @@ function getPreClosureConfig() {
     './build-system/babel-plugins/babel-plugin-transform-inline-isenumvalue',
     './build-system/babel-plugins/babel-plugin-transform-fix-leading-comments',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
+    './build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace',
     reactJsxPlugin,
     argv.esm || argv.sxg
       ? './build-system/babel-plugins/babel-plugin-transform-dev-methods'

--- a/build-system/babel-config/test-config.js
+++ b/build-system/babel-config/test-config.js
@@ -53,6 +53,7 @@ function getTestConfig() {
     './build-system/babel-plugins/babel-plugin-transform-jss',
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
     '@babel/plugin-transform-classes',
+    './build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace',
     reactJsxPlugin,
   ].filter(Boolean);
   const testPresets = [presetEnv];

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -42,6 +42,7 @@ function getUnminifiedConfig() {
     './build-system/babel-plugins/babel-plugin-transform-promise-resolve',
     './build-system/babel-plugins/babel-plugin-transform-amp-extension-call',
     '@babel/plugin-transform-classes',
+    './build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace',
     reactJsxPlugin,
   ].filter(Boolean);
   const unminifiedPresets = [presetEnv];

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -41,7 +41,6 @@ const svgTags = new Set([
   'feTile',
   'feTurbulence',
   'filter',
-  'foreignObject',
   'g',
   'image',
   'line',
@@ -91,6 +90,11 @@ module.exports = function (babel) {
           return;
         }
         const {name} = path.node.name;
+        if (name === 'foreignObject') {
+          throw path.buildCodeFrameError(
+            '<foreignObject> is not supported. See src/core/dom/jsx.js'
+          );
+        }
         if (svgTags.has(name)) {
           path.node.attributes = path.node.attributes.filter(
             // We can remove this for bundle size since the renderer will

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -96,11 +96,6 @@ module.exports = function (babel) {
           );
         }
         if (svgTags.has(name)) {
-          path.node.attributes = path.node.attributes.filter(
-            // We can remove this for bundle size since the renderer will
-            // create the element with a given namespace anyway.
-            (attr) => attr.name.name !== 'xmlns'
-          );
           path.node.attributes.push(t.jsxAttribute(t.jsxIdentifier('__svg')));
         }
       },

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -89,8 +89,7 @@ module.exports = function (babel) {
         if (!isCoreDomJsx) {
           return;
         }
-        const {name} = path.node.name;
-        if (!svgTags.has(name)) {
+        if (!svgTags.has(path.node.name.name)) {
           return;
         }
         if (path.node.attributes.find((attr) => attr.name.name === 'xmlns')) {

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -2,8 +2,8 @@
  * @fileoverview
  * SVG Elements must be especially created with createElementNS.
  *
- * This transforms JSX elements with SVG namespaces so that they include an
- * '__svg' magic prop in order to create the DOM nodes correctly.
+ * This transforms SVG-related JSX elements in order to always include an
+ * 'xmlns' prop that's used to create the DOM nodes correctly.
  *
  * This prop is consumed by core/dom/jsx. We ignore files that do not import
  * this module.
@@ -90,14 +90,18 @@ module.exports = function (babel) {
           return;
         }
         const {name} = path.node.name;
-        if (name === 'foreignObject') {
-          throw path.buildCodeFrameError(
-            '<foreignObject> is not supported. See src/core/dom/jsx.js'
-          );
+        if (!svgTags.has(name)) {
+          return;
         }
-        if (svgTags.has(name)) {
-          path.node.attributes.push(t.jsxAttribute(t.jsxIdentifier('__svg')));
+        if (path.node.attributes.find((attr) => attr.name.name === 'xmlns')) {
+          return;
         }
+        path.node.attributes.push(
+          t.jsxAttribute(
+            t.jsxIdentifier('xmlns'),
+            t.stringLiteral('http://www.w3.org/2000/svg')
+          )
+        );
       },
     },
   };

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -41,6 +41,7 @@ const svgTags = new Set([
   'feTile',
   'feTurbulence',
   'filter',
+  'foreignObject',
   'g',
   'image',
   'line',

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -80,6 +80,7 @@ module.exports = function (babel) {
             ImportDeclaration(path) {
               if (path.node.source.value.endsWith('/core/dom/jsx')) {
                 isCoreDomJsx = true;
+                path.stop();
               }
             },
           });

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -91,6 +91,11 @@ module.exports = function (babel) {
         }
         const {name} = path.node.name;
         if (svgTags.has(name)) {
+          path.node.attributes = path.node.attributes.filter(
+            // We can remove this for bundle size since the renderer will
+            // create the element with a given namespace anyway.
+            (attr) => attr.name.name !== 'xmlns'
+          );
           path.node.attributes.push(t.jsxAttribute(t.jsxIdentifier('__svg')));
         }
       },

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview
+ * SVG Elements must be especially created with createElementNS.
+ *
+ * This transforms JSX elements with SVG namespaces so that they include an
+ * '__svg' magic prop in order to create the DOM nodes correctly.
+ *
+ * This prop is consumed by core/dom/jsx. We ignore files that do not import
+ * this module.
+ */
+
+const svgTags = new Set([
+  'animate',
+  'circle',
+  'clipPath',
+  'defs',
+  'desc',
+  'ellipse',
+  'feBlend',
+  'feColorMatrix',
+  'feComponentTransfer',
+  'feComposite',
+  'feConvolveMatrix',
+  'feDiffuseLighting',
+  'feDisplacementMap',
+  'feDistantLight',
+  'feFlood',
+  'feFuncA',
+  'feFuncB',
+  'feFuncG',
+  'feFuncR',
+  'feGaussianBlur',
+  'feImage',
+  'feMerge',
+  'feMergeNode',
+  'feMorphology',
+  'feOffset',
+  'fePointLight',
+  'feSpecularLighting',
+  'feSpotLight',
+  'feTile',
+  'feTurbulence',
+  'filter',
+  'foreignObject',
+  'g',
+  'image',
+  'line',
+  'linearGradient',
+  'marker',
+  'mask',
+  'metadata',
+  'path',
+  'pattern',
+  'polygon',
+  'polyline',
+  'radialGradient',
+  'rect',
+  'stop',
+  'svg',
+  'switch',
+  'symbol',
+  'text',
+  'textPath',
+  'tspan',
+  'use',
+  'view',
+]);
+
+module.exports = function (babel) {
+  const {types: t} = babel;
+
+  let isCoreDomJsx = false;
+  return {
+    name: 'dom-jsx-svg-namespace',
+    visitor: {
+      Program: {
+        enter(path) {
+          isCoreDomJsx = false;
+          path.traverse({
+            ImportDeclaration(path) {
+              if (path.node.source.value.endsWith('/core/dom/jsx')) {
+                isCoreDomJsx = true;
+              }
+            },
+          });
+        },
+      },
+      JSXOpeningElement(path) {
+        if (!isCoreDomJsx) {
+          return;
+        }
+        const {name} = path.node.name;
+        if (svgTags.has(name)) {
+          path.node.attributes.push(t.jsxAttribute(t.jsxIdentifier('__svg')));
+        }
+      },
+    },
+  };
+};

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -95,6 +95,9 @@ module.exports = function (babel) {
             '<foreignObject> is not supported. See src/core/dom/jsx.js'
           );
         }
+        if (!svgTags.has(name)) {
+          return;
+        }
         if (path.node.attributes.find((attr) => attr.name.name === 'xmlns')) {
           return;
         }

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/index.js
@@ -41,7 +41,6 @@ const svgTags = new Set([
   'feTile',
   'feTurbulence',
   'filter',
-  'foreignObject',
   'g',
   'image',
   'line',
@@ -90,8 +89,11 @@ module.exports = function (babel) {
         if (!isCoreDomJsx) {
           return;
         }
-        if (!svgTags.has(path.node.name.name)) {
-          return;
+        const {name} = path.node.name;
+        if (name === 'foreignObject') {
+          throw path.buildCodeFrameError(
+            '<foreignObject> is not supported. See src/core/dom/jsx.js'
+          );
         }
         if (path.node.attributes.find((attr) => attr.name.name === 'xmlns')) {
           return;

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/input.mjs
@@ -1,0 +1,10 @@
+// Import does not end with core/dom/jsx so we ignore this file.
+/** @jsx Preact.createElement */
+import * as Preact from 'preact';
+
+() => <svg />;
+() => <path foo="bar" />;
+() => <circle foo="bar" />;
+
+() => <div />;
+() => <span class="whatever" />;

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/input.mjs
@@ -3,6 +3,7 @@
 import * as Preact from 'preact';
 
 () => <svg />;
+() => <svg xmlns="http://www.w3.org/2000/svg" />;
 () => <path foo="bar" />;
 () => <circle foo="bar" />;
 

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/options.json
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../..",
+    "@babel/plugin-transform-react-jsx"
+  ]
+}

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/output.mjs
@@ -5,6 +5,10 @@ import * as Preact from 'preact';
 
 () => Preact.createElement("svg", null);
 
+() => Preact.createElement("svg", {
+  xmlns: "http://www.w3.org/2000/svg"
+});
+
 () => Preact.createElement("path", {
   foo: "bar"
 });

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/ignored/output.mjs
@@ -1,0 +1,20 @@
+// Import does not end with core/dom/jsx so we ignore this file.
+
+/** @jsx Preact.createElement */
+import * as Preact from 'preact';
+
+() => Preact.createElement("svg", null);
+
+() => Preact.createElement("path", {
+  foo: "bar"
+});
+
+() => Preact.createElement("circle", {
+  foo: "bar"
+});
+
+() => Preact.createElement("div", null);
+
+() => Preact.createElement("span", {
+  class: "whatever"
+});

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/input.mjs
@@ -2,6 +2,7 @@
 import * as jsx from '../ANYWHERE_THAT_LEADS_TO/core/dom/jsx';
 
 () => <svg />;
+() => <svg xmlns="http://www.w3.org/2000/svg" />;
 () => <path foo="bar" />;
 () => <circle foo="bar" />;
 

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/input.mjs
@@ -1,0 +1,9 @@
+/** @jsx jsx.createElement */
+import * as jsx from '../ANYWHERE_THAT_LEADS_TO/core/dom/jsx';
+
+() => <svg />;
+() => <path foo="bar" />;
+() => <circle foo="bar" />;
+
+() => <div />;
+() => <span class="whatever" />;

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/options.json
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../..",
+    "@babel/plugin-transform-react-jsx"
+  ]
+}

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/output.mjs
@@ -2,21 +2,21 @@
 import * as jsx from '../ANYWHERE_THAT_LEADS_TO/core/dom/jsx';
 
 () => jsx.createElement("svg", {
-  __svg: true
+  xmlns: "http://www.w3.org/2000/svg"
 });
 
 () => jsx.createElement("svg", {
-  __svg: true
+  xmlns: "http://www.w3.org/2000/svg"
 });
 
 () => jsx.createElement("path", {
   foo: "bar",
-  __svg: true
+  xmlns: "http://www.w3.org/2000/svg"
 });
 
 () => jsx.createElement("circle", {
   foo: "bar",
-  __svg: true
+  xmlns: "http://www.w3.org/2000/svg"
 });
 
 () => jsx.createElement("div", null);

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/output.mjs
@@ -1,0 +1,22 @@
+/** @jsx jsx.createElement */
+import * as jsx from '../ANYWHERE_THAT_LEADS_TO/core/dom/jsx';
+
+() => jsx.createElement("svg", {
+  __svg: true
+});
+
+() => jsx.createElement("path", {
+  foo: "bar",
+  __svg: true
+});
+
+() => jsx.createElement("circle", {
+  foo: "bar",
+  __svg: true
+});
+
+() => jsx.createElement("div", null);
+
+() => jsx.createElement("span", {
+  class: "whatever"
+});

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/fixtures/transform/sets-prop/output.mjs
@@ -5,6 +5,10 @@ import * as jsx from '../ANYWHERE_THAT_LEADS_TO/core/dom/jsx';
   __svg: true
 });
 
+() => jsx.createElement("svg", {
+  __svg: true
+});
+
 () => jsx.createElement("path", {
   foo: "bar",
   __svg: true

--- a/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace/test/index.js
@@ -1,0 +1,3 @@
+const runner = require('@babel/helper-plugin-test-runner').default;
+
+runner(__dirname);

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -82,7 +82,15 @@ export function createElement(tag, props, ...children) {
   if (typeof tag !== 'string') {
     return tag({...props, children});
   }
-  const element = self.document.createElement(tag);
+  // We expect the __svg magic prop to be set during compilation time.
+  // See babel-plugin-dom-jsx-svg-namespace
+  const isSvg = props?.__svg;
+  if (isSvg) {
+    delete props['__svg'];
+  }
+  const element = isSvg
+    ? self.document.createElementNS('http://www.w3.org/2000/svg', tag)
+    : self.document.createElement(tag);
   appendChild(element, children);
   if (props) {
     Object.keys(props).forEach((name) => {

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -24,11 +24,6 @@
  * 🚫 No dangerouslySetInnerHTML
  *   - You should not do this anyway.
  *
- * 🚫 No SVG <foreignObject>
- *   - This tag is rather obscure. You should be able to restructure your tree.
- *     If you absolutely need it, get in touch with `@alanorozco` to consider
- *     enabling support.
- *
  * TODO(https://go.amp.dev/issue/36679): Lint these unsupported features.
  */
 import {devAssert} from '#core/assert';
@@ -87,14 +82,14 @@ export function createElement(tag, props, ...children) {
   if (typeof tag !== 'string') {
     return tag({...props, children});
   }
-  // We expect the __svg magic prop to be set during compilation time.
+  // We expect all SVG-related tags to have `xmlns` set during build time.
   // See babel-plugin-dom-jsx-svg-namespace
-  const isSvg = props?.__svg;
-  if (isSvg) {
-    delete props['__svg'];
+  const xmlns = props?.['xmlns'];
+  if (xmlns) {
+    delete props['xmlns'];
   }
-  const element = isSvg
-    ? self.document.createElementNS('http://www.w3.org/2000/svg', tag)
+  const element = xmlns
+    ? self.document.createElementNS(xmlns, tag)
     : self.document.createElement(tag);
   appendChild(element, children);
   if (props) {

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -24,6 +24,11 @@
  * 🚫 No dangerouslySetInnerHTML
  *   - You should not do this anyway.
  *
+ * 🚫 No SVG <foreignObject>
+ *   - This tag is rather obscure. You should be able to restructure your tree.
+ *     If you absolutely need it, get in touch with `@alanorozco` to consider
+ *     enabling support.
+ *
  * TODO(https://go.amp.dev/issue/36679): Lint these unsupported features.
  */
 import {devAssert} from '#core/assert';

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -144,18 +144,20 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
     );
   });
 
-  it('renders with SVG namespace with props.__svg', () => {
-    const withProp = createElement('svg', {__svg: true});
-    expect(withProp.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+  it('renders with SVG namespace with props.xmlns', () => {
+    const xmlns = 'http://www.w3.org/2000/svg';
+    const withProp = createElement('svg', {xmlns});
+    expect(withProp.namespaceURI).to.equal(xmlns);
     const withoutProp = createElement('svg');
-    expect(withoutProp.namespaceURI).to.not.equal('http://www.w3.org/2000/svg');
+    expect(withoutProp.namespaceURI).to.not.equal(xmlns);
   });
 
-  it('renders with SVG namespace with props.__svg (compiled)', () => {
+  it('renders with SVG namespace with props.xmlns (compiled)', () => {
+    const xmlns = 'http://www.w3.org/2000/svg';
     const withProp = <svg />;
-    expect(withProp.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+    expect(withProp.namespaceURI).to.equal(xmlns);
     const withoutProp = <div />;
-    expect(withoutProp.namespaceURI).to.not.equal('http://www.w3.org/2000/svg');
+    expect(withoutProp.namespaceURI).to.not.equal(xmlns);
   });
 
   describe('unsupported JSX features', () => {

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -144,6 +144,20 @@ describes.sandboxed('#core/dom/jsx', {}, (env) => {
     );
   });
 
+  it('renders with SVG namespace with props.__svg', () => {
+    const withProp = createElement('svg', {__svg: true});
+    expect(withProp.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+    const withoutProp = createElement('svg');
+    expect(withoutProp.namespaceURI).to.not.equal('http://www.w3.org/2000/svg');
+  });
+
+  it('renders with SVG namespace with props.__svg (compiled)', () => {
+    const withProp = <svg />;
+    expect(withProp.namespaceURI).to.equal('http://www.w3.org/2000/svg');
+    const withoutProp = <div />;
+    expect(withoutProp.namespaceURI).to.not.equal('http://www.w3.org/2000/svg');
+  });
+
   describe('unsupported JSX features', () => {
     it('does not support Fragments', () => {
       allowConsoleError(() => {


### PR DESCRIPTION
SVG Elements must be especially created with `createElementNS`.

This transforms SVG-related JSX elements in order to always include an `xmlns` prop that's used to create the DOM nodes correctly.

This prop is consumed by `core/dom/jsx`. We ignore files that do not import this module.

Fixes #36713