### PR TITLE
🏗 Lint uses of `core/dom/jsx`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -165,6 +165,7 @@ module.exports = {
     'local/await-expect': 2,
     'local/camelcase': 2,
     'local/closure-type-primitives': 2,
+    'local/core-dom-jsx': 2,
     'local/dict-string-keys': 2,
     'local/enums': 2,
     'local/get-mode-usage': 2,

--- a/build-system/eslint-rules/core-dom-jsx.js
+++ b/build-system/eslint-rules/core-dom-jsx.js
@@ -18,8 +18,7 @@ module.exports = function (context) {
         isValidStyleOrClassValue(node.consequent, isClass) &&
         isValidStyleOrClassValue(node.alternate, isClass)
       );
-    }
-    if (node?.type === 'BinaryExpression') {
+    } else if (node?.type === 'BinaryExpression') {
       // Concatenating anything to a string is valid
       if (node.operator === '+') {
         return (

--- a/build-system/eslint-rules/core-dom-jsx.js
+++ b/build-system/eslint-rules/core-dom-jsx.js
@@ -11,6 +11,13 @@ module.exports = function (context) {
    * @return {boolean}
    */
   function isValidStyleOrClassValue(node, isClass = false) {
+    if (node?.type === 'ConditionalExpression') {
+      // Both possible outcomes of a ternary must be valid
+      return (
+        isValidStyleOrClassValue(node.consequent, isClass) &&
+        isValidStyleOrClassValue(node.alternate, isClass)
+      );
+    }
     if (node?.type === 'BinaryExpression') {
       // Concatenating anything to a string is valid
       if (node.operator === '+') {
@@ -82,7 +89,7 @@ module.exports = function (context) {
           context.report({
             node: node.value,
             message: [
-              `Value of prop \`${name}\` must be a "string", a \`template \${literal}\`, or wrapped in either of objstr() or String().`,
+              `The inline result of \`${name}\` must resolve to a "string", a \`template \${literal}\`, or a call to either objstr() or String().`,
               `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
             ].join('\n - '),
           });
@@ -92,7 +99,7 @@ module.exports = function (context) {
           context.report({
             node: node.value,
             message: [
-              `Value of prop \`${name}\` must be a "string", a \`template \${literal}\`, or wrapped in String()`,
+              `The inline result of \`${name}\` must resolve to a "string", a \`template \${literal}\`, or a call to String().`,
               `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
             ].join('\n - '),
           });

--- a/build-system/eslint-rules/core-dom-jsx.js
+++ b/build-system/eslint-rules/core-dom-jsx.js
@@ -77,27 +77,26 @@ module.exports = function (context) {
       if (!value || isValidStyleOrClassValue(value)) {
         return;
       }
-      if (
-        name === 'class' &&
-        !isValidStyleOrClassValue(value.expression, /* isClass */ true)
-      ) {
-        context.report({
-          node: node.value,
-          message: [
-            `Value of prop \`${name}\` must be a "string", a \`template \${literal}\`, or wrapped in either of objstr() or String().`,
-            `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
-          ].join('\n - '),
-        });
-        return;
-      }
-      if (name === 'style' && !isValidStyleOrClassValue(value.expression)) {
-        context.report({
-          node: node.value,
-          message: [
-            `Value of prop \`${name}\` must be a "string", a \`template \${literal}\`, or wrapped in String()`,
-            `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
-          ].join('\n - '),
-        });
+      if (name === 'class') {
+        if (!isValidStyleOrClassValue(value.expression, /* isClass */ true)) {
+          context.report({
+            node: node.value,
+            message: [
+              `Value of prop \`${name}\` must be a "string", a \`template \${literal}\`, or wrapped in either of objstr() or String().`,
+              `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
+            ].join('\n - '),
+          });
+        }
+      } else if (name === 'style') {
+        if (!isValidStyleOrClassValue(value.expression)) {
+          context.report({
+            node: node.value,
+            message: [
+              `Value of prop \`${name}\` must be a "string", a \`template \${literal}\`, or wrapped in String()`,
+              `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
+            ].join('\n - '),
+          });
+        }
       }
     },
   };

--- a/build-system/eslint-rules/core-dom-jsx.js
+++ b/build-system/eslint-rules/core-dom-jsx.js
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Lints JSX features not supported by core/dom/jsx
+ */
+
+module.exports = function (context) {
+  let isCoreDomJsx = false;
+  return {
+    Program() {
+      isCoreDomJsx = false;
+    },
+    ImportNamespaceSpecifier(node) {
+      if (node.parent.source.value.endsWith('core/dom/jsx')) {
+        isCoreDomJsx = true;
+      }
+    },
+    JSXFragment(node) {
+      if (!isCoreDomJsx) {
+        return;
+      }
+      context.report({
+        node,
+        message:
+          'Fragments are not supported. Change into an array of elements, or wrap in a root element.',
+      });
+    },
+    JSXOpeningElement(node) {
+      if (!isCoreDomJsx) {
+        return;
+      }
+      if (node.name.name === 'foreignObject') {
+        context.report({
+          node: node.name,
+          message: `<${node.name.name}> is not supported.`,
+        });
+      }
+    },
+    JSXAttribute(node) {
+      if (!isCoreDomJsx) {
+        return;
+      }
+      if (node.name.name === 'dangerouslySetInnerHTML') {
+        context.report({
+          node: node.name,
+          message: `\`<${node.name.name}>\` is not supported.`,
+        });
+        return;
+      }
+      if (
+        !node.value ||
+        node.value.type === 'Literal' ||
+        node.value.expression?.type === 'Literal' ||
+        node.value.expression?.type === 'TemplateLiteral'
+      ) {
+        return;
+      }
+      if (node.name.name === 'class') {
+        if (
+          node.value.expression?.callee?.name !== 'String' &&
+          node.value.expression?.callee?.name?.toLowerCase() !== 'objstr'
+        ) {
+          context.report({
+            node: node.value,
+            message: [
+              `Value of prop \`${node.name.name}\` must be a "string", a \`template \${literal}\`, or wrapped in either of objstr() or String().`,
+              `objstr() is preferred: https://git.io/JXPfq`,
+              `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
+            ].join('\n - '),
+          });
+        }
+      } else if (node.name.name === 'style') {
+        if (node.value.expression?.callee?.name !== 'String') {
+          context.report({
+            node: node.value,
+            message: [
+              `Value of prop \`${node.name.name}\` must be a "string", a \`template \${literal}\`, or wrapped in String()`,
+              `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
+            ].join('\n - '),
+          });
+        }
+      }
+    },
+  };
+};

--- a/build-system/eslint-rules/core-dom-jsx.js
+++ b/build-system/eslint-rules/core-dom-jsx.js
@@ -26,6 +26,7 @@ module.exports = function (context) {
           isValidStyleOrClassValue(node.right, isClass)
         );
       }
+    } else if (node?.type === 'LogicalExpression') {
       // Any left falsy is okay
       if (node.operator === '&&') {
         return isValidStyleOrClassValue(node.right, isClass);

--- a/build-system/eslint-rules/core-dom-jsx.js
+++ b/build-system/eslint-rules/core-dom-jsx.js
@@ -41,6 +41,9 @@ module.exports = function (context) {
       // Calls to functions that return a string
       const {name} = node.callee;
       return name === 'String' || (isClass && name?.toLowerCase() === 'objstr');
+    } else if (node?.type === 'ObjectExpression') {
+      // Style attributes can be objects
+      return !isClass;
     }
     return node?.type === 'Literal' || node?.type === 'TemplateLiteral';
   }
@@ -160,7 +163,7 @@ module.exports = function (context) {
           context.report({
             node: node.value,
             message: [
-              `The inline result of \`${name}\` must resolve to a "string", a \`template \${literal}\`, or a call to String().`,
+              `The inline result of \`${name}\` must resolve to an {objectExpression: ''}, a "string", a \`template \${literal}\`, or a call to String().`,
               `Take caution when wrapping boolean or nullish values in String(). Do \`String(foo || '')\``,
             ].join('\n - '),
           });

--- a/build-system/eslint-rules/core-dom-jsx.js
+++ b/build-system/eslint-rules/core-dom-jsx.js
@@ -27,6 +27,12 @@ module.exports = function (context) {
         );
       }
     } else if (node?.type === 'LogicalExpression') {
+      if (node.operator === '||' || node.operator === '??') {
+        return (
+          isValidStyleOrClassValue(node.left, isClass) &&
+          isValidStyleOrClassValue(node.right, isClass)
+        );
+      }
       // Any left falsy is okay
       if (node.operator === '&&') {
         return isValidStyleOrClassValue(node.right, isClass);
@@ -136,7 +142,7 @@ module.exports = function (context) {
         return;
       }
       const {value} = node;
-      if (!value || isValidStyleOrClassValue(value)) {
+      if (!value || value.type === 'Literal') {
         return;
       }
       if (name === 'class') {

--- a/build-system/eslint-rules/preact.js
+++ b/build-system/eslint-rules/preact.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const astUtils = require('eslint/lib/rules/utils/ast-utils');
-
 // Enforces importing a Preact namespace specifier if using JSX
 //
 // Good
@@ -61,19 +59,16 @@ module.exports = {
 
     let imported = false;
     let warned = false;
-    let staticTemplate = false;
 
     return {
       Program() {
         imported = false;
         warned = false;
-        staticTemplate = false;
       },
 
       ImportNamespaceSpecifier(node) {
         if (node.local.name === 'Preact') {
           imported = true;
-          staticTemplate = node.parent.source.value !== '#preact';
         }
       },
 
@@ -83,67 +78,6 @@ module.exports = {
 
       JSXFragment(node) {
         requirePreact(node);
-      },
-
-      JSXSpreadAttribute(node) {
-        if (!staticTemplate) {
-          return;
-        }
-
-        context.report({
-          node,
-          message: [
-            'Static JSX Templates are required to use static attribute definitions',
-            'This prevents an issue with spread attributes accidentally overriding a "safe" attribute with user-provided data.',
-          ].join('\n\t'),
-        });
-      },
-
-      JSXOpeningElement(node) {
-        if (!staticTemplate) {
-          return;
-        }
-
-        const {name} = node;
-        if (name.type === 'JSXMemberExpression') {
-          return context.report({
-            node,
-            message: [
-              'Static JSX Templates are required to use regular DOM nodes or Imported Components',
-              'This prevents an issue with `<json.type />` accidentally creating a <script> node.',
-            ].join('\n\t'),
-          });
-        }
-
-        if (name.name && /^[a-z]/.test(name.name)) {
-          return;
-        }
-
-        const variable = astUtils.getVariableByName(
-          context.getScope(),
-          name.name
-        );
-
-        if (!variable || variable.defs.length === 0) {
-          return context.report({
-            node,
-            message: `Could not find ${name.name} in the lexcial scope`,
-          });
-        }
-
-        for (const def of variable.defs) {
-          if (def.type === 'ImportBinding' || def.type === 'FunctionName') {
-            continue;
-          }
-
-          context.report({
-            node,
-            message: [
-              'Static JSX Templates are required to use regular DOM nodes or Imported Components',
-              'This prevents an issue with `<UserProvidedType />` accidentally creating a <script> node.',
-            ].join('\n\t'),
-          });
-        }
       },
     };
   },

--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -10,6 +10,7 @@ import {LocalizedStringId} from '#service/localization/strings';
 import {Services} from '#service';
 import {createShadowRootWithStyle} from './utils';
 import {localize} from './amp-story-localization-service';
+import objStr from 'obj-str';
 
 /**
  * @param {!Element} element
@@ -17,10 +18,11 @@ import {localize} from './amp-story-localization-service';
  */
 const renderHintElement = (element) => (
   <aside
-    class={
-      'i-amphtml-story-hint-container ' +
-      'i-amphtml-story-system-reset i-amphtml-hidden'
-    }
+    class={objStr({
+      'i-amphtml-story-hint-container': true,
+      'i-amphtml-story-system-reset': true,
+      'i-amphtml-hidden': true,
+    })}
   >
     <div class="i-amphtml-story-navigation-help-overlay">
       <div class="i-amphtml-story-navigation-help-section prev-page">

--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -10,7 +10,6 @@ import {LocalizedStringId} from '#service/localization/strings';
 import {Services} from '#service';
 import {createShadowRootWithStyle} from './utils';
 import {localize} from './amp-story-localization-service';
-import objStr from 'obj-str';
 
 /**
  * @param {!Element} element
@@ -18,11 +17,10 @@ import objStr from 'obj-str';
  */
 const renderHintElement = (element) => (
   <aside
-    class={objStr({
-      'i-amphtml-story-hint-container': true,
-      'i-amphtml-story-system-reset': true,
-      'i-amphtml-hidden': true,
-    })}
+    class={
+      'i-amphtml-story-hint-container ' +
+      'i-amphtml-story-system-reset i-amphtml-hidden'
+    }
   >
     <div class="i-amphtml-story-navigation-help-overlay">
       <div class="i-amphtml-story-navigation-help-section prev-page">

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -31,7 +31,6 @@ import {getSourceOrigin} from '../../../src/url';
 import {setImportantStyles} from '#core/dom/style';
 import {toArray} from '#core/types/array';
 import {localize} from './amp-story-localization-service';
-import objstr from 'obj-str';
 
 /** @private @const {string} */
 const AD_SHOWING_ATTRIBUTE = 'ad-showing';
@@ -93,12 +92,7 @@ const HIDE_MESSAGE_TIMEOUT_MS = 1500;
  */
 const renderSystemLayerElement = (element) => (
   <aside class="i-amphtml-story-system-layer i-amphtml-story-system-reset">
-    <a
-      class={objstr({
-        [ATTRIBUTION_CLASS]: true,
-      })}
-      target="_blank"
-    >
+    <a class={String(ATTRIBUTION_CLASS)} target="_blank">
       <div class="i-amphtml-story-attribution-logo-container">
         <img alt="" class="i-amphtml-story-attribution-logo" />
       </div>
@@ -115,10 +109,7 @@ const renderSystemLayerElement = (element) => (
     <div class="i-amphtml-story-system-layer-buttons">
       <div
         role="button"
-        class={objstr({
-          [INFO_CLASS]: true,
-          'i-amphtml-story-button': true,
-        })}
+        class={INFO_CLASS + ' i-amphtml-story-button'}
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_INFO_BUTTON_LABEL
@@ -146,20 +137,14 @@ const renderSystemLayerElement = (element) => (
           </div>
         </div>
         <button
-          class={objstr({
-            [UNMUTE_CLASS]: true,
-            'i-amphtml-story-button': true,
-          })}
+          class={UNMUTE_CLASS + ' i-amphtml-story-button'}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_BUTTON_LABEL
           )}
         />
         <button
-          class={objstr({
-            [MUTE_CLASS]: true,
-            'i-amphtml-story-button': true,
-          })}
+          class={MUTE_CLASS + ' i-amphtml-story-button'}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_LABEL
@@ -168,20 +153,14 @@ const renderSystemLayerElement = (element) => (
       </div>
       <div class="i-amphtml-paused-display">
         <button
-          class={objstr({
-            [PAUSE_CLASS]: true,
-            'i-amphtml-story-button': true,
-          })}
+          class={PAUSE_CLASS + ' i-amphtml-story-button'}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_PAUSE_BUTTON_LABEL
           )}
         />
         <button
-          class={objstr({
-            [PLAY_CLASS]: true,
-            'i-amphtml-story-button': true,
-          })}
+          class={PLAY_CLASS + ' i-amphtml-story-button'}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_PLAY_BUTTON_LABEL
@@ -189,31 +168,26 @@ const renderSystemLayerElement = (element) => (
         />
       </div>
       <button
-        class={objstr({
-          [SKIP_TO_NEXT_CLASS]: true,
-          'i-amphtml-story-ui-hide-button': true,
-          'i-amphtml-story-button': true,
-        })}
+        class={
+          SKIP_TO_NEXT_CLASS +
+          ' i-amphtml-story-ui-hide-button i-amphtml-story-button'
+        }
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_SKIP_TO_NEXT_BUTTON_LABEL
         )}
       />
       <button
-        class={objstr({
-          [SHARE_CLASS]: true,
-          'i-amphtml-story-button': true,
-        })}
+        class={SHARE_CLASS + ' i-amphtml-story-button'}
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_SHARE_BUTTON_LABEL
         )}
       />
       <button
-        class={objstr({
-          [CLOSE_CLASS]: true,
-          'i-amphtml-story-ui-hide-button i-amphtml-story-button': true,
-        })}
+        class={
+          CLOSE_CLASS + ' i-amphtml-story-ui-hide-button i-amphtml-story-button'
+        }
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -31,6 +31,7 @@ import {getSourceOrigin} from '../../../src/url';
 import {setImportantStyles} from '#core/dom/style';
 import {toArray} from '#core/types/array';
 import {localize} from './amp-story-localization-service';
+import objstr from 'obj-str';
 
 /** @private @const {string} */
 const AD_SHOWING_ATTRIBUTE = 'ad-showing';
@@ -92,7 +93,12 @@ const HIDE_MESSAGE_TIMEOUT_MS = 1500;
  */
 const renderSystemLayerElement = (element) => (
   <aside class="i-amphtml-story-system-layer i-amphtml-story-system-reset">
-    <a class={ATTRIBUTION_CLASS} target="_blank">
+    <a
+      class={objstr({
+        [ATTRIBUTION_CLASS]: true,
+      })}
+      target="_blank"
+    >
       <div class="i-amphtml-story-attribution-logo-container">
         <img alt="" class="i-amphtml-story-attribution-logo" />
       </div>
@@ -109,7 +115,10 @@ const renderSystemLayerElement = (element) => (
     <div class="i-amphtml-story-system-layer-buttons">
       <div
         role="button"
-        class={INFO_CLASS + ' i-amphtml-story-button'}
+        class={objstr({
+          [INFO_CLASS]: true,
+          'i-amphtml-story-button': true,
+        })}
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_INFO_BUTTON_LABEL
@@ -137,14 +146,20 @@ const renderSystemLayerElement = (element) => (
           </div>
         </div>
         <button
-          class={UNMUTE_CLASS + ' i-amphtml-story-button'}
+          class={objstr({
+            [UNMUTE_CLASS]: true,
+            'i-amphtml-story-button': true,
+          })}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_AUDIO_UNMUTE_BUTTON_LABEL
           )}
         />
         <button
-          class={MUTE_CLASS + ' i-amphtml-story-button'}
+          class={objstr({
+            [MUTE_CLASS]: true,
+            'i-amphtml-story-button': true,
+          })}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_AUDIO_MUTE_BUTTON_LABEL
@@ -153,14 +168,20 @@ const renderSystemLayerElement = (element) => (
       </div>
       <div class="i-amphtml-paused-display">
         <button
-          class={PAUSE_CLASS + ' i-amphtml-story-button'}
+          class={objstr({
+            [PAUSE_CLASS]: true,
+            'i-amphtml-story-button': true,
+          })}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_PAUSE_BUTTON_LABEL
           )}
         />
         <button
-          class={PLAY_CLASS + ' i-amphtml-story-button'}
+          class={objstr({
+            [PLAY_CLASS]: true,
+            'i-amphtml-story-button': true,
+          })}
           aria-label={localize(
             element,
             LocalizedStringId.AMP_STORY_PLAY_BUTTON_LABEL
@@ -168,26 +189,31 @@ const renderSystemLayerElement = (element) => (
         />
       </div>
       <button
-        class={
-          SKIP_TO_NEXT_CLASS +
-          ' i-amphtml-story-ui-hide-button i-amphtml-story-button'
-        }
+        class={objstr({
+          [SKIP_TO_NEXT_CLASS]: true,
+          'i-amphtml-story-ui-hide-button': true,
+          'i-amphtml-story-button': true,
+        })}
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_SKIP_TO_NEXT_BUTTON_LABEL
         )}
       />
       <button
-        class={SHARE_CLASS + ' i-amphtml-story-button'}
+        class={objstr({
+          [SHARE_CLASS]: true,
+          'i-amphtml-story-button': true,
+        })}
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_SHARE_BUTTON_LABEL
         )}
       />
       <button
-        class={
-          CLOSE_CLASS + ' i-amphtml-story-ui-hide-button i-amphtml-story-button'
-        }
+        class={objstr({
+          [CLOSE_CLASS]: true,
+          'i-amphtml-story-ui-hide-button i-amphtml-story-button': true,
+        })}
         aria-label={localize(
           element,
           LocalizedStringId.AMP_STORY_CLOSE_BUTTON_LABEL

--- a/extensions/amp-story/1.0/toast.js
+++ b/extensions/amp-story/1.0/toast.js
@@ -3,9 +3,6 @@ import {Services} from '#service';
 import {removeElement} from '#core/dom';
 import {getWin} from '#core/window';
 
-/** @private @const {string} */
-const TOAST_CLASSNAME = 'i-amphtml-story-toast';
-
 /**
  * The 'alert' role assertively announces toast content to screen readers.
  * @private @const {string}
@@ -31,7 +28,7 @@ export class Toast {
     const win = getWin(storyEl);
 
     const toast = (
-      <div class={TOAST_CLASSNAME} role={TOAST_ROLE}>
+      <div class="i-amphtml-story-toast" role={TOAST_ROLE}>
         {childNodeOrText}
       </div>
     );

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -28,8 +28,6 @@
  *   - This tag is rather obscure. You should be able to restructure your tree.
  *     If you absolutely need it, get in touch with `@alanorozco` to consider
  *     enabling support.
- *
- * TODO(https://go.amp.dev/issue/36679): Lint these unsupported features.
  */
 import {devAssert} from '#core/assert';
 

--- a/test/unit/core/dom/test-jsx.js
+++ b/test/unit/core/dom/test-jsx.js
@@ -1,6 +1,9 @@
 import {dispatchCustomEvent} from '#core/dom/index';
 import * as Preact from '#core/dom/jsx';
 
+// We test invalid uses, so we disable the lint rule.
+/* eslint-disable local/core-dom-jsx */
+
 const {createElement} = Preact;
 
 describes.sandboxed('#core/dom/jsx', {}, (env) => {


### PR DESCRIPTION
Closes #36679

This handles all caveats mentioned except mapped attribute names, which are handled by `local/preact-preferred-props`

Also transfers relevant rules from `local/preact` into `local/core-dom-jsx`.