### PR TITLE
closure builds: keep license comments

### DIFF
--- a/build-system/compile/post-closure-babel.js
+++ b/build-system/compile/post-closure-babel.js
@@ -25,7 +25,6 @@ async function terserMinify(code) {
     },
     output: {
       beautify: !!argv.pretty_print,
-      comments: /\/*/,
       // eslint-disable-next-line local/camelcase
       keep_quoted_props: true,
     },


### PR DESCRIPTION
**summary**
Default behavior for both closure and terser is to remove all comments besides for copyright licenses. This PR reenables that.