### PR TITLE
Generate stable test outputs for better bundle-size comparisions

### DIFF
--- a/build-system/pr-check/bundle-size-module-build.js
+++ b/build-system/pr-check/bundle-size-module-build.js
@@ -18,7 +18,7 @@ const jobName = 'bundle-size-module-build.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp dist --noconfig --esm');
+  timedExecOrDie('amp dist --noconfig --esm --version_override 0000000000000');
   storeModuleBuildToWorkspace();
 }
 

--- a/build-system/pr-check/bundle-size-nomodule-build.js
+++ b/build-system/pr-check/bundle-size-nomodule-build.js
@@ -18,7 +18,7 @@ const jobName = 'bundle-size-nomodule-build.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp dist --noconfig');
+  timedExecOrDie('amp dist --noconfig --version_override 0000000000000');
   storeNomoduleBuildToWorkspace();
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -542,6 +542,22 @@ async function minify(code, map) {
         // eslint-disable-next-line local/camelcase
         keep_quoted: /** @type {'strict'} */ ('strict'),
       },
+      // eslint-disable-next-line local/camelcase
+      nth_identifier: {
+        get(num) {
+          const leading =
+            '$ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz';
+          const all = leading + '0123456789';
+          let charset = leading;
+          let id = '';
+          do {
+            id += charset[num % charset.length];
+            num = Math.floor(num / charset.length);
+            charset = all;
+          } while (num > 0);
+          return id;
+        },
+      },
     },
     compress: {
       // Settled on this count by incrementing number until there was no more


### PR DESCRIPTION
I'm getting annoyed with all the `±0.01kb` changes in our bundle-size outputs, which aren't actually cased by any change in the file. It's just Terser detecting the relative frequency of chars in the files it outputs, which it uses to prioritize certain chars over others.