### PR TITLE
🖍 [Page Attachments] Add the 'Read more' string for translation

### DIFF
--- a/extensions/amp-story/1.0/_locales/en.json
+++ b/extensions/amp-story/1.0/_locales/en.json
@@ -254,5 +254,9 @@
   "99": {
     "string": "Form successfully submitted",
     "description": "Text displayed to users when they press a button to submit a form, and this submission succeeds."
+  },
+  "100": {
+    "string": "Read more",
+    "description": "Label for a button to open a drawer containing additional content."
   }
 }

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -153,9 +153,11 @@ const renderOutlinkUI = (pageEl, attachmentEl) => {
     anchorChild?.textContent ||
     attachmentEl.getAttribute('cta-text') ||
     attachmentEl.getAttribute('data-cta-text');
-  const openLabel = openLabelAttr
-    ? openLabelAttr.trim()
-    : localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
+  // TODO(#36724): Clean this up once the "Read more" CTA has been translated.
+  const fallbackCta =
+    localize(pageEl, LocalizedStringId.AMP_STORY_READ_MORE) ??
+    localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
+  const openLabel = (openLabelAttr && openLabelAttr.trim()) || fallbackCta;
   ctaLabelEl.textContent = openLabel;
   openAttachmentEl.setAttribute('aria-label', openLabel);
 
@@ -197,9 +199,11 @@ const renderInlineUi = (pageEl, attachmentEl) => {
   const openLabelAttr =
     attachmentEl.getAttribute('cta-text') ||
     attachmentEl.getAttribute('data-cta-text');
-  const openLabel =
-    (openLabelAttr && openLabelAttr.trim()) ||
+  // TODO(#36724): Clean this up once the "Read more" CTA has been translated.
+  const fallbackCta =
+    localize(pageEl, LocalizedStringId.AMP_STORY_READ_MORE) ??
     localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
+  const openLabel = (openLabelAttr && openLabelAttr.trim()) || fallbackCta;
   openAttachmentEl.setAttribute('aria-label', openLabel);
 
   if (openLabel !== 'none') {

--- a/extensions/amp-story/1.0/amp-story-open-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-open-page-attachment.js
@@ -153,11 +153,9 @@ const renderOutlinkUI = (pageEl, attachmentEl) => {
     anchorChild?.textContent ||
     attachmentEl.getAttribute('cta-text') ||
     attachmentEl.getAttribute('data-cta-text');
-  // TODO(#36724): Clean this up once the "Read more" CTA has been translated.
-  const fallbackCta =
-    localize(pageEl, LocalizedStringId.AMP_STORY_READ_MORE) ??
-    localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
-  const openLabel = (openLabelAttr && openLabelAttr.trim()) || fallbackCta;
+  const openLabel = openLabelAttr
+    ? openLabelAttr.trim()
+    : localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
   ctaLabelEl.textContent = openLabel;
   openAttachmentEl.setAttribute('aria-label', openLabel);
 
@@ -199,11 +197,9 @@ const renderInlineUi = (pageEl, attachmentEl) => {
   const openLabelAttr =
     attachmentEl.getAttribute('cta-text') ||
     attachmentEl.getAttribute('data-cta-text');
-  // TODO(#36724): Clean this up once the "Read more" CTA has been translated.
-  const fallbackCta =
-    localize(pageEl, LocalizedStringId.AMP_STORY_READ_MORE) ??
+  const openLabel =
+    (openLabelAttr && openLabelAttr.trim()) ||
     localize(pageEl, LocalizedStringId.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL);
-  const openLabel = (openLabelAttr && openLabelAttr.trim()) || fallbackCta;
   openAttachmentEl.setAttribute('aria-label', openLabel);
 
   if (openLabel !== 'none') {

--- a/src/service/localization/strings.js
+++ b/src/service/localization/strings.js
@@ -9,7 +9,7 @@ import {parseJson} from '#core/types/object/json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 100
+ * Next ID: 101
  *
  * @const @enum {string}
  */
@@ -51,6 +51,7 @@ export const LocalizedStringId = {
   AMP_STORY_PAUSE_BUTTON_LABEL: '85',
   AMP_STORY_PLAY_BUTTON_LABEL: '86',
   AMP_STORY_PREVIOUS_PAGE: '93',
+  AMP_STORY_READ_MORE: '100',
   AMP_STORY_REPLAY: '92',
   AMP_STORY_SHARE_BUTTON_LABEL: '69',
   AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT: '4',


### PR DESCRIPTION
As discussed in #36724, we are updating the default CTA for page attachments from "Swipe up" to "Read more". This PR adds this new "Read more" string in the appropriate places to be translated.