### PR TITLE
gallery/carousel fix: restore public function

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -405,6 +405,16 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     return this.pos_ != maxPos;
   }
 
+  /** Used by amp-lightbox-gallery */
+  interactionNext() {
+    this.controls_.interactionNext();
+  }
+
+  /** Used by amp-lightbox-gallery */
+  interactionPrev() {
+    this.controls_.interactionPrev();
+  }
+
   /**
    * Cancels the touchmove events for the element so that viewer does not
    * consider the swipes in the carousel as swipes for changing AMP documents.

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -368,6 +368,16 @@ export class AmpSlideScroll extends AMP.BaseElement {
     }
   }
 
+  /** Used by amp-lightbox-gallery */
+  interactionNext() {
+    this.controls_.interactionNext();
+  }
+
+  /** Used by amp-lightbox-gallery */
+  interactionPrev() {
+    this.controls_.interactionPrev();
+  }
+
   /**
    * Does all the work needed to proceed to next
    * desired direction.


### PR DESCRIPTION
**summary**
Turns out gallery depends on the public API of carousel:
https://github.com/ampproject/amphtml/blob/abfe09e34b17a53fc676f9f2ae98ad8065fd5d77/extensions/amp-lightbox-gallery/0.1/amp-lightbox-gallery.js#L509-L515

I changed that public API in https://github.com/ampproject/amphtml/commit/a3b02b44afff558c5dded72dd3659761bf98083a. Resulting in this new error:

![image](https://user-images.githubusercontent.com/4656974/141002256-17471394-449a-4319-907d-b68c9cd85df1.png)


**testing done**
- `npx amp`
- Open up http://0.0.0.0:8000/examples/lightbox-gallery.amp.html, click an img, ensure arrow buttons proceed to next/prev image