### PR TITLE
🏗🚮 Remove `text-table`

### DIFF
--- a/build-system/tasks/get-zindex/index.js
+++ b/build-system/tasks/get-zindex/index.js
@@ -5,7 +5,6 @@ const fs = require('fs');
 const path = require('path');
 const Postcss = require('postcss');
 const prettier = require('prettier');
-const textTable = require('text-table');
 const {
   getJscodeshiftReport,
   jscodeshiftAsync,
@@ -18,15 +17,7 @@ const {writeDiffOrFail} = require('../../common/diff');
 /** @type {Postcss.default} */
 const postcss = /** @type {*} */ (Postcss);
 
-const tableHeaders = [
-  ['context', 'z-index', 'file'],
-  ['---', '---', '---'],
-];
-
-const tableOptions = {
-  align: ['l', 'l', 'l'],
-  hsep: '   |   ',
-};
+const tableHeaders = ['context', 'z-index', 'file'];
 
 const preamble = `
 **Run \`amp get-zindex --fix\` to generate this file.**
@@ -219,8 +210,12 @@ async function getZindex() {
   );
 
   const filename = 'css/Z_INDEX.md';
-  const rows = [...tableHeaders, ...createTable(filesData)];
-  const table = textTable(rows, tableOptions);
+  const rows = [
+    tableHeaders,
+    tableHeaders.map(() => '-'),
+    ...createTable(filesData),
+  ];
+  const table = rows.map((row) => row.join(' | ')).join('\n');
   const output = await prettierFormat(filename, `${preamble}\n\n${table}`);
 
   await writeDiffOrFail(

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,7 +178,6 @@
         "tar": "6.1.11",
         "tempy": "1.0.1",
         "terser": "5.9.0",
-        "text-table": "0.2.0",
         "traverse": "0.6.6",
         "typescript": "4.4.4",
         "util": "0.12.4",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,6 @@
     "tar": "6.1.11",
     "tempy": "1.0.1",
     "terser": "5.9.0",
-    "text-table": "0.2.0",
     "traverse": "0.6.6",
     "typescript": "4.4.4",
     "util": "0.12.4",


### PR DESCRIPTION
It's redundant since it's used on a script that `prettier`-formats the output, with the same results.