### PR TITLE
🐛 Fix amp-video custom poster fit with different aspect ratio

### DIFF
--- a/extensions/amp-video/1.0/component.js
+++ b/extensions/amp-video/1.0/component.js
@@ -29,6 +29,7 @@ import {
 import {useResourcesNotify} from '#preact/utils';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
+import {setStyle} from '#core/dom/style';
 
 /**
  * @param {?{getMetadata: (function():?JsonObject|undefined)}} player
@@ -91,6 +92,7 @@ function VideoWrapperWithRef(
 
   const [muted, setMuted] = useState(autoplay);
   const [playing, setPlaying_] = useState(false);
+  const [initialPlay, setinitialPlay] = useState(true);
   const [metadata, setMetadata] = useState(/** @type {?MetadataDef}*/ (null));
   const [hasUserInteracted, setHasUserInteracted] = useState(!autoplay);
 
@@ -125,13 +127,18 @@ function VideoWrapperWithRef(
   const onPlayingStateRef = useValueRef(onPlayingState);
   const setPlayingState = useCallback(
     (playing) => {
+      if (initialPlay && playing) {
+        setStyle(playerRef.current, 'object-fit', 'contain');
+        setinitialPlay(false);
+      }
+
       setPlaying_(playing);
       const onPlayingState = onPlayingStateRef.current;
       if (onPlayingState) {
         onPlayingState(playing);
       }
     },
-    [onPlayingStateRef]
+    [onPlayingStateRef, initialPlay]
   );
 
   // Reset playing state when the video player is unmounted.

--- a/extensions/amp-video/1.0/component.jss.js
+++ b/extensions/amp-video/1.0/component.jss.js
@@ -5,6 +5,7 @@ export const fillStretch = {
   'position': 'relative',
   'width': '100%',
   'height': '100%',
+  'object-fit': 'cover',
 };
 
 export const fillContentOverlay = {

--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -15,6 +15,7 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
   let playerReadyState;
   let play;
   let pause;
+  let style;
 
   let metadata;
 
@@ -25,7 +26,7 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
       },
       play,
       pause,
-      style: {},
+      style,
       getMetadata: () => metadata,
     }));
     return <></>;
@@ -35,6 +36,7 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
     playerReadyState = undefined;
     pause = env.sandbox.spy();
     play = env.sandbox.spy();
+    style = {};
 
     metadata = {
       'title': 'Test player title',
@@ -212,6 +214,23 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
     );
     await wrapper.find(TestPlayer).invoke('onPlaying')();
     expect(onPlayingState).to.be.calledOnce.calledWith(true);
+  });
+
+  it('should add object-fit property after play', async () => {
+    const onPlayingState = env.sandbox.spy();
+    const ref = createRef();
+    const wrapper = mount(
+      <VideoWrapper
+        ref={ref}
+        component={TestPlayer}
+        sources={<div></div>}
+        onPlayingState={onPlayingState}
+      />
+    );
+
+    // onPlaying
+    await wrapper.find(TestPlayer).invoke('onPlaying')();
+    expect(style).to.deep.equal({'object-fit': 'contain'});
   });
 
   describe('MediaSession', () => {

--- a/extensions/amp-video/1.0/test/test-video-wrapper.js
+++ b/extensions/amp-video/1.0/test/test-video-wrapper.js
@@ -25,6 +25,7 @@ describes.sandboxed('VideoWrapper Preact component', {}, (env) => {
       },
       play,
       pause,
+      style: {},
       getMetadata: () => metadata,
     }));
     return <></>;


### PR DESCRIPTION
- Use `object-fit: cover` for the amp-video custom poster and update the `object-fit` to `contain` after the video initial play.
- This PR currently addresses the custom poster fit issue for the amp-video `1.0` version only.

Addresses: #28383 
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
