### PR TITLE
✨[amp-story] Disable first page animations when `#embedMode=3`

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -127,6 +127,7 @@ export let State;
 /** @const @enum {string} */
 export const StateProperty = {
   // Embed options.
+  CAN_ANIMATE_FIRST_PAGE: 'canAnimateFirstPage',
   CAN_INSERT_AUTOMATIC_AD: 'canInsertAutomaticAd',
   CAN_SHOW_AUDIO_UI: 'canShowAudioUi',
   CAN_SHOW_NAVIGATION_OVERLAY_HINT: 'canShowNavigationOverlayHint',
@@ -556,6 +557,7 @@ export class AmpStoryStoreService {
     // Compiler won't resolve the object keys and trigger an error for missing
     // properties, so we have to force the type.
     return /** @type {!State} */ ({
+      [StateProperty.CAN_ANIMATE_FIRST_PAGE]: true,
       [StateProperty.CAN_INSERT_AUTOMATIC_AD]: true,
       [StateProperty.CAN_SHOW_AUDIO_UI]: true,
       [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: true,
@@ -631,6 +633,7 @@ export class AmpStoryStoreService {
       case EmbedMode.PREVIEW:
         return {
           [StateProperty.PREVIEW_STATE]: true,
+          [StateProperty.CAN_ANIMATE_FIRST_PAGE]: false,
           [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
           [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
           [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: false,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -127,7 +127,6 @@ export let State;
 /** @const @enum {string} */
 export const StateProperty = {
   // Embed options.
-  CAN_ANIMATE_FIRST_PAGE: 'canAnimateFirstPage',
   CAN_INSERT_AUTOMATIC_AD: 'canInsertAutomaticAd',
   CAN_SHOW_AUDIO_UI: 'canShowAudioUi',
   CAN_SHOW_NAVIGATION_OVERLAY_HINT: 'canShowNavigationOverlayHint',
@@ -557,7 +556,6 @@ export class AmpStoryStoreService {
     // Compiler won't resolve the object keys and trigger an error for missing
     // properties, so we have to force the type.
     return /** @type {!State} */ ({
-      [StateProperty.CAN_ANIMATE_FIRST_PAGE]: true,
       [StateProperty.CAN_INSERT_AUTOMATIC_AD]: true,
       [StateProperty.CAN_SHOW_AUDIO_UI]: true,
       [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: true,
@@ -633,7 +631,6 @@ export class AmpStoryStoreService {
       case EmbedMode.PREVIEW:
         return {
           [StateProperty.PREVIEW_STATE]: true,
-          [StateProperty.CAN_ANIMATE_FIRST_PAGE]: false,
           [StateProperty.CAN_INSERT_AUTOMATIC_AD]: false,
           [StateProperty.CAN_SHOW_NAVIGATION_OVERLAY_HINT]: false,
           [StateProperty.CAN_SHOW_PAGINATION_BUTTONS]: false,

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -81,6 +81,7 @@ import {getLocalizationService} from './amp-story-localization-service';
 import {getMode, isModeDevelopment} from '../../../src/mode';
 import {getHistoryState as getWindowHistoryState} from '#core/window/history';
 import {isExperimentOn} from '#experiments';
+import {isPreviewMode} from './embed-mode';
 import {isRTL} from '#core/dom';
 import {parseQueryString} from '#core/types/string/url';
 import {
@@ -402,7 +403,7 @@ export class AmpStory extends AMP.BaseElement {
     }
     if (
       isExperimentOn(this.win, 'story-disable-animations-first-page') ||
-      !this.storeService_.get(StateProperty.CAN_ANIMATE_FIRST_PAGE) ||
+      isPreviewMode(this.win) ||
       prefersReducedMotion(this.win)
     ) {
       Services.performanceFor(this.win).addEnabledExperiment(

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -402,6 +402,7 @@ export class AmpStory extends AMP.BaseElement {
     }
     if (
       isExperimentOn(this.win, 'story-disable-animations-first-page') ||
+      !this.storeService_.get(StateProperty.CAN_ANIMATE_FIRST_PAGE) ||
       prefersReducedMotion(this.win)
     ) {
       Services.performanceFor(this.win).addEnabledExperiment(

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -29,6 +29,7 @@ import {
 } from '#core/dom/query';
 import {timeStrToMillis, unscaledClientRect} from './utils';
 import {isExperimentOn} from '#experiments';
+import {StateProperty, getStoreService} from './amp-story-store-service';
 
 const TAG = 'AMP-STORY';
 
@@ -545,11 +546,15 @@ export class AnimationManager {
     /** @private @const */
     this.builderPromise_ = this.createAnimationBuilderPromise_();
 
+    const storeService = getStoreService(this.ampdoc_.win);
+    const animationDisabled =
+      isExperimentOn(ampdoc.win, 'story-disable-animations-first-page') ||
+      !storeService.get(StateProperty.CAN_ANIMATE_FIRST_PAGE);
+
     /** @private @const {bool} */
     this.skipAnimations_ =
       prefersReducedMotion(ampdoc.win) ||
-      (isExperimentOn(ampdoc.win, 'story-disable-animations-first-page') &&
-        matches(page, 'amp-story-page:first-of-type'));
+      (animationDisabled && matches(page, 'amp-story-page:first-of-type'));
 
     /** @private {?Array<!AnimationRunner>} */
     this.runners_ = null;

--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -29,7 +29,7 @@ import {
 } from '#core/dom/query';
 import {timeStrToMillis, unscaledClientRect} from './utils';
 import {isExperimentOn} from '#experiments';
-import {StateProperty, getStoreService} from './amp-story-store-service';
+import {isPreviewMode} from './embed-mode';
 
 const TAG = 'AMP-STORY';
 
@@ -546,15 +546,15 @@ export class AnimationManager {
     /** @private @const */
     this.builderPromise_ = this.createAnimationBuilderPromise_();
 
-    const storeService = getStoreService(this.ampdoc_.win);
-    const animationDisabled =
+    const firstPageAnimationDisabled =
       isExperimentOn(ampdoc.win, 'story-disable-animations-first-page') ||
-      !storeService.get(StateProperty.CAN_ANIMATE_FIRST_PAGE);
+      isPreviewMode(ampdoc.win);
 
     /** @private @const {bool} */
     this.skipAnimations_ =
       prefersReducedMotion(ampdoc.win) ||
-      (animationDisabled && matches(page, 'amp-story-page:first-of-type'));
+      (firstPageAnimationDisabled &&
+        matches(page, 'amp-story-page:first-of-type'));
 
     /** @private {?Array<!AnimationRunner>} */
     this.runners_ = null;

--- a/extensions/amp-story/1.0/embed-mode.js
+++ b/extensions/amp-story/1.0/embed-mode.js
@@ -76,3 +76,13 @@ export function parseEmbedMode(str) {
     ? /** @type {!EmbedMode} */ (embedModeIndex)
     : EmbedMode.NOT_EMBEDDED;
 }
+
+/**
+ * Determine if the current embed mode is PREVIEW.
+ * @param {!Window} win
+ * @return {boolean}
+ */
+export function isPreviewMode(win) {
+  const embedMode = parseEmbedMode(win.location.hash);
+  return embedMode === EmbedMode.PREVIEW;
+}


### PR DESCRIPTION
Allows viewers setting this param to disable animation. Referred to as `EmbedMode.PREVIEW` in the codebase.