### PR TITLE
adds basic tests to amp-gallery-lightbox, reintroduce goCallback to amp-carousel 0.1

### DIFF
--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -640,6 +640,21 @@ export class AmpCarousel extends AMP.BaseElement {
   attributeMutated_(name, newValue) {
     this.responsiveAttributes_.updateAttribute(name, newValue);
   }
+
+  /**
+   * Used by amp-lightbox-gallery
+   *
+   * Does all the work needed to proceed to next
+   * desired direction.
+   * @param {number} dir -1 or 1
+   */
+  goCallback(dir) {
+    if (dir === 1) {
+      this.interactionNext();
+    } else {
+      this.interactionPrev();
+    }
+  }
 }
 
 AMP.extension('amp-base-carousel', '0.1', (AMP) => {

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -41,7 +41,7 @@ function isSizer(el) {
   return el.tagName === 'I-AMPHTML-SIZER';
 }
 
-class AmpCarousel extends AMP.BaseElement {
+export class AmpCarousel extends AMP.BaseElement {
   /** @override @nocollapse */
   static prerenderAllowed() {
     return true;

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -95,7 +95,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
         const {args} = invocation;
         if (args) {
           const index = parseInt(args['index'], 10);
-          this.goToSlide_(index);
+          this.goToSlide(index);
         }
       },
       ActionTrust.LOW
@@ -184,10 +184,9 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
   /**
    * Scrolls to the slide at the given slide index.
    * @param {number} index
-   * @private
    * @return {*} TODO(#23582): Specify return type
    */
-  goToSlide_(index) {
+  goToSlide(index) {
     const noOfSlides = this.cells_.length;
 
     if (!isFinite(index) || index < 0 || index >= noOfSlides) {

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -151,9 +151,8 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
    * desired direction.
    * @param {number} dir -1 or 1
    * @param {boolean} animate
-   * @param {boolean=} opt_autoplay
    */
-  go(dir, animate, opt_autoplay) {
+  go(dir, animate) {
     const newPos = this.nextPos_(this.pos_, dir);
     const oldPos = this.pos_;
 
@@ -413,6 +412,18 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
   /** Used by amp-lightbox-gallery */
   interactionPrev() {
     this.controls_.interactionPrev();
+  }
+
+  /**
+   * Used by amp-lightbox-gallery
+   *
+   * Does all the work needed to proceed to next
+   * desired direction.
+   * @param {number} dir -1 or 1
+   * @param {boolean} animate
+   */
+  goCallback(dir, animate) {
+    this.go(dir, animate);
   }
 
   /**

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -385,6 +385,17 @@ export class AmpSlideScroll extends AMP.BaseElement {
    * @param {boolean} animate
    * @param {boolean=} opt_autoplay
    */
+  goCallback(dir, animate, opt_autoplay) {
+    this.go(dir, animate, opt_autoplay);
+  }
+
+  /**
+   * Does all the work needed to proceed to next
+   * desired direction.
+   * @param {number} dir -1 or 1
+   * @param {boolean} animate
+   * @param {boolean=} opt_autoplay
+   */
   go(dir, animate, opt_autoplay) {
     const trust = opt_autoplay ? ActionTrust.LOW : ActionTrust.HIGH;
     this.moveSlide(dir, animate, trust);

--- a/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
@@ -1,5 +1,3 @@
-import {expect} from 'chai';
-
 import {AmpCarousel as AmpBaseCarousel} from 'extensions/amp-base-carousel/0.1/amp-base-carousel';
 import {AmpScrollableCarousel} from 'extensions/amp-carousel/0.1/scrollable-carousel';
 import {AmpSlideScroll} from 'extensions/amp-carousel/0.1/slidescroll';

--- a/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
@@ -40,16 +40,16 @@ describes.realWin(
       });
 
       it('carousels must have expected functions on their prototype', () => {
-        function assertHasInteractions(klass) {
+        function assertHasFunctions(klass) {
           expect(klass.prototype.interactionNext).ok;
           expect(klass.prototype.interactionPrev).ok;
           expect(klass.prototype.goToSlide).ok;
           expect(klass.prototype.goCallback).ok;
         }
 
-        assertHasInteractions(AmpScrollableCarousel);
-        assertHasInteractions(AmpSlideScroll);
-        assertHasInteractions(AmpBaseCarousel);
+        assertHasFunctions(AmpScrollableCarousel);
+        assertHasFunctions(AmpSlideScroll);
+        assertHasFunctions(AmpBaseCarousel);
       });
     });
   }

--- a/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
@@ -39,10 +39,12 @@ describes.realWin(
         });
       });
 
-      it('each carousel must have an interactionNext and interactionPrev', () => {
+      it('carousels must have expected functions on their prototype', () => {
         function assertHasInteractions(klass) {
           expect(klass.prototype.interactionNext).ok;
           expect(klass.prototype.interactionPrev).ok;
+          expect(klass.prototype.goToSlide).ok;
+          expect(klass.prototype.goCallback).ok;
         }
 
         assertHasInteractions(AmpScrollableCarousel);

--- a/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
+++ b/extensions/amp-lightbox-gallery/0.1/test/test-amp-lightbox-gallery.js
@@ -1,3 +1,9 @@
+import {expect} from 'chai';
+
+import {AmpCarousel as AmpBaseCarousel} from 'extensions/amp-base-carousel/0.1/amp-base-carousel';
+import {AmpScrollableCarousel} from 'extensions/amp-carousel/0.1/scrollable-carousel';
+import {AmpSlideScroll} from 'extensions/amp-carousel/0.1/slidescroll';
+
 import {installLightboxGallery} from '../amp-lightbox-gallery';
 
 const TAG = 'amp-lightbox-gallery';
@@ -31,6 +37,17 @@ describes.realWin(
           expect(container[0].tagName).to.equal('DIV');
           done();
         });
+      });
+
+      it('each carousel must have an interactionNext and interactionPrev', () => {
+        function assertHasInteractions(klass) {
+          expect(klass.prototype.interactionNext).ok;
+          expect(klass.prototype.interactionPrev).ok;
+        }
+
+        assertHasInteractions(AmpScrollableCarousel);
+        assertHasInteractions(AmpSlideScroll);
+        assertHasInteractions(AmpBaseCarousel);
       });
     });
   }


### PR DESCRIPTION
**summary**
Context: https://github.com/ampproject/amphtml/issues/36871

- Adds super basic test for confirming that the carousels `amp-gallery-lightbox` depends on have the expected functions on their prototype
- Adds `goCallback` back to the SlidableCarousel and ScrollableCarousel classes
- [preexisting bug]: Renames `goToSlide_` to `goToSlide` for scrollable carousel
- [preexisting bug] Adds `goCallback` to amp-base-carousel