### PR TITLE
🏗🐛 Restore blank.html for visual diff tests

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -573,7 +573,9 @@ async function createEmptyBuild(browser) {
   const page = await newPage(browser);
 
   try {
-    await page.goto('about:blank');
+    await page.goto(
+      `http://${HOST}:${PORT}/examples/visual-tests/blank-page/blank.html`
+    );
   } catch {
     // Ignore failures
   }


### PR DESCRIPTION
Turns out Percy won't snapshot a page with the url `about:blank`, so `--empty` builds fail because of the change I made in #36673