### PR TITLE
build-system: opt bento into esbuild

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -75,9 +75,28 @@ function getMinifiedConfig() {
     presets: [presetEnv],
     retainLines: true,
     assumptions: {
+      arrayLikeIsIterable: true,
+      constantReexports: true,
       constantSuper: true,
+      enumerableModuleMeta: true,
+      // TODO: determine if ignoreFunctionLength can be enabled
+      // https://babeljs.io/docs/en/assumptions#ignorefunctionlength
+      ignoreFunctionLength: false,
+      ignoreToPrimitiveHint: true,
+      iterableIsArray: false,
+      mutableTemplateObject: false,
       noClassCalls: true,
+      noDocumentAll: true,
+      noIncompleteNsImportDetection: true,
+      noNewArrows: true,
+      objectRestNoSymbols: true,
+      privateFieldsAsProperties: false,
+      pureGetters: true,
       setClassMethods: true,
+      setComputedProperties: true,
+      setPublicClassFields: true,
+      setSpreadProperties: true,
+      skipForOfIteratorClosing: true,
     },
   };
 }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -620,7 +620,7 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
    */
   async function doCompileJs(options) {
     const buildResult =
-      options.minify && shouldUseClosure()
+      options.minify && shouldUseClosure(options)
         ? compileMinifiedJs(srcDir, srcFilename, destDir, options)
         : esbuildCompile(srcDir, srcFilename, destDir, options);
     if (options.onWatchBuild) {
@@ -811,9 +811,14 @@ function massageSourcemaps(sourcemapsFile, options) {
 
 /**
  * Returns whether or not we should compile with Closure Compiler.
+ * @param {Object} options
  * @return {boolean}
  */
-function shouldUseClosure() {
+function shouldUseClosure(options) {
+  if (options.bento) {
+    return false;
+  }
+
   // Normally setting this server-side experiment flag would be handled by
   // the release process automatically. Since this experiment is actually on the build system
   // itself instead of runtime, it is never run through babel (where the replacements usually happen).

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -566,6 +566,7 @@ async function minify(code, map) {
     },
     output: {
       beautify: !!argv.pretty_print,
+      comments: false,
       // eslint-disable-next-line local/camelcase
       keep_quoted_props: true,
     },

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -814,7 +814,7 @@ function massageSourcemaps(sourcemapsFile, options) {
  * @param {Object} options
  * @return {boolean}
  */
-function shouldUseClosure(options) {
+function shouldUseClosure(options = {}) {
   if (options.bento) {
     return false;
   }


### PR DESCRIPTION
**summary**
Partial for https://github.com/ampproject/amphtml/issues/35264

Migrates AMP 1.0 Components to the `esbuild` path rather than being built with Closure.