### PR TITLE
🏗 Transform `style` objects into string expressions

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -25,6 +25,7 @@ function getMinifiedConfig() {
 
   const plugins = [
     'optimize-objstr',
+    './build-system/babel-plugins/babel-plugin-jsx-style-object',
     getImportResolverPlugin(),
     argv.coverage ? 'babel-plugin-istanbul' : null,
     './build-system/babel-plugins/babel-plugin-imported-helpers',

--- a/build-system/babel-config/pre-closure-config.js
+++ b/build-system/babel-config/pre-closure-config.js
@@ -25,6 +25,7 @@ function getPreClosureConfig() {
   const replacePlugin = getReplacePlugin();
   const preClosurePlugins = [
     'optimize-objstr',
+    './build-system/babel-plugins/babel-plugin-jsx-style-object',
     getImportResolverPlugin(),
     argv.coverage ? 'babel-plugin-istanbul' : null,
     './build-system/babel-plugins/babel-plugin-imported-helpers',

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -32,6 +32,7 @@ function getUnminifiedConfig() {
   ];
   const replacePlugin = getReplacePlugin();
   const unminifiedPlugins = [
+    './build-system/babel-plugins/babel-plugin-jsx-style-object',
     getImportResolverPlugin(),
     argv.coverage ? 'babel-plugin-istanbul' : null,
     replacePlugin,

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
@@ -12,33 +12,54 @@ const baseModule = 'core/dom/jsx';
 const helperModule = 'core/dom/jsx-style-property-string';
 const helperFn = 'jsxStylePropertyString';
 
+// All values from here, converted to dash-case:
+// https://github.com/facebook/react/blob/a7c5726/packages/react-dom/src/shared/CSSProperty.js
 const nonDimensional = new Set([
   'animation-iteration-count',
+  'aspect-ratio',
+  'border-image-outset',
+  'border-image-slice',
+  'border-image-width',
   'box-flex',
   'box-flex-group',
   'box-ordinal-group',
   'column-count',
-  'fill-opacity',
+  'columns',
   'flex',
   'flex-grow',
   'flex-positive',
   'flex-shrink',
   'flex-negative',
   'flex-order',
+  'grid-area',
+  'grid-row',
+  'grid-row-end',
+  'grid-row-span',
+  'grid-row-start',
+  'grid-column',
+  'grid-column-end',
+  'grid-column-span',
+  'grid-column-start',
   'font-weight',
   'line-clamp',
   'line-height',
   'opacity',
   'order',
   'orphans',
-  'stop-opacity',
-  'stroke-dashoffset',
-  'stroke-opacity',
-  'stroke-width',
   'tab-size',
   'widows',
   'z-index',
   'zoom',
+
+  // SVG-related properties
+  'fill-opacity',
+  'flood-opacity',
+  'stop-opacity',
+  'stroke-dasharray',
+  'stroke-dashoffset',
+  'stroke-miterlimit',
+  'stroke-opacity',
+  'stroke-width',
 ]);
 
 module.exports = function (babel) {

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
@@ -126,7 +126,11 @@ module.exports = function (babel) {
   /** @param {babel.NodePath} path */
   function replaceExpression(path) {
     if (path.isLogicalExpression()) {
-      if (path.node.operator === '&&' || path.node.operator === '||') {
+      if (
+        path.node.operator === '&&' ||
+        path.node.operator === '||' ||
+        path.node.operator === '??'
+      ) {
         replaceExpression(path.get('right'));
       }
       return;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
@@ -73,7 +73,7 @@ module.exports = function (babel) {
   let programPath = null;
 
   /**
-   * @param {babel.NodePath<import('@babel/types').ObjectProperty>} path
+   * @param {babel.NodePath<babel.types.ObjectProperty>} path
    * @return {?babel.Node}
    */
   function transformProp(path) {

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
@@ -1,0 +1,177 @@
+/**
+ * @fileoverview
+ * Converts Object Expression syntax in `style={{foo: 'bar'}}` to a concatenated
+ * string expression.
+ *
+ * This only transforms a file if it imports the `baseModule` for JSX below,
+ * which lacks runtime support for converting the Object into a string.
+ * This transform takes that responsibility instead.
+ */
+
+const baseModule = 'core/dom/jsx';
+const helperModule = 'core/dom/jsx-style-property-string';
+const helperFn = 'jsxStylePropertyString';
+
+const nonDimensional = new Set([
+  'animation-iteration-count',
+  'box-flex',
+  'box-flex-group',
+  'box-ordinal-group',
+  'column-count',
+  'fill-opacity',
+  'flex',
+  'flex-grow',
+  'flex-positive',
+  'flex-shrink',
+  'flex-negative',
+  'flex-order',
+  'font-weight',
+  'line-clamp',
+  'line-height',
+  'opacity',
+  'order',
+  'orphans',
+  'stop-opacity',
+  'stroke-dashoffset',
+  'stroke-opacity',
+  'stroke-width',
+  'tab-size',
+  'widows',
+  'z-index',
+  'zoom',
+]);
+
+module.exports = function (babel) {
+  const {types: t} = babel;
+
+  const dashCase = (camelCase) =>
+    camelCase.replace(/[A-Z]/g, '-$&').toLowerCase();
+
+  let hasBaseModule = false;
+  let hasHelperModule = false;
+  let programPath = null;
+
+  /**
+   * @param {babel.NodePath<import('@babel/types').ObjectProperty>} path
+   * @return {babel.Node}
+   */
+  function transformProp(path) {
+    // @ts-ignore
+    const name = path.node.key.name || path.node.key.value;
+    const cssName = dashCase(name);
+    const isDimensional = !nonDimensional.has(cssName);
+    const value = path.get('value');
+    const evaluated = value.evaluate();
+
+    // If we can evaluate the value, return a composed string.
+    if (evaluated.confident) {
+      const {value} = evaluated;
+      if (value != null) {
+        const withUnit =
+          isDimensional && typeof value === 'number' ? `${value}px` : value;
+        return t.stringLiteral(`${cssName}:${withUnit};`);
+      }
+    }
+
+    // Otherwise call the helper function to evaluate nullish and dimensional values.
+    if (!hasHelperModule && programPath) {
+      hasHelperModule = true;
+      programPath.unshiftContainer(
+        'body',
+        t.importDeclaration(
+          [t.importSpecifier(t.identifier(helperFn), t.identifier(helperFn))],
+          t.stringLiteral(helperModule)
+        )
+      );
+    }
+    const args = [t.stringLiteral(cssName), value.node];
+    if (isDimensional) {
+      args.push(t.booleanLiteral(true));
+    }
+    return t.callExpression(t.identifier(helperFn), args);
+  }
+
+  /**
+   * @param {babel.Node[]} props
+   * @return {?babel.Node}
+   */
+  function mergeTransformedIntoExpr(props) {
+    let expr = null;
+    let prev = null;
+    while (props.length) {
+      const part = props.shift();
+      // Collapse adjacent strings.
+      if (t.isStringLiteral(prev) && t.isStringLiteral(part)) {
+        // @ts-ignore
+        prev.value += part.value;
+      } else {
+        if (!expr) {
+          expr = part;
+        } else {
+          expr = t.binaryExpression('+', expr, part);
+        }
+        prev = part;
+      }
+    }
+    return expr;
+  }
+
+  return {
+    name: 'jsx-style-object',
+    visitor: {
+      Program: {
+        enter(path) {
+          programPath = path;
+          hasBaseModule = false;
+          hasHelperModule = false;
+          path.traverse({
+            ImportDeclaration(path) {
+              if (path.node.source.value.endsWith(helperModule)) {
+                hasHelperModule = true;
+              } else if (path.node.source.value.endsWith(baseModule)) {
+                hasBaseModule = true;
+              }
+              if (hasHelperModule && hasBaseModule) {
+                path.stop();
+              } else {
+                path.skip();
+              }
+            },
+          });
+        },
+      },
+      JSXAttribute(path) {
+        if (!hasBaseModule) {
+          return;
+        }
+        if (!t.isJSXIdentifier(path.node.name, {name: 'style'})) {
+          return;
+        }
+        const objectExpression = path.get('value.expression');
+        if (!objectExpression.isObjectExpression()) {
+          return;
+        }
+        const props = objectExpression.node.properties.map((_, i) => {
+          const prop = objectExpression.get(`properties.${i}`);
+          if (prop.isSpreadElement()) {
+            throw prop.buildCodeFrameError(
+              'You should not use spread properties in style object expressions.'
+            );
+          }
+          if (prop.node.computed) {
+            throw prop
+              .get('key')
+              .buildCodeFrameError(
+                'You should not use computed props in style object expressions. Instead, use multiple properties directly. They can be "null" when unwanted.'
+              );
+          }
+          return transformProp(prop);
+        });
+        const merged = mergeTransformedIntoExpr(props);
+        if (merged) {
+          objectExpression.replaceWith(merged);
+        }
+      },
+    },
+  };
+};

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/index.js
@@ -9,7 +9,6 @@
  */
 
 const {addNamed} = require('@babel/helper-module-imports');
-const {template} = require('@babel/core');
 
 const baseModule = 'core/dom/jsx';
 const helperModule = '#core/dom/jsx-style-property-string';
@@ -74,29 +73,6 @@ module.exports = function (babel) {
   let hasBaseModule = false;
 
   /**
-   * @param {babel.Node} node
-   * @return {boolean}
-   */
-  function couldBeDimensionalValue(node) {
-    if (t.isBinaryExpression(node)) {
-      node = /** @type {babel.types.BinaryExpression} */ (node);
-      return (
-        node.operator === '+' &&
-        couldBeDimensionalValue(node.left) &&
-        couldBeDimensionalValue(node.right)
-      );
-    }
-    if (t.isConditionalExpression(node)) {
-      node = /** @type {babel.types.ConditionalExpression} */ (node);
-      return (
-        couldBeDimensionalValue(node.consequent) ||
-        couldBeDimensionalValue(node.alternate)
-      );
-    }
-    return !t.isStringLiteral(node) && !t.isTemplateLiteral(node);
-  }
-
-  /**
    * @param {babel.NodePath<babel.types.ObjectProperty>} path
    * @return {?babel.Node}
    */
@@ -117,11 +93,6 @@ module.exports = function (babel) {
       const withUnit =
         isDimensional && typeof value === 'number' ? `${value}px` : value;
       return t.stringLiteral(`${cssName}:${withUnit};`);
-    }
-
-    // If the value cannot result in a number, return a string expression.
-    if (!couldBeDimensionalValue(value.node)) {
-      return template.expression(`'${cssName}:' + ${value} + ';'`)();
     }
 
     // Otherwise call the helper function to evaluate nullish and dimensional values.

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/input.mjs
@@ -1,0 +1,94 @@
+import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
+
+const dimensional = () => <div style={{width: 100, height}} />;
+
+const nonDimensional = () => (
+  <div>
+    <div style={{animationIterationCount}} />
+    <div style={{'animation-iteration-count': 5}} />
+    <div style={{aspectRatio}} />
+    <div style={{'aspect-ratio': 1.5}} />
+    <div style={{borderImageOutset}} />
+    <div style={{'border-image-outset': 2}} />
+    <div style={{borderImageSlice}} />
+    <div style={{'border-image-slice': 8}} />
+    <div style={{borderImageWidth}} />
+    <div style={{'border-image-width': 7}} />
+    <div style={{boxFlex}} />
+    <div style={{'box-flex': 4}} />
+    <div style={{boxFlexGroup}} />
+    <div style={{'box-flex-group': 6}} />
+    <div style={{boxOrdinalGroup}} />
+    <div style={{'box-ordinal-group': 8}} />
+    <div style={{columnCount}} />
+    <div style={{'column-count': 6}} />
+    <div style={{columns}} />
+    <div style={{'columns': 7}} />
+    <div style={{flex}} />
+    <div style={{'flex': 5}} />
+    <div style={{flexGrow}} />
+    <div style={{'flex-grow': 1}} />
+    <div style={{flexPositive}} />
+    <div style={{'flex-positive': 5}} />
+    <div style={{flexShrink}} />
+    <div style={{'flex-shrink': 6}} />
+    <div style={{flexNegative}} />
+    <div style={{'flex-negative': 3}} />
+    <div style={{flexOrder}} />
+    <div style={{'flex-order': 9}} />
+    <div style={{gridArea}} />
+    <div style={{'grid-area': 3}} />
+    <div style={{gridRow}} />
+    <div style={{'grid-row': 10}} />
+    <div style={{gridRowEnd}} />
+    <div style={{'grid-row-end': 3}} />
+    <div style={{gridRowSpan}} />
+    <div style={{'grid-row-span': 5}} />
+    <div style={{gridRowStart}} />
+    <div style={{'grid-row-start': 5}} />
+    <div style={{gridColumn}} />
+    <div style={{'grid-column': 5}} />
+    <div style={{gridColumnEnd}} />
+    <div style={{'grid-column-end': 2}} />
+    <div style={{gridColumnSpan}} />
+    <div style={{'grid-column-span': 9}} />
+    <div style={{gridColumnStart}} />
+    <div style={{'grid-column-start': 4}} />
+    <div style={{fontWeight}} />
+    <div style={{'font-weight': 1}} />
+    <div style={{lineClamp}} />
+    <div style={{'line-clamp': 6}} />
+    <div style={{lineHeight}} />
+    <div style={{'line-height': 1.5}} />
+    <div style={{opacity}} />
+    <div style={{'opacity': 0.2}} />
+    <div style={{order}} />
+    <div style={{'order': 0}} />
+    <div style={{orphans}} />
+    <div style={{'orphans': 0}} />
+    <div style={{tabSize}} />
+    <div style={{'tab-size': 4}} />
+    <div style={{widows}} />
+    <div style={{'widows': 1}} />
+    <div style={{zIndex}} />
+    <div style={{'z-index': 2}} />
+    <div style={{zoom}} />
+    <div style={{'zoom': 8}} />
+    <div style={{fillOpacity}} />
+    <div style={{'fill-opacity': 3}} />
+    <div style={{floodOpacity}} />
+    <div style={{'flood-opacity': 0.5}} />
+    <div style={{stopOpacity}} />
+    <div style={{'stop-opacity': 0.75}} />
+    <div style={{strokeDasharray}} />
+    <div style={{'stroke-dasharray': 10}} />
+    <div style={{strokeDashoffset}} />
+    <div style={{'stroke-dashoffset': 10}} />
+    <div style={{strokeMiterlimit}} />
+    <div style={{'stroke-miterlimit': 8}} />
+    <div style={{strokeOpacity}} />
+    <div style={{'stroke-opacity': 0.9}} />
+    <div style={{strokeWidth}} />
+    <div style={{'stroke-width': 8}} />
+  </div>
+);

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/input.mjs
@@ -1,8 +1,21 @@
 import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
 
-const dimensional = () => <div style={{width: 100, height}} />;
+const cannotBeDimensional = () => (
+  <div
+    style={{
+      backgroundImage: `url(${url})`,
+      height: height + 'px',
+      font: serif ? 'serif' : getSansFont(),
+      'font-size': large ? '2em' : '1em',
+    }}
+  />
+);
 
-const nonDimensional = () => (
+const dimensional = () => (
+  <div style={{width: 100, height, fontSize: large ? 30 : 15}} />
+);
+
+const neverDimensional = () => (
   <div>
     <div style={{animationIterationCount}} />
     <div style={{'animation-iteration-count': 5}} />

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/input.mjs
@@ -1,21 +1,8 @@
 import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
 
-const cannotBeDimensional = () => (
-  <div
-    style={{
-      backgroundImage: `url(${url})`,
-      height: height + 'px',
-      font: serif ? 'serif' : getSansFont(),
-      'font-size': large ? '2em' : '1em',
-    }}
-  />
-);
+const dimensional = () => <div style={{width: 100, height}} />;
 
-const dimensional = () => (
-  <div style={{width: 100, height, fontSize: large ? 30 : 15}} />
-);
-
-const neverDimensional = () => (
+const nonDimensional = () => (
   <div>
     <div style={{animationIterationCount}} />
     <div style={{'animation-iteration-count': 5}} />

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/options.json
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../..",
+    "@babel/plugin-syntax-jsx"
+  ]
+}

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/output.mjs
@@ -1,0 +1,136 @@
+import { jsxStylePropertyString as _jsxStylePropertyString44 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString43 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString42 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString41 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString40 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString39 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString38 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString37 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString36 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString35 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString34 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString33 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString32 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString31 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString30 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString29 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString28 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString27 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString26 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString25 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString24 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString23 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString22 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString21 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString20 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString19 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString18 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString17 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString16 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString15 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString14 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString13 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString12 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString11 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString10 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString9 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString8 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString7 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString6 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString5 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString4 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString3 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString2 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString } from "#core/dom/jsx-style-property-string";
+import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
+
+const dimensional = () => <div style={"width:100px;" + _jsxStylePropertyString("height", height, true)} />;
+
+const nonDimensional = () => <div>
+    <div style={_jsxStylePropertyString2("animation-iteration-count", animationIterationCount)} />
+    <div style={"animation-iteration-count:5;"} />
+    <div style={_jsxStylePropertyString3("aspect-ratio", aspectRatio)} />
+    <div style={"aspect-ratio:1.5;"} />
+    <div style={_jsxStylePropertyString4("border-image-outset", borderImageOutset)} />
+    <div style={"border-image-outset:2;"} />
+    <div style={_jsxStylePropertyString5("border-image-slice", borderImageSlice)} />
+    <div style={"border-image-slice:8;"} />
+    <div style={_jsxStylePropertyString6("border-image-width", borderImageWidth)} />
+    <div style={"border-image-width:7;"} />
+    <div style={_jsxStylePropertyString7("box-flex", boxFlex)} />
+    <div style={"box-flex:4;"} />
+    <div style={_jsxStylePropertyString8("box-flex-group", boxFlexGroup)} />
+    <div style={"box-flex-group:6;"} />
+    <div style={_jsxStylePropertyString9("box-ordinal-group", boxOrdinalGroup)} />
+    <div style={"box-ordinal-group:8;"} />
+    <div style={_jsxStylePropertyString10("column-count", columnCount)} />
+    <div style={"column-count:6;"} />
+    <div style={_jsxStylePropertyString11("columns", columns)} />
+    <div style={"columns:7;"} />
+    <div style={_jsxStylePropertyString12("flex", flex)} />
+    <div style={"flex:5;"} />
+    <div style={_jsxStylePropertyString13("flex-grow", flexGrow)} />
+    <div style={"flex-grow:1;"} />
+    <div style={_jsxStylePropertyString14("flex-positive", flexPositive)} />
+    <div style={"flex-positive:5;"} />
+    <div style={_jsxStylePropertyString15("flex-shrink", flexShrink)} />
+    <div style={"flex-shrink:6;"} />
+    <div style={_jsxStylePropertyString16("flex-negative", flexNegative)} />
+    <div style={"flex-negative:3;"} />
+    <div style={_jsxStylePropertyString17("flex-order", flexOrder)} />
+    <div style={"flex-order:9;"} />
+    <div style={_jsxStylePropertyString18("grid-area", gridArea)} />
+    <div style={"grid-area:3;"} />
+    <div style={_jsxStylePropertyString19("grid-row", gridRow)} />
+    <div style={"grid-row:10;"} />
+    <div style={_jsxStylePropertyString20("grid-row-end", gridRowEnd)} />
+    <div style={"grid-row-end:3;"} />
+    <div style={_jsxStylePropertyString21("grid-row-span", gridRowSpan)} />
+    <div style={"grid-row-span:5;"} />
+    <div style={_jsxStylePropertyString22("grid-row-start", gridRowStart)} />
+    <div style={"grid-row-start:5;"} />
+    <div style={_jsxStylePropertyString23("grid-column", gridColumn)} />
+    <div style={"grid-column:5;"} />
+    <div style={_jsxStylePropertyString24("grid-column-end", gridColumnEnd)} />
+    <div style={"grid-column-end:2;"} />
+    <div style={_jsxStylePropertyString25("grid-column-span", gridColumnSpan)} />
+    <div style={"grid-column-span:9;"} />
+    <div style={_jsxStylePropertyString26("grid-column-start", gridColumnStart)} />
+    <div style={"grid-column-start:4;"} />
+    <div style={_jsxStylePropertyString27("font-weight", fontWeight)} />
+    <div style={"font-weight:1;"} />
+    <div style={_jsxStylePropertyString28("line-clamp", lineClamp)} />
+    <div style={"line-clamp:6;"} />
+    <div style={_jsxStylePropertyString29("line-height", lineHeight)} />
+    <div style={"line-height:1.5;"} />
+    <div style={_jsxStylePropertyString30("opacity", opacity)} />
+    <div style={"opacity:0.2;"} />
+    <div style={_jsxStylePropertyString31("order", order)} />
+    <div style={"order:0;"} />
+    <div style={_jsxStylePropertyString32("orphans", orphans)} />
+    <div style={"orphans:0;"} />
+    <div style={_jsxStylePropertyString33("tab-size", tabSize)} />
+    <div style={"tab-size:4;"} />
+    <div style={_jsxStylePropertyString34("widows", widows)} />
+    <div style={"widows:1;"} />
+    <div style={_jsxStylePropertyString35("z-index", zIndex)} />
+    <div style={"z-index:2;"} />
+    <div style={_jsxStylePropertyString36("zoom", zoom)} />
+    <div style={"zoom:8;"} />
+    <div style={_jsxStylePropertyString37("fill-opacity", fillOpacity)} />
+    <div style={"fill-opacity:3;"} />
+    <div style={_jsxStylePropertyString38("flood-opacity", floodOpacity)} />
+    <div style={"flood-opacity:0.5;"} />
+    <div style={_jsxStylePropertyString39("stop-opacity", stopOpacity)} />
+    <div style={"stop-opacity:0.75;"} />
+    <div style={_jsxStylePropertyString40("stroke-dasharray", strokeDasharray)} />
+    <div style={"stroke-dasharray:10;"} />
+    <div style={_jsxStylePropertyString41("stroke-dashoffset", strokeDashoffset)} />
+    <div style={"stroke-dashoffset:10;"} />
+    <div style={_jsxStylePropertyString42("stroke-miterlimit", strokeMiterlimit)} />
+    <div style={"stroke-miterlimit:8;"} />
+    <div style={_jsxStylePropertyString43("stroke-opacity", strokeOpacity)} />
+    <div style={"stroke-opacity:0.9;"} />
+    <div style={_jsxStylePropertyString44("stroke-width", strokeWidth)} />
+    <div style={"stroke-width:8;"} />
+  </div>;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/output.mjs
@@ -1,5 +1,3 @@
-import { jsxStylePropertyString as _jsxStylePropertyString46 } from "#core/dom/jsx-style-property-string";
-import { jsxStylePropertyString as _jsxStylePropertyString45 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString44 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString43 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString42 } from "#core/dom/jsx-style-property-string";
@@ -46,95 +44,93 @@ import { jsxStylePropertyString as _jsxStylePropertyString2 } from "#core/dom/js
 import { jsxStylePropertyString as _jsxStylePropertyString } from "#core/dom/jsx-style-property-string";
 import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
 
-const cannotBeDimensional = () => <div style={'background-image:' + `url(${url})` + ';' + ('height:' + height + 'px' + ';') + _jsxStylePropertyString("font", serif ? 'serif' : getSansFont(), true) + ('font-size:' + large ? '2em' : '1em' + ';')} />;
+const dimensional = () => <div style={"width:100px;" + _jsxStylePropertyString("height", height, true)} />;
 
-const dimensional = () => <div style={"width:100px;" + _jsxStylePropertyString2("height", height, true) + _jsxStylePropertyString3("font-size", large ? 30 : 15, true)} />;
-
-const neverDimensional = () => <div>
-    <div style={_jsxStylePropertyString4("animation-iteration-count", animationIterationCount)} />
+const nonDimensional = () => <div>
+    <div style={_jsxStylePropertyString2("animation-iteration-count", animationIterationCount)} />
     <div style={"animation-iteration-count:5;"} />
-    <div style={_jsxStylePropertyString5("aspect-ratio", aspectRatio)} />
+    <div style={_jsxStylePropertyString3("aspect-ratio", aspectRatio)} />
     <div style={"aspect-ratio:1.5;"} />
-    <div style={_jsxStylePropertyString6("border-image-outset", borderImageOutset)} />
+    <div style={_jsxStylePropertyString4("border-image-outset", borderImageOutset)} />
     <div style={"border-image-outset:2;"} />
-    <div style={_jsxStylePropertyString7("border-image-slice", borderImageSlice)} />
+    <div style={_jsxStylePropertyString5("border-image-slice", borderImageSlice)} />
     <div style={"border-image-slice:8;"} />
-    <div style={_jsxStylePropertyString8("border-image-width", borderImageWidth)} />
+    <div style={_jsxStylePropertyString6("border-image-width", borderImageWidth)} />
     <div style={"border-image-width:7;"} />
-    <div style={_jsxStylePropertyString9("box-flex", boxFlex)} />
+    <div style={_jsxStylePropertyString7("box-flex", boxFlex)} />
     <div style={"box-flex:4;"} />
-    <div style={_jsxStylePropertyString10("box-flex-group", boxFlexGroup)} />
+    <div style={_jsxStylePropertyString8("box-flex-group", boxFlexGroup)} />
     <div style={"box-flex-group:6;"} />
-    <div style={_jsxStylePropertyString11("box-ordinal-group", boxOrdinalGroup)} />
+    <div style={_jsxStylePropertyString9("box-ordinal-group", boxOrdinalGroup)} />
     <div style={"box-ordinal-group:8;"} />
-    <div style={_jsxStylePropertyString12("column-count", columnCount)} />
+    <div style={_jsxStylePropertyString10("column-count", columnCount)} />
     <div style={"column-count:6;"} />
-    <div style={_jsxStylePropertyString13("columns", columns)} />
+    <div style={_jsxStylePropertyString11("columns", columns)} />
     <div style={"columns:7;"} />
-    <div style={_jsxStylePropertyString14("flex", flex)} />
+    <div style={_jsxStylePropertyString12("flex", flex)} />
     <div style={"flex:5;"} />
-    <div style={_jsxStylePropertyString15("flex-grow", flexGrow)} />
+    <div style={_jsxStylePropertyString13("flex-grow", flexGrow)} />
     <div style={"flex-grow:1;"} />
-    <div style={_jsxStylePropertyString16("flex-positive", flexPositive)} />
+    <div style={_jsxStylePropertyString14("flex-positive", flexPositive)} />
     <div style={"flex-positive:5;"} />
-    <div style={_jsxStylePropertyString17("flex-shrink", flexShrink)} />
+    <div style={_jsxStylePropertyString15("flex-shrink", flexShrink)} />
     <div style={"flex-shrink:6;"} />
-    <div style={_jsxStylePropertyString18("flex-negative", flexNegative)} />
+    <div style={_jsxStylePropertyString16("flex-negative", flexNegative)} />
     <div style={"flex-negative:3;"} />
-    <div style={_jsxStylePropertyString19("flex-order", flexOrder)} />
+    <div style={_jsxStylePropertyString17("flex-order", flexOrder)} />
     <div style={"flex-order:9;"} />
-    <div style={_jsxStylePropertyString20("grid-area", gridArea)} />
+    <div style={_jsxStylePropertyString18("grid-area", gridArea)} />
     <div style={"grid-area:3;"} />
-    <div style={_jsxStylePropertyString21("grid-row", gridRow)} />
+    <div style={_jsxStylePropertyString19("grid-row", gridRow)} />
     <div style={"grid-row:10;"} />
-    <div style={_jsxStylePropertyString22("grid-row-end", gridRowEnd)} />
+    <div style={_jsxStylePropertyString20("grid-row-end", gridRowEnd)} />
     <div style={"grid-row-end:3;"} />
-    <div style={_jsxStylePropertyString23("grid-row-span", gridRowSpan)} />
+    <div style={_jsxStylePropertyString21("grid-row-span", gridRowSpan)} />
     <div style={"grid-row-span:5;"} />
-    <div style={_jsxStylePropertyString24("grid-row-start", gridRowStart)} />
+    <div style={_jsxStylePropertyString22("grid-row-start", gridRowStart)} />
     <div style={"grid-row-start:5;"} />
-    <div style={_jsxStylePropertyString25("grid-column", gridColumn)} />
+    <div style={_jsxStylePropertyString23("grid-column", gridColumn)} />
     <div style={"grid-column:5;"} />
-    <div style={_jsxStylePropertyString26("grid-column-end", gridColumnEnd)} />
+    <div style={_jsxStylePropertyString24("grid-column-end", gridColumnEnd)} />
     <div style={"grid-column-end:2;"} />
-    <div style={_jsxStylePropertyString27("grid-column-span", gridColumnSpan)} />
+    <div style={_jsxStylePropertyString25("grid-column-span", gridColumnSpan)} />
     <div style={"grid-column-span:9;"} />
-    <div style={_jsxStylePropertyString28("grid-column-start", gridColumnStart)} />
+    <div style={_jsxStylePropertyString26("grid-column-start", gridColumnStart)} />
     <div style={"grid-column-start:4;"} />
-    <div style={_jsxStylePropertyString29("font-weight", fontWeight)} />
+    <div style={_jsxStylePropertyString27("font-weight", fontWeight)} />
     <div style={"font-weight:1;"} />
-    <div style={_jsxStylePropertyString30("line-clamp", lineClamp)} />
+    <div style={_jsxStylePropertyString28("line-clamp", lineClamp)} />
     <div style={"line-clamp:6;"} />
-    <div style={_jsxStylePropertyString31("line-height", lineHeight)} />
+    <div style={_jsxStylePropertyString29("line-height", lineHeight)} />
     <div style={"line-height:1.5;"} />
-    <div style={_jsxStylePropertyString32("opacity", opacity)} />
+    <div style={_jsxStylePropertyString30("opacity", opacity)} />
     <div style={"opacity:0.2;"} />
-    <div style={_jsxStylePropertyString33("order", order)} />
+    <div style={_jsxStylePropertyString31("order", order)} />
     <div style={"order:0;"} />
-    <div style={_jsxStylePropertyString34("orphans", orphans)} />
+    <div style={_jsxStylePropertyString32("orphans", orphans)} />
     <div style={"orphans:0;"} />
-    <div style={_jsxStylePropertyString35("tab-size", tabSize)} />
+    <div style={_jsxStylePropertyString33("tab-size", tabSize)} />
     <div style={"tab-size:4;"} />
-    <div style={_jsxStylePropertyString36("widows", widows)} />
+    <div style={_jsxStylePropertyString34("widows", widows)} />
     <div style={"widows:1;"} />
-    <div style={_jsxStylePropertyString37("z-index", zIndex)} />
+    <div style={_jsxStylePropertyString35("z-index", zIndex)} />
     <div style={"z-index:2;"} />
-    <div style={_jsxStylePropertyString38("zoom", zoom)} />
+    <div style={_jsxStylePropertyString36("zoom", zoom)} />
     <div style={"zoom:8;"} />
-    <div style={_jsxStylePropertyString39("fill-opacity", fillOpacity)} />
+    <div style={_jsxStylePropertyString37("fill-opacity", fillOpacity)} />
     <div style={"fill-opacity:3;"} />
-    <div style={_jsxStylePropertyString40("flood-opacity", floodOpacity)} />
+    <div style={_jsxStylePropertyString38("flood-opacity", floodOpacity)} />
     <div style={"flood-opacity:0.5;"} />
-    <div style={_jsxStylePropertyString41("stop-opacity", stopOpacity)} />
+    <div style={_jsxStylePropertyString39("stop-opacity", stopOpacity)} />
     <div style={"stop-opacity:0.75;"} />
-    <div style={_jsxStylePropertyString42("stroke-dasharray", strokeDasharray)} />
+    <div style={_jsxStylePropertyString40("stroke-dasharray", strokeDasharray)} />
     <div style={"stroke-dasharray:10;"} />
-    <div style={_jsxStylePropertyString43("stroke-dashoffset", strokeDashoffset)} />
+    <div style={_jsxStylePropertyString41("stroke-dashoffset", strokeDashoffset)} />
     <div style={"stroke-dashoffset:10;"} />
-    <div style={_jsxStylePropertyString44("stroke-miterlimit", strokeMiterlimit)} />
+    <div style={_jsxStylePropertyString42("stroke-miterlimit", strokeMiterlimit)} />
     <div style={"stroke-miterlimit:8;"} />
-    <div style={_jsxStylePropertyString45("stroke-opacity", strokeOpacity)} />
+    <div style={_jsxStylePropertyString43("stroke-opacity", strokeOpacity)} />
     <div style={"stroke-opacity:0.9;"} />
-    <div style={_jsxStylePropertyString46("stroke-width", strokeWidth)} />
+    <div style={_jsxStylePropertyString44("stroke-width", strokeWidth)} />
     <div style={"stroke-width:8;"} />
   </div>;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/dimensional/output.mjs
@@ -1,3 +1,5 @@
+import { jsxStylePropertyString as _jsxStylePropertyString46 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString45 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString44 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString43 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString42 } from "#core/dom/jsx-style-property-string";
@@ -44,93 +46,95 @@ import { jsxStylePropertyString as _jsxStylePropertyString2 } from "#core/dom/js
 import { jsxStylePropertyString as _jsxStylePropertyString } from "#core/dom/jsx-style-property-string";
 import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
 
-const dimensional = () => <div style={"width:100px;" + _jsxStylePropertyString("height", height, true)} />;
+const cannotBeDimensional = () => <div style={'background-image:' + `url(${url})` + ';' + ('height:' + height + 'px' + ';') + _jsxStylePropertyString("font", serif ? 'serif' : getSansFont(), true) + ('font-size:' + large ? '2em' : '1em' + ';')} />;
 
-const nonDimensional = () => <div>
-    <div style={_jsxStylePropertyString2("animation-iteration-count", animationIterationCount)} />
+const dimensional = () => <div style={"width:100px;" + _jsxStylePropertyString2("height", height, true) + _jsxStylePropertyString3("font-size", large ? 30 : 15, true)} />;
+
+const neverDimensional = () => <div>
+    <div style={_jsxStylePropertyString4("animation-iteration-count", animationIterationCount)} />
     <div style={"animation-iteration-count:5;"} />
-    <div style={_jsxStylePropertyString3("aspect-ratio", aspectRatio)} />
+    <div style={_jsxStylePropertyString5("aspect-ratio", aspectRatio)} />
     <div style={"aspect-ratio:1.5;"} />
-    <div style={_jsxStylePropertyString4("border-image-outset", borderImageOutset)} />
+    <div style={_jsxStylePropertyString6("border-image-outset", borderImageOutset)} />
     <div style={"border-image-outset:2;"} />
-    <div style={_jsxStylePropertyString5("border-image-slice", borderImageSlice)} />
+    <div style={_jsxStylePropertyString7("border-image-slice", borderImageSlice)} />
     <div style={"border-image-slice:8;"} />
-    <div style={_jsxStylePropertyString6("border-image-width", borderImageWidth)} />
+    <div style={_jsxStylePropertyString8("border-image-width", borderImageWidth)} />
     <div style={"border-image-width:7;"} />
-    <div style={_jsxStylePropertyString7("box-flex", boxFlex)} />
+    <div style={_jsxStylePropertyString9("box-flex", boxFlex)} />
     <div style={"box-flex:4;"} />
-    <div style={_jsxStylePropertyString8("box-flex-group", boxFlexGroup)} />
+    <div style={_jsxStylePropertyString10("box-flex-group", boxFlexGroup)} />
     <div style={"box-flex-group:6;"} />
-    <div style={_jsxStylePropertyString9("box-ordinal-group", boxOrdinalGroup)} />
+    <div style={_jsxStylePropertyString11("box-ordinal-group", boxOrdinalGroup)} />
     <div style={"box-ordinal-group:8;"} />
-    <div style={_jsxStylePropertyString10("column-count", columnCount)} />
+    <div style={_jsxStylePropertyString12("column-count", columnCount)} />
     <div style={"column-count:6;"} />
-    <div style={_jsxStylePropertyString11("columns", columns)} />
+    <div style={_jsxStylePropertyString13("columns", columns)} />
     <div style={"columns:7;"} />
-    <div style={_jsxStylePropertyString12("flex", flex)} />
+    <div style={_jsxStylePropertyString14("flex", flex)} />
     <div style={"flex:5;"} />
-    <div style={_jsxStylePropertyString13("flex-grow", flexGrow)} />
+    <div style={_jsxStylePropertyString15("flex-grow", flexGrow)} />
     <div style={"flex-grow:1;"} />
-    <div style={_jsxStylePropertyString14("flex-positive", flexPositive)} />
+    <div style={_jsxStylePropertyString16("flex-positive", flexPositive)} />
     <div style={"flex-positive:5;"} />
-    <div style={_jsxStylePropertyString15("flex-shrink", flexShrink)} />
+    <div style={_jsxStylePropertyString17("flex-shrink", flexShrink)} />
     <div style={"flex-shrink:6;"} />
-    <div style={_jsxStylePropertyString16("flex-negative", flexNegative)} />
+    <div style={_jsxStylePropertyString18("flex-negative", flexNegative)} />
     <div style={"flex-negative:3;"} />
-    <div style={_jsxStylePropertyString17("flex-order", flexOrder)} />
+    <div style={_jsxStylePropertyString19("flex-order", flexOrder)} />
     <div style={"flex-order:9;"} />
-    <div style={_jsxStylePropertyString18("grid-area", gridArea)} />
+    <div style={_jsxStylePropertyString20("grid-area", gridArea)} />
     <div style={"grid-area:3;"} />
-    <div style={_jsxStylePropertyString19("grid-row", gridRow)} />
+    <div style={_jsxStylePropertyString21("grid-row", gridRow)} />
     <div style={"grid-row:10;"} />
-    <div style={_jsxStylePropertyString20("grid-row-end", gridRowEnd)} />
+    <div style={_jsxStylePropertyString22("grid-row-end", gridRowEnd)} />
     <div style={"grid-row-end:3;"} />
-    <div style={_jsxStylePropertyString21("grid-row-span", gridRowSpan)} />
+    <div style={_jsxStylePropertyString23("grid-row-span", gridRowSpan)} />
     <div style={"grid-row-span:5;"} />
-    <div style={_jsxStylePropertyString22("grid-row-start", gridRowStart)} />
+    <div style={_jsxStylePropertyString24("grid-row-start", gridRowStart)} />
     <div style={"grid-row-start:5;"} />
-    <div style={_jsxStylePropertyString23("grid-column", gridColumn)} />
+    <div style={_jsxStylePropertyString25("grid-column", gridColumn)} />
     <div style={"grid-column:5;"} />
-    <div style={_jsxStylePropertyString24("grid-column-end", gridColumnEnd)} />
+    <div style={_jsxStylePropertyString26("grid-column-end", gridColumnEnd)} />
     <div style={"grid-column-end:2;"} />
-    <div style={_jsxStylePropertyString25("grid-column-span", gridColumnSpan)} />
+    <div style={_jsxStylePropertyString27("grid-column-span", gridColumnSpan)} />
     <div style={"grid-column-span:9;"} />
-    <div style={_jsxStylePropertyString26("grid-column-start", gridColumnStart)} />
+    <div style={_jsxStylePropertyString28("grid-column-start", gridColumnStart)} />
     <div style={"grid-column-start:4;"} />
-    <div style={_jsxStylePropertyString27("font-weight", fontWeight)} />
+    <div style={_jsxStylePropertyString29("font-weight", fontWeight)} />
     <div style={"font-weight:1;"} />
-    <div style={_jsxStylePropertyString28("line-clamp", lineClamp)} />
+    <div style={_jsxStylePropertyString30("line-clamp", lineClamp)} />
     <div style={"line-clamp:6;"} />
-    <div style={_jsxStylePropertyString29("line-height", lineHeight)} />
+    <div style={_jsxStylePropertyString31("line-height", lineHeight)} />
     <div style={"line-height:1.5;"} />
-    <div style={_jsxStylePropertyString30("opacity", opacity)} />
+    <div style={_jsxStylePropertyString32("opacity", opacity)} />
     <div style={"opacity:0.2;"} />
-    <div style={_jsxStylePropertyString31("order", order)} />
+    <div style={_jsxStylePropertyString33("order", order)} />
     <div style={"order:0;"} />
-    <div style={_jsxStylePropertyString32("orphans", orphans)} />
+    <div style={_jsxStylePropertyString34("orphans", orphans)} />
     <div style={"orphans:0;"} />
-    <div style={_jsxStylePropertyString33("tab-size", tabSize)} />
+    <div style={_jsxStylePropertyString35("tab-size", tabSize)} />
     <div style={"tab-size:4;"} />
-    <div style={_jsxStylePropertyString34("widows", widows)} />
+    <div style={_jsxStylePropertyString36("widows", widows)} />
     <div style={"widows:1;"} />
-    <div style={_jsxStylePropertyString35("z-index", zIndex)} />
+    <div style={_jsxStylePropertyString37("z-index", zIndex)} />
     <div style={"z-index:2;"} />
-    <div style={_jsxStylePropertyString36("zoom", zoom)} />
+    <div style={_jsxStylePropertyString38("zoom", zoom)} />
     <div style={"zoom:8;"} />
-    <div style={_jsxStylePropertyString37("fill-opacity", fillOpacity)} />
+    <div style={_jsxStylePropertyString39("fill-opacity", fillOpacity)} />
     <div style={"fill-opacity:3;"} />
-    <div style={_jsxStylePropertyString38("flood-opacity", floodOpacity)} />
+    <div style={_jsxStylePropertyString40("flood-opacity", floodOpacity)} />
     <div style={"flood-opacity:0.5;"} />
-    <div style={_jsxStylePropertyString39("stop-opacity", stopOpacity)} />
+    <div style={_jsxStylePropertyString41("stop-opacity", stopOpacity)} />
     <div style={"stop-opacity:0.75;"} />
-    <div style={_jsxStylePropertyString40("stroke-dasharray", strokeDasharray)} />
+    <div style={_jsxStylePropertyString42("stroke-dasharray", strokeDasharray)} />
     <div style={"stroke-dasharray:10;"} />
-    <div style={_jsxStylePropertyString41("stroke-dashoffset", strokeDashoffset)} />
+    <div style={_jsxStylePropertyString43("stroke-dashoffset", strokeDashoffset)} />
     <div style={"stroke-dashoffset:10;"} />
-    <div style={_jsxStylePropertyString42("stroke-miterlimit", strokeMiterlimit)} />
+    <div style={_jsxStylePropertyString44("stroke-miterlimit", strokeMiterlimit)} />
     <div style={"stroke-miterlimit:8;"} />
-    <div style={_jsxStylePropertyString43("stroke-opacity", strokeOpacity)} />
+    <div style={_jsxStylePropertyString45("stroke-opacity", strokeOpacity)} />
     <div style={"stroke-opacity:0.9;"} />
-    <div style={_jsxStylePropertyString44("stroke-width", strokeWidth)} />
+    <div style={_jsxStylePropertyString46("stroke-width", strokeWidth)} />
     <div style={"stroke-width:8;"} />
   </div>;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/ignored/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/ignored/input.mjs
@@ -1,0 +1,11 @@
+const ignoredBecauseNamespaceIsNotImported = () => (
+  <div
+    style={{
+      color: null,
+      'background-color': red,
+      backgroundImage,
+      opacity: 0,
+      width: 100,
+    }}
+  />
+);

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/ignored/options.json
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/ignored/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../..",
+    "@babel/plugin-syntax-jsx"
+  ]
+}

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/ignored/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/ignored/output.mjs
@@ -1,0 +1,7 @@
+const ignoredBecauseNamespaceIsNotImported = () => <div style={{
+  color: null,
+  'background-color': red,
+  backgroundImage,
+  opacity: 0,
+  width: 100
+}} />;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/nested/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/nested/input.mjs
@@ -1,0 +1,13 @@
+import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
+
+const logicalAnd = () => <div style={x && {background: 'red'}} />;
+
+const logicalAndDeep = () => <div style={x && foo && {color: 'red'}} />;
+
+const logicalOr = () => <div style={x || {background: 'red'}} />;
+
+const ternary = () => <div style={x ? {color: 'red'} : {background: 'red'}} />;
+
+const ternaryNested = () => (
+  <div style={x ? (y ? {color: 'red'} : null) : {background: 'red'}} />
+);

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/nested/options.json
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/nested/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../..",
+    "@babel/plugin-syntax-jsx"
+  ]
+}

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/nested/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/nested/output.mjs
@@ -1,0 +1,11 @@
+import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
+
+const logicalAnd = () => <div style={x && "background:red;"} />;
+
+const logicalAndDeep = () => <div style={x && foo && "color:red;"} />;
+
+const logicalOr = () => <div style={x || "background:red;"} />;
+
+const ternary = () => <div style={x ? "color:red;" : "background:red;"} />;
+
+const ternaryNested = () => <div style={x ? y ? "color:red;" : null : "background:red;"} />;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
@@ -1,0 +1,90 @@
+import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
+
+const randomObjectExpressionsAreUnmodified = () => ({
+  background,
+  color: null,
+});
+
+const nonObjectExpressionsAreUnmodified = () => (
+  <div>
+    <div style={foo} />
+    <div style={foo ? 'foo: bar;' : null} />
+  </div>
+);
+
+const red = 'red';
+const otherAttributesAreUnmodified = () => (
+  <div
+    foo={{
+      color: null,
+      'background-color': red,
+      backgroundImage,
+      opacity: 0,
+      width: 100,
+    }}
+  />
+);
+
+const modified = () => (
+  <div
+    style={{
+      color: null,
+      'background-color': red,
+      backgroundImage,
+      opacity: 0,
+      width: 100,
+    }}
+  />
+);
+
+let dynamic = 0;
+function modifyDynamicValue() {
+  dynamic = 1;
+}
+
+let backgroundColor = 'blue';
+
+const constantsAreCollapsed = () => (
+  <div
+    style={{
+      backgroundColor,
+      width: 100,
+      color: 'white',
+      opacity: dynamic,
+    }}
+  />
+);
+
+const dimensional = () => <div style={{width: 100, height}} />;
+
+const flex = 1;
+const nonDimensional = () => (
+  <div>
+    <div style={{animationIterationCount}} />
+    <div style={{boxFlex}} />
+    <div style={{boxFlexGroup}} />
+    <div style={{boxOrdinalGroup}} />
+    <div style={{columnCount}} />
+    <div style={{fillOpacity: 0}} />
+    <div style={{flex}} />
+    <div style={{flexGrow}} />
+    <div style={{flexPositive}} />
+    <div style={{flexShrink}} />
+    <div style={{flexNegative}} />
+    <div style={{flexOrder}} />
+    <div style={{fontWeight}} />
+    <div style={{lineClamp}} />
+    <div style={{lineHeight}} />
+    <div style={{opacity: 0.5}} />
+    <div style={{order}} />
+    <div style={{orphans}} />
+    <div style={{stopOpacity}} />
+    <div style={{strokeDashoffset}} />
+    <div style={{strokeOpacity}} />
+    <div style={{strokeWidth}} />
+    <div style={{tabSize}} />
+    <div style={{widows}} />
+    <div style={{zIndex}} />
+    <div style={{zoom}} />
+  </div>
+);

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
@@ -30,11 +30,33 @@ const modified = () => (
     style={{
       color: null,
       'background-color': red,
-      backgroundImage,
+      backgroundImage: `url(${url})`,
       opacity: 0,
       width: 100,
+      height: height + 'px',
+      font: serif ? 'serif' : getSansFont(),
+      'font-size': large ? '2em' : '1em',
     }}
   />
+);
+
+const cannotBeDimensional = () => (
+  <div
+    style={{
+      color: null,
+      'background-color': red,
+      backgroundImage: `url(${url})`,
+      opacity: 0,
+      width: 100,
+      height: height + 'px',
+      font: serif ? 'serif' : getSansFont(),
+      'font-size': large ? '2em' : '1em',
+    }}
+  />
+);
+
+const couldBeDimensional = () => (
+  <span style={{fontSize: large ? 30 : 15}}></span>
 );
 
 const emptyStringValueIsRemoved = () => <div style={{background: ''}} />;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
@@ -30,33 +30,11 @@ const modified = () => (
     style={{
       color: null,
       'background-color': red,
-      backgroundImage: `url(${url})`,
+      backgroundImage,
       opacity: 0,
       width: 100,
-      height: height + 'px',
-      font: serif ? 'serif' : getSansFont(),
-      'font-size': large ? '2em' : '1em',
     }}
   />
-);
-
-const cannotBeDimensional = () => (
-  <div
-    style={{
-      color: null,
-      'background-color': red,
-      backgroundImage: `url(${url})`,
-      opacity: 0,
-      width: 100,
-      height: height + 'px',
-      font: serif ? 'serif' : getSansFont(),
-      'font-size': large ? '2em' : '1em',
-    }}
-  />
-);
-
-const couldBeDimensional = () => (
-  <span style={{fontSize: large ? 30 : 15}}></span>
 );
 
 const emptyStringValueIsRemoved = () => <div style={{background: ''}} />;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
@@ -37,6 +37,8 @@ const modified = () => (
   />
 );
 
+const emptyStringValueIsRemoved = () => <div style={{background: ''}} />;
+
 let dynamic = 0;
 function modifyDynamicValue() {
   dynamic = 1;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/input.mjs
@@ -46,7 +46,7 @@ function modifyDynamicValue() {
 
 let backgroundColor = 'blue';
 
-const constantsAreCollapsed = () => (
+const constants = () => (
   <div
     style={{
       backgroundColor,
@@ -57,36 +57,11 @@ const constantsAreCollapsed = () => (
   />
 );
 
-const dimensional = () => <div style={{width: 100, height}} />;
-
-const flex = 1;
-const nonDimensional = () => (
-  <div>
-    <div style={{animationIterationCount}} />
-    <div style={{boxFlex}} />
-    <div style={{boxFlexGroup}} />
-    <div style={{boxOrdinalGroup}} />
-    <div style={{columnCount}} />
-    <div style={{fillOpacity: 0}} />
-    <div style={{flex}} />
-    <div style={{flexGrow}} />
-    <div style={{flexPositive}} />
-    <div style={{flexShrink}} />
-    <div style={{flexNegative}} />
-    <div style={{flexOrder}} />
-    <div style={{fontWeight}} />
-    <div style={{lineClamp}} />
-    <div style={{lineHeight}} />
-    <div style={{opacity: 0.5}} />
-    <div style={{order}} />
-    <div style={{orphans}} />
-    <div style={{stopOpacity}} />
-    <div style={{strokeDashoffset}} />
-    <div style={{strokeOpacity}} />
-    <div style={{strokeWidth}} />
-    <div style={{tabSize}} />
-    <div style={{widows}} />
-    <div style={{zIndex}} />
-    <div style={{zoom}} />
-  </div>
+const empty = () => (
+  <div
+    style={{
+      background: '',
+      color: null,
+    }}
+  />
 );

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/options.json
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../..",
+    "@babel/plugin-syntax-jsx"
+  ]
+}

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
@@ -1,5 +1,3 @@
-import { jsxStylePropertyString as _jsxStylePropertyString4 } from "#core/dom/jsx-style-property-string";
-import { jsxStylePropertyString as _jsxStylePropertyString3 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString2 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString } from "#core/dom/jsx-style-property-string";
 import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
@@ -24,11 +22,7 @@ const otherAttributesAreUnmodified = () => <div foo={{
   width: 100
 }} />;
 
-const modified = () => <div style={"background-color:red;" + ('background-image:' + `url(${url})` + ';') + "opacity:0;" + "width:100px;" + ('height:' + height + 'px' + ';') + _jsxStylePropertyString("font", serif ? 'serif' : getSansFont(), true) + ('font-size:' + large ? '2em' : '1em' + ';')} />;
-
-const cannotBeDimensional = () => <div style={"background-color:red;" + ('background-image:' + `url(${url})` + ';') + "opacity:0;" + "width:100px;" + ('height:' + height + 'px' + ';') + _jsxStylePropertyString2("font", serif ? 'serif' : getSansFont(), true) + ('font-size:' + large ? '2em' : '1em' + ';')} />;
-
-const couldBeDimensional = () => <span style={_jsxStylePropertyString3("font-size", large ? 30 : 15, true)}></span>;
+const modified = () => <div style={"background-color:red;" + _jsxStylePropertyString("background-image", backgroundImage, true) + "opacity:0;" + "width:100px;"} />;
 
 const emptyStringValueIsRemoved = () => <div style={""} />;
 
@@ -40,6 +34,6 @@ function modifyDynamicValue() {
 
 let backgroundColor = 'blue';
 
-const constants = () => <div style={"background-color:blue;" + "width:100px;" + "color:white;" + _jsxStylePropertyString4("opacity", dynamic)} />;
+const constants = () => <div style={"background-color:blue;" + "width:100px;" + "color:white;" + _jsxStylePropertyString2("opacity", dynamic)} />;
 
 const empty = () => <div style={""} />;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
@@ -1,4 +1,5 @@
-import { jsxStylePropertyString } from "core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString2 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString } from "#core/dom/jsx-style-property-string";
 import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
 
 const randomObjectExpressionsAreUnmodified = () => ({
@@ -21,11 +22,9 @@ const otherAttributesAreUnmodified = () => <div foo={{
   width: 100
 }} />;
 
-const modified = () => <div style={"background-color:red;" + jsxStylePropertyString("background-image", backgroundImage, true) + "opacity:0;width:100px;"} />;
+const modified = () => <div style={"background-color:red;" + _jsxStylePropertyString("background-image", backgroundImage, true) + "opacity:0;" + "width:100px;"} />;
 
-const emptyStringValueIsRemoved = () => <div style={{
-  background: ''
-}} />;
+const emptyStringValueIsRemoved = () => <div style={""} />;
 
 let dynamic = 0;
 
@@ -35,37 +34,6 @@ function modifyDynamicValue() {
 
 let backgroundColor = 'blue';
 
-const constantsAreCollapsed = () => <div style={"background-color:blue;width:100px;color:white;" + jsxStylePropertyString("opacity", dynamic)} />;
+const constants = () => <div style={"background-color:blue;" + "width:100px;" + "color:white;" + _jsxStylePropertyString2("opacity", dynamic)} />;
 
-const dimensional = () => <div style={"width:100px;" + jsxStylePropertyString("height", height, true)} />;
-
-const flex = 1;
-
-const nonDimensional = () => <div>
-    <div style={jsxStylePropertyString("animation-iteration-count", animationIterationCount)} />
-    <div style={jsxStylePropertyString("box-flex", boxFlex)} />
-    <div style={jsxStylePropertyString("box-flex-group", boxFlexGroup)} />
-    <div style={jsxStylePropertyString("box-ordinal-group", boxOrdinalGroup)} />
-    <div style={jsxStylePropertyString("column-count", columnCount)} />
-    <div style={"fill-opacity:0;"} />
-    <div style={"flex:1;"} />
-    <div style={jsxStylePropertyString("flex-grow", flexGrow)} />
-    <div style={jsxStylePropertyString("flex-positive", flexPositive)} />
-    <div style={jsxStylePropertyString("flex-shrink", flexShrink)} />
-    <div style={jsxStylePropertyString("flex-negative", flexNegative)} />
-    <div style={jsxStylePropertyString("flex-order", flexOrder)} />
-    <div style={jsxStylePropertyString("font-weight", fontWeight)} />
-    <div style={jsxStylePropertyString("line-clamp", lineClamp)} />
-    <div style={jsxStylePropertyString("line-height", lineHeight)} />
-    <div style={"opacity:0.5;"} />
-    <div style={jsxStylePropertyString("order", order)} />
-    <div style={jsxStylePropertyString("orphans", orphans)} />
-    <div style={jsxStylePropertyString("stop-opacity", stopOpacity)} />
-    <div style={jsxStylePropertyString("stroke-dashoffset", strokeDashoffset)} />
-    <div style={jsxStylePropertyString("stroke-opacity", strokeOpacity)} />
-    <div style={jsxStylePropertyString("stroke-width", strokeWidth)} />
-    <div style={jsxStylePropertyString("tab-size", tabSize)} />
-    <div style={jsxStylePropertyString("widows", widows)} />
-    <div style={jsxStylePropertyString("z-index", zIndex)} />
-    <div style={jsxStylePropertyString("zoom", zoom)} />
-  </div>;
+const empty = () => <div style={""} />;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
@@ -21,7 +21,11 @@ const otherAttributesAreUnmodified = () => <div foo={{
   width: 100
 }} />;
 
-const modified = () => <div style={jsxStylePropertyString("color", null, true) + "background-color:red;" + jsxStylePropertyString("background-image", backgroundImage, true) + "opacity:0;width:100px;"} />;
+const modified = () => <div style={"background-color:red;" + jsxStylePropertyString("background-image", backgroundImage, true) + "opacity:0;width:100px;"} />;
+
+const emptyStringValueIsRemoved = () => <div style={{
+  background: ''
+}} />;
 
 let dynamic = 0;
 

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
@@ -1,3 +1,5 @@
+import { jsxStylePropertyString as _jsxStylePropertyString4 } from "#core/dom/jsx-style-property-string";
+import { jsxStylePropertyString as _jsxStylePropertyString3 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString2 } from "#core/dom/jsx-style-property-string";
 import { jsxStylePropertyString as _jsxStylePropertyString } from "#core/dom/jsx-style-property-string";
 import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
@@ -22,7 +24,11 @@ const otherAttributesAreUnmodified = () => <div foo={{
   width: 100
 }} />;
 
-const modified = () => <div style={"background-color:red;" + _jsxStylePropertyString("background-image", backgroundImage, true) + "opacity:0;" + "width:100px;"} />;
+const modified = () => <div style={"background-color:red;" + ('background-image:' + `url(${url})` + ';') + "opacity:0;" + "width:100px;" + ('height:' + height + 'px' + ';') + _jsxStylePropertyString("font", serif ? 'serif' : getSansFont(), true) + ('font-size:' + large ? '2em' : '1em' + ';')} />;
+
+const cannotBeDimensional = () => <div style={"background-color:red;" + ('background-image:' + `url(${url})` + ';') + "opacity:0;" + "width:100px;" + ('height:' + height + 'px' + ';') + _jsxStylePropertyString2("font", serif ? 'serif' : getSansFont(), true) + ('font-size:' + large ? '2em' : '1em' + ';')} />;
+
+const couldBeDimensional = () => <span style={_jsxStylePropertyString3("font-size", large ? 30 : 15, true)}></span>;
 
 const emptyStringValueIsRemoved = () => <div style={""} />;
 
@@ -34,6 +40,6 @@ function modifyDynamicValue() {
 
 let backgroundColor = 'blue';
 
-const constants = () => <div style={"background-color:blue;" + "width:100px;" + "color:white;" + _jsxStylePropertyString2("opacity", dynamic)} />;
+const constants = () => <div style={"background-color:blue;" + "width:100px;" + "color:white;" + _jsxStylePropertyString4("opacity", dynamic)} />;
 
 const empty = () => <div style={""} />;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/fixtures/transform/transformed/output.mjs
@@ -1,0 +1,67 @@
+import { jsxStylePropertyString } from "core/dom/jsx-style-property-string";
+import * as jsx from 'ANYWHERE_LEADING_TO/core/dom/jsx';
+
+const randomObjectExpressionsAreUnmodified = () => ({
+  background,
+  color: null
+});
+
+const nonObjectExpressionsAreUnmodified = () => <div>
+    <div style={foo} />
+    <div style={foo ? 'foo: bar;' : null} />
+  </div>;
+
+const red = 'red';
+
+const otherAttributesAreUnmodified = () => <div foo={{
+  color: null,
+  'background-color': red,
+  backgroundImage,
+  opacity: 0,
+  width: 100
+}} />;
+
+const modified = () => <div style={jsxStylePropertyString("color", null, true) + "background-color:red;" + jsxStylePropertyString("background-image", backgroundImage, true) + "opacity:0;width:100px;"} />;
+
+let dynamic = 0;
+
+function modifyDynamicValue() {
+  dynamic = 1;
+}
+
+let backgroundColor = 'blue';
+
+const constantsAreCollapsed = () => <div style={"background-color:blue;width:100px;color:white;" + jsxStylePropertyString("opacity", dynamic)} />;
+
+const dimensional = () => <div style={"width:100px;" + jsxStylePropertyString("height", height, true)} />;
+
+const flex = 1;
+
+const nonDimensional = () => <div>
+    <div style={jsxStylePropertyString("animation-iteration-count", animationIterationCount)} />
+    <div style={jsxStylePropertyString("box-flex", boxFlex)} />
+    <div style={jsxStylePropertyString("box-flex-group", boxFlexGroup)} />
+    <div style={jsxStylePropertyString("box-ordinal-group", boxOrdinalGroup)} />
+    <div style={jsxStylePropertyString("column-count", columnCount)} />
+    <div style={"fill-opacity:0;"} />
+    <div style={"flex:1;"} />
+    <div style={jsxStylePropertyString("flex-grow", flexGrow)} />
+    <div style={jsxStylePropertyString("flex-positive", flexPositive)} />
+    <div style={jsxStylePropertyString("flex-shrink", flexShrink)} />
+    <div style={jsxStylePropertyString("flex-negative", flexNegative)} />
+    <div style={jsxStylePropertyString("flex-order", flexOrder)} />
+    <div style={jsxStylePropertyString("font-weight", fontWeight)} />
+    <div style={jsxStylePropertyString("line-clamp", lineClamp)} />
+    <div style={jsxStylePropertyString("line-height", lineHeight)} />
+    <div style={"opacity:0.5;"} />
+    <div style={jsxStylePropertyString("order", order)} />
+    <div style={jsxStylePropertyString("orphans", orphans)} />
+    <div style={jsxStylePropertyString("stop-opacity", stopOpacity)} />
+    <div style={jsxStylePropertyString("stroke-dashoffset", strokeDashoffset)} />
+    <div style={jsxStylePropertyString("stroke-opacity", strokeOpacity)} />
+    <div style={jsxStylePropertyString("stroke-width", strokeWidth)} />
+    <div style={jsxStylePropertyString("tab-size", tabSize)} />
+    <div style={jsxStylePropertyString("widows", widows)} />
+    <div style={jsxStylePropertyString("z-index", zIndex)} />
+    <div style={jsxStylePropertyString("zoom", zoom)} />
+  </div>;

--- a/build-system/babel-plugins/babel-plugin-jsx-style-object/test/index.js
+++ b/build-system/babel-plugins/babel-plugin-jsx-style-object/test/index.js
@@ -1,0 +1,3 @@
+const runner = require('@babel/helper-plugin-test-runner').default;
+
+runner(__dirname);

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -60,7 +60,7 @@ const renderElement = (element, config, consentId, logoSrc) => (
           <div
             class="i-amphtml-story-consent-logo"
             style={
-              logoSrc ? `background-image: url('${logoSrc}') !important;` : ''
+              logoSrc ? {backgroundImage: `url('${logoSrc}') !important`} : ''
             }
           />
         </div>

--- a/src/core/dom/jsx-style-property-string.js
+++ b/src/core/dom/jsx-style-property-string.js
@@ -7,7 +7,7 @@
  * @return {string}
  */
 export function jsxStylePropertyString(property, value, opt_isDimensional) {
-  if (value == null) {
+  if (value == null || value === '') {
     return '';
   }
   const withUnit =

--- a/src/core/dom/jsx-style-property-string.js
+++ b/src/core/dom/jsx-style-property-string.js
@@ -1,0 +1,16 @@
+/**
+ * Output helper for babel-plugin-jsx-style-object.
+ * You should not use this directly.
+ * @param {string} property
+ * @param {*} value
+ * @param {string=} opt_isDimensional
+ * @return {string}
+ */
+export function jsxStylePropertyString(property, value, opt_isDimensional) {
+  if (value == null) {
+    return '';
+  }
+  const withUnit =
+    opt_isDimensional && typeof value === 'number' ? `${value}px` : value;
+  return `${property}:${withUnit};`;
+}

--- a/test/unit/core/dom/test-jsx-style-property-string.js
+++ b/test/unit/core/dom/test-jsx-style-property-string.js
@@ -12,6 +12,17 @@ describes.sandboxed('jsxStylePropertyString', {}, () => {
     ).to.equal('');
   });
 
+  it('returns empty string with empty string', () => {
+    expect(jsxStylePropertyString('a', '')).to.equal('');
+    expect(jsxStylePropertyString('b', '')).to.equal('');
+    expect(jsxStylePropertyString('c', '', /* isDimensional */ true)).to.equal(
+      ''
+    );
+    expect(jsxStylePropertyString('d', '', /* isDimensional */ true)).to.equal(
+      ''
+    );
+  });
+
   it('returns string value', () => {
     expect(jsxStylePropertyString('background', 'red')).to.equal(
       'background:red;'

--- a/test/unit/core/dom/test-jsx-style-property-string.js
+++ b/test/unit/core/dom/test-jsx-style-property-string.js
@@ -1,0 +1,37 @@
+import {jsxStylePropertyString} from '#core/dom/jsx-style-property-string';
+
+describes.sandboxed('jsxStylePropertyString', {}, () => {
+  it('returns empty string with nullish', () => {
+    expect(jsxStylePropertyString('a', null)).to.equal('');
+    expect(jsxStylePropertyString('b', undefined)).to.equal('');
+    expect(
+      jsxStylePropertyString('c', null, /* isDimensional */ true)
+    ).to.equal('');
+    expect(
+      jsxStylePropertyString('d', undefined, /* isDimensional */ true)
+    ).to.equal('');
+  });
+
+  it('returns string value', () => {
+    expect(jsxStylePropertyString('background', 'red')).to.equal(
+      'background:red;'
+    );
+    expect(
+      jsxStylePropertyString('background', 'red', /* isDimensional */ true)
+    ).to.equal('background:red;');
+  });
+
+  it('returns non-dimensional number value as-is', () => {
+    expect(jsxStylePropertyString('flex', 1)).to.equal('flex:1;');
+    expect(jsxStylePropertyString('opacity', 0.5)).to.equal('opacity:0.5;');
+  });
+
+  it('returns dimensional number value with px', () => {
+    expect(
+      jsxStylePropertyString('width', 150, /* isDimensional */ true)
+    ).to.equal('width:150px;');
+    expect(
+      jsxStylePropertyString('height', 321, /* isDimensional */ true)
+    ).to.equal('height:321px;');
+  });
+});


### PR DESCRIPTION
Converts Object Expression syntax in `style={{foo: 'bar'}}` to a concatenated string expression.

This only transforms a file if it imports the `core/dom/jsx` module, which lacks runtime support for converting the Object into a string. This transform takes that responsibility instead.
