### PR TITLE
🏗 Explicitly use node LTS for GH actions workflows

### DIFF
--- a/.github/workflows/cross-platform-builds.yml
+++ b/.github/workflows/cross-platform-builds.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
+          check-latest: true
           node-version: lts/*
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh

--- a/.github/workflows/cross-platform-builds.yml
+++ b/.github/workflows/cross-platform-builds.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Set Up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: ${{ matrix.flavor }}

--- a/.github/workflows/cut-nightly.yml
+++ b/.github/workflows/cut-nightly.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
+          check-latest: true
           node-version: lts/*
 
       - name: Set Up Environment

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           check-latest: true
           registry-url: https://registry.npmjs.org
-          node-version: '16'
+          node-version: lts/*
       - name: Install dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: Get latest scripts

--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
+          check-latest: true
           node-version: lts/*
       - uses: actions/checkout@v2
       - run: bash ./.github/workflows/install_dependencies.sh

--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: lts/*
       - uses: actions/checkout@v2
       - name: Add progress comment to cherry-pick issue for Stable and LTS
         if: github.event_name == 'issues' && github.event.action == 'opened'

--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
+          check-latest: true
           node-version: lts/*
       - uses: actions/checkout@v2
       - name: Add progress comment to cherry-pick issue for Stable and LTS

--- a/.github/workflows/sweep-experiments.yml
+++ b/.github/workflows/sweep-experiments.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
+          check-latest: true
           node-version: lts/*
 
       - name: Set Up Environment

--- a/.github/workflows/sweep-experiments.yml
+++ b/.github/workflows/sweep-experiments.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: lts/*
 
       - name: Set Up Environment
         run: sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}


### PR DESCRIPTION
@twifkak noticed that our "cross-platform builds" workflow has been [failing](https://github.com/ampproject/amphtml/actions/runs/1418014332) for a while. Turns out GH actions [still defaults](https://github.com/ampproject/amphtml/runs/4096255028?check_suite_focus=true#step:3:12) to node 14.

**PR Highlights:**
- Explicitly use Node LTS for all workflows that also do a full install of `amphtml` packages. (Workflows that don't do so have been left alone.)
- Also remove any hardcoded references to node 16 (resolves [this](https://github.com/ampproject/amphtml/pull/36646#pullrequestreview-792057870) comment).