### PR TITLE
amp-form: allow xssi-prefix for amphtml and amp4ads

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2351,6 +2351,7 @@ tags {  # <form method=GET ...>
     }
     disallowed_value_regex: "__amp_source_origin"
   }
+  attrs: { name: "xssi-prefix" }
   attr_lists: "form-name-attr"
 }
 tags {  # <form method=POST ...>


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/36843