### PR TITLE
🏗 Serve Markdown files

### DIFF
--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -72,11 +72,13 @@ async function getHtmlTextContent(html) {
  * @return {Promise<?string>}
  */
 async function getFirstParagraphOrSentence(markdown, maxLengthChars) {
-  const token = marked.lexer(markdown).find(({type}) => type === 'paragraph');
+  const token = marked.Lexer.lex(markdown).find(
+    ({type}) => type === 'paragraph'
+  );
   if (!token) {
     return null;
   }
-  const html = marked.parser([token]);
+  const html = marked.Parser.parse([token]);
   const paragraph = await getHtmlTextContent(html);
   if (paragraph.length <= maxLengthChars) {
     return paragraph;

--- a/build-system/server/new-server/router.js
+++ b/build-system/server/new-server/router.js
@@ -1,6 +1,26 @@
 const router = require('express').Router();
+const {
+  // @ts-ignore
+  renderMarkdown,
+  // @ts-ignore
+  renderMarkdownSnippet,
+} = require('./transforms/dist/markdown');
 // @ts-ignore
 const {transform} = require('./transforms/dist/transform');
+
+/**
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {string} content
+ */
+function serveHtml(req, res, content) {
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  if (req.query.__amp_source_origin) {
+    res.setHeader('Access-Control-Allow-Origin', req.query.__amp_source_origin);
+    res.setHeader('Access-Control-Allow-Credentials', 'true');
+  }
+  res.end(content);
+}
 
 router.get('/examples/*.html', async (req, res) => {
   let transformedHTML;
@@ -13,12 +33,19 @@ router.get('/examples/*.html', async (req, res) => {
         `pipeline.\n${e.message}`
     );
   }
-  res.setHeader('Content-Type', 'text/html; charset=utf-8');
-  if (req.query.__amp_source_origin) {
-    res.setHeader('Access-Control-Allow-Origin', req.query.__amp_source_origin);
-    res.setHeader('Access-Control-Allow-Credentials', 'true');
-  }
-  res.end(transformedHTML);
+  serveHtml(req, res, transformedHTML);
+});
+
+router.get('/*.md', async (req, res) => {
+  const filename = req.path;
+  const html = await renderMarkdown(filename, process.cwd());
+  serveHtml(req, res, html);
+});
+
+router.get('/*.md.html', async (req, res) => {
+  const filename = req.path.replace(/.html$/, '');
+  const html = await renderMarkdownSnippet(filename, process.cwd());
+  serveHtml(req, res, html);
 });
 
 module.exports = router;

--- a/build-system/server/new-server/router.js
+++ b/build-system/server/new-server/router.js
@@ -1,4 +1,4 @@
-const router = require('express').Router();
+const express = require('express');
 const {
   // @ts-ignore
   renderMarkdown,
@@ -9,8 +9,8 @@ const {
 const {transform} = require('./transforms/dist/transform');
 
 /**
- * @param {import('express').Request} req
- * @param {import('express').Response} res
+ * @param {express.Request} req
+ * @param {express.Response} res
  * @param {string} content
  */
 function serveHtml(req, res, content) {
@@ -21,6 +21,8 @@ function serveHtml(req, res, content) {
   }
   res.end(content);
 }
+
+const router = express.Router();
 
 router.get('/examples/*.html', async (req, res) => {
   let transformedHTML;

--- a/build-system/server/new-server/router.js
+++ b/build-system/server/new-server/router.js
@@ -6,7 +6,7 @@ const {
   renderMarkdownSnippet,
 } = require('./transforms/dist/markdown');
 // @ts-ignore
-const {transform} = require('./transforms/dist/transform');
+const {transform, transformHtml} = require('./transforms/dist/transform');
 
 /**
  * @param {express.Request} req
@@ -47,7 +47,7 @@ router.get('/*.md', async (req, res) => {
 router.get('/*.md.html', async (req, res) => {
   const filename = req.path.replace(/.html$/, '');
   const html = await renderMarkdownSnippet(filename, process.cwd());
-  const transformedHtml = await transform(html);
+  const transformedHtml = await transformHtml(html);
   serveHtml(req, res, transformedHtml);
 });
 

--- a/build-system/server/new-server/router.js
+++ b/build-system/server/new-server/router.js
@@ -47,7 +47,8 @@ router.get('/*.md', async (req, res) => {
 router.get('/*.md.html', async (req, res) => {
   const filename = req.path.replace(/.html$/, '');
   const html = await renderMarkdownSnippet(filename, process.cwd());
-  serveHtml(req, res, html);
+  const transformedHtml = await transform(html);
+  serveHtml(req, res, transformedHtml);
 });
 
 module.exports = router;

--- a/build-system/server/new-server/transforms/markdown.ts
+++ b/build-system/server/new-server/transforms/markdown.ts
@@ -68,7 +68,7 @@ export function wrapTextBody(body: string, title: string): string {
             line-height: 1.4;
             margin: 0;
             padding: 10px 20px;
-            font-size: 16px;
+            font-size: 14px;
           }
           pre {
             color: #444;

--- a/build-system/server/new-server/transforms/markdown.ts
+++ b/build-system/server/new-server/transforms/markdown.ts
@@ -1,0 +1,89 @@
+// @ts-ignore
+import dedent from 'dedent';
+import {readFile} from 'fs/promises';
+import {marked, Lexer, Parser} from 'marked';
+import {basename} from 'path';
+
+async function lexFile(filename: string) {
+  const markdown = await readFile(filename, 'utf8');
+  return Lexer.lex(markdown);
+}
+
+export function getHtmlSnippetFromMarkdown(
+  tokens: marked.Token[]
+): marked.Tokens.Code | null {
+  for (const token of tokens) {
+    if (
+      token.type === 'code' &&
+      token.lang === 'html' &&
+      token.text.includes('<html>')
+    ) {
+      return token;
+    }
+  }
+  return null;
+}
+
+export async function renderMarkdown(filename: string, cwd = '.') {
+  const tokens = await lexFile(`${cwd}/${filename}`);
+  const snippet = getHtmlSnippetFromMarkdown(tokens);
+  if (snippet) {
+    const link = `[**▶️ Run this snippet**](${filename}.html)`;
+    const index = tokens.indexOf(snippet);
+    tokens.splice(index, 0, ...Lexer.lex(link));
+  }
+  const body = Parser.parse(tokens);
+  return wrapTextBody(body, basename(filename));
+}
+
+export async function renderMarkdownSnippet(filename: string, cwd = '.') {
+  const tokens = await lexFile(`${cwd}/${filename}`);
+  const snippet = getHtmlSnippetFromMarkdown(tokens);
+  if (snippet) {
+    return snippet.text;
+  }
+  const body = dedent(/* HTML */ `
+    <p>
+      To add a runnable snippet, make sure that
+      <code><a href="${filename}">${filename}</a></code> contains:
+    </p>
+    <pre><code>${dedent(`
+      &lt;html&gt;
+        ...
+      &lt;/html&gt;
+    `)}</code></pre>
+  `);
+  return wrapTextBody(body, basename(filename));
+}
+
+export function wrapTextBody(body: string, title: string): string {
+  return dedent(/* HTML */ `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>${title}</title>
+        <style>
+          body {
+            font-family: sans-serif;
+            line-height: 1.4;
+            margin: 0;
+            padding: 10px 20px;
+            font-size: 16px;
+          }
+          pre {
+            color: #444;
+            overflow: auto;
+            margin: 20px -20px;
+            padding: 0 20px;
+          }
+          a {
+            text-decoration: none;
+          }
+        </style>
+      </head>
+      <body>
+        ${body}
+      </body>
+    </html>
+  `);
+}

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -1,5 +1,3 @@
-
-
 import fs from 'fs';
 import minimist from 'minimist';
 import posthtml from 'posthtml';

--- a/build-system/server/new-server/transforms/transform.ts
+++ b/build-system/server/new-server/transforms/transform.ts
@@ -33,7 +33,11 @@ if (ESM) {
 
 export async function transform(fileLocation: string): Promise<string> {
   const source = await fs.promises.readFile(fileLocation, 'utf8');
-  const result = await posthtml(transforms).process(source);
+  return transformHtml(source);
+}
+
+export async function transformHtml(content: string): Promise<string> {
+  const result = await posthtml(transforms).process(content);
   return result.html;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@types/eslint": "7.28.2",
         "@types/fs-extra": "9.0.13",
         "@types/klaw": "3.0.3",
+        "@types/marked": "4.0.0",
         "@types/minimist": "1.2.2",
         "@types/mocha": "8.2.3",
         "@types/node": "14.17.32",
@@ -4121,6 +4122,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/marked": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.0.tgz",
+      "integrity": "sha512-Zuz0vlQDfPuop4aFFWFdFTTpVmFqkwAQJ4Onxmgc2ZMxhgaO0UxEwWpz23uHXd9QhwsFB1BJBmWNjheZmqdBuQ==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -25667,6 +25674,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/marked": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.0.0.tgz",
+      "integrity": "sha512-Zuz0vlQDfPuop4aFFWFdFTTpVmFqkwAQJ4Onxmgc2ZMxhgaO0UxEwWpz23uHXd9QhwsFB1BJBmWNjheZmqdBuQ==",
+      "dev": true
     },
     "@types/minimist": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/eslint": "7.28.2",
     "@types/fs-extra": "9.0.13",
     "@types/klaw": "3.0.3",
+    "@types/marked": "4.0.0",
     "@types/minimist": "1.2.2",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.32",


### PR DESCRIPTION
Browsing to an `.md.html` file will extract this code snippet if present, and run it:

````md
```html
<html>
  ...
</html>
```
````

This allows us to ensure that all the Bento HTML examples are runnable, allowing us to modify them and test them as we go.

Addionally, browsing to an `.md` file directly will render it, and place a link to its `.md.html` peer if a snippet like above is present.

https://user-images.githubusercontent.com/254946/141052242-8648ff85-8a5e-43ec-9e12-f9be62700295.mov
