### PR TITLE
terser: enable toplevel, less hacky fix for nameCache local vars

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -551,6 +551,7 @@ async function minify(code, map) {
       keep_quoted_props: true,
     },
     sourceMap: {content: map},
+    toplevel: true,
     module: !!argv.esm,
     nameCache,
   };


### PR DESCRIPTION
Addresses part of https://github.com/ampproject/amphtml/issues/36476#issuecomment-952373926 by enabling the `toplevel` flag.

This significantly shrinks our .js bento builds.
```
extensions/amp-jwplayer/1.0/dist/web-component.js: Δ -5.02KB
extensions/amp-timeago/1.0/dist/web-component.js: Δ -2.68KB
extensions/amp-base-carousel/1.0/dist/web-component.js: Δ -4.04KB
extensions/amp-stream-gallery/1.0/dist/web-component.js: Δ -4.13KB
extensions/amp-lightbox-gallery/1.0/dist/web-component.js: Δ -4.07KB
```
