### PR TITLE
🏗✨ Add lazy-build support for nested CSS imports

### DIFF
--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -1,7 +1,8 @@
 'use strict';
 
+const cssImports = require('css-imports');
 const cssnano = require('cssnano');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const postcss = require('postcss');
 const postcssImport = require('postcss-import');
@@ -99,11 +100,35 @@ async function transformCssString(contents, opt_filename) {
  */
 async function jsifyCssAsync(filename) {
   const {contents, hash: filehash} = await batchedRead(filename);
-  const hash = md5(filehash, await getEnvironmentHash());
+  const imports = await getCssImports(filename);
+  const importHashes = await Promise.all(
+    imports.map(async (importedFile) => (await batchedRead(importedFile)).hash)
+  );
+  const hash = md5(filehash, ...importHashes, await getEnvironmentHash());
   const result = await transformCss(contents, hash, filename);
 
   result.warnings.forEach((warn) => log(red(warn)));
   return result.css + '\n/*# sourceURL=/' + filename + '*/';
+}
+
+/**
+ * Computes the transitive closure of CSS files imported by the given file.
+ * @param {string} cssFile
+ * @return {Promise<!Array<string>>}
+ */
+async function getCssImports(cssFile) {
+  const contents = await fs.readFile(cssFile);
+  const topLevelImports = cssImports(contents)
+    .map((result) => result.path)
+    .filter((importedFile) => !importedFile.startsWith('http'))
+    .map((importedFile) => path.join(path.dirname(cssFile), importedFile));
+  if (topLevelImports.length == 0) {
+    return topLevelImports;
+  }
+  const nestedImports = await Promise.all(
+    topLevelImports.map(async (file) => await getCssImports(file))
+  );
+  return topLevelImports.concat(nestedImports).flat();
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "codecov": "3.8.3",
         "commander": "7.2.0",
         "connect-header": "0.0.5",
+        "css-imports": "0.3.1",
         "css-selector-tokenizer": "0.8.0",
         "css-what": "5.1.0",
         "cssnano": "5.0.8",
@@ -6934,6 +6935,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-imports": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/css-imports/-/css-imports-0.3.1.tgz",
+      "integrity": "sha1-Xd4qUbwggtcymbFHvVvgPj9Jisw=",
+      "dev": true,
+      "dependencies": {
+        "strip-comments": "~0.1.6"
       }
     },
     "node_modules/css-jss": {
@@ -21556,6 +21566,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strip-comments": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-0.1.6.tgz",
+      "integrity": "sha1-JnsGlX5gbzWHVAXL+wPK5pKrHhY=",
+      "dev": true
+    },
     "node_modules/strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -28049,6 +28065,15 @@
       "dev": true,
       "requires": {
         "timsort": "^0.3.0"
+      }
+    },
+    "css-imports": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/css-imports/-/css-imports-0.3.1.tgz",
+      "integrity": "sha1-Xd4qUbwggtcymbFHvVvgPj9Jisw=",
+      "dev": true,
+      "requires": {
+        "strip-comments": "~0.1.6"
       }
     },
     "css-jss": {
@@ -38186,6 +38211,12 @@
     },
     "strip-color": {
       "version": "0.1.0",
+      "dev": true
+    },
+    "strip-comments": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-0.1.6.tgz",
+      "integrity": "sha1-JnsGlX5gbzWHVAXL+wPK5pKrHhY=",
       "dev": true
     },
     "strip-final-newline": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "codecov": "3.8.3",
     "commander": "7.2.0",
     "connect-header": "0.0.5",
+    "css-imports": "0.3.1",
     "css-selector-tokenizer": "0.8.0",
     "css-what": "5.1.0",
     "cssnano": "5.0.8",


### PR DESCRIPTION
This PR enables the `amp` dev server's watcher to fully rebuild extensions when a nested CSS file is modified.

**User flow:**

1. Launch dev server
```
amp
```

2. Load an `amp-story` [test page](http://127.0.0.1:8000/examples/amp-story/amp-story-desktop-one-panel.html) in a browser
![image](https://user-images.githubusercontent.com/26553114/140111845-c09fde09-d44f-4b88-bb7f-bc7c7c6dfe07.png)

3. Modify a nested CSS file. E.g. Change `background` from `none` to `yellow` in `pagination-buttons.css`
https://github.com/ampproject/amphtml/blob/b829088d4a7e7ca9be0892b585b16e253c93fc9e/extensions/amp-story/1.0/pagination-buttons.css#L17

4. Refresh the browser after the dev server rebuilds `amp-story`
![image](https://user-images.githubusercontent.com/26553114/140113593-0e9b0f75-108a-45a4-b6de-f5df1a7d44bb.png)

Fixes #33826 
