### PR TITLE
🧪[story-ads] move exp check earlier in lifecycle

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -110,6 +110,9 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
+    // TODO(ccordry): properly block on this when #cap check is possible.
+    this.askPlayerForActiveExperiments_();
+
     return Services.storyStoreServiceForOrNull(this.win).then(
       (storeService) => {
         devAssert(storeService, 'Could not retrieve AmpStoryStoreService');
@@ -165,7 +168,6 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
         if (!this.placementAlgorithm_.isStoryEligible()) {
           return;
         }
-        this.askPlayerForActiveExperiments_();
         this.analytics_ = getServicePromiseForDoc(
           this.element,
           STORY_AD_ANALYTICS

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -84,7 +84,6 @@ describes.realWin(
         env.sandbox.stub(viewer, 'isEmbedded').returns(true);
         new MockStoryImpl(storyElement);
         addStoryAutoAdsConfig(adElement);
-        await autoAds.buildCallback();
       });
 
       it('handles null response', async () => {
@@ -95,7 +94,7 @@ describes.realWin(
         env.sandbox
           .stub(viewer, 'sendMessageAwaitResponse')
           .returns(Promise.resolve(null));
-        await autoAds.layoutCallback();
+        await autoAds.buildCallback();
         expect(forceExpStub).not.to.be.called;
       });
 
@@ -107,7 +106,7 @@ describes.realWin(
         env.sandbox
           .stub(viewer, 'sendMessageAwaitResponse')
           .returns(Promise.resolve({experimentIds: []}));
-        await autoAds.layoutCallback();
+        await autoAds.buildCallback();
         expect(forceExpStub).not.to.be.called;
       });
 
@@ -115,7 +114,7 @@ describes.realWin(
         env.sandbox
           .stub(viewer, 'sendMessageAwaitResponse')
           .returns(Promise.resolve({experimentIds: [123]}));
-        await autoAds.layoutCallback();
+        await autoAds.buildCallback();
         expect(getExperimentBranch(win, 'fake-exp')).to.equal('123');
       });
 
@@ -127,7 +126,7 @@ describes.realWin(
         env.sandbox
           .stub(viewer, 'sendMessageAwaitResponse')
           .returns(Promise.resolve({experimentIds: [456]}));
-        await autoAds.layoutCallback();
+        await autoAds.buildCallback();
         expect(forceExpStub).not.to.be.called;
       });
     });


### PR DESCRIPTION
This is a bit racy until we are able to block properly on a viewer capability check. Until then we should send the message and await the response as early as possible.