### PR TITLE
Examples: create document for component hydration

### DIFF
--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -44,11 +44,10 @@ function posthtmlGetAmpFormat(tree) {
 /**
  * Gets the AMP format type for the given HTML file by parsing its contents and
  * examining the root element.
- * @param {string} file
+ * @param {string} source
  * @return {Promise<string>}
  */
-async function getAmpFormat(file) {
-  const source = await readFile(file, 'utf8');
+async function getAmpFormat(source) {
   if (!formatSuffixes.some((suffix) => source.includes(suffix))) {
     return defaultFormat;
   }
@@ -65,9 +64,14 @@ async function getFileGroups(filesToCheck) {
   logLocalDev(green('Sorting HTML fixtures into format groups...'));
   const fileGroups = {AMP4ADS: [], AMP4EMAIL: [], AMP: []};
   await Promise.all(
-    filesToCheck.map(async (file) =>
-      fileGroups[await getAmpFormat(file)].push(file)
-    )
+    filesToCheck.map(async (file) => {
+      const source = await readFile(file, 'utf8');
+      if (source.includes('<!-- skip-validation -->')) {
+        return;
+      }
+
+      fileGroups[await getAmpFormat(source)].push(file);
+    })
   );
   return fileGroups;
 }

--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -44,10 +44,11 @@ function posthtmlGetAmpFormat(tree) {
 /**
  * Gets the AMP format type for the given HTML file by parsing its contents and
  * examining the root element.
- * @param {string} source
+ * @param {string} file
  * @return {Promise<string>}
  */
-async function getAmpFormat(source) {
+async function getAmpFormat(file) {
+  const source = await readFile(file, 'utf8');
   if (!formatSuffixes.some((suffix) => source.includes(suffix))) {
     return defaultFormat;
   }
@@ -64,14 +65,9 @@ async function getFileGroups(filesToCheck) {
   logLocalDev(green('Sorting HTML fixtures into format groups...'));
   const fileGroups = {AMP4ADS: [], AMP4EMAIL: [], AMP: []};
   await Promise.all(
-    filesToCheck.map(async (file) => {
-      const source = await readFile(file, 'utf8');
-      if (source.includes('<!-- skip-validation -->')) {
-        return;
-      }
-
-      fileGroups[await getAmpFormat(source)].push(file);
-    })
+    filesToCheck.map(async (file) =>
+      fileGroups[await getAmpFormat(file)].push(file)
+    )
   );
   return fileGroups;
 }

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -411,6 +411,9 @@ const htmlFixtureGlobs = [
   '!test/fixtures/e2e/amphtml-ads/image.html',
   '!test/fixtures/e2e/amphtml-ads/lightbox-ad.a4a.html',
   '!test/fixtures/e2e/amphtml-ads/text.html',
+
+  // The following is a server-rendered file which is technically invalid.
+  '!examples/compiler-hydration.html',
 ];
 
 /**

--- a/examples/compiler-hydration.html
+++ b/examples/compiler-hydration.html
@@ -1,4 +1,3 @@
-<!-- skip-validation -->
 <!doctype html>
 <html ⚡ lang="en">
 <head>

--- a/examples/compiler-hydration.html
+++ b/examples/compiler-hydration.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Hydration Test</title>
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+    <!--
+        Manual test file for hydration of server-rendered components.
+        Unlike most AMPHTML pages, this file's components should all be rendered.
+    -->
+
+    <!-- Should create a circle with a 1:1 aspect ratio -->
+    <amp-layout layout="responsive" width="1" height="1" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive" i-amphtml-ssr="">
+        <i-amphtml-sizer slot="i-amphtml-svc" style="padding-top: 100%;"></i-amphtml-sizer>
+        <div class="i-amphtml-fill-content">
+            <svg viewBox="0 0 100 100"><circle cx="50%" cy="50%" r="40%" stroke="black" stroke-width="3"></circle>
+                Sorry, your browser does not support inline SVG.
+            </svg>
+        </div>
+    </amp-layout>
+
+    <!-- Should create a small amp-fit-text with a large lorum ipsum, yielding small text. -->
+    <amp-fit-text width="111px" height="222px" class="i-amphtml-layout-fixed i-amphtml-layout-size-defined" i-amphtml-layout="fixed" i-amphtml-ssr="" style="width: 111px; height: 222px;">
+        <div class="i-amphtml-fill-content i-amphtml-fit-text-content">
+            <div class="i-amphtml-fit-text-content-wrapper">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed ultrices massa. Fusce lacus magna, blandit sed suscipit at, congue mollis sem. Vestibulum molestie tortor eu dui dictum, eget pharetra orci ultricies. Donec venenatis pellentesque massa sit amet mollis. Praesent nisl metus, egestas eu turpis a, tincidunt imperdiet purus. Nulla tincidunt vulputate porta. Sed vitae lacinia ligula, in ultricies ante. Nunc ornare lacus in bibendum mattis. Cras ultricies vel eros pulvinar laoreet. Curabitur sed magna a est interdum mattis eu eget magna. Nam sit amet massa volutpat, pellentesque urna id, pretium magna. Praesent et enim ante. Vestibulum ultricies, urna ac ullamcorper scelerisque, augue est scelerisque massa, nec rhoncus orci sapien at ipsum. Fusce egestas sem non finibus euismod</div>
+        </div>
+        <div class="i-amphtml-fit-text-measurer">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed ultrices massa. Fusce lacus magna, blandit sed suscipit at, congue mollis sem. Vestibulum molestie tortor eu dui dictum, eget pharetra orci ultricies. Donec venenatis pellentesque massa sit amet mollis. Praesent nisl metus, egestas eu turpis a, tincidunt imperdiet purus. Nulla tincidunt vulputate porta. Sed vitae lacinia ligula, in ultricies ante. Nunc ornare lacus in bibendum mattis. Cras ultricies vel eros pulvinar laoreet. Curabitur sed magna a est interdum mattis eu eget magna. Nam sit amet massa volutpat, pellentesque urna id, pretium magna. Praesent et enim ante. Vestibulum ultricies, urna ac ullamcorper scelerisque, augue est scelerisque massa, nec rhoncus orci sapien at ipsum. Fusce egestas sem non finibus euismod</div>
+    </amp-fit-text>
+</html>

--- a/examples/compiler-hydration.html
+++ b/examples/compiler-hydration.html
@@ -7,6 +7,15 @@
   <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom>
+      h1 {
+          text-align: center;
+      }
+      amp-fit-text {
+          left: 50%;
+          transform: translateX(-50%);
+      }
+  </style>
 </head>
 <body>
     <!--
@@ -14,21 +23,30 @@
         Unlike most AMPHTML pages, this file's components should all be rendered.
     -->
 
-    <!-- Should create a circle with a 1:1 aspect ratio -->
-    <amp-layout layout="responsive" width="1" height="1" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive" i-amphtml-ssr="">
-        <i-amphtml-sizer slot="i-amphtml-svc" style="padding-top: 100%;"></i-amphtml-sizer>
+    <h1><code>amp-layout</code> with a 4:1 responsive ratio </h1>
+    <amp-layout layout="responsive" width="4" height="1" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive" i-amphtml-ssr="">
+        <i-amphtml-sizer slot="i-amphtml-svc" style="padding-top: 25%;"></i-amphtml-sizer>
         <div class="i-amphtml-fill-content">
-            <svg viewBox="0 0 100 100"><circle cx="50%" cy="50%" r="40%" stroke="black" stroke-width="3"></circle>
+            <svg viewBox="0 0 100 25">
+                <circle cx="50%" cy="50%" r="15%" stroke="black" stroke-width="3"></circle>
                 Sorry, your browser does not support inline SVG.
             </svg>
         </div>
     </amp-layout>
 
-    <!-- Should create a small amp-fit-text with a large lorum ipsum, yielding small text. -->
+    <h1><code>amp-fit-text</code> with large text</h1>
     <amp-fit-text width="111px" height="222px" class="i-amphtml-layout-fixed i-amphtml-layout-size-defined" i-amphtml-layout="fixed" i-amphtml-ssr="" style="width: 111px; height: 222px;">
         <div class="i-amphtml-fill-content i-amphtml-fit-text-content">
             <div class="i-amphtml-fit-text-content-wrapper">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed ultrices massa. Fusce lacus magna, blandit sed suscipit at, congue mollis sem. Vestibulum molestie tortor eu dui dictum, eget pharetra orci ultricies. Donec venenatis pellentesque massa sit amet mollis. Praesent nisl metus, egestas eu turpis a, tincidunt imperdiet purus. Nulla tincidunt vulputate porta. Sed vitae lacinia ligula, in ultricies ante. Nunc ornare lacus in bibendum mattis. Cras ultricies vel eros pulvinar laoreet. Curabitur sed magna a est interdum mattis eu eget magna. Nam sit amet massa volutpat, pellentesque urna id, pretium magna. Praesent et enim ante. Vestibulum ultricies, urna ac ullamcorper scelerisque, augue est scelerisque massa, nec rhoncus orci sapien at ipsum. Fusce egestas sem non finibus euismod</div>
         </div>
         <div class="i-amphtml-fit-text-measurer">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer sed ultrices massa. Fusce lacus magna, blandit sed suscipit at, congue mollis sem. Vestibulum molestie tortor eu dui dictum, eget pharetra orci ultricies. Donec venenatis pellentesque massa sit amet mollis. Praesent nisl metus, egestas eu turpis a, tincidunt imperdiet purus. Nulla tincidunt vulputate porta. Sed vitae lacinia ligula, in ultricies ante. Nunc ornare lacus in bibendum mattis. Cras ultricies vel eros pulvinar laoreet. Curabitur sed magna a est interdum mattis eu eget magna. Nam sit amet massa volutpat, pellentesque urna id, pretium magna. Praesent et enim ante. Vestibulum ultricies, urna ac ullamcorper scelerisque, augue est scelerisque massa, nec rhoncus orci sapien at ipsum. Fusce egestas sem non finibus euismod</div>
+    </amp-fit-text>
+
+    <h1><code>amp-fit-text</code> with short text</h1>
+    <amp-fit-text width="111px" height="222px" class="i-amphtml-layout-fixed i-amphtml-layout-size-defined" i-amphtml-layout="fixed" i-amphtml-ssr="" style="width: 111px; height: 222px;">
+        <div class="i-amphtml-fill-content i-amphtml-fit-text-content">
+            <div class="i-amphtml-fit-text-content-wrapper">Hello, world</div>
+        </div>
+        <div class="i-amphtml-fit-text-measurer">Hello, world</div>
     </amp-fit-text>
 </html>

--- a/examples/compiler-hydration.html
+++ b/examples/compiler-hydration.html
@@ -1,3 +1,4 @@
+<!-- skip-validation -->
 <!doctype html>
 <html ⚡ lang="en">
 <head>


### PR DESCRIPTION
**summary**
Creates a new amp document in the `examples/` directory for showcasing component hydration.

<img width="755" alt="component hydration" src="https://user-images.githubusercontent.com/4656974/140791423-2d6e6d68-66cc-4da7-8f60-2c3cb6966c49.png">