### PR TITLE
story-runtime: measure bundle size of merging v0.js and amp-story

### DIFF
--- a/build-system/compile/bundles.config.js
+++ b/build-system/compile/bundles.config.js
@@ -164,6 +164,19 @@ exports.jsBundles = {
       includePolyfills: false,
     },
   },
+  // Currently: 60.99 + 69.26 --> 130.25 (559.88 uncompressed)
+  // Single binary: 123.91 kb (547.19 uncompressed)
+  'story.js': {
+    srcDir: './src/',
+    srcFilename: 'story.js',
+    destDir: './dist',
+    minifiedDestDir: './dist',
+    options: {
+      minifiedName: 'story-v0.js',
+      includePolyfills: true,
+      wrapper: wrappers.mainBinary,
+    },
+  },
   'amp.js': {
     srcDir: './src/',
     srcFilename: 'amp.js',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -160,6 +160,7 @@ async function compileAllJs(options) {
     doBuildJs(jsBundles, 'amp-story-player.js', options),
     doBuildJs(jsBundles, 'amp-inabox-host.js', options),
     doBuildJs(jsBundles, 'amp-shadow.js', options),
+    doBuildJs(jsBundles, 'story.js', options),
     doBuildJs(jsBundles, 'amp-inabox.js', options),
   ]);
   await compileCoreRuntime(options);

--- a/src/story.js
+++ b/src/story.js
@@ -1,0 +1,158 @@
+/**
+ * The entry point for AMP Runtime (v0.js) when AMP Runtime = AMP Doc.
+ */
+
+// src/polyfills.js must be the first import.
+import './polyfills';
+
+import {TickLabel} from '#core/constants/enums';
+import {whenDocumentComplete} from '#core/document/ready';
+import * as mode from '#core/mode';
+
+import {Services} from '#service';
+import {installDocService} from '#service/ampdoc-impl';
+import {
+  installAmpdocServices,
+  installBuiltinElements,
+  installRuntimeServices,
+} from '#service/core-services';
+import {stubElementsForDoc} from '#service/custom-element-registry';
+import {installPerformanceService} from '#service/performance-impl';
+import {installPlatformService} from '#service/platform-impl';
+
+import {installAutoLightboxExtension} from './auto-lightbox';
+import {startupChunk} from './chunk';
+import {markUnresolvedElements} from './custom-element';
+import {installErrorReporting} from './error-reporting';
+import {fontStylesheetTimeout} from './font-stylesheet-timeout';
+import {maybeTrackImpression} from './impression';
+import {getMode} from './mode';
+import {preconnectToOrigin} from './preconnect';
+import {installPullToRefreshBlocker} from './pull-to-refresh';
+import {adoptWithMultidocDeps} from './runtime';
+import {installStandaloneExtension} from './standalone';
+import {
+  installStylesForDoc,
+  makeBodyVisible,
+  makeBodyVisibleRecovery,
+} from './style-installer';
+import {maybeValidate} from './validator-integration';
+
+import {cssText as ampDocCss} from '../build/ampdoc.css';
+import {cssText as ampSharedCss} from '../build/ampshared.css';
+import 'extensions/amp-story/1.0/amp-story.js';
+
+/**
+ * Execute the bootstrap
+ * @param {!./service/ampdoc-impl.AmpDoc} ampdoc
+ * @param {!./service/performance-impl.Performance} perf
+ */
+function bootstrap(ampdoc, perf) {
+  startupChunk(self.document, function services() {
+    // Core services.
+    installRuntimeServices(self);
+    installAmpdocServices(ampdoc);
+    // We need the core services (viewer/resources) to start instrumenting
+    perf.coreServicesAvailable();
+    maybeTrackImpression(self);
+  });
+  startupChunk(self.document, function adoptWindow() {
+    adoptWithMultidocDeps(self);
+  });
+  startupChunk(self.document, function builtins() {
+    // Builtins.
+    installBuiltinElements(self);
+  });
+  startupChunk(self.document, function stub() {
+    // Pre-stub already known elements.
+    stubElementsForDoc(ampdoc);
+    whenDocumentComplete(self.document).then(() => markUnresolvedElements());
+  });
+  startupChunk(
+    self.document,
+    function final() {
+      if (!IS_SXG) {
+        installPullToRefreshBlocker(self);
+      }
+      installAutoLightboxExtension(ampdoc);
+      installStandaloneExtension(ampdoc);
+      maybeValidate(self);
+      makeBodyVisible(self.document);
+      preconnectToOrigin(self.document);
+    },
+    /* makes the body visible */ true
+  );
+  startupChunk(self.document, function finalTick() {
+    perf.tick(TickLabel.END_INSTALL_STYLES);
+    Services.resourcesForDoc(ampdoc).ampInitComplete();
+    // TODO(erwinm): move invocation of the `flush` method when we have the
+    // new ticks in place to batch the ticks properly.
+    perf.flush();
+  });
+}
+
+// Store the originalHash as early as possible. Trying to debug:
+// https://github.com/ampproject/amphtml/issues/6070
+if (self.location) {
+  self.location['originalHash'] = self.location.hash;
+}
+
+/** @type {!./service/ampdoc-impl.AmpDocService} */
+let ampdocService;
+// We must under all circumstances call makeBodyVisible.
+// It is much better to have AMP tags not rendered than having
+// a completely blank page.
+try {
+  // Should happen first.
+  installErrorReporting(self); // Also calls makeBodyVisibleRecovery on errors.
+
+  // Declare that this runtime will support a single root doc. Should happen
+  // as early as possible.
+  installDocService(self, /* isSingleDoc */ true);
+  ampdocService = Services.ampdocServiceFor(self);
+} catch (e) {
+  // In case of an error call this.
+  makeBodyVisibleRecovery(self.document);
+  throw e;
+}
+startupChunk(self.document, function initial() {
+  /** @const {!./service/ampdoc-impl.AmpDoc} */
+  const ampdoc = ampdocService.getAmpDoc(self.document);
+  installPlatformService(self);
+  installPerformanceService(self);
+  /** @const {!./service/performance-impl.Performance} */
+  const perf = Services.performanceFor(self);
+  if (mode.isEsm()) {
+    perf.addEnabledExperiment('esm');
+  }
+  fontStylesheetTimeout(self);
+  perf.tick(TickLabel.INSTALL_STYLES);
+  if (mode.isEsm()) {
+    bootstrap(ampdoc, perf);
+    return;
+  }
+
+  installStylesForDoc(
+    ampdoc,
+    ampDocCss + ampSharedCss,
+    () => bootstrap(ampdoc, perf),
+    /* opt_isRuntimeCss */ true,
+    /* opt_ext */ 'amp-runtime'
+  );
+});
+
+// Output a message to the console and add an attribute to the <html>
+// tag to give some information that can be used in error reports.
+// (At least by sophisticated users).
+if (self.console) {
+  (console.info || console.log).call(
+    console,
+    `Powered by AMP ⚡ HTML – Version ${mode.version()}`,
+    self.location.href
+  );
+}
+// This code is eleminated in prod build through a babel transformer.
+if (getMode().localDev) {
+  self.document.documentElement.setAttribute('esm', mode.isEsm() ? 1 : 0);
+}
+self.document.documentElement.setAttribute('amp-version', mode.version());


### PR DESCRIPTION
```
// Currently (v0.mjs + amp-story.mjs): 60.99 + 69.26 --> 130.25 (559.88 uncompressed)
// Single binary (story-v0.mjs): 123.91 kb (547.19 uncompressed)
```