### PR TITLE
Update Validator Instruction about Docker image

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -129,11 +129,11 @@ Now `cd amphtml/validator` and run `python build.py`.
 In the case the test passes in your local machine but fails in Circle CI,
 you can use docker to reproduce the test errors.
 
-1. Start an interactive docker container
+1. Start an interactive docker container. Note that you will be the `root` user inside the docker container.
     ```bash
-    docker run -it node:lts-buster bash
+    docker run -it -u root cimg/openjdk:17.0-node bash
     ```
-1. Run following commands in the container. Note that you are already the `root` user inside the docker container.
+1. Run following commands in the container.
     ```bash
     apt update
     apt install -y sudo


### PR DESCRIPTION
Update the Validator Instruction to use docker image `cimg/openjdk:17.0-node`, which is the same as [CircleCI config](https://github.com/ampproject/amphtml/blob/504411bcf4e86bb92df1482ce985d9ad458a2a7d/.circleci/config.yml#L63).

The difference is that `cimg/openjdk:17.0-node` uses `g++ 9.3.0` while `node:lts-buster` uses `g++ 8.3.0`.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
