### PR TITLE
🏗 Save Git cache in MacOS jobs on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,10 @@ commands:
           install-npm: false
       - node/install-packages
   setup_vm:
+    parameters:
+      save-git-cache:
+        type: boolean
+        default: false
     steps:
       - attach_workspace:
           at: /tmp
@@ -107,7 +111,8 @@ commands:
       - run:
           name: 'Maybe Gracefully Halt'
           command: /tmp/restored-workspace/maybe_gracefully_halt.sh
-      - checkout_repo
+      - checkout_repo:
+          save-git-cache: << parameters.save-git-cache >>
       - run:
           name: 'Configure Development Environment'
           command: |
@@ -368,7 +373,8 @@ jobs:
     executor:
       name: macos-medium
     steps:
-      - setup_vm
+      - setup_vm:
+          save-git-cache: true
       - enable_safari_automation
       - run:
           name: '⭐ Browser Tests (Safari) ⭐'


### PR DESCRIPTION
The Git cache on CircleCI is platform-dependent, so the Safari test job was cloning from scratch every time - for some reason, it can take multiple minutes to finish the clone step:
![image](https://user-images.githubusercontent.com/1839738/141173005-7fef51ca-fc56-4299-ba63-5c52b9d70177.png)

This PR saves the Git cache specifically for this single MacOS job, which can be reused later:
![image](https://user-images.githubusercontent.com/1839738/141173167-bc3745bd-257c-49bf-805c-6eb2b7d809b9.png)
