### PR TITLE
🏗♻️ Annotate use of Preact-style prop names

### DIFF
--- a/build-system/babel-plugins/babel-plugin-react-style-props/index.js
+++ b/build-system/babel-plugins/babel-plugin-react-style-props/index.js
@@ -17,7 +17,7 @@ module.exports = function (babel) {
     if (name === 'class') {
       return 'className';
     }
-    return null;
+    return name;
   }
 
   return {
@@ -25,9 +25,7 @@ module.exports = function (babel) {
     visitor: {
       JSXAttribute(path) {
         const reactStyle = getReactStyle(path.node.name.name);
-        if (reactStyle) {
-          path.node.name.name = reactStyle;
-        }
+        path.node.name.name = reactStyle;
       },
       CallExpression(path) {
         if (!t.isIdentifier(path.node.callee, {name: propNameFn})) {
@@ -38,9 +36,7 @@ module.exports = function (babel) {
           throw arg.buildCodeFrameError('Should be string literal');
         }
         const reactStyle = getReactStyle(arg.node.value);
-        if (reactStyle) {
-          path.replaceWith(t.stringLiteral(reactStyle));
-        }
+        path.replaceWith(t.stringLiteral(reactStyle));
       },
     },
   };

--- a/build-system/babel-plugins/babel-plugin-react-style-props/index.js
+++ b/build-system/babel-plugins/babel-plugin-react-style-props/index.js
@@ -3,16 +3,43 @@
  * Transforms Preact-style props ("class") into React-style ("className")
  */
 
+const propNameFn = 'propName';
+
 module.exports = function (babel) {
   const {types: t} = babel;
+
+  /**
+   * @param {string} name
+   * @return {?string}
+   */
+  function getReactStyle(name) {
+    // TODO(wg-bento): This mapping is incomplete.
+    if (name === 'class') {
+      return 'className';
+    }
+    return null;
+  }
 
   return {
     name: 'react-style-props',
     visitor: {
       JSXAttribute(path) {
-        // TODO(wg-bento): This mapping is incomplete.
-        if (t.isJSXIdentifier(path.node.name, {name: 'class'})) {
-          path.node.name.name = 'className';
+        const reactStyle = getReactStyle(path.node.name.name);
+        if (reactStyle) {
+          path.node.name.name = reactStyle;
+        }
+      },
+      CallExpression(path) {
+        if (!t.isIdentifier(path.node.callee, {name: propNameFn})) {
+          return;
+        }
+        const arg = path.get('arguments.0');
+        if (!arg.isStringLiteral()) {
+          throw arg.buildCodeFrameError('Should be string literal');
+        }
+        const reactStyle = getReactStyle(arg.node.value);
+        if (reactStyle) {
+          path.replaceWith(t.stringLiteral(reactStyle));
         }
       },
     },

--- a/build-system/babel-plugins/babel-plugin-react-style-props/test/fixtures/transform/function/input.js
+++ b/build-system/babel-plugins/babel-plugin-react-style-props/test/fixtures/transform/function/input.js
@@ -1,0 +1,2 @@
+propName('class');
+propName('foobarbaz');

--- a/build-system/babel-plugins/babel-plugin-react-style-props/test/fixtures/transform/function/options.json
+++ b/build-system/babel-plugins/babel-plugin-react-style-props/test/fixtures/transform/function/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../..",
+    "@babel/plugin-transform-react-jsx"
+  ]
+}

--- a/build-system/babel-plugins/babel-plugin-react-style-props/test/fixtures/transform/function/output.js
+++ b/build-system/babel-plugins/babel-plugin-react-style-props/test/fixtures/transform/function/output.js
@@ -1,0 +1,2 @@
+"className";
+"foobarbaz";

--- a/build-system/eslint-rules/preact-preferred-props.js
+++ b/build-system/eslint-rules/preact-preferred-props.js
@@ -188,7 +188,7 @@ module.exports = {
         }
       },
 
-      'CallExpression[callee.name="propName"]': function (node) {
+      `CallExpression[callee.name="${propNameFn}"]`: function (node) {
         if (
           node.arguments.length !== 1 ||
           node.arguments[0].type !== 'Literal' ||

--- a/build-system/eslint-rules/preact-preferred-props.js
+++ b/build-system/eslint-rules/preact-preferred-props.js
@@ -188,7 +188,7 @@ module.exports = {
         }
       },
 
-      `CallExpression[callee.name="${propNameFn}"]`: function (node) {
+      [`CallExpression[callee.name="${propNameFn}"]`]: function (node) {
         if (
           node.arguments.length !== 1 ||
           node.arguments[0].type !== 'Literal' ||

--- a/build-system/eslint-rules/preact-preferred-props.js
+++ b/build-system/eslint-rules/preact-preferred-props.js
@@ -148,21 +148,23 @@ module.exports = {
           context.report({
             node: prop,
             message,
-            fix: function* (fixer) {
+            fix(fixer) {
+              const fixes = [];
               if (!addedImportDecl) {
                 addedImportDecl = true;
-                if (lastImportDecl) {
-                  yield fixer.insertTextAfter(lastImportDecl, importDecl);
-                } else {
-                  yield fixer.insertTextBefore(program.body[0], importDecl);
-                }
+                fixes.push(
+                  lastImportDecl
+                    ? fixer.insertTextAfter(lastImportDecl, importDecl)
+                    : fixer.insertTextBefore(program.body[0], importDecl)
+                );
               }
               const computed = `[${propNameFn}('${preferred}')]`;
-              if (!prop.key.value) {
-                yield fixer.insertTextBefore(prop, `${computed}: `);
-              } else {
-                yield fixer.replaceText(prop.key, computed);
-              }
+              fixes.push(
+                !prop.key.value
+                  ? fixer.insertTextBefore(prop, `${computed}: `)
+                  : fixer.replaceText(prop.key, computed)
+              );
+              return fixes;
             },
           });
         }

--- a/extensions/amp-accordion/1.0/component.js
+++ b/extensions/amp-accordion/1.0/component.js
@@ -19,6 +19,7 @@ import {
 } from '#preact';
 import {forwardRef} from '#preact/compat';
 import {WithAmpContext} from '#preact/context';
+import {propName} from '#preact/utils';
 
 import {animateCollapse, animateExpand} from './animations';
 import {useStyles} from './component.jss';
@@ -339,10 +340,10 @@ export function BentoAccordionSection({
 export function BentoAccordionHeader({
   as: Comp = 'div',
   children,
-  'class': className = '',
   id,
   role = 'button',
-  tabIndex = 0,
+  [propName('class')]: className = '',
+  [propName('tabIndex')]: tabIndex = 0,
   ...rest
 }) {
   const {contentId, expanded, headerId, setHeaderId, toggleHandler} =
@@ -378,9 +379,9 @@ export function BentoAccordionHeader({
 export function BentoAccordionContent({
   as: Comp = 'div',
   children,
-  'class': className = '',
   id,
   role = 'region',
+  [propName('class')]: className = '',
   ...rest
 }) {
   const ref = useRef(null);

--- a/extensions/amp-base-carousel/1.0/arrow.js
+++ b/extensions/amp-base-carousel/1.0/arrow.js
@@ -2,6 +2,7 @@ import * as Preact from '#preact';
 import {useCallback} from '#preact';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
+import {propName} from '#preact/utils';
 
 /**
  * @param {!BentoBaseCarouselDef.ArrowProps} props
@@ -50,9 +51,9 @@ export function Arrow({
 function DefaultArrow({
   'aria-disabled': ariaDisabled,
   by,
-  'class': className,
   disabled,
   onClick,
+  [propName('class')]: className,
 }) {
   const classes = useStyles();
   return (

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -10,6 +10,7 @@ import {
   useState,
 } from '#preact';
 import {useStyles} from './thumbnails.jss';
+import {propName} from '#preact/utils';
 
 /**
  * @param {!BentoInlineGalleryDef.BentoThumbnailProps} props
@@ -18,8 +19,8 @@ import {useStyles} from './thumbnails.jss';
 export function BentoInlineGalleryThumbnails({
   aspectRatio,
   children,
-  'class': className = '',
   loop = false,
+  [propName('class')]: className = '',
   ...rest
 }) {
   const classes = useStyles();

--- a/extensions/amp-selector/1.0/base-element.js
+++ b/extensions/amp-selector/1.0/base-element.js
@@ -11,6 +11,7 @@ import {dict} from '#core/types/object';
 import * as Preact from '#preact';
 import {useCallback, useLayoutEffect, useRef} from '#preact';
 import {PreactBaseElement} from '#preact/base-element';
+import {propName} from '#preact/utils';
 
 import {BentoSelector, BentoSelectorOption} from './component';
 
@@ -130,7 +131,7 @@ export function OptionShim({
   role = 'option',
   selected,
   shimDomElement,
-  tabIndex,
+  [propName('tabIndex')]: tabIndex,
 }) {
   const syncEvent = useCallback(
     (type, handler) => {
@@ -185,8 +186,8 @@ function SelectorShim({
   onKeyDown,
   role = 'listbox',
   shimDomElement,
-  tabIndex,
   value,
+  [propName('tabIndex')]: tabIndex,
 }) {
   const input = useRef(null);
   if (!input.current) {

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -16,6 +16,7 @@ import {
   useState,
 } from '#preact';
 import {forwardRef} from '#preact/compat';
+import {propName} from '#preact/utils';
 
 import {useStyles} from './component.jss';
 
@@ -51,7 +52,7 @@ function SelectorWithRef(
     name,
     onChange,
     role = 'listbox',
-    tabIndex,
+    [propName('tabIndex')]: tabIndex,
     children,
     ...rest
   },
@@ -267,13 +268,13 @@ export {BentoSelector};
  */
 export function BentoSelectorOption({
   as: Comp = 'div',
-  'class': className = '',
   disabled = false,
   focus: customFocus,
   index,
   option,
   role = 'option',
-  tabIndex,
+  [propName('class')]: className = '',
+  [propName('tabIndex')]: tabIndex,
   ...rest
 }) {
   const classes = useStyles();

--- a/extensions/amp-social-share/1.0/component.js
+++ b/extensions/amp-social-share/1.0/component.js
@@ -4,7 +4,7 @@ import {parseQueryString} from '#core/types/string/url';
 
 import * as Preact from '#preact';
 import {Wrapper} from '#preact/component';
-import {useResourcesNotify} from '#preact/utils';
+import {propName, useResourcesNotify} from '#preact/utils';
 
 import {useStyles} from './component.jss';
 import {getSocialConfig} from './social-share-config';
@@ -31,10 +31,10 @@ export function BentoSocialShare({
   height,
   params,
   style,
-  tabIndex = 0,
   target,
   type,
   width,
+  [propName('tabIndex')]: tabIndex = 0,
   ...rest
 }) {
   useResourcesNotify();

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -12,6 +12,7 @@ import {
 } from '#preact';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
+import {propName} from '#preact/utils';
 
 const DEFAULT_VISIBLE_COUNT = 1;
 const OUTSET_ARROWS_WIDTH = 100;
@@ -26,7 +27,7 @@ function BentoStreamGalleryWithRef(props, ref) {
     arrowPrevAs = DefaultArrow,
     arrowNextAs = DefaultArrow,
     children,
-    'class': className,
+    [propName('class')]: className,
     extraSpace,
     maxItemWidth = Number.MAX_VALUE,
     minItemWidth = 1,
@@ -130,10 +131,10 @@ export {BentoStreamGallery};
 function DefaultArrow({
   'aria-disabled': ariaDisabled,
   by,
-  'class': className,
   disabled,
   onClick,
   outsetArrows,
+  [propName('class')]: className,
 }) {
   const classes = useStyles();
   return (

--- a/extensions/amp-video/1.0/component.js
+++ b/extensions/amp-video/1.0/component.js
@@ -26,7 +26,7 @@ import {
   useRef,
   useState,
 } from '#preact';
-import {useResourcesNotify} from '#preact/utils';
+import {propName, useResourcesNotify} from '#preact/utils';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
 
@@ -67,7 +67,6 @@ const getMetadata = (player, props) =>
 function VideoWrapperWithRef(
   {
     autoplay = false,
-    'class': className,
     component: Component = 'video',
     controls = false,
     loading: loadingProp,
@@ -80,6 +79,7 @@ function VideoWrapperWithRef(
     sources,
     src,
     style,
+    [propName('class')]: className,
     ...rest
   },
   ref

--- a/src/preact/component/contain.js
+++ b/src/preact/component/contain.js
@@ -1,5 +1,6 @@
 import * as Preact from '#preact';
 import {forwardRef} from '#preact/compat';
+import {propName} from '#preact/utils';
 
 const CONTAIN = [
   null, // 0: none
@@ -38,7 +39,6 @@ function ContainWrapperWithRef(
   {
     as: Comp = 'div',
     children,
-    'class': className,
     contentAs: ContentComp = 'div',
     contentClassName,
     contentProps,
@@ -50,6 +50,7 @@ function ContainWrapperWithRef(
     'style': style,
     wrapperClassName,
     wrapperStyle,
+    [propName('class')]: className,
     ...rest
   },
   ref

--- a/src/preact/component/wrapper.js
+++ b/src/preact/component/wrapper.js
@@ -1,5 +1,6 @@
 import * as Preact from '#preact';
 import {forwardRef} from '#preact/compat';
+import {propName} from '#preact/utils';
 
 /**
  * The wrapper component provides the canonical wrapper for components whose
@@ -13,10 +14,10 @@ function WrapperWithRef(
   {
     as: Comp = 'div',
     children,
-    'class': className,
     'style': style,
     wrapperClassName,
     wrapperStyle,
+    [propName('class')]: className,
     ...rest
   },
   ref

--- a/src/preact/utils.js
+++ b/src/preact/utils.js
@@ -44,3 +44,16 @@ export function useMergeRefs(refs) {
     refs
   );
 }
+
+/**
+ * Required to use `props` whose name would be usually be mapped in
+ * Preact-to-React style.
+ * This passes through the value during development, because we render on Preact.
+ * It's an annotation so that we can convert these values when we transform the
+ * React build.
+ * @param {string} name
+ * @return {string}
+ */
+export function propName(name) {
+  return name;
+}


### PR DESCRIPTION
Partial for #35678

For safety of prop name replacement, and consistent with either Preact or React style, replace e.g. `propName('class')` when destructuring props.

- Added passthrough function `propName()`.
- Updated Babel plugin to replace function uses.
- Updated eslint rule so that it generates `[propName('class')]: className`, and verifies uses of `propName()`.