### PR TITLE
🐛 fix jwplayer consent & add fixture

### DIFF
--- a/extensions/amp-jwplayer/1.0/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/1.0/amp-jwplayer.js
@@ -1,14 +1,57 @@
+import {dict} from '#core/types/object';
+
 import {isExperimentOn} from '#experiments';
 
 import {userAssert} from '#utils/log';
 
 import {BaseElement} from './base-element';
 
+import {
+  getConsentMetadata,
+  getConsentPolicyInfo,
+  getConsentPolicyState,
+} from '../../../src/consent';
+
 /** @const {string} */
 const TAG = 'amp-jwplayer';
 
 /** @implements {../../../src/video-interface.VideoInterface} */
 class AmpJwplayer extends BaseElement {
+  /** @override */
+  init() {
+    const consentPolicy = this.getConsentPolicy();
+    if (consentPolicy) {
+      this.getConsentInfo().then((consentInfo) => {
+        const policyState = consentInfo[0];
+        const policyInfo = consentInfo[1];
+        const policyMetadata = consentInfo[2];
+        this.mutateProps(
+          dict({
+            'consentParams': {
+              'policyState': policyState,
+              'policyInfo': policyInfo,
+              'policyMetadata': policyMetadata,
+            },
+          })
+        );
+      });
+    }
+
+    return super.init();
+  }
+
+  /**
+   * @param {string} policy
+   * @return {Promise}
+   */
+  getConsentInfo(policy) {
+    return Promise.all([
+      getConsentPolicyState(this.element, policy),
+      getConsentPolicyInfo(this.element, policy),
+      getConsentMetadata(this.element, policy),
+    ]);
+  }
+
   /** @override */
   isLayoutSupported(layout) {
     userAssert(

--- a/extensions/amp-jwplayer/1.0/base-element.js
+++ b/extensions/amp-jwplayer/1.0/base-element.js
@@ -3,35 +3,12 @@ import {dict} from '#core/types/object';
 
 import {BentoJwplayer} from './component';
 
-import {
-  getConsentMetadata,
-  getConsentPolicyInfo,
-  getConsentPolicyState,
-} from '../../../src/consent';
 import {VideoBaseElement} from '../../amp-video/1.0/video-base-element';
 
 export class BaseElement extends VideoBaseElement {
   /** @override */
   init() {
     super.init();
-
-    const consentPolicy = this.getConsentPolicy();
-    if (consentPolicy) {
-      this.getConsentInfo().then((consentInfo) => {
-        const policyState = consentInfo[0];
-        const policyInfo = consentInfo[1];
-        const policyMetadata = consentInfo[2];
-        this.mutateProps(
-          dict({
-            'consentParams': {
-              'policyState': policyState,
-              'policyInfo': policyInfo,
-              'policyMetadata': policyMetadata,
-            },
-          })
-        );
-      });
-    }
 
     return dict({
       'queryParams': this.mergeQueryParams(
@@ -42,18 +19,6 @@ export class BaseElement extends VideoBaseElement {
         this.element.getAttribute('data-content-search')
       ),
     });
-  }
-
-  /**
-   * @param {string} policy
-   * @return {Promise}
-   */
-  getConsentInfo(policy) {
-    return Promise.all([
-      getConsentPolicyState(this.element, policy),
-      getConsentPolicyInfo(this.element, policy),
-      getConsentMetadata(this.element, policy),
-    ]);
   }
 
   /**

--- a/test/fixtures/e2e/bento/jwplayer.html
+++ b/test/fixtures/e2e/bento/jwplayer.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8" />
+  <title>Bento Jwplayer</title>
+  <script type="module" async src="https://cdn.ampproject.org/bento.mjs"></script>
+
+  <script async src="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.js"></script>
+  <link rel="stylesheet" href="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.css">
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
+
+</head>
+
+<body>
+
+  <bento-jwplayer
+    id="jwplayer"
+    data-player-id="BjcwyK37"
+    data-media-id="CtaIzmFs"
+    style="width: 480px; height: 270px"
+  ></bento-jwplayer>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
Moves consent retrieval to amp layer since it depends on amp service and consent in bento is still being tbd (?)

Creates minimal fixture for jwplayer.html
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
