### PR TITLE
🏗 Also fix blank page snapshot with `amp visual-diff --main`

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -316,7 +316,9 @@ async function runVisualTests(browser, webpages) {
 
   if (argv.main) {
     const page = await newPage(browser);
-    await page.goto('about:blank');
+    await page.goto(
+      `http://${HOST}:${PORT}/examples/visual-tests/blank-page/blank.html`
+    );
     // @ts-ignore Type mismatch in library
     await percySnapshot(page, 'Blank page', SNAPSHOT_SINGLE_BUILD_OPTIONS);
   }


### PR DESCRIPTION
Followup fix for #36770 