### PR TITLE
🏗 Temporarily disable Storybook AMP environment

### DIFF
--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -11,6 +11,7 @@ const {isCiBuild} = require('../../common/ci');
 const {isPullRequestBuild} = require('../../common/ci');
 const {log} = require('../../common/logging');
 const {writeFileSync} = require('fs-extra');
+const {yellow} = require('kleur/colors');
 
 const ENV_PORTS = {
   amp: 9001,
@@ -29,6 +30,13 @@ const envConfigDir = (env) => path.join(__dirname, `${env}-env`);
  * @param {string} env 'amp' or 'preact'
  */
 function launchEnv(env) {
+  if (env === 'amp') {
+    log(
+      yellow('AMP environment for storybook is temporarily disabled.\n') +
+        'See https://github.com/ampproject/storybook-addon-amp/issues/57'
+    );
+    return;
+  }
   log(`Launching storybook for the ${cyan(env)} environment...`);
   const {'storybook_port': port = ENV_PORTS[env]} = argv;
   execScriptAsync(

--- a/build-system/tasks/storybook/index.js
+++ b/build-system/tasks/storybook/index.js
@@ -58,6 +58,14 @@ function launchEnv(env) {
  * @param {string} env 'amp' or 'preact'
  */
 function buildEnv(env) {
+  if (env === 'amp') {
+    log(
+      yellow('AMP environment for storybook is temporarily disabled.\n') +
+        'See https://github.com/ampproject/storybook-addon-amp/issues/57'
+    );
+    return;
+  }
+
   const configDir = envConfigDir(env);
 
   if (env === 'amp' && isPullRequestBuild()) {

--- a/build-system/tasks/storybook/package-lock.json
+++ b/build-system/tasks/storybook/package-lock.json
@@ -8,7 +8,6 @@
       "name": "amp-storybook",
       "version": "0.1.0",
       "devDependencies": {
-        "@ampproject/storybook-addon": "1.1.9",
         "@babel/core": "7.15.8",
         "@babel/preset-react": "7.14.5",
         "@babel/runtime-corejs3": "7.15.4",
@@ -16,116 +15,13 @@
         "@storybook/addon-controls": "6.3.12",
         "@storybook/addon-knobs": "6.3.1",
         "@storybook/addon-viewport": "6.3.12",
+        "@storybook/client-api": "6.3.12",
         "@storybook/preact": "6.3.12",
         "babel-loader": "8.2.3",
         "core-js": "3.19.0",
         "preact": "10.5.15",
         "preact-render-to-string": "5.1.19",
         "styled-jsx": "4.0.1"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.9.tgz",
-      "integrity": "sha512-msn6ElmpnvvEJ6xc7AOfdWmOrIHwvd29SZmbm/NUVXfvrUy9W9bS+t62/g0N2R3CrNG/tvH7f54DFjy8u9Xp5w==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/client-api": "^5.3.19",
-        "@types/styled-jsx": "^2.2.8",
-        "preact": "^10.4.1",
-        "preact-render-to-string": "^5.1.7",
-        "react-dom": "^16.13.1",
-        "react-pdf": "^4.0.5",
-        "styled-jsx": "^3.2.5"
-      },
-      "peerDependencies": {
-        "@storybook/addons": "^5.0.0",
-        "@storybook/components": "^5.0.0",
-        "@storybook/theming": "^5.0.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon/node_modules/@babel/types": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon/node_modules/convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon/node_modules/loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dev": true,
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@ampproject/storybook-addon/node_modules/styled-jsx": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-3.4.7.tgz",
-      "integrity": "sha512-PkImcCsovR39byv4Tz83tAPsYs2CiTPOmDSplhe0lsIFVYJyd7rzJ7fbm41vSNsF/lnO+Ob5n/jgMookwY0pww==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "7.8.3",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "convert-source-map": "1.7.0",
-        "loader-utils": "1.2.3",
-        "source-map": "0.7.3",
-        "string-hash": "1.1.3",
-        "stylis": "3.5.4",
-        "stylis-rule-sheet": "0.0.10"
-      },
-      "peerDependencies": {
-        "react": "15.x.x || 16.x.x || 17.x.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2302,59 +2198,6 @@
         }
       }
     },
-    "node_modules/@storybook/addon-a11y/node_modules/@storybook/channel-postmessage": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-      "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "qs": "^6.10.0",
-        "telejson": "^5.3.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addon-a11y/node_modules/@storybook/client-api": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-      "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": "6.3.12",
-        "@storybook/channel-postmessage": "6.3.12",
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "@storybook/csf": "0.0.1",
-        "@types/qs": "^6.9.5",
-        "@types/webpack-env": "^1.16.0",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "lodash": "^4.17.20",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0",
-        "regenerator-runtime": "^0.13.7",
-        "stable": "^0.1.8",
-        "store2": "^2.12.0",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/@storybook/addon-controls": {
       "version": "6.3.12",
       "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-6.3.12.tgz",
@@ -2385,59 +2228,6 @@
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/addon-controls/node_modules/@storybook/channel-postmessage": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-      "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "qs": "^6.10.0",
-        "telejson": "^5.3.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addon-controls/node_modules/@storybook/client-api": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-      "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": "6.3.12",
-        "@storybook/channel-postmessage": "6.3.12",
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "@storybook/csf": "0.0.1",
-        "@types/qs": "^6.9.5",
-        "@types/webpack-env": "^1.16.0",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "lodash": "^4.17.20",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0",
-        "regenerator-runtime": "^0.13.7",
-        "stable": "^0.1.8",
-        "store2": "^2.12.0",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@storybook/addon-knobs": {
@@ -2663,59 +2453,6 @@
         }
       }
     },
-    "node_modules/@storybook/builder-webpack4/node_modules/@storybook/channel-postmessage": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-      "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "qs": "^6.10.0",
-        "telejson": "^5.3.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/@storybook/client-api": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-      "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": "6.3.12",
-        "@storybook/channel-postmessage": "6.3.12",
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "@storybook/csf": "0.0.1",
-        "@types/qs": "^6.9.5",
-        "@types/webpack-env": "^1.16.0",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "lodash": "^4.17.20",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0",
-        "regenerator-runtime": "^0.13.7",
-        "stable": "^0.1.8",
-        "store2": "^2.12.0",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
     "node_modules/@storybook/builder-webpack4/node_modules/babel-plugin-macros": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -2917,50 +2654,22 @@
       }
     },
     "node_modules/@storybook/channel-postmessage": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.21.tgz",
-      "integrity": "sha512-CfoP7aEbZtJ35R9zeujMRdIwprETUi+Ve+y84DhXYQ2uJ0rR3vO4zHLZnxMMyJ5VnYOfuO042uch07+EKBz40Q==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
+      "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
       "dev": true,
       "dependencies": {
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "telejson": "^3.2.0"
-      }
-    },
-    "node_modules/@storybook/channel-postmessage/node_modules/@storybook/channels": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.21.tgz",
-      "integrity": "sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/channel-postmessage/node_modules/@storybook/client-logger": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.21.tgz",
-      "integrity": "sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/channel-postmessage/node_modules/telejson": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
-      "integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/is-function": "^1.0.0",
+        "@storybook/channels": "6.3.12",
+        "@storybook/client-logger": "6.3.12",
+        "@storybook/core-events": "6.3.12",
+        "core-js": "^3.8.2",
         "global": "^4.4.0",
-        "is-function": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "is-symbol": "^1.0.3",
-        "isobject": "^4.0.0",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3"
+        "qs": "^6.10.0",
+        "telejson": "^5.3.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/channels": {
@@ -2979,189 +2688,37 @@
       }
     },
     "node_modules/@storybook/client-api": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.21.tgz",
-      "integrity": "sha512-vS4DfA2Avvl7JNQymO4e3RUNoTWIGVfZJ70Irnd6PTAZNojbCXTYuigDavrmyf83F3g5rQpwmSAPjuoi/X/FRA==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
+      "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
       "dev": true,
       "dependencies": {
-        "@storybook/addons": "5.3.21",
-        "@storybook/channel-postmessage": "5.3.21",
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "@storybook/core-events": "5.3.21",
+        "@storybook/addons": "6.3.12",
+        "@storybook/channel-postmessage": "6.3.12",
+        "@storybook/channels": "6.3.12",
+        "@storybook/client-logger": "6.3.12",
+        "@storybook/core-events": "6.3.12",
         "@storybook/csf": "0.0.1",
-        "@types/webpack-env": "^1.15.0",
-        "core-js": "^3.0.1",
-        "eventemitter3": "^4.0.0",
-        "global": "^4.3.2",
-        "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.6.0",
-        "stable": "^0.1.8",
-        "ts-dedent": "^1.1.0",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/@storybook/addons": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.21.tgz",
-      "integrity": "sha512-Ji/21WADTLVbTbiKcZ64BcL0Es+h1Afxx3kNmGJqPSTUYroCwIFCT9mUzCqU6G+YyWaISAmTii5UJkTwMkChwA==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/api": "5.3.21",
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "@storybook/core-events": "5.3.21",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "util-deprecate": "^1.0.2"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/@storybook/api": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.21.tgz",
-      "integrity": "sha512-K1o4an/Rx8daKRDooks6qzN6ZGyqizeacZZbair3F8CsSfTgrr2zCcf9pgKojLQa9koEmMHlcdb2KnS+GwPEgA==",
-      "dev": true,
-      "dependencies": {
-        "@reach/router": "^1.2.1",
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "@storybook/core-events": "5.3.21",
-        "@storybook/csf": "0.0.1",
-        "@storybook/router": "5.3.21",
-        "@storybook/theming": "5.3.21",
-        "@types/reach__router": "^1.2.3",
-        "core-js": "^3.0.1",
-        "fast-deep-equal": "^2.0.1",
-        "global": "^4.3.2",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "prop-types": "^15.6.2",
-        "react": "^16.8.3",
-        "semver": "^6.0.0",
-        "shallow-equal": "^1.1.0",
-        "store2": "^2.7.1",
-        "telejson": "^3.2.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "peerDependencies": {
-        "regenerator-runtime": "*"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/@storybook/channels": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.21.tgz",
-      "integrity": "sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/@storybook/client-logger": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.21.tgz",
-      "integrity": "sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/@storybook/core-events": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.21.tgz",
-      "integrity": "sha512-/Zsm1sKAh6pzQv8jQUmuhM7nuM01ZljIRKy8p2HjPNlMjDB5yaRkBfyeAUXUg+qXNI6aHVWa4jGdPEdwwY4oLA==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^3.0.1"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/@storybook/router": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.21.tgz",
-      "integrity": "sha512-c29m5UikK5Q1lyd6FltOGFhIcpd6PIb855YS3OUNe3F6ZA1tfJ+aNKrCBc65d1c+fvCGG76dYYYv0RvwEmKXXg==",
-      "dev": true,
-      "dependencies": {
-        "@reach/router": "^1.2.1",
-        "@storybook/csf": "0.0.1",
-        "@types/reach__router": "^1.2.3",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.6.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/@storybook/theming": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.21.tgz",
-      "integrity": "sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==",
-      "dev": true,
-      "dependencies": {
-        "@emotion/core": "^10.0.20",
-        "@emotion/styled": "^10.0.17",
-        "@storybook/client-logger": "5.3.21",
-        "core-js": "^3.0.1",
-        "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.19",
-        "global": "^4.3.2",
-        "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
-        "prop-types": "^15.7.2",
-        "resolve-from": "^5.0.0",
-        "ts-dedent": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
-    },
-    "node_modules/@storybook/client-api/node_modules/polished": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
-      "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/telejson": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
-      "integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/is-function": "^1.0.0",
+        "@types/qs": "^6.9.5",
+        "@types/webpack-env": "^1.16.0",
+        "core-js": "^3.8.2",
         "global": "^4.4.0",
-        "is-function": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "is-symbol": "^1.0.3",
-        "isobject": "^4.0.0",
-        "lodash": "^4.17.15",
-        "memoizerific": "^1.11.3"
-      }
-    },
-    "node_modules/@storybook/client-api/node_modules/ts-dedent": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.2.0.tgz",
-      "integrity": "sha512-6zSJp23uQI+Txyz5LlXMXAHpUhY4Hi0oluXny0OgIR7g/Cromq4vDBnhtbBdyIV34g0pgwxUvnvg+jLJe4c1NA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.10"
+        "lodash": "^4.17.20",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
+        "stable": "^0.1.8",
+        "store2": "^2.12.0",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@storybook/client-logger": {
@@ -3282,59 +2839,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@storybook/core-client/node_modules/@storybook/channel-postmessage": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-      "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "qs": "^6.10.0",
-        "telejson": "^5.3.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/core-client/node_modules/@storybook/client-api": {
-      "version": "6.3.12",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-      "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addons": "6.3.12",
-        "@storybook/channel-postmessage": "6.3.12",
-        "@storybook/channels": "6.3.12",
-        "@storybook/client-logger": "6.3.12",
-        "@storybook/core-events": "6.3.12",
-        "@storybook/csf": "0.0.1",
-        "@types/qs": "^6.9.5",
-        "@types/webpack-env": "^1.16.0",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "lodash": "^4.17.20",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0",
-        "regenerator-runtime": "^0.13.7",
-        "stable": "^0.1.8",
-        "store2": "^2.12.0",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@storybook/core-common": {
@@ -4227,15 +3731,6 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
-    },
-    "node_modules/@types/styled-jsx": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@types/styled-jsx/-/styled-jsx-2.2.9.tgz",
-      "integrity": "sha512-W/iTlIkGEyTBGTEvZCey8EgQlQ5l0DwMqi3iOXlLs2kyBwYTXHKEiU6IZ5EwoRwngL8/dGYuzezSup89ttVHLw==",
-      "dev": true,
-      "dependencies": {
-        "@types/react": "*"
-      }
     },
     "node_modules/@types/tapable": {
       "version": "1.0.8",
@@ -7786,12 +7281,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -10053,15 +9542,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -10531,15 +10011,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/make-cancellable-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.1.0.tgz",
-      "integrity": "sha512-X5Opjm2xcZsOLuJ+Bnhb4t5yfu4ehlA3OKEYLtqUchgVzL/QaqW373ZUVxVHKwvJ38cmYuR4rAHD2yUvAIkTPA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/wojtekmaj/make-cancellable-promise?sponsor=1"
-      }
-    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -10560,15 +10031,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/make-event-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.3.0.tgz",
-      "integrity": "sha512-oWiDZMcVB1/A487251hEWza1xzgCzl6MXxe9aF24l5Bt9N9UEbqTqKumEfuuLhmlhRZYnc+suVvW4vUs8bwO7Q==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
       }
     },
     "node_modules/map-cache": {
@@ -10727,15 +10189,6 @@
       "dependencies": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "node_modules/merge-class-names": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
-      "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/wojtekmaj/merge-class-names?sponsor=1"
       }
     },
     "node_modules/merge-descriptors": {
@@ -11081,12 +10534,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=",
-      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.6.5",
@@ -11856,19 +11303,6 @@
       },
       "engines": {
         "node": ">=0.12"
-      }
-    },
-    "node_modules/pdfjs-dist": {
-      "version": "2.1.266",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.1.266.tgz",
-      "integrity": "sha512-Jy7o1wE3NezPxozexSbq4ltuLT0Z21ew/qrEiAEeUZzHxMHGk4DUV1D7RuCXg5vJDvHmjX1YssN+we9QfRRgXQ==",
-      "dev": true,
-      "dependencies": {
-        "node-ensure": "^0.0.0",
-        "worker-loader": "^2.0.0"
-      },
-      "peerDependencies": {
-        "webpack": "^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -13092,27 +12526,6 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
-    "node_modules/react-pdf": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-4.2.0.tgz",
-      "integrity": "sha512-Ao44mZszfPwtCUsrXHtXnhM+czTvPxfG5wqssbWgj2onL70TKSOKGzQfCH4csCnNDOKji/Pc/s0Og70/VOE+Rg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "make-cancellable-promise": "^1.0.0",
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "pdfjs-dist": "2.1.266",
-        "prop-types": "^15.6.2"
-      },
-      "funding": {
-        "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0",
-        "react-dom": "^16.3.0"
-      }
-    },
     "node_modules/react-popper": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
@@ -14031,12 +13444,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "dev": true
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -16885,35 +16292,6 @@
         "errno": "~0.1.7"
       }
     },
-    "node_modules/worker-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
-      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
-      "dev": true,
-      "dependencies": {
-        "loader-utils": "^1.0.0",
-        "schema-utils": "^0.4.0"
-      },
-      "engines": {
-        "node": ">= 6.9.0 || >= 8.9.0"
-      },
-      "peerDependencies": {
-        "webpack": "^3.0.0 || ^4.0.0-alpha.0 || ^4.0.0"
-      }
-    },
-    "node_modules/worker-loader/node_modules/schema-utils": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-      "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/worker-rpc": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/worker-rpc/-/worker-rpc-0.1.1.tgz",
@@ -16983,91 +16361,6 @@
     }
   },
   "dependencies": {
-    "@ampproject/storybook-addon": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@ampproject/storybook-addon/-/storybook-addon-1.1.9.tgz",
-      "integrity": "sha512-msn6ElmpnvvEJ6xc7AOfdWmOrIHwvd29SZmbm/NUVXfvrUy9W9bS+t62/g0N2R3CrNG/tvH7f54DFjy8u9Xp5w==",
-      "dev": true,
-      "requires": {
-        "@storybook/client-api": "^5.3.19",
-        "@types/styled-jsx": "^2.2.8",
-        "preact": "^10.4.1",
-        "preact-render-to-string": "^5.1.7",
-        "react-dom": "^16.13.1",
-        "react-pdf": "^4.0.5",
-        "styled-jsx": "^3.2.5"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-          "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "convert-source-map": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.1"
-          }
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-          "dev": true
-        },
-        "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-          "dev": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
-          }
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        },
-        "styled-jsx": {
-          "version": "3.4.7",
-          "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-3.4.7.tgz",
-          "integrity": "sha512-PkImcCsovR39byv4Tz83tAPsYs2CiTPOmDSplhe0lsIFVYJyd7rzJ7fbm41vSNsF/lnO+Ob5n/jgMookwY0pww==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "7.8.3",
-            "babel-plugin-syntax-jsx": "6.18.0",
-            "convert-source-map": "1.7.0",
-            "loader-utils": "1.2.3",
-            "source-map": "0.7.3",
-            "string-hash": "1.1.3",
-            "stylis": "3.5.4",
-            "stylis-rule-sheet": "0.0.10"
-          }
-        }
-      }
-    },
     "@babel/code-frame": {
       "version": "7.15.8",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.15.8.tgz",
@@ -18610,49 +17903,6 @@
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0",
         "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "@storybook/channel-postmessage": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-          "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "qs": "^6.10.0",
-            "telejson": "^5.3.2"
-          }
-        },
-        "@storybook/client-api": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-          "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-          "dev": true,
-          "requires": {
-            "@storybook/addons": "6.3.12",
-            "@storybook/channel-postmessage": "6.3.12",
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "@storybook/csf": "0.0.1",
-            "@types/qs": "^6.9.5",
-            "@types/webpack-env": "^1.16.0",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "lodash": "^4.17.20",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.10.0",
-            "regenerator-runtime": "^0.13.7",
-            "stable": "^0.1.8",
-            "store2": "^2.12.0",
-            "ts-dedent": "^2.0.0",
-            "util-deprecate": "^1.0.2"
-          }
-        }
       }
     },
     "@storybook/addon-controls": {
@@ -18669,49 +17919,6 @@
         "@storybook/theming": "6.3.12",
         "core-js": "^3.8.2",
         "ts-dedent": "^2.0.0"
-      },
-      "dependencies": {
-        "@storybook/channel-postmessage": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-          "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "qs": "^6.10.0",
-            "telejson": "^5.3.2"
-          }
-        },
-        "@storybook/client-api": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-          "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-          "dev": true,
-          "requires": {
-            "@storybook/addons": "6.3.12",
-            "@storybook/channel-postmessage": "6.3.12",
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "@storybook/csf": "0.0.1",
-            "@types/qs": "^6.9.5",
-            "@types/webpack-env": "^1.16.0",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "lodash": "^4.17.20",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.10.0",
-            "regenerator-runtime": "^0.13.7",
-            "stable": "^0.1.8",
-            "store2": "^2.12.0",
-            "ts-dedent": "^2.0.0",
-            "util-deprecate": "^1.0.2"
-          }
-        }
       }
     },
     "@storybook/addon-knobs": {
@@ -18875,47 +18082,6 @@
         "webpack-virtual-modules": "^0.2.2"
       },
       "dependencies": {
-        "@storybook/channel-postmessage": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-          "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "qs": "^6.10.0",
-            "telejson": "^5.3.2"
-          }
-        },
-        "@storybook/client-api": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-          "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-          "dev": true,
-          "requires": {
-            "@storybook/addons": "6.3.12",
-            "@storybook/channel-postmessage": "6.3.12",
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "@storybook/csf": "0.0.1",
-            "@types/qs": "^6.9.5",
-            "@types/webpack-env": "^1.16.0",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "lodash": "^4.17.20",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.10.0",
-            "regenerator-runtime": "^0.13.7",
-            "stable": "^0.1.8",
-            "store2": "^2.12.0",
-            "ts-dedent": "^2.0.0",
-            "util-deprecate": "^1.0.2"
-          }
-        },
         "babel-plugin-macros": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -19085,52 +18251,18 @@
       }
     },
     "@storybook/channel-postmessage": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.21.tgz",
-      "integrity": "sha512-CfoP7aEbZtJ35R9zeujMRdIwprETUi+Ve+y84DhXYQ2uJ0rR3vO4zHLZnxMMyJ5VnYOfuO042uch07+EKBz40Q==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
+      "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "core-js": "^3.0.1",
-        "global": "^4.3.2",
-        "telejson": "^3.2.0"
-      },
-      "dependencies": {
-        "@storybook/channels": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.21.tgz",
-          "integrity": "sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/client-logger": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.21.tgz",
-          "integrity": "sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "telejson": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
-          "integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
-          "dev": true,
-          "requires": {
-            "@types/is-function": "^1.0.0",
-            "global": "^4.4.0",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.3",
-            "isobject": "^4.0.0",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3"
-          }
-        }
+        "@storybook/channels": "6.3.12",
+        "@storybook/client-logger": "6.3.12",
+        "@storybook/core-events": "6.3.12",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "qs": "^6.10.0",
+        "telejson": "^5.3.2"
       }
     },
     "@storybook/channels": {
@@ -19145,174 +18277,29 @@
       }
     },
     "@storybook/client-api": {
-      "version": "5.3.21",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.21.tgz",
-      "integrity": "sha512-vS4DfA2Avvl7JNQymO4e3RUNoTWIGVfZJ70Irnd6PTAZNojbCXTYuigDavrmyf83F3g5rQpwmSAPjuoi/X/FRA==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
+      "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.3.21",
-        "@storybook/channel-postmessage": "5.3.21",
-        "@storybook/channels": "5.3.21",
-        "@storybook/client-logger": "5.3.21",
-        "@storybook/core-events": "5.3.21",
+        "@storybook/addons": "6.3.12",
+        "@storybook/channel-postmessage": "6.3.12",
+        "@storybook/channels": "6.3.12",
+        "@storybook/client-logger": "6.3.12",
+        "@storybook/core-events": "6.3.12",
         "@storybook/csf": "0.0.1",
-        "@types/webpack-env": "^1.15.0",
-        "core-js": "^3.0.1",
-        "eventemitter3": "^4.0.0",
-        "global": "^4.3.2",
-        "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.15",
+        "@types/qs": "^6.9.5",
+        "@types/webpack-env": "^1.16.0",
+        "core-js": "^3.8.2",
+        "global": "^4.4.0",
+        "lodash": "^4.17.20",
         "memoizerific": "^1.11.3",
-        "qs": "^6.6.0",
+        "qs": "^6.10.0",
+        "regenerator-runtime": "^0.13.7",
         "stable": "^0.1.8",
-        "ts-dedent": "^1.1.0",
+        "store2": "^2.12.0",
+        "ts-dedent": "^2.0.0",
         "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "@storybook/addons": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.21.tgz",
-          "integrity": "sha512-Ji/21WADTLVbTbiKcZ64BcL0Es+h1Afxx3kNmGJqPSTUYroCwIFCT9mUzCqU6G+YyWaISAmTii5UJkTwMkChwA==",
-          "dev": true,
-          "requires": {
-            "@storybook/api": "5.3.21",
-            "@storybook/channels": "5.3.21",
-            "@storybook/client-logger": "5.3.21",
-            "@storybook/core-events": "5.3.21",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/api": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.21.tgz",
-          "integrity": "sha512-K1o4an/Rx8daKRDooks6qzN6ZGyqizeacZZbair3F8CsSfTgrr2zCcf9pgKojLQa9koEmMHlcdb2KnS+GwPEgA==",
-          "dev": true,
-          "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/channels": "5.3.21",
-            "@storybook/client-logger": "5.3.21",
-            "@storybook/core-events": "5.3.21",
-            "@storybook/csf": "0.0.1",
-            "@storybook/router": "5.3.21",
-            "@storybook/theming": "5.3.21",
-            "@types/reach__router": "^1.2.3",
-            "core-js": "^3.0.1",
-            "fast-deep-equal": "^2.0.1",
-            "global": "^4.3.2",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3",
-            "prop-types": "^15.6.2",
-            "react": "^16.8.3",
-            "semver": "^6.0.0",
-            "shallow-equal": "^1.1.0",
-            "store2": "^2.7.1",
-            "telejson": "^3.2.0",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/channels": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.21.tgz",
-          "integrity": "sha512-OXoFs9XtBVg/cCk6lYMrxkzaNlJRf54ABdorp7YAAj7S9tRL1JxOZHxmjNQwEoiRvssmem2rAWtEAxfuEANsAA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/client-logger": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.21.tgz",
-          "integrity": "sha512-OzQkwpZ5SK9cXD9Mv6lxPGPot+hSZvnkEW12kpt1AHfJz4ET26YTDOI3oetPsjfRJo6qYLeQX8+wF7rklfXbzA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/core-events": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.21.tgz",
-          "integrity": "sha512-/Zsm1sKAh6pzQv8jQUmuhM7nuM01ZljIRKy8p2HjPNlMjDB5yaRkBfyeAUXUg+qXNI6aHVWa4jGdPEdwwY4oLA==",
-          "dev": true,
-          "requires": {
-            "core-js": "^3.0.1"
-          }
-        },
-        "@storybook/router": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.21.tgz",
-          "integrity": "sha512-c29m5UikK5Q1lyd6FltOGFhIcpd6PIb855YS3OUNe3F6ZA1tfJ+aNKrCBc65d1c+fvCGG76dYYYv0RvwEmKXXg==",
-          "dev": true,
-          "requires": {
-            "@reach/router": "^1.2.1",
-            "@storybook/csf": "0.0.1",
-            "@types/reach__router": "^1.2.3",
-            "core-js": "^3.0.1",
-            "global": "^4.3.2",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.6.0",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/theming": {
-          "version": "5.3.21",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.21.tgz",
-          "integrity": "sha512-FZbxjizqdO9lV5LUixPio/7+6UdPiswCzTJn8Hcot9uwwgfnrViRdN7xyjmSYRqv9nHP3OlYbtdeCAgZ4aPq8g==",
-          "dev": true,
-          "requires": {
-            "@emotion/core": "^10.0.20",
-            "@emotion/styled": "^10.0.17",
-            "@storybook/client-logger": "5.3.21",
-            "core-js": "^3.0.1",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.19",
-            "global": "^4.3.2",
-            "memoizerific": "^1.11.3",
-            "polished": "^3.3.1",
-            "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0",
-            "ts-dedent": "^1.1.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "polished": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.2.tgz",
-          "integrity": "sha512-pQKtpZGmsZrW8UUpQMAnR7s3ppHeMQVNyMDKtUyKwuvDmklzcEyM5Kllb3JyE/sE/x7arDmyd35i+4vp99H6sQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5"
-          }
-        },
-        "telejson": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
-          "integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
-          "dev": true,
-          "requires": {
-            "@types/is-function": "^1.0.0",
-            "global": "^4.4.0",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.3",
-            "isobject": "^4.0.0",
-            "lodash": "^4.17.15",
-            "memoizerific": "^1.11.3"
-          }
-        },
-        "ts-dedent": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-1.2.0.tgz",
-          "integrity": "sha512-6zSJp23uQI+Txyz5LlXMXAHpUhY4Hi0oluXny0OgIR7g/Cromq4vDBnhtbBdyIV34g0pgwxUvnvg+jLJe4c1NA==",
-          "dev": true
-        }
       }
     },
     "@storybook/client-logger": {
@@ -19390,49 +18377,6 @@
         "ts-dedent": "^2.0.0",
         "unfetch": "^4.2.0",
         "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "@storybook/channel-postmessage": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-6.3.12.tgz",
-          "integrity": "sha512-Ou/2Ga3JRTZ/4sSv7ikMgUgLTeZMsXXWLXuscz4oaYhmOqAU9CrJw0G1NitwBgK/+qC83lEFSLujHkWcoQDOKg==",
-          "dev": true,
-          "requires": {
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "qs": "^6.10.0",
-            "telejson": "^5.3.2"
-          }
-        },
-        "@storybook/client-api": {
-          "version": "6.3.12",
-          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-6.3.12.tgz",
-          "integrity": "sha512-xnW+lKKK2T774z+rOr9Wopt1aYTStfb86PSs9p3Fpnc2Btcftln+C3NtiHZl8Ccqft8Mz/chLGgewRui6tNI8g==",
-          "dev": true,
-          "requires": {
-            "@storybook/addons": "6.3.12",
-            "@storybook/channel-postmessage": "6.3.12",
-            "@storybook/channels": "6.3.12",
-            "@storybook/client-logger": "6.3.12",
-            "@storybook/core-events": "6.3.12",
-            "@storybook/csf": "0.0.1",
-            "@types/qs": "^6.9.5",
-            "@types/webpack-env": "^1.16.0",
-            "core-js": "^3.8.2",
-            "global": "^4.4.0",
-            "lodash": "^4.17.20",
-            "memoizerific": "^1.11.3",
-            "qs": "^6.10.0",
-            "regenerator-runtime": "^0.13.7",
-            "stable": "^0.1.8",
-            "store2": "^2.12.0",
-            "ts-dedent": "^2.0.0",
-            "util-deprecate": "^1.0.2"
-          }
-        }
       }
     },
     "@storybook/core-common": {
@@ -20140,15 +19084,6 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
-    },
-    "@types/styled-jsx": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@types/styled-jsx/-/styled-jsx-2.2.9.tgz",
-      "integrity": "sha512-W/iTlIkGEyTBGTEvZCey8EgQlQ5l0DwMqi3iOXlLs2kyBwYTXHKEiU6IZ5EwoRwngL8/dGYuzezSup89ttVHLw==",
-      "dev": true,
-      "requires": {
-        "@types/react": "*"
-      }
     },
     "@types/tapable": {
       "version": "1.0.8",
@@ -23045,12 +21980,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
-    },
     "events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -24777,12 +23706,6 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
-    "is-plain-object": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-      "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -25134,12 +24057,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "make-cancellable-promise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.1.0.tgz",
-      "integrity": "sha512-X5Opjm2xcZsOLuJ+Bnhb4t5yfu4ehlA3OKEYLtqUchgVzL/QaqW373ZUVxVHKwvJ38cmYuR4rAHD2yUvAIkTPA==",
-      "dev": true
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -25157,12 +24074,6 @@
           "dev": true
         }
       }
-    },
-    "make-event-props": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.3.0.tgz",
-      "integrity": "sha512-oWiDZMcVB1/A487251hEWza1xzgCzl6MXxe9aF24l5Bt9N9UEbqTqKumEfuuLhmlhRZYnc+suVvW4vUs8bwO7Q==",
-      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
@@ -25288,12 +24199,6 @@
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
       }
-    },
-    "merge-class-names": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.4.2.tgz",
-      "integrity": "sha512-bOl98VzwCGi25Gcn3xKxnR5p/WrhWFQB59MS/aGENcmUc6iSm96yrFDF0XSNurX9qN4LbJm0R9kfvsQ17i8zCw==",
-      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -25576,12 +24481,6 @@
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
       }
-    },
-    "node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=",
-      "dev": true
     },
     "node-fetch": {
       "version": "2.6.5",
@@ -26189,16 +25088,6 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "pdfjs-dist": {
-      "version": "2.1.266",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.1.266.tgz",
-      "integrity": "sha512-Jy7o1wE3NezPxozexSbq4ltuLT0Z21ew/qrEiAEeUZzHxMHGk4DUV1D7RuCXg5vJDvHmjX1YssN+we9QfRRgXQ==",
-      "dev": true,
-      "requires": {
-        "node-ensure": "^0.0.0",
-        "worker-loader": "^2.0.0"
       }
     },
     "picocolors": {
@@ -27146,20 +26035,6 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
     },
-    "react-pdf": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-4.2.0.tgz",
-      "integrity": "sha512-Ao44mZszfPwtCUsrXHtXnhM+czTvPxfG5wqssbWgj2onL70TKSOKGzQfCH4csCnNDOKji/Pc/s0Og70/VOE+Rg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "make-cancellable-promise": "^1.0.0",
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "pdfjs-dist": "2.1.266",
-        "prop-types": "^15.6.2"
-      }
-    },
     "react-popper": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
@@ -27898,12 +26773,6 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
-    },
-    "shallow-equal": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
-      "dev": true
     },
     "shallowequal": {
       "version": "1.1.0",
@@ -30181,28 +29050,6 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
-      }
-    },
-    "worker-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
-      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.0",
-        "schema-utils": "^0.4.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
       }
     },
     "worker-rpc": {

--- a/build-system/tasks/storybook/package.json
+++ b/build-system/tasks/storybook/package.json
@@ -4,7 +4,6 @@
   "description": "amp storybook tasks",
   "main": "index.js",
   "devDependencies": {
-    "@ampproject/storybook-addon": "1.1.9",
     "@babel/core": "7.15.8",
     "@babel/preset-react": "7.14.5",
     "@babel/runtime-corejs3": "7.15.4",
@@ -12,6 +11,7 @@
     "@storybook/addon-controls": "6.3.12",
     "@storybook/addon-knobs": "6.3.1",
     "@storybook/addon-viewport": "6.3.12",
+    "@storybook/client-api": "6.3.12",
     "@storybook/preact": "6.3.12",
     "babel-loader": "8.2.3",
     "core-js": "3.19.0",


### PR DESCRIPTION
`@ampproject/storybook-addon` has outdated peer dependencies that conflict with the main install. Disable the AMP environment for now so that the Preact environment can run.

We'll update the addon soon: https://github.com/ampproject/storybook-addon-amp/issues/57

Additionally, we were relying on `@storybook/client-api` as a transitive dependency from the addon. Install it so that Storybook can run.