### PR TITLE
🏗 Restore hard-coded node version in GH actions setup

### DIFF
--- a/.github/workflows/cross-platform-builds.yml
+++ b/.github/workflows/cross-platform-builds.yml
@@ -19,8 +19,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
-          check-latest: true
-          node-version: lts/*
+          node-version: 16
       - name: Install Dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: ${{ matrix.flavor }}

--- a/.github/workflows/cut-nightly.yml
+++ b/.github/workflows/cut-nightly.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
-          check-latest: true
-          node-version: lts/*
+          node-version: 16
 
       - name: Set Up Environment
         run: sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -45,9 +45,8 @@ jobs:
           ref: ${{ github.events.inputs.ampversion }}
       - uses: actions/setup-node@v2
         with:
-          check-latest: true
           registry-url: https://registry.npmjs.org
-          node-version: lts/*
+          node-version: 16
       - name: Install dependencies
         run: bash ./.github/workflows/install_dependencies.sh
       - name: Get latest scripts

--- a/.github/workflows/release-tagger.yml
+++ b/.github/workflows/release-tagger.yml
@@ -27,8 +27,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          check-latest: true
-          node-version: lts/*
+          node-version: 16
       - uses: actions/checkout@v2
       - run: bash ./.github/workflows/install_dependencies.sh
       - name: Run tagger

--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -12,8 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          check-latest: true
-          node-version: lts/*
+          node-version: 16
       - uses: actions/checkout@v2
       - name: Add progress comment to cherry-pick issue for Stable and LTS
         if: github.event_name == 'issues' && github.event.action == 'opened'

--- a/.github/workflows/sweep-experiments.yml
+++ b/.github/workflows/sweep-experiments.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v2
         with:
-          check-latest: true
-          node-version: lts/*
+          node-version: 16
 
       - name: Set Up Environment
         run: sudo chown -R $(whoami) $(npm config get prefix)/{lib/node_modules,bin,share}


### PR DESCRIPTION
While installing node on GH actions, it turns out that `check-latest: true` and `node-version: lts/*` [don't guarantee](https://github.com/ampproject/amphtml/pull/36746#discussion_r742258250) that the latest active LTS version is installed. Probably related to https://github.com/actions/setup-node/issues/26 or https://github.com/actions/setup-node/issues/355.

![140177357-7d2de489-5582-437c-a2d7-8e4acd8957de](https://user-images.githubusercontent.com/26553114/140378457-f3974097-cf53-40cc-9ee8-c24f11c3047a.png)

This PR restores the hard-coded `node-version: 16` and removes `check-latest`. We can revisit this next year when the next active LTS is released.

Addresses https://github.com/ampproject/amphtml/pull/36746#discussion_r742258250
