### PR TITLE
🐛[story-ads] fix shared exp parsing

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -52,8 +52,9 @@ const MUSTACHE_TAG = 'amp-mustache';
  * Map of experiment IDs that might be enabled by the player to
  * their experiment names. Used to toggle client side experiment on.
  * @const {Object<string, string>}
+ * @visibleForTesting
  */
-const RELEVANT_PLAYER_EXPS = {
+export const RELEVANT_PLAYER_EXPS = {
   [StoryAdSegmentExp.CONTROL]: StoryAdSegmentExp.ID,
   [StoryAdSegmentExp.NO_ADVANCE_BOTH]: StoryAdSegmentExp.ID,
   [StoryAdSegmentExp.NO_ADVANCE_AD]: StoryAdSegmentExp.ID,
@@ -193,7 +194,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
           ids.forEach((id) => {
             const relevantExp = RELEVANT_PLAYER_EXPS[id];
             if (relevantExp) {
-              forceExperimentBranch(this.win, relevantExp, id);
+              forceExperimentBranch(this.win, relevantExp, id.toString());
             }
           });
         }

--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -2,9 +2,7 @@ import {CommonSignals} from '#core/constants/common-signals';
 import {toggleAttribute} from '#core/dom';
 import {svgFor} from '#core/dom/static-template';
 import {setStyle} from '#core/dom/style';
-import {isArray} from '#core/types';
 import {dict} from '#core/types/object';
-import {tryParseJson} from '#core/types/object/json';
 
 import {forceExperimentBranch, getExperimentBranch} from '#experiments';
 import {
@@ -187,19 +185,19 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
     if (!viewer.isEmbedded()) {
       return;
     }
-    viewer./*OK*/ sendMessageAwaitResponse('playerExperiments').then((json) => {
-      if (json) {
-        const obj = tryParseJson(json);
-        const ids = obj['experimentIds'];
-        isArray(ids) &&
+    viewer
+      ./*OK*/ sendMessageAwaitResponse('playerExperiments')
+      .then((expObj) => {
+        const ids = expObj?.['experimentIds'];
+        if (ids) {
           ids.forEach((id) => {
             const relevantExp = RELEVANT_PLAYER_EXPS[id];
             if (relevantExp) {
               forceExperimentBranch(this.win, relevantExp, id);
             }
           });
-      }
-    });
+        }
+      });
   }
 
   /**


### PR DESCRIPTION
The response from `sendMessageAwaitResponse` is already parsed (not JSON) so we don't need to parse again.

Also add some tests.