### PR TITLE
📖 Bento docs: Full snippets have `<html>` and `<%-- example --%>`

### DIFF
--- a/extensions/amp-accordion/1.0/README.md
+++ b/extensions/amp-accordion/1.0/README.md
@@ -36,47 +36,54 @@ defineBentoAccordion();
 The example below contains an `bento-accordion` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
-```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-accordion-1.0.js"
-  ></script>
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="https://cdn.ampproject.org/v0/bento-accordion-1.0.css"
-  />
-</head>
-<body>
-  <bento-accordion id="my-accordion">
-    <section>
-      <h2>Section 1</h2>
-      <p>Content in section 1.</p>
-    </section>
-    <section>
-      <h2>Section 2</h2>
-      <div>Content in section 2.</div>
-    </section>
-    <section expanded>
-      <h2>Section 3</h2>
-      <div>Content in section 3.</div>
-    </section>
-  </bento-accordion>
-  <script>
-    (async () => {
-      const accordion = document.querySelector('#my-accordion');
-      await customElements.whenDefined('bento-accordion');
-      const api = await accordion.getApi();
+<!--% example %-->
 
-      // programatically expand all sections
-      api.expand();
-      // programatically collapse all sections
-      api.collapse();
-    })();
-  </script>
-</body>
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-accordion-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-accordion-1.0.css"
+    />
+  </head>
+  <body>
+    <body>
+      <bento-accordion id="my-accordion">
+        <section>
+          <h2>Section 1</h2>
+          <p>Content in section 1.</p>
+        </section>
+        <section>
+          <h2>Section 2</h2>
+          <div>Content in section 2.</div>
+        </section>
+        <section expanded>
+          <h2>Section 3</h2>
+          <div>Content in section 3.</div>
+        </section>
+      </bento-accordion>
+      <script>
+        (async () => {
+          const accordion = document.querySelector('#my-accordion');
+          await customElements.whenDefined('bento-accordion');
+          const api = await accordion.getApi();
+
+          // programatically expand all sections
+          api.expand();
+          // programatically collapse all sections
+          api.collapse();
+        })();
+      </script>
+    </body>
+  </body>
+</html>
 ```
 
 ### Interactivity and API usage

--- a/extensions/amp-base-carousel/1.0/README.md
+++ b/extensions/amp-base-carousel/1.0/README.md
@@ -27,63 +27,71 @@ defineBentoBaseCarousel();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-base-carousel {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.js"
-  ></script>
-  <style>
-    bento-base-carousel,
-    bento-base-carousel > div {
-      aspect-ratio: 4/1;
-    }
-    .red {
-      background: darkred;
-    }
-    .blue {
-      background: steelblue;
-    }
-    .green {
-      background: seagreen;
-    }
-  </style>
-</head>
-<bento-base-carousel id="my-carousel">
-  <div class="red"></div>
-  <div class="blue"></div>
-  <div class="green"></div>
-</bento-base-carousel>
-<div class="buttons" style="margin-top: 8px">
-  <button id="prev-button">Go to previous slide</button>
-  <button id="next-button">Go to next slide</button>
-  <button id="go-to-button">Go to slide with green gradient</button>
-</div>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-base-carousel {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.js"
+    ></script>
+    <style>
+      bento-base-carousel,
+      bento-base-carousel > div {
+        aspect-ratio: 4/1;
+      }
+      .red {
+        background: darkred;
+      }
+      .blue {
+        background: steelblue;
+      }
+      .green {
+        background: seagreen;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-base-carousel id="my-carousel">
+      <div class="red"></div>
+      <div class="blue"></div>
+      <div class="green"></div>
+    </bento-base-carousel>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="prev-button">Go to previous slide</button>
+      <button id="next-button">Go to next slide</button>
+      <button id="go-to-button">Go to slide with green gradient</button>
+    </div>
 
-<script>
-  (async () => {
-    const carousel = document.querySelector('#my-carousel');
-    await customElements.whenDefined('bento-base-carousel');
-    const api = await carousel.getApi();
+    <script>
+      (async () => {
+        const carousel = document.querySelector('#my-carousel');
+        await customElements.whenDefined('bento-base-carousel');
+        const api = await carousel.getApi();
 
-    // programatically advance to next slide
-    api.next();
+        // programatically advance to next slide
+        api.next();
 
-    // set up button actions
-    document.querySelector('#prev-button').onclick = () => api.prev();
-    document.querySelector('#next-button').onclick = () => api.next();
-    document.querySelector('#go-to-button').onclick = () => api.goToSlide(2);
-  })();
-</script>
+        // set up button actions
+        document.querySelector('#prev-button').onclick = () => api.prev();
+        document.querySelector('#next-button').onclick = () => api.next();
+        document.querySelector('#go-to-button').onclick = () =>
+          api.goToSlide(2);
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Interactivity and API usage

--- a/extensions/amp-embedly-card/1.0/README.md
+++ b/extensions/amp-embedly-card/1.0/README.md
@@ -25,64 +25,71 @@ defineBentoEmbedlyCard();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-embedly-card {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-embedly-card-1.0.js"
-  ></script>
-  <style>
-    bento-embedly-card {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
-<body>
-  <bento-embedly-key value="12af2e3543ee432ca35ac30a4b4f656a">
-  </bento-embedly-key>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-embedly-card {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-embedly-card-1.0.js"
+    ></script>
+    <style>
+      bento-embedly-card {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <body>
+      <bento-embedly-key value="12af2e3543ee432ca35ac30a4b4f656a">
+      </bento-embedly-key>
 
-  <bento-embedly-card
-    data-url="https://twitter.com/AMPhtml/status/986750295077040128"
-    data-card-theme="dark"
-    data-card-controls="0"
-  >
-  </bento-embedly-card>
+      <bento-embedly-card
+        data-url="https://twitter.com/AMPhtml/status/986750295077040128"
+        data-card-theme="dark"
+        data-card-controls="0"
+      >
+      </bento-embedly-card>
 
-  <bento-embedly-card
-    id="my-url"
-    data-url="https://www.youtube.com/watch?v=LZcKdHinUhE"
-  >
-  </bento-embedly-card>
+      <bento-embedly-card
+        id="my-url"
+        data-url="https://www.youtube.com/watch?v=LZcKdHinUhE"
+      >
+      </bento-embedly-card>
 
-  <div class="buttons" style="margin-top: 8px">
-    <button id="change-url">Change embed</button>
-  </div>
+      <div class="buttons" style="margin-top: 8px">
+        <button id="change-url">Change embed</button>
+      </div>
 
-  <script>
-    (async () => {
-      const embedlyCard = document.querySelector('#my-url');
-      await customElements.whenDefined('bento-embedly-card');
+      <script>
+        (async () => {
+          const embedlyCard = document.querySelector('#my-url');
+          await customElements.whenDefined('bento-embedly-card');
 
-      // set up button actions
-      document.querySelector('#change-url').onclick = () => {
-        embedlyCard.setAttribute(
-          'data-url',
-          'https://www.youtube.com/watch?v=wcJSHR0US80'
-        );
-      };
-    })();
-  </script>
-</body>
+          // set up button actions
+          document.querySelector('#change-url').onclick = () => {
+            embedlyCard.setAttribute(
+              'data-url',
+              'https://www.youtube.com/watch?v=wcJSHR0US80'
+            );
+          };
+        })();
+      </script>
+    </body>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-facebook/1.0/README.md
+++ b/extensions/amp-facebook/1.0/README.md
@@ -21,218 +21,247 @@ defineBentoFacebook();
 
 ##### Embed a Facebook Post
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-facebook {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
-  ></script>
-  <style>
-    bento-facebook {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-facebook {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
+    ></script>
+    <style>
+      bento-facebook {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-facebook
+      id="facebook-post"
+      data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373"
+    >
+    </bento-facebook>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-facebook-post">Change Facebook post</button>
+    </div>
 
-<bento-facebook
-  id="facebook-post"
-  data-href="https://www.facebook.com/ParksCanada/posts/1712989015384373"
->
-</bento-facebook>
-<div class="buttons" style="margin-top: 8px">
-  <button id="change-facebook-post">Change Facebook post</button>
-</div>
-
-<script>
-  (async () => {
-    const facebookPost = document.querySelector('#facebook-post');
-    await customElements.whenDefined('bento-facebook');
-    // set up button actions
-    document.querySelector('#change-facebook-post').onclick = () => {
-      facebookPost.setAttribute(
-        'data-href',
-        'https://www.facebook.com/NASA/photos/a.67899501771/10159193669016772/'
-      );
-    };
-  })();
-</script>
-
+    <script>
+      (async () => {
+        const facebookPost = document.querySelector('#facebook-post');
+        await customElements.whenDefined('bento-facebook');
+        // set up button actions
+        document.querySelector('#change-facebook-post').onclick = () => {
+          facebookPost.setAttribute(
+            'data-href',
+            'https://www.facebook.com/NASA/photos/a.67899501771/10159193669016772/'
+          );
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ##### Embed a Facebook Video
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-facebook {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
-  ></script>
-  <style>
-    bento-facebook {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-facebook {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
+    ></script>
+    <style>
+      bento-facebook {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-facebook
+      id="facebook-video"
+      data-embed-as="video"
+      data-href="https://www.facebook.com/nasaearth/videos/10155187938052139"
+    >
+    </bento-facebook>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-facebook-video">Change Facebook video</button>
+    </div>
 
-<bento-facebook
-  id="facebook-video"
-  data-embed-as="video"
-  data-href="https://www.facebook.com/nasaearth/videos/10155187938052139"
->
-</bento-facebook>
-<div class="buttons" style="margin-top: 8px">
-  <button id="change-facebook-video">Change Facebook video</button>
-</div>
-
-<script>
-  (async () => {
-    const facebookVideo = document.querySelector('#facebook-video');
-    await customElements.whenDefined('bento-facebook');
-    // set up button actions
-    document.querySelector('#change-facebook-video').onclick = () => {
-      facebookVideo.setAttribute(
-        'data-href',
-        'https://www.facebook.com/NASA/videos/846648316199961/'
-      );
-    };
-  })();
-</script>
+    <script>
+      (async () => {
+        const facebookVideo = document.querySelector('#facebook-video');
+        await customElements.whenDefined('bento-facebook');
+        // set up button actions
+        document.querySelector('#change-facebook-video').onclick = () => {
+          facebookVideo.setAttribute(
+            'data-href',
+            'https://www.facebook.com/NASA/videos/846648316199961/'
+          );
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ##### Embed a Facebook Page
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-facebook {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
-  ></script>
-  <style>
-    bento-facebook {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-facebook {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
+    ></script>
+    <style>
+      bento-facebook {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-facebook
+      id="facebook-video"
+      data-embed-as="video"
+      data-href="https://www.facebook.com/nasaearth/videos/10155187938052139"
+    >
+    </bento-facebook>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-facebook-video">Change Facebook video</button>
+    </div>
 
-<bento-facebook
-  id="facebook-video"
-  data-embed-as="video"
-  data-href="https://www.facebook.com/nasaearth/videos/10155187938052139"
->
-</bento-facebook>
-<div class="buttons" style="margin-top: 8px">
-  <button id="change-facebook-video">Change Facebook video</button>
-</div>
-
-<script>
-  (async () => {
-    const facebookVideo = document.querySelector('#facebook-video');
-    await customElements.whenDefined('bento-facebook');
-    // set up button actions
-    document.querySelector('#change-facebook-video').onclick = () => {
-      facebookVideo.setAttribute(
-        'data-href',
-        'https://www.facebook.com/NASA/videos/846648316199961/'
-      );
-    };
-  })();
-</script>
+    <script>
+      (async () => {
+        const facebookVideo = document.querySelector('#facebook-video');
+        await customElements.whenDefined('bento-facebook');
+        // set up button actions
+        document.querySelector('#change-facebook-video').onclick = () => {
+          facebookVideo.setAttribute(
+            'data-href',
+            'https://www.facebook.com/NASA/videos/846648316199961/'
+          );
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ##### Embed a Facebook Like Button
 
-```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-facebook {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
-  ></script>
-  <style>
-    bento-facebook {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
+<!--% example %-->
 
-<bento-facebook
-  id="facebook-video"
-  data-embed-as="like"
-  data-href="https://www.facebook.com/nasaearth/videos/10155187938052139"
->
-</bento-facebook>
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-facebook {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
+    ></script>
+    <style>
+      bento-facebook {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-facebook
+      id="facebook-video"
+      data-embed-as="like"
+      data-href="https://www.facebook.com/nasaearth/videos/10155187938052139"
+    >
+    </bento-facebook>
+  </body>
+</html>
 ```
 
 ##### Embed a Facebook Comment Section
 
-```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-facebook {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
-  ></script>
-  <style>
-    bento-facebook {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
+<!--% example %-->
 
-<bento-facebook
-  id="facebook-comments"
-  data-embed-as="comments"
-  data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185"
->
-</bento-facebook>
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-facebook {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-facebook-1.0.js"
+    ></script>
+    <style>
+      bento-facebook {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-facebook
+      id="facebook-comments"
+      data-embed-as="comments"
+      data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185"
+    >
+    </bento-facebook>
+  </body>
+</html>
 ```
 
 ### Layout and Style

--- a/extensions/amp-fit-text/1.0/README.md
+++ b/extensions/amp-fit-text/1.0/README.md
@@ -23,39 +23,50 @@ defineBentoFitText();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-fit-text {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-</head>
-<bento-fit-text id="my-fit-text">
-  Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque inermis
-  reprehendunt.
-</bento-fit-text>
-<div class="buttons" style="margin-top: 8px">
-  <button id="font-button">Change max-font-size</button>
-  <button id="content-button">Change content</button>
-</div>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-fit-text-1.0.js"
+    ></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-fit-text {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-fit-text id="my-fit-text">
+      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
+      inermis reprehendunt.
+    </bento-fit-text>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="font-button">Change max-font-size</button>
+      <button id="content-button">Change content</button>
+    </div>
 
-<script>
-  (async () => {
-    const fitText = document.querySelector('#my-fit-text');
-    await customElements.whenDefined('bento-fit-text');
+    <script>
+      (async () => {
+        const fitText = document.querySelector('#my-fit-text');
+        await customElements.whenDefined('bento-fit-text');
 
-    // set up button actions
-    document.querySelector('#font-button').onclick = () =>
-      fitText.setAttribute('max-font-size', '40');
-    document.querySelector('#content-button').onclick = () =>
-      (fitText.textContent = 'new content');
-  })();
-</script>
+        // set up button actions
+        document.querySelector('#font-button').onclick = () =>
+          fitText.setAttribute('max-font-size', '40');
+        document.querySelector('#content-button').onclick = () =>
+          (fitText.textContent = 'new content');
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Overflowing content

--- a/extensions/amp-iframe/1.0/README.md
+++ b/extensions/amp-iframe/1.0/README.md
@@ -25,39 +25,46 @@ defineBentoIframe();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-iframe-1.0.js"
-  ></script>
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="https://cdn.ampproject.org/v0/bento-iframe-1.0.css"
-  />
-</head>
-<bento-iframe
-  id="my-iframe"
-  src="https://en.wikipedia.org/wiki/Bento"
-  style="width: 800px; height: 600px"
->
-</bento-iframe>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-iframe-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-iframe-1.0.css"
+    />
+  </head>
+  <body>
+    <bento-iframe
+      id="my-iframe"
+      src="https://en.wikipedia.org/wiki/Bento"
+      style="width: 800px; height: 600px"
+    >
+    </bento-iframe>
 
-<button id="change-source">Change source</button>
+    <button id="change-source">Change source</button>
 
-<script>
-  (async () => {
-    const iframeEl = document.querySelector('#my-iframe');
-    await customElements.whenDefined('bento-iframe');
+    <script>
+      (async () => {
+        const iframeEl = document.querySelector('#my-iframe');
+        await customElements.whenDefined('bento-iframe');
 
-    // Reload iframe with new src
-    document.querySelector('#change-source').onclick = () => {
-      iframeEl.setAttribute('src', 'https://example.com');
-    };
-  })();
-</script>
+        // Reload iframe with new src
+        document.querySelector('#change-source').onclick = () => {
+          iframeEl.setAttribute('src', 'https://example.com');
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-inline-gallery/1.0/README.md
+++ b/extensions/amp-inline-gallery/1.0/README.md
@@ -25,31 +25,61 @@ defineBentoInlineGallery();
 
 The example below contains a `bento-inline-gallery` consisting of three slides with thumbnails and a pagination indicator.
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
 
-  <script async src="https://cdn.ampproject.org/v0/bento-inline-gallery-1.0.js"></script>
-  <link rel="stylesheet" href="https://cdn.ampproject.org/v0/bento-inline-gallery-1.0.css">
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-inline-gallery-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://cdn.ampproject.org/v0/bento-inline-gallery-1.0.css"
+    />
 
-  <script async src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.js"></script>
-  <link rel="stylesheet" href="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.css">
-<body>
-  <bento-inline-gallery id="inline-gallery">
-    <bento-inline-gallery-thumbnails style="height: 100px;" loop></bento-inline-gallery-thumbnails>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.css"
+    />
+  </head>
+  <body>
+    <body>
+      <bento-inline-gallery id="inline-gallery">
+        <bento-inline-gallery-thumbnails
+          style="height: 100px"
+          loop
+        ></bento-inline-gallery-thumbnails>
 
-    <bento-base-carousel style="height: 200px;" snap-align="center" visible-count="3" loop>
-      <img src="img1.jpeg" data-thumbnail-src="img1-thumbnail.jpeg" />
-      <img src="img2.jpeg" data-thumbnail-src="img2-thumbnail.jpeg" />
-      <img src="img3.jpeg" data-thumbnail-src="img3-thumbnail.jpeg" />
-      <img src="img4.jpeg" data-thumbnail-src="img4-thumbnail.jpeg" />
-      <img src="img5.jpeg" data-thumbnail-src="img5-thumbnail.jpeg" />
-      <img src="img6.jpeg" data-thumbnail-src="img6-thumbnail.jpeg" />
-    </bento-base-carousel>
+        <bento-base-carousel
+          style="height: 200px"
+          snap-align="center"
+          visible-count="3"
+          loop
+        >
+          <img src="img1.jpeg" data-thumbnail-src="img1-thumbnail.jpeg" />
+          <img src="img2.jpeg" data-thumbnail-src="img2-thumbnail.jpeg" />
+          <img src="img3.jpeg" data-thumbnail-src="img3-thumbnail.jpeg" />
+          <img src="img4.jpeg" data-thumbnail-src="img4-thumbnail.jpeg" />
+          <img src="img5.jpeg" data-thumbnail-src="img5-thumbnail.jpeg" />
+          <img src="img6.jpeg" data-thumbnail-src="img6-thumbnail.jpeg" />
+        </bento-base-carousel>
 
-    <bento-inline-gallery-pagination style="height: 20px;"></bento-inline-gallery-pagination>
-  </bento-inline-gallery>
-</body>
+        <bento-inline-gallery-pagination
+          style="height: 20px"
+        ></bento-inline-gallery-pagination>
+      </bento-inline-gallery>
+    </body>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-instagram/1.0/README.md
+++ b/extensions/amp-instagram/1.0/README.md
@@ -21,43 +21,50 @@ defineBentoInstagram();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-instagram-1.0.js"
-  ></script>
-  <style>
-    bento-instagram {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-</head>
-<body>
-  <bento-instagram
-    id="my-instagram"
-    data-shortcode="CKXYAzuj7TE"
-    data-captioned
-    style="height: 800px; width: 400px;"
-  >
-  </bento-instagram>
-  <button id="change-shortcode">Change shortcode</button>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-instagram-1.0.js"
+    ></script>
+    <style>
+      bento-instagram {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+  </head>
+  <body>
+    <body>
+      <bento-instagram
+        id="my-instagram"
+        data-shortcode="CKXYAzuj7TE"
+        data-captioned
+        style="height: 800px; width: 400px"
+      >
+      </bento-instagram>
+      <button id="change-shortcode">Change shortcode</button>
 
-  <script>
-    (async () => {
-      const instagram = document.querySelector('#my-instagram');
-      await customElements.whenDefined('bento-instagram');
+      <script>
+        (async () => {
+          const instagram = document.querySelector('#my-instagram');
+          await customElements.whenDefined('bento-instagram');
 
-      // set up button actions
-      document.querySelector('#change-shortcode').onclick = () => {
-        instagram.dataset.shortcode = '1totVhIFXl';
-      };
-    })();
-  </script>
-</body>
+          // set up button actions
+          document.querySelector('#change-shortcode').onclick = () => {
+            instagram.dataset.shortcode = '1totVhIFXl';
+          };
+        })();
+      </script>
+    </body>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-jwplayer/1.0/README.md
+++ b/extensions/amp-jwplayer/1.0/README.md
@@ -24,41 +24,48 @@ defineBentoJwplayer();
 The example below contains an `bento-jwplayer` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.js"
-  ></script>
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.css"
-  />
-</head>
-<body>
-  <bento-jwplayer
-    id="jwplayer"
-    data-player-id="BjcwyK37"
-    data-media-id="CtaIzmFs"
-    style="width: 480px; height: 270px"
-  ></bento-jwplayer>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.css"
+    />
+  </head>
+  <body>
+    <body>
+      <bento-jwplayer
+        id="jwplayer"
+        data-player-id="BjcwyK37"
+        data-media-id="CtaIzmFs"
+        style="width: 480px; height: 270px"
+      ></bento-jwplayer>
 
-  <script>
-    (async () => {
-      const twitter = document.querySelector('#jwplayer');
-      await customElements.whenDefined('bento-twitter');
+      <script>
+        (async () => {
+          const twitter = document.querySelector('#jwplayer');
+          await customElements.whenDefined('bento-twitter');
 
-      const api = player.getApi();
-      api.play();
-      api.pause();
-      api.mute();
-      api.unmute();
-      api.requestFullscreen();
-    })();
-  </script>
-</body>
+          const api = player.getApi();
+          api.play();
+          api.pause();
+          api.mute();
+          api.unmute();
+          api.requestFullscreen();
+        })();
+      </script>
+    </body>
+  </body>
+</html>
 ```
 
 ### Interactivity and API usage

--- a/extensions/amp-lightbox-gallery/1.0/README.md
+++ b/extensions/amp-lightbox-gallery/1.0/README.md
@@ -23,48 +23,54 @@ defineBentoLightboxGallery();
 
 ### Example: Import via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-lightbox-gallery[hidden] {
-      display: none !important;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-lightbox-gallery-1.0.js"
-  ></script>
-</head>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-lightbox-gallery[hidden] {
+        display: none !important;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-lightbox-gallery-1.0.js"
+    ></script>
+  </head>
+  <body>
+    <figure>
+      <img
+        id="my-img"
+        width="360"
+        height="240"
+        src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1498&q=80"
+        lightbox
+      />
+      <figcaption>dog wearing yellow shirt.</figcaption>
+    </figure>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-img">change image</button>
+    </div>
 
-<figure>
-  <img
-    id="my-img"
-    width="360"
-    height="240"
-    src="https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1498&q=80"
-    lightbox
-  />
-  <figcaption>dog wearing yellow shirt.</figcaption>
-</figure>
-<div class="buttons" style="margin-top: 8px">
-  <button id="change-img">change image</button>
-</div>
-
-<script>
-  (async () => {
-    const img = document.queryselector('#my-img');
-    await customelements.whendefined('img');
-    // set up button actions
-    document.queryselector('#change-img').onclick = () => {
-      img.setattribute(
-        'src',
-        'https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80'
-      );
-    };
-  })();
-</script>
+    <script>
+      (async () => {
+        const img = document.queryselector('#my-img');
+        await customelements.whendefined('img');
+        // set up button actions
+        document.queryselector('#change-img').onclick = () => {
+          img.setattribute(
+            'src',
+            'https://images.unsplash.com/photo-1603123853880-a92fafb7809f?ixlib=rb-1.2.1&auto=format&fit=crop&w=1498&q=80'
+          );
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 To use `bento-liightbox-gallery`, ensure the required script is included in your `<head>` section,

--- a/extensions/amp-lightbox/1.0/README.md
+++ b/extensions/amp-lightbox/1.0/README.md
@@ -21,35 +21,42 @@ defineBentoLightbox();
 
 ### Example: Import via `<script>`
 
-```html
-<head>
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="https://cdn.ampproject.org/v0/bento-lightbox-1.0.css"
-  />
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-lightbox-1.0.js"
-  ></script>
-</head>
-<bento-lightbox id="my-lightbox">
-  Lightboxed content
-  <button id="close-button">Close lightbox</button>
-</bento-lightbox>
-<button id="open-button">Open lightbox</button>
-<script>
-  (async () => {
-    const lightbox = document.querySelector('#my-lightbox');
-    await customElements.whenDefined('bento-lightbox');
-    const api = await lightbox.getApi();
+<!--% example %-->
 
-    // set up button actions
-    document.querySelector('#open-button').onclick = () => api.open();
-    document.querySelector('#close-button').onclick = () => api.close();
-  })();
-</script>
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-lightbox-1.0.css"
+    />
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-lightbox-1.0.js"
+    ></script>
+  </head>
+  <body>
+    <bento-lightbox id="my-lightbox">
+      Lightboxed content
+      <button id="close-button">Close lightbox</button>
+    </bento-lightbox>
+    <button id="open-button">Open lightbox</button>
+    <script>
+      (async () => {
+        const lightbox = document.querySelector('#my-lightbox');
+        await customElements.whenDefined('bento-lightbox');
+        const api = await lightbox.getApi();
+
+        // set up button actions
+        document.querySelector('#open-button').onclick = () => api.open();
+        document.querySelector('#close-button').onclick = () => api.close();
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Interactivity and API usage

--- a/extensions/amp-mathml/1.0/README.md
+++ b/extensions/amp-mathml/1.0/README.md
@@ -24,62 +24,69 @@ defineBentoMathml();
 The example below contains an `bento-mathml` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-mathml-1.0.js"
-  ></script>
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="https://cdn.ampproject.org/v0/bento-mathml-1.0.css"
-  />
-</head>
-<body>
-  <h2>The Quadratic Formula</h2>
-  <bento-mathml
-    style="height: 40px"
-    data-formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"
-  ></bento-mathml>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-mathml-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-mathml-1.0.css"
+    />
+  </head>
+  <body>
+    <body>
+      <h2>The Quadratic Formula</h2>
+      <bento-mathml
+        style="height: 40px"
+        data-formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"
+      ></bento-mathml>
 
-  <h2>Cauchy's Integral Formula</h2>
-  <bento-mathml
-    style="height: 41px"
-    data-formula="\[f(a) = \frac{1}{2\pi i} \oint\frac{f(z)}{z-a}dz\]"
-  ></bento-mathml>
+      <h2>Cauchy's Integral Formula</h2>
+      <bento-mathml
+        style="height: 41px"
+        data-formula="\[f(a) = \frac{1}{2\pi i} \oint\frac{f(z)}{z-a}dz\]"
+      ></bento-mathml>
 
-  <h2>Double angle formula for Cosines</h2>
-  <bento-mathml
-    style="height: 19px"
-    data-formula="\[cos(θ+φ)=\cos(θ)\cos(φ)−\sin(θ)\sin(φ)\]"
-  ></bento-mathml>
+      <h2>Double angle formula for Cosines</h2>
+      <bento-mathml
+        style="height: 19px"
+        data-formula="\[cos(θ+φ)=\cos(θ)\cos(φ)−\sin(θ)\sin(φ)\]"
+      ></bento-mathml>
 
-  <h2>Inline formula</h2>
-  <p>
-    This is an example of a formula of
-    <bento-mathml
-      style="height: 11px; width: 8px"
-      inline
-      data-formula="`x`"
-    ></bento-mathml
-    >,
-    <bento-mathml
-      style="height: 40px; width: 147px"
-      inline
-      data-formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"
-    ></bento-mathml>
-    placed inline in the middle of a block of text.
-    <bento-mathml
-      style="height: 19px; width: 72px"
-      inline
-      data-formula="\( \cos(θ+φ) \)"
-    ></bento-mathml>
-    This shows how the formula will fit inside a block of text and can be styled
-    with CSS.
-  </p>
-</body>
+      <h2>Inline formula</h2>
+      <p>
+        This is an example of a formula of
+        <bento-mathml
+          style="height: 11px; width: 8px"
+          inline
+          data-formula="`x`"
+        ></bento-mathml
+        >,
+        <bento-mathml
+          style="height: 40px; width: 147px"
+          inline
+          data-formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"
+        ></bento-mathml>
+        placed inline in the middle of a block of text.
+        <bento-mathml
+          style="height: 19px; width: 72px"
+          inline
+          data-formula="\( \cos(θ+φ) \)"
+        ></bento-mathml>
+        This shows how the formula will fit inside a block of text and can be
+        styled with CSS.
+      </p>
+    </body>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-selector/1.0/README.md
+++ b/extensions/amp-selector/1.0/README.md
@@ -19,30 +19,37 @@ defineBentoSelector();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-selector {
-      display: block;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-selector-1.0.js"
-  ></script>
-</head>
-<body>
-  <bento-selector class="sample-selector">
-    <ul>
-      <li option="1">Option 1</li>
-      <li option="2">Option 2</li>
-      <li option="3">Option 3</li>
-      <li option="4">Option 4</li>
-    </ul>
-  </bento-selector>
-</body>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-selector {
+        display: block;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-selector-1.0.js"
+    ></script>
+  </head>
+  <body>
+    <body>
+      <bento-selector class="sample-selector">
+        <ul>
+          <li option="1">Option 1</li>
+          <li option="2">Option 2</li>
+          <li option="3">Option 3</li>
+          <li option="4">Option 4</li>
+        </ul>
+      </bento-selector>
+    </body>
+  </body>
+</html>
 ```
 
 ### Usage notes

--- a/extensions/amp-sidebar/1.0/README.md
+++ b/extensions/amp-sidebar/1.0/README.md
@@ -21,47 +21,54 @@ defineBentoSidebar();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-sidebar:not([open]) {
-      display: none !important;
-    }
-  </style>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-sidebar-1.0.js"
-  ></script>
-</head>
-<body>
-  <bento-sidebar id="sidebar1" side="right">
-    <ul>
-      <li>Nav item 1</li>
-      <li>Nav item 2</li>
-      <li>Nav item 3</li>
-      <li>Nav item 4</li>
-      <li>Nav item 5</li>
-      <li>Nav item 6</li>
-    </ul>
-  </bento-sidebar>
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-sidebar:not([open]) {
+        display: none !important;
+      }
+    </style>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-sidebar-1.0.js"
+    ></script>
+  </head>
+  <body>
+    <body>
+      <bento-sidebar id="sidebar1" side="right">
+        <ul>
+          <li>Nav item 1</li>
+          <li>Nav item 2</li>
+          <li>Nav item 3</li>
+          <li>Nav item 4</li>
+          <li>Nav item 5</li>
+          <li>Nav item 6</li>
+        </ul>
+      </bento-sidebar>
 
-  <div class="buttons" style="margin-top: 8px">
-    <button id="open-sidebar">Open sidebar</button>
-  </div>
+      <div class="buttons" style="margin-top: 8px">
+        <button id="open-sidebar">Open sidebar</button>
+      </div>
 
-  <script>
-    (async () => {
-      const sidebar = document.querySelector('#sidebar1');
-      await customElements.whenDefined('bento-sidebar');
-      const api = await sidebar.getApi();
+      <script>
+        (async () => {
+          const sidebar = document.querySelector('#sidebar1');
+          await customElements.whenDefined('bento-sidebar');
+          const api = await sidebar.getApi();
 
-      // set up button actions
-      document.querySelector('#open-sidebar').onclick = () => api.open();
-    })();
-  </script>
-</body>
+          // set up button actions
+          document.querySelector('#open-sidebar').onclick = () => api.open();
+        })();
+      </script>
+    </body>
+  </body>
+</html>
 ```
 
 ### Interactivity and API usage

--- a/extensions/amp-social-share/1.0/README.md
+++ b/extensions/amp-social-share/1.0/README.md
@@ -23,54 +23,60 @@ defineBentoSocialShare();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-social-share {
-      display: inline-block;
-      overflow: hidden;
-      position: relative;
-      box-sizing: border-box;
-      width: 60px;
-      height: 44px;
-    }
-  </style>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-twitter-1.0.js"
-  ></script>
-  <style>
-    bento-social-share {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
+<!DOCTYPE html>
+<html>
+  <head>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-social-share {
+        display: inline-block;
+        overflow: hidden;
+        position: relative;
+        box-sizing: border-box;
+        width: 60px;
+        height: 44px;
+      }
+    </style>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-twitter-1.0.js"
+    ></script>
+    <style>
+      bento-social-share {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-social-share
+      id="my-share"
+      type="twitter"
+      aria-label="Share on Twitter"
+    ></bento-social-share>
 
-<bento-social-share
-  id="my-share"
-  type="twitter"
-  aria-label="Share on Twitter"
-></bento-social-share>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-share">Change share button</button>
+    </div>
 
-<div class="buttons" style="margin-top: 8px">
-  <button id="change-share">Change share button</button>
-</div>
+    <script>
+      (async () => {
+        const button = document.querySelector('#my-share');
+        await customElements.whenDefined('bento-social-share');
 
-<script>
-  (async () => {
-    const button = document.querySelector('#my-share');
-    await customElements.whenDefined('bento-social-share');
-
-    // set up button actions
-    document.querySelector('#change-share').onclick = () => {
-      twitter.setAttribute('type', 'linkedin');
-      twitter.setAttribute('aria-label', 'Share on LinkedIn');
-    };
-  })();
-</script>
+        // set up button actions
+        document.querySelector('#change-share').onclick = () => {
+          twitter.setAttribute('type', 'linkedin');
+          twitter.setAttribute('aria-label', 'Share on LinkedIn');
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-soundcloud/1.0/README.md
+++ b/extensions/amp-soundcloud/1.0/README.md
@@ -21,49 +21,56 @@ defineBentoSoundcloud();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-soundcloud {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-soundcloud-1.0.js"
-  ></script>
-  <style>
-    bento-soundcloud {
-      aspect-ratio: 1;
-    }
-  </style>
-</head>
-<bento-soundcloud
-  id="my-track"
-  data-trackid="243169232"
-  data-visual="true"
-></bento-soundcloud>
-<div class="buttons" style="margin-top: 8px">
-  <button id="change-track">Change track</button>
-</div>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-soundcloud {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-soundcloud-1.0.js"
+    ></script>
+    <style>
+      bento-soundcloud {
+        aspect-ratio: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-soundcloud
+      id="my-track"
+      data-trackid="243169232"
+      data-visual="true"
+    ></bento-soundcloud>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-track">Change track</button>
+    </div>
 
-<script>
-  (async () => {
-    const soundcloud = document.querySelector('#my-track');
-    await customElements.whenDefined('bento-soundcloud');
+    <script>
+      (async () => {
+        const soundcloud = document.querySelector('#my-track');
+        await customElements.whenDefined('bento-soundcloud');
 
-    // set up button actions
-    document.querySelector('#change-track').onclick = () => {
-      soundcloud.setAttribute('data-trackid', '243169232');
-      soundcloud.setAttribute('data-color', 'ff5500');
-      soundcloud.removeAttribute('data-visual');
-    };
-  })();
-</script>
+        // set up button actions
+        document.querySelector('#change-track').onclick = () => {
+          soundcloud.setAttribute('data-trackid', '243169232');
+          soundcloud.setAttribute('data-color', 'ff5500');
+          soundcloud.removeAttribute('data-visual');
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-stream-gallery/1.0/README.md
+++ b/extensions/amp-stream-gallery/1.0/README.md
@@ -27,44 +27,51 @@ defineBentoStreamGallery();
 The example below contains an `bento-stream-gallery` with three sections. The
 `expanded` attribute on the third section expands it on page load.
 
-```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-stream-gallery-1.0.js"
-  ></script>
-  <link
-    rel="stylesheet"
-    type="text/css"
-    href="https://cdn.ampproject.org/v0/bento-stream-gallery-1.0.css"
-  />
-</head>
-<body>
-  <bento-stream-gallery>
-    <img src="img1.png" />
-    <img src="img2.png" />
-    <img src="img3.png" />
-    <img src="img4.png" />
-    <img src="img5.png" />
-    <img src="img6.png" />
-    <img src="img7.png" />
-  </bento-stream-gallery>
-  <script>
-    (async () => {
-      const streamGallery = document.querySelector('#my-stream-gallery');
-      await customElements.whenDefined('bento-stream-gallery');
-      const api = await streamGallery.getApi();
+<!--% example %-->
 
-      // programatically expand all sections
-      api.next();
-      // programatically collapse all sections
-      api.prev();
-      // programatically go to slide
-      api.goToSlide(4);
-    })();
-  </script>
-</body>
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-stream-gallery-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-stream-gallery-1.0.css"
+    />
+  </head>
+  <body>
+    <body>
+      <bento-stream-gallery>
+        <img src="img1.png" />
+        <img src="img2.png" />
+        <img src="img3.png" />
+        <img src="img4.png" />
+        <img src="img5.png" />
+        <img src="img6.png" />
+        <img src="img7.png" />
+      </bento-stream-gallery>
+      <script>
+        (async () => {
+          const streamGallery = document.querySelector('#my-stream-gallery');
+          await customElements.whenDefined('bento-stream-gallery');
+          const api = await streamGallery.getApi();
+
+          // programatically expand all sections
+          api.next();
+          // programatically collapse all sections
+          api.prev();
+          // programatically go to slide
+          api.goToSlide(4);
+        })();
+      </script>
+    </body>
+  </body>
+</html>
 ```
 
 ### Interactivity and API usage

--- a/extensions/amp-timeago/1.0/README.md
+++ b/extensions/amp-timeago/1.0/README.md
@@ -21,48 +21,56 @@ defineBentoTimeago();
 
 ### Example: Import via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-timeago-1.0.js"
-  ></script>
-  <style>
-    bento-timeago {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-</head>
-<bento-timeago
-  id="my-timeago"
-  datetime="2017-04-11T00:37:33.809Z"
-  locale="en"
-  style="height: 30px">
-    Saturday 11 April 2017 00.37
-</bento-timeago>
-<div class="buttons" style="margin-top: 8px">
-  <button id="ar-button">Change locale to Arabic</button>
-  <button id="en-button">Change locale to English</button>
-  <button id="now-button">Change time to now</button>
-</div>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-timeago-1.0.js"
+    ></script>
+    <style>
+      bento-timeago {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-timeago
+      id="my-timeago"
+      datetime="2017-04-11T00:37:33.809Z"
+      locale="en"
+      style="height: 30px"
+    >
+      Saturday 11 April 2017 00.37
+    </bento-timeago>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="ar-button">Change locale to Arabic</button>
+      <button id="en-button">Change locale to English</button>
+      <button id="now-button">Change time to now</button>
+    </div>
 
-<script>
-  (async () => {
-    const timeago = document.querySelector('#my-timeago');
-    await customElements.whenDefined('bento-timeago');
+    <script>
+      (async () => {
+        const timeago = document.querySelector('#my-timeago');
+        await customElements.whenDefined('bento-timeago');
 
-    // set up button actions
-    document.querySelector('#ar-button').onclick = () =>
-      timeago.setAttribute('locale', 'ar');
-    document.querySelector('#en-button').onclick = () =>
-      timeago.setAttribute('locale', 'en');
-    document.querySelector('#now-button').onclick = () =>
-      timeago.setAttribute('datetime', 'now');
-  })();
-</script>
+        // set up button actions
+        document.querySelector('#ar-button').onclick = () =>
+          timeago.setAttribute('locale', 'ar');
+        document.querySelector('#en-button').onclick = () =>
+          timeago.setAttribute('locale', 'en');
+        document.querySelector('#now-button').onclick = () =>
+          timeago.setAttribute('datetime', 'now');
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-twitter/1.0/README.md
+++ b/extensions/amp-twitter/1.0/README.md
@@ -21,44 +21,52 @@ defineBentoTwitters();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-twitter {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-twitter-1.0.js"
-  ></script>
-  <style>
-    bento-twitter {
-      width: 375px;
-      height: 472px;
-    }
-  </style>
-</head>
-<bento-twitter id="my-tweet" data-tweetid="885634330868850689"> </bento-twitter>
-<div class="buttons" style="margin-top: 8px">
-  <button id="change-tweet">Change tweet</button>
-</div>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-twitter {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-twitter-1.0.js"
+    ></script>
+    <style>
+      bento-twitter {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-twitter id="my-tweet" data-tweetid="885634330868850689">
+    </bento-twitter>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-tweet">Change tweet</button>
+    </div>
 
-<script>
-  (async () => {
-    const twitter = document.querySelector('#my-tweet');
-    await customElements.whenDefined('bento-twitter');
+    <script>
+      (async () => {
+        const twitter = document.querySelector('#my-tweet');
+        await customElements.whenDefined('bento-twitter');
 
-    // set up button actions
-    document.querySelector('#change-tweet').onclick = () => {
-      twitter.setAttribute('data-tweetid', '495719809695621121');
-    };
-  })();
-</script>
+        // set up button actions
+        document.querySelector('#change-tweet').onclick = () => {
+          twitter.setAttribute('data-tweetid', '495719809695621121');
+        };
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Layout and style

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -21,43 +21,50 @@ defineBentoWordpressEmbed();
 
 ### Example: Include via `<script>`
 
+<!--% example %-->
+
 ```html
-<head>
-  <script src="https://cdn.ampproject.org/bento.js"></script>
-  <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
-  <style>
-    bento-wordpress-embed {
-      display: block;
-      overflow: hidden;
-      position: relative;
-    }
-  </style>
-  <script
-    async
-    src="https://cdn.ampproject.org/v0/bento-wordpress-embed-1.0.js"
-  ></script>
-</head>
-<bento-wordpress-embed
-  id="my-embed"
-  data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
-></bento-wordpress-embed>
-<div class="buttons" style="margin-top: 8px">
-  <button id="switch-button">Switch embed</button>
-</div>
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="https://cdn.ampproject.org/bento.js"></script>
+    <!-- These styles prevent Cumulative Layout Shift on the unupgraded custom element -->
+    <style>
+      bento-wordpress-embed {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-wordpress-embed-1.0.js"
+    ></script>
+  </head>
+  <body>
+    <bento-wordpress-embed
+      id="my-embed"
+      data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+    ></bento-wordpress-embed>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="switch-button">Switch embed</button>
+    </div>
 
-<script>
-  (async () => {
-    const embed = document.querySelector('#my-embed');
-    await customElements.whenDefined('bento-wordpress-embed');
+    <script>
+      (async () => {
+        const embed = document.querySelector('#my-embed');
+        await customElements.whenDefined('bento-wordpress-embed');
 
-    // set up button actions
-    document.querySelector('#switch-button').onclick = () =>
-      embed.setAttribute(
-        'data-url',
-        'https://make.wordpress.org/core/2021/09/09/core-editor-improvement-cascading-impact-of-improvements-to-featured-images/'
-      );
-  })();
-</script>
+        // set up button actions
+        document.querySelector('#switch-button').onclick = () =>
+          embed.setAttribute(
+            'data-url',
+            'https://make.wordpress.org/core/2021/09/09/core-editor-improvement-cascading-impact-of-improvements-to-featured-images/'
+          );
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Layout and style


### PR DESCRIPTION
- Some snippets were incorrectly formatted because they did not include `<body>` or `<html>`. Fixed.
- Adds `<%-- example --%>` as an annotation for the docs website.