### PR TITLE
Detect if a link[rel=stylesheet] has been SSR'd/installed for an extension

### DIFF
--- a/examples/amp-story/amp-story-1.0.css
+++ b/examples/amp-story/amp-story-1.0.css
@@ -1,0 +1,1 @@
+amp-story {}

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -272,6 +272,8 @@ function styleLoaded(doc, style) {
   const sheets = doc.styleSheets;
   for (let i = 0; i < sheets.length; i++) {
     const sheet = sheets[i];
+    // The `style` param here can be an instance of a `link[rel=stylesheet]` or
+    // a `style` element. Both can be an "ownerNode" of a CSSStyleSheet
     if (sheet.ownerNode == style) {
       return true;
     }

--- a/src/style-installer.js
+++ b/src/style-installer.js
@@ -95,8 +95,13 @@ function insertStyleElement(cssRoot, cssText, isRuntimeCss, ext) {
   // Check if it has already been created or discovered.
   if (key) {
     const existing = getExistingStyleElement(cssRoot, styleMap, key);
+    // If we find a `link[rel=stylesheet]` to an extensions css, it is
+    // prioritized and not overwritten as the document would most likely
+    // be a transformed document and that the extension will also most likely
+    // be an extension without a CSS to install for optimization.
     if (existing) {
-      if (existing.textContent !== cssText) {
+      // Only overwrite the textContent if it is a `style` tag.
+      if (existing.tagName == 'STYLE' && existing.textContent !== cssText) {
         existing.textContent = cssText;
       }
       return existing;
@@ -142,7 +147,7 @@ function getExistingStyleElement(cssRoot, styleMap, key) {
     return styleMap[key];
   }
   // Check if the style has already been added by the server layout.
-  const existing = cssRoot./*OK*/ querySelector(`style[${key}]`);
+  const existing = cssRoot./*OK*/ querySelector(`style[${key}], link[${key}]`);
   if (existing) {
     styleMap[key] = existing;
     return existing;

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -252,19 +252,19 @@ describes.sandboxed('Styles', {}, () => {
 
         it('should discover existing extension link[rel=stylesheet] and not overwrite it', () => {
           const serverEl = doc.createElement('link');
-          serverEl.setAttribute('amp-extension', 'amp-ext1');
+          serverEl.setAttribute('amp-extension', 'amp-story');
           serverEl.setAttribute(
             'href',
             '/examples/amp-story/amp-story-1.0.css'
           );
           serverEl.setAttribute('rel', 'stylesheet');
           head.appendChild(serverEl);
-          const promise = installStylesAsPromise('other{}', false, 'amp-ext1');
+          const promise = installStylesAsPromise('other{}', false, 'amp-story');
           return promise.then((styleEl) => {
-            expect(head.__AMP_CSS_SM['amp-ext1']).to.not.exist;
+            expect(head.__AMP_CSS_SM['amp-story']).to.not.exist;
             expect(styleEl).to.equal(serverEl);
             expect(
-              head.querySelectorAll('link[amp-extension=amp-ext1]')
+              head.querySelectorAll('link[amp-extension=amp-story]')
             ).to.have.length(1);
           });
         });

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -241,7 +241,7 @@ describes.sandboxed('Styles', {}, () => {
           head.appendChild(serverEl);
           const promise = installStylesAsPromise('other{}', false, 'amp-ext1');
           return promise.then((styleEl) => {
-            expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
+            expect(head.__AMP_CSS_SM['amp-ext1']).to.not.exist;
             expect(styleEl).to.equal(serverEl);
             expect(styleEl.textContent).to.equal('other{}');
             expect(
@@ -261,7 +261,7 @@ describes.sandboxed('Styles', {}, () => {
           head.appendChild(serverEl);
           const promise = installStylesAsPromise('other{}', false, 'amp-ext1');
           return promise.then((styleEl) => {
-            expect(head.__AMP_CSS_SM['amp-story']).to.not.exist;
+            expect(head.__AMP_CSS_SM['amp-ext1']).to.not.exist;
             expect(styleEl).to.equal(serverEl);
             expect(
               head.querySelectorAll('link[amp-extension=amp-ext1]')

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -250,6 +250,25 @@ describes.sandboxed('Styles', {}, () => {
           });
         });
 
+        it('should discover existing extension link[rel=stylesheet] and not overwrite it', () => {
+          const serverEl = doc.createElement('link');
+          serverEl.setAttribute('amp-extension', 'amp-ext1');
+          serverEl.setAttribute(
+            'href',
+            '/examples/amp-story/amp-story-1.0.css'
+          );
+          serverEl.setAttribute('rel', 'stylesheet');
+          head.appendChild(serverEl);
+          const promise = installStylesAsPromise('other{}', false, 'amp-ext1');
+          return promise.then((styleEl) => {
+            expect(head.__AMP_CSS_SM['amp-story']).to.not.exist;
+            expect(styleEl).to.equal(serverEl);
+            expect(
+              head.querySelectorAll('link[amp-extension=amp-ext1]')
+            ).to.have.length(1);
+          });
+        });
+
         it('should re-create extension style', () => {
           installStylesAsPromise('runtime{}', true);
           const promise = installStylesAsPromise('other{}', false, 'amp-ext1');

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -262,7 +262,9 @@ describes.sandboxed('Styles', {}, () => {
           const promise = installStylesAsPromise('other{}', false, 'amp-story');
           return promise.then((styleEl) => {
             expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
-            expect(head.__AMP_CSS_SM['amp-extension=amp-story']).to.equal(serverEl);
+            expect(head.__AMP_CSS_SM['amp-extension=amp-story']).to.equal(
+              serverEl
+            );
             expect(styleEl).to.equal(serverEl);
             expect(
               head.querySelectorAll('link[amp-extension=amp-story]')

--- a/test/unit/test-style-installer.js
+++ b/test/unit/test-style-installer.js
@@ -241,7 +241,7 @@ describes.sandboxed('Styles', {}, () => {
           head.appendChild(serverEl);
           const promise = installStylesAsPromise('other{}', false, 'amp-ext1');
           return promise.then((styleEl) => {
-            expect(head.__AMP_CSS_SM['amp-ext1']).to.not.exist;
+            expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
             expect(styleEl).to.equal(serverEl);
             expect(styleEl.textContent).to.equal('other{}');
             expect(
@@ -261,7 +261,8 @@ describes.sandboxed('Styles', {}, () => {
           head.appendChild(serverEl);
           const promise = installStylesAsPromise('other{}', false, 'amp-story');
           return promise.then((styleEl) => {
-            expect(head.__AMP_CSS_SM['amp-story']).to.not.exist;
+            expect(head.__AMP_CSS_SM['amp-runtime']).to.not.exist;
+            expect(head.__AMP_CSS_SM['amp-extension=amp-story']).to.equal(serverEl);
             expect(styleEl).to.equal(serverEl);
             expect(
               head.querySelectorAll('link[amp-extension=amp-story]')


### PR DESCRIPTION
Some amp optimizers will in the future add a link[rel=stylesheet] for an
extension to improve their performance. We need to be able to detect and
not overwrite the installed styles by the external stylesheet.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
