### PR TITLE
🏗 split the {beta,experimental} channels in `versioning.json` into {-opt-in,-traffic} channels

### DIFF
--- a/build-system/global-configs/versioning.json
+++ b/build-system/global-configs/versioning.json
@@ -1,7 +1,9 @@
 {
-  "beta": "030000000000000",
+  "beta-opt-in": "030000000000000",
+  "beta-traffic": "030000000000000",
   "control": "020000000000000",
-  "experimental": "000000000000000",
+  "experimental-opt-in": "000000000000000",
+  "experimental-traffic": "000000000000000",
   "experimentA": null,
   "experimentB": null,
   "experimentC": null,

--- a/build-system/json-schemas/versioning.json
+++ b/build-system/json-schemas/versioning.json
@@ -3,9 +3,11 @@
   "description": "Versioning (RTV) information",
   "type": "object",
   "required": [
-    "beta",
+    "beta-opt-in",
+    "beta-traffic",
     "control",
-    "experimental",
+    "experimental-opt-in",
+    "experimental-traffic",
     "experimentA",
     "experimentB",
     "experimentC",
@@ -15,17 +17,9 @@
     "stable"
   ],
   "properties": {
-    "beta": {
-      "type": "string",
-      "pattern": "03\\d{13}"
-    },
     "control": {
       "type": "string",
       "pattern": "02\\d{13}"
-    },
-    "experimental": {
-      "type": "string",
-      "pattern": "00\\d{13}"
     },
     "experimentA": {
       "type": [
@@ -48,10 +42,6 @@
       ],
       "pattern": "12\\d{13}"
     },
-    "lts": {
-      "type": "string",
-      "pattern": "01\\d{13}"
-    },
     "nightly": {
       "type": "string",
       "pattern": "04\\d{13}"
@@ -59,8 +49,18 @@
     "nightly-control": {
       "type": "string",
       "pattern": "05\\d{13}"
+    }
+  },
+  "patternProperties": {
+    "beta-(opt-in|traffic)": {
+      "type": "string",
+      "pattern": "03\\d{13}"
     },
-    "stable": {
+    "experimental-(opt-in|traffic)": {
+      "type": "string",
+      "pattern": "00\\d{13}"
+    },
+    "(stable|lts)": {
       "type": "string",
       "pattern": "01\\d{13}"
     }


### PR DESCRIPTION
Unlike other channels, these two have a different promote day for opt-in and for traffic