### PR TITLE
[amp story shopping] attachment as element child.

### DIFF
--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -18,13 +18,13 @@
         publisher-logo-src="example.com/logo.png"
         poster-portrait-src="example.com/poster.jpg">
       <amp-story-page id="cover">
-        <!-- <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
-        <amp-story-grid-layer template="vertical">
-          <amp-story-shopping-tag></amp-story-shopping-tag>
-        </amp-story-grid-layer>
-        <amp-story-shopping-attachment layout='fill'></amp-story-shopping-attachment> -->
+        <!-- 
+          An amp-story-shopping-attachment on the first page will throw an error
+          "this.attachmentEl.signals is not a function"  
+        -->
       </amp-story-page>
       
+      <!-- works on any other page than the first. -->
       <amp-story-page id="default">
         <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
         <amp-story-grid-layer template="vertical">

--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -17,12 +17,20 @@
         publisher="AMP Story Shopping"
         publisher-logo-src="example.com/logo.png"
         poster-portrait-src="example.com/poster.jpg">
+      <amp-story-page id="cover">
+        <!-- <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+        <amp-story-shopping-attachment layout='fill'></amp-story-shopping-attachment> -->
+      </amp-story-page>
+      
       <amp-story-page id="default">
         <amp-story-shopping-config layout='nodisplay'></amp-story-shopping-config>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag></amp-story-shopping-tag>
         </amp-story-grid-layer>
-        <amp-story-shopping-attachment layout='nodisplay'></amp-story-shopping-attachment>
+        <amp-story-shopping-attachment layout='fill'></amp-story-shopping-attachment>
       </amp-story-page>
 
       <amp-story-page id="dark-theme">
@@ -30,7 +38,7 @@
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag></amp-story-shopping-tag>
         </amp-story-grid-layer>
-        <amp-story-shopping-attachment layout='nodisplay' theme="dark"></amp-story-shopping-attachment>
+        <amp-story-shopping-attachment layout='fill' theme="dark"></amp-story-shopping-attachment>
       </amp-story-page>
     </amp-story>
   </body>

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -13,7 +13,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
   /** @override */
   buildCallback() {
     super.buildCallback();
-    this.templateWrapper = <div>test</div>;
+    this.templateWrapper = <div></div>;
     this.attachmentEl = (
       <amp-story-page-attachment layout="nodisplay">
         {this.templateWrapper}

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -1,32 +1,49 @@
-import {Layout, applyFillContent} from '#core/dom/layout';
+import * as Preact from '#core/dom/jsx';
+import {Layout} from '#core/dom/layout';
+import {CommonSignals} from '#core/constants/common-signals';
 
-import {AmpStoryPageAttachment} from 'extensions/amp-story/1.0/amp-story-page-attachment';
-
-const TAG = 'amp-story-shopping-attachment';
-
-export class AmpStoryShoppingAttachment extends AmpStoryPageAttachment {
+export class AmpStoryShoppingAttachment extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-
-    /** @private {string} */
-    this.myText_ = TAG;
-
-    /** @private {?Element} */
-    this.container_ = null;
+    this.attachmentEl = null;
+    this.attachmentImpl = null;
   }
 
   /** @override */
   buildCallback() {
     super.buildCallback();
-    this.container_ = this.element.ownerDocument.createElement('div');
-    this.container_.textContent = this.myText_;
-    this.element.appendChild(this.container_);
-    applyFillContent(this.container_, /* replacedContent */ true);
+    this.templateWrapper = <div>test</div>;
+    this.attachmentEl = (
+      <amp-story-page-attachment layout="nodisplay">
+        {this.templateWrapper}
+      </amp-story-page-attachment>
+    );
+    this.element.appendChild(this.attachmentEl);
+  }
+
+  /** @override */
+  layoutCallback() {
+    // Get reference to impl.
+    return this.attachmentEl
+      .signals()
+      .whenSignal(CommonSignals.LOAD_END)
+      .then(() => this.attachmentEl.getImpl())
+      .then((attachmentImpl) => (this.attachmentImpl = attachmentImpl));
+  }
+
+  open() {
+    this.setTemplate_();
+    this.attachmentImpl.open();
+  }
+
+  // Set template when opening
+  setTemplate_() {
+    this.templateWrapper.innerHTML = 'PLP template';
   }
 
   /** @override */
   isLayoutSupported(layout) {
-    return layout == Layout.NODISPLAY;
+    return layout == Layout.FILL;
   }
 }


### PR DESCRIPTION
Demo of appending an `amp-story-page-attachment` instead of extending it.

**This does not work when the `amp-story-shopping-attachment` is on the first page of the story.**
An `this.attachmentEl.signals is not a function` is thrown. 