### PR TITLE
🏗 Build all CSS in an extension's dir, and remove `cssBinaries`

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -529,14 +529,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-inline-gallery",
-        "amp-inline-gallery-captions",
-        "amp-inline-gallery-pagination",
-        "amp-inline-gallery-slide",
-        "amp-inline-gallery-thumbnails"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -545,9 +538,6 @@
     "latestVersion": "0.1",
     "options": {
       "hasCss": true,
-      "cssBinaries": [
-        "amp-inline-gallery-pagination"
-      ],
       "npm": true,
       "bento": true
     }
@@ -976,20 +966,7 @@
     "version": "1.0",
     "latestVersion": "1.0",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-consent",
-        "amp-story-draggable-drawer-header",
-        "amp-story-form",
-        "amp-story-hint",
-        "amp-story-info-dialog",
-        "amp-story-open-page-attachment",
-        "amp-story-share",
-        "amp-story-share-menu",
-        "amp-story-system-layer",
-        "amp-story-tooltip",
-        "amp-story-unsupported-browser-layer"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1005,15 +982,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-auto-ads-ad-badge",
-        "amp-story-auto-ads-attribution",
-        "amp-story-auto-ads-cta-button",
-        "amp-story-auto-ads-inabox",
-        "amp-story-auto-ads-progress-bar",
-        "amp-story-auto-ads-shared"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1050,19 +1019,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-interactive-binary-poll",
-        "amp-story-interactive-img",
-        "amp-story-interactive-img-poll",
-        "amp-story-interactive-img-quiz",
-        "amp-story-interactive-poll",
-        "amp-story-interactive-quiz",
-        "amp-story-interactive-results",
-        "amp-story-interactive-results-detailed",
-        "amp-story-interactive-slider",
-        "amp-story-interactive-disclaimer"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1086,12 +1043,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-story-shopping",
-        "amp-story-shopping-attachment",
-        "amp-story-shopping-tag"
-      ]
+      "hasCss": true
     }
   },
   {
@@ -1156,11 +1108,7 @@
     "version": "0.1",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true,
-      "cssBinaries": [
-        "amp-truncate-text",
-        "amp-truncate-text-shadow"
-      ]
+      "hasCss": true
     }
   },
   {

--- a/build-system/tasks/css/index.js
+++ b/build-system/tasks/css/index.js
@@ -77,7 +77,7 @@ async function copyCss() {
   for (const {outCss} of cssEntryPoints) {
     await fs.copy(`build/css/${outCss}`, `dist/${outCss}`);
   }
-  const cssFiles = await fastGlob('build/css/amp-*.css');
+  const cssFiles = await fastGlob('build/css/*.css');
   await Promise.all(
     cssFiles.map((cssFile) => {
       return fs.copy(cssFile, `dist/v0/${path.basename(cssFile)}`);

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -564,10 +564,11 @@ async function getCssForJssFile(jssFile) {
  */
 async function buildExtensionCss(extDir, name, version, options) {
   const aliasBundle = extensionAliasBundles[name];
-  const aliasVersion =
-    aliasBundle?.version == version ? aliasBundle.version : null;
+  const aliasedVersion =
+    aliasBundle?.version == version ? aliasBundle.aliasedVersion : null;
 
-  const versions = [version, aliasVersion].filter(Boolean);
+  const versions = [version, aliasedVersion].filter(Boolean);
+
   const bundles = await fastGlob(`${extDir}/*.css`);
 
   await Promise.all(
@@ -623,7 +624,6 @@ async function buildBentoCss(name, versions, minifiedAmpCss) {
   const bentoName = getBentoName(name);
   const renamedCss = await renameSelectorsToBentoTagNames(minifiedAmpCss);
   await writeCssBinaries(bentoName, versions, renamedCss);
-  await writeVersions(`dist/v0/${bentoName}`, 'css', versions, renamedCss);
 }
 
 /**
@@ -770,7 +770,7 @@ async function getBentoBuildFilename(dir, name, mode, options) {
  */
 async function generateBentoEntryPointSource(name, toExport, options) {
   const css = options.hasCss
-    ? await fs.readFile(`build/${name}-${options.version}.css`, 'utf8')
+    ? await fs.readFile(`build/css/${name}-${options.version}.css`, 'utf8')
     : null;
 
   return dedent(`

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -570,17 +570,17 @@ async function buildExtensionCss(extDir, name, version, options) {
   const versions = [version, aliasVersion].filter(Boolean);
   const bundles = await fastGlob(`${extDir}/*.css`);
 
-  const parallel = bundles.map(async (filename) => {
-    const name = path.basename(filename, '.css');
-    const css = await jsifyCssAsync(filename);
-    await writeCssBinaries(name, versions, css);
+  await Promise.all(
+    bundles.map(async (filename) => {
+      const name = path.basename(filename, '.css');
+      const css = await jsifyCssAsync(filename);
+      await writeCssBinaries(name, versions, css);
 
-    if (options.bento) {
-      await buildBentoCss(name, versions, css);
-    }
-  });
-
-  await Promise.all(parallel);
+      if (options.bento) {
+        await buildBentoCss(name, versions, css);
+      }
+    })
+  );
 }
 
 /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -80,7 +80,6 @@ const DEFAULT_EXTENSION_SET = ['amp-loader', 'amp-auto-lightbox'];
  *   version?: string,
  *   hasCss?: boolean,
  *   loadPriority?: string,
- *   cssBinaries?: Array<string>,
  *   extraGlobs?: Array<string>,
  *   binaries?: Array<ExtensionBinaryDef>,
  *   npm?: boolean,
@@ -564,55 +563,50 @@ async function getCssForJssFile(jssFile) {
  * @return {!Promise}
  */
 async function buildExtensionCss(extDir, name, version, options) {
-  /**
-   * Writes CSS binaries
-   *
-   * @param {string} name
-   * @param {string} css
-   */
-  function writeCssBinaries(name, css) {
-    const jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
-    const jsName = `build/${name}.js`;
-    const cssName = `build/css/${name}`;
-    fs.writeFileSync(jsName, jsCss, 'utf-8');
-    fs.writeFileSync(cssName, css, 'utf-8');
-  }
-
   const aliasBundle = extensionAliasBundles[name];
-  const isAliased = aliasBundle && aliasBundle.version == version;
+  const aliasVersion =
+    aliasBundle?.version == version ? aliasBundle.version : null;
 
-  const mainCssPromise = jsifyCssAsync(`${extDir}/${name}.css`);
+  const versions = [version, aliasVersion].filter(Boolean);
+  const bundles = await fastGlob(`${extDir}/*.css`);
 
-  const mainCssBinaryPromise = mainCssPromise.then((mainCss) => {
-    writeCssBinaries(`${name}-${version}.css`, mainCss);
-    if (isAliased) {
-      writeCssBinaries(`${name}-${aliasBundle.aliasedVersion}.css`, mainCss);
+  const parallel = bundles.map(async (filename) => {
+    const name = path.basename(filename, '.css');
+    const css = await jsifyCssAsync(filename);
+    await writeCssBinaries(name, versions, css);
+
+    if (options.bento) {
+      await buildBentoCss(name, versions, css);
     }
   });
 
-  const parallel = [mainCssBinaryPromise];
-
-  if (options.bento) {
-    const bentoCssPromise = mainCssPromise.then((mainCss) =>
-      buildBentoCss(name, version, mainCss)
-    );
-    parallel.push(bentoCssPromise);
-  }
-
-  if (Array.isArray(options.cssBinaries)) {
-    parallel.push(
-      ...options.cssBinaries.map((name) => {
-        return jsifyCssAsync(`${extDir}/${name}.css`).then((css) => {
-          writeCssBinaries(`${name}-${version}.css`, css);
-          if (isAliased) {
-            writeCssBinaries(`${name}-${aliasBundle.aliasedVersion}.css`, css);
-          }
-        });
-      })
-    );
-  }
-
   await Promise.all(parallel);
+}
+
+/**
+ * @param {string} name
+ * @param {string[]} versions
+ * @param {string} css
+ * @return {!Promise}
+ */
+async function writeCssBinaries(name, versions, css) {
+  const jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
+  await writeVersions(`build/${name}`, 'js', versions, jsCss);
+  await writeVersions(`build/${name}`, 'css', versions, css);
+}
+
+/**
+ * @param {string} prefix
+ * @param {string} fileExtension
+ * @param {string[]} versions
+ * @param {string} content
+ * @return {!Promise<void>}
+ */
+async function writeVersions(prefix, fileExtension, versions, content) {
+  for (const version of versions) {
+    const outfile = `${prefix}-${version}.${fileExtension}`;
+    await fs.outputFile(outfile, content);
+  }
 }
 
 /**
@@ -621,15 +615,15 @@ async function buildExtensionCss(extDir, name, version, options) {
  * As a result of taking already minified code as source, this function is
  * fairly fast and not cached.
  * @param {string} name
- * @param {string} version
+ * @param {string[]} versions
  * @param {string} minifiedAmpCss
  * @return {!Promise}
  */
-async function buildBentoCss(name, version, minifiedAmpCss) {
+async function buildBentoCss(name, versions, minifiedAmpCss) {
   const bentoName = getBentoName(name);
   const renamedCss = await renameSelectorsToBentoTagNames(minifiedAmpCss);
-  await fs.outputFile(`build/${bentoName}-${version}.css`, renamedCss);
-  await fs.outputFile(`dist/v0/${bentoName}-${version}.css`, renamedCss);
+  await writeCssBinaries(bentoName, versions, renamedCss);
+  await writeVersions(`dist/v0/${bentoName}`, 'css', versions, renamedCss);
 }
 
 /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -591,7 +591,7 @@ async function buildExtensionCss(extDir, name, version, options) {
  */
 async function writeCssBinaries(name, versions, css) {
   const jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
-  await writeVersions(`build/${name}`, 'js', versions, jsCss);
+  await writeVersions(`build/${name}`, 'css.js', versions, jsCss);
   await writeVersions(`build/css/${name}`, 'css', versions, css);
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -592,7 +592,7 @@ async function buildExtensionCss(extDir, name, version, options) {
 async function writeCssBinaries(name, versions, css) {
   const jsCss = 'export const CSS = ' + JSON.stringify(css) + ';\n';
   await writeVersions(`build/${name}`, 'js', versions, jsCss);
-  await writeVersions(`build/${name}`, 'css', versions, css);
+  await writeVersions(`build/css/${name}`, 'css', versions, css);
 }
 
 /**


### PR DESCRIPTION
This is a more flexible model since changing the built CSS binaries does not require OWNERS approval on the `extensions.json` file. 

Even though we might be building some files unnecessarily if they're `@import`ed, in practice the task takes just as long to complete. 