### PR TITLE
⏪ Remove `bento_supported_version` from `amp-render` validator spec

### DIFF
--- a/extensions/amp-render/validator-amp-render.protoascii
+++ b/extensions/amp-render/validator-amp-render.protoascii
@@ -5,7 +5,6 @@ tags: {  # amp-render
     name: "amp-render"
     version: "1.0"
     version: "latest"
-    bento_supported_version: "1.0"
   }
   attr_lists: "common-extension-attrs"
 }


### PR DESCRIPTION
Since `amp-render` is not Bento per https://github.com/ampproject/amphtml/pull/36601, the `bento_supported_version` flag should be removed from the validator spec.