### PR TITLE
Fix flying carpet rendering

### DIFF
--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.css
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.css
@@ -32,17 +32,20 @@ amp-fx-flying-carpet > .i-amphtml-fx-flying-carpet-clip > .i-amphtml-fx-flying-c
   top: 0 !important;
   width: 100%;
   height: 100%;
-  /*
-   * Included to force slow webkit browsers (Android) into rendering the
-   * container using the GPU.
-   */
-  -webkit-transform: translateZ(0) !important;
 
   /* Center contents in the container */
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+}
+
+/*
+ * Included to force slow webkit browsers (Android) into rendering the
+ * container using the GPU.
+ */
+amp-fx-flying-carpet > .i-amphtml-fx-flying-carpet-clip > .i-amphtml-fx-flying-carpet-container.i-amphtml-fx-flying-carpet-container-fix {
+  -webkit-transform: translateZ(0) !important;
 }
 
 .i-amphtml-fx-flying-carpet-container > .i-amphtml-layout-responsive,

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -1,5 +1,6 @@
 import {CommonSignals} from '#core/constants/common-signals';
 import {Layout} from '#core/dom/layout';
+import {createViewportObserver} from '#core/dom/layout/viewport-observer';
 import {realChildElements, realChildNodes} from '#core/dom/query';
 import {setStyle} from '#core/dom/style';
 
@@ -143,7 +144,26 @@ export class AmpFlyingCarpet extends AMP.BaseElement {
       this.children_
     );
     this.observeNewChildren_();
+    this.forceClipDraw_();
     return Promise.resolve();
+  }
+
+  /**
+   * Something causes browsers to forget to redraw the content of the container when they become visible.
+   * @private
+   */
+  forceClipDraw_() {
+    const inob = new this.win.IntersectionObserver(
+      (entries) => {
+        const last = entries[entries.length - 1];
+        this.container_.classList.toggle(
+          'i-amphtml-fx-flying-carpet-container-fix',
+          last.isIntersecting
+        );
+      },
+      {threshold: 0.01}
+    );
+    inob.observe(this.element);
   }
 
   /**

--- a/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
+++ b/extensions/amp-fx-flying-carpet/0.1/amp-fx-flying-carpet.js
@@ -1,6 +1,5 @@
 import {CommonSignals} from '#core/constants/common-signals';
 import {Layout} from '#core/dom/layout';
-import {createViewportObserver} from '#core/dom/layout/viewport-observer';
 import {realChildElements, realChildNodes} from '#core/dom/query';
 import {setStyle} from '#core/dom/style';
 


### PR DESCRIPTION
Something has recently changed in browsers, where they forgot to paint the contents of our flying carpet when it comes into view. Luckily, we can force them to redraw as we enter the viewport and they'll correctly display.

See this working at https://output.jsbin.com/jibufud/quiet.

Fixes https://github.com/ampproject/amp.dev/issues/6219
Re: https://bugs.chromium.org/p/chromium/issues/detail?id=1269529