### PR TITLE
Remove extraneous preact/compat code in bento.js bundle

### DIFF
--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -12,12 +12,9 @@ import {CarouselContext} from './carousel-context';
 import {ContainWrapper} from '#preact/component';
 import {Scroller} from './scroller';
 import {WithAmpContext} from '#preact/context';
-import {forwardRef, toChildArray} from '#preact/compat';
-import {isRTL} from '#core/dom';
-import {sequentialIdGenerator} from '#core/data-structures/id-generator';
-import {getWin} from '#core/window';
 import {
   cloneElement,
+  toChildArray,
   useCallback,
   useContext,
   useEffect,
@@ -27,6 +24,10 @@ import {
   useRef,
   useState,
 } from '#preact';
+import {forwardRef} from '#preact/compat';
+import {isRTL} from '#core/dom';
+import {sequentialIdGenerator} from '#core/data-structures/id-generator';
+import {getWin} from '#core/window';
 import {useStyles} from './component.jss';
 import {mod} from '#core/math';
 

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -3,13 +3,13 @@ import {sequentialIdGenerator} from '#core/data-structures/id-generator';
 import * as Preact from '#preact';
 import {
   cloneElement,
+  toChildArray,
   useCallback,
   useContext,
   useLayoutEffect,
   useMemo,
   useState,
 } from '#preact';
-import {toChildArray} from '#preact/compat';
 
 import {BentoLightboxGalleryContext} from './context';
 

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -1,15 +1,16 @@
 import * as Preact from '#preact';
 import {BentoBaseCarousel} from '../../amp-base-carousel/1.0/component';
-import {forwardRef, toChildArray} from '#preact/compat';
-import {setStyle} from '#core/dom/style';
-import {getWin} from '#core/window';
+import {forwardRef} from '#preact/compat';
 import {
+  toChildArray,
   useCallback,
   useImperativeHandle,
   useLayoutEffect,
   useRef,
   useState,
 } from '#preact';
+import {setStyle} from '#core/dom/style';
+import {getWin} from '#core/window';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
 import {propName} from '#preact/utils';

--- a/src/preact/compat.js
+++ b/src/preact/compat.js
@@ -1,27 +1,31 @@
-import * as compat from /*OK*/ 'preact/compat';
+/**
+ * todo(kvchari): replace with official solution from preact
+ * copying forwardRef implementation from https://gist.github.com/developit/974b5e4e582df8e954c5a7981603cd37
+ * preact contains a bug where importing forwardRef imports a lot of extraneous code due to side-effects.
+ * see issue for more information https://github.com/preactjs/preact/issues/3295
+ */
+import {options} from /*OK*/ 'preact';
 
+options.__b = function (o, v) {
+  if (v.type && v.type._f && (v.props.ref = v.ref)) {
+    v.ref = null;
+  }
+  o && o(v);
+}.bind(0, options.__b);
 /**
  * @param {function(T, {current: (R|null)}):PreactDef.Renderable} fn
  * @return {function(T):PreactDef.Renderable}
  * @template T, R
  */
 export function forwardRef(fn) {
-  return compat.forwardRef(fn);
-}
-
-/**
- * @param {PreactDef.VNode} vnode
- * @param {HTMLElement} container
- * @return {PreactDef.VNode}
- */
-export function createPortal(vnode, container) {
-  return compat.createPortal(vnode, container);
-}
-
-/**
- * @param {...PreactDef.Renderable} unusedChildren
- * @return {!Array<PreactDef.Renderable>}
- */
-export function toChildArray(unusedChildren) {
-  return compat.Children.toArray.apply(undefined, arguments);
+  /**
+   * @param {*} p
+   * @return {*}
+   */
+  function F(p) {
+    const {ref} = p;
+    delete p.ref;
+    return fn(p, ref);
+  }
+  return (F._f = F);
 }

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -145,3 +145,5 @@ export function useCallback(cb, opt_deps) {
 export function useImperativeHandle(ref, create, opt_deps) {
   return hooks.useImperativeHandle(ref, create, opt_deps);
 }
+
+export {toChildArray} from 'preact';


### PR DESCRIPTION
- Removes createPortal because it's not used
- Moves `toChildArray` to use implementation from `preact`
- Replace `forwardRef` from `preact/compat` with copy/pasted implementation: Preact has a bug that causes (a lot) of unnecessary extra code to be added to the bundle due to its side-effects. This PR manually implements `forwardRef` by copy/pasting the impl from the preact source so we don't take the extra cruft. We should change this use the exported `forwardRef` at whichever time preact fixes this bug. See issue for more information https://github.com/preactjs/preact/issues/3295

Reduces `bento.js` size from 18.038kb to 16.270kb (-1.768kb)

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
