### PR TITLE
🏗  Extract `{attrPrefix}` and `{type: 'date'}` from `parseProps()`

### DIFF
--- a/extensions/amp-brightcove/1.0/base-element.js
+++ b/extensions/amp-brightcove/1.0/base-element.js
@@ -1,5 +1,6 @@
 import {BentoBrightcove} from './component';
 import {VideoBaseElement} from '../../amp-video/1.0/video-base-element';
+import {createParseAttrsWithPrefix} from '#preact/parse-props';
 
 export class BaseElement extends VideoBaseElement {}
 
@@ -20,7 +21,7 @@ BaseElement['props'] = {
   },
   'playlistId': {attr: 'data-playlist-id', type: 'string'},
   'referrer': {attr: 'data-referrer', type: 'string'},
-  'urlParams': {attrPrefix: 'data-param-', type: 'string'},
+  'urlParams': createParseAttrsWithPrefix('data-param-'),
   'videoId': {attr: 'data-video-id', type: 'string'},
   // TODO(wg-bento): These props have no internal implementation yet.
   'dock': {attr: 'dock', media: true},

--- a/extensions/amp-date-display/1.0/base-element.js
+++ b/extensions/amp-date-display/1.0/base-element.js
@@ -1,6 +1,7 @@
 import {parseDateAttrs as parseDateAttrsBase} from '#core/dom/parse-date-attributes';
 
 import {PreactBaseElement} from '#preact/base-element';
+import {createParseAttrsWithPrefix} from '#preact/parse-props';
 
 import {BentoDateDisplay} from './component';
 
@@ -17,7 +18,7 @@ BaseElement['props'] = {
   },
   'displayIn': {attr: 'display-in'},
   'locale': {attr: 'locale'},
-  'localeOptions': {attrPrefix: 'data-options-'},
+  'localeOptions': createParseAttrsWithPrefix('data-options-'),
 };
 
 /** @override */

--- a/extensions/amp-jwplayer/1.0/base-element.js
+++ b/extensions/amp-jwplayer/1.0/base-element.js
@@ -1,6 +1,8 @@
 import {getDataParamsFromAttributes} from '#core/dom';
 import {dict} from '#core/types/object';
 
+import {createParseAttrsWithPrefix} from '#preact/parse-props';
+
 import {BentoJwplayer} from './component';
 
 import {
@@ -106,8 +108,8 @@ BaseElement['props'] = {
   'contentRecency': {attr: 'data-content-recency'},
   'contentBackfill': {attr: 'data-content-backfill', type: 'boolean'},
   'adCustParams': {attr: 'data-ad-cust-params'},
-  'adMacros': {attrPrefix: 'data-ad-macro-'},
-  'config': {attrPrefix: 'data-config-'},
+  'adMacros': createParseAttrsWithPrefix('data-ad-macro-'),
+  'config': createParseAttrsWithPrefix('data-config-'),
   'autoplay': {attr: 'autoplay', type: 'boolean'},
   // TODO(wg-bento): These props have no internal implementation yet.
   'dock': {attr: 'dock', media: true},

--- a/extensions/amp-twitter/1.0/base-element.js
+++ b/extensions/amp-twitter/1.0/base-element.js
@@ -1,4 +1,5 @@
 import {PreactBaseElement} from '#preact/base-element';
+import {createParseAttrsWithPrefix} from '#preact/parse-props';
 import {BentoTwitter} from './component';
 
 export class BaseElement extends PreactBaseElement {}
@@ -9,7 +10,7 @@ BaseElement['Component'] = BentoTwitter;
 /** @override */
 BaseElement['props'] = {
   'title': {attr: 'title'}, // Needed for Preact component
-  'options': {attrPrefix: 'data-'}, // Needed to render componoent upon mutation
+  'options': createParseAttrsWithPrefix('data-'), // Needed to render componoent upon mutation
 };
 
 /** @override */

--- a/extensions/amp-youtube/1.0/base-element.js
+++ b/extensions/amp-youtube/1.0/base-element.js
@@ -1,3 +1,5 @@
+import {createParseAttrsWithPrefix} from '#preact/parse-props';
+
 import {BentoYoutube} from './component';
 
 import {VideoBaseElement} from '../../amp-video/1.0/video-base-element';
@@ -16,7 +18,7 @@ BaseElement['props'] = {
   'liveChannelid': {attr: 'data-live-channelid'},
   'dock': {attr: 'dock', media: true},
   'credentials': {attr: 'credentials'},
-  'params': {attrPrefix: 'data-param-'},
+  'params': createParseAttrsWithPrefix('data-param-'),
 };
 
 /** @override */

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -30,7 +30,12 @@ import {BaseElement} from '#preact/bento-ce';
 
 import {WithAmpContext} from './context';
 import {CanPlay, CanRender, LoadingProp} from './contextprops';
-import {AmpElementPropDef, collectProps} from './parse-props';
+import {
+  AmpElementPropDef,
+  HAS_SELECTOR,
+  checkPropsFor,
+  collectProps,
+} from './parse-props';
 
 import {installShadowStyle} from '../shadow-embed';
 
@@ -81,25 +86,10 @@ const UNSLOTTED_GROUP = 'unslotted';
 const MATCH_ANY = () => true;
 
 /**
- * @param {!Object<string, !AmpElementPropDef>} propDefs
- * @param {function(!AmpElementPropDef):boolean} cb
- * @return {boolean}
- */
-function checkPropsFor(propDefs, cb) {
-  return Object.values(propDefs).some(cb);
-}
-
-/**
  * @param {!AmpElementPropDef} def
  * @return {boolean}
  */
 const HAS_MEDIA = (def) => !!def.media;
-
-/**
- * @param {!AmpElementPropDef} def
- * @return {boolean}
- */
-const HAS_SELECTOR = (def) => typeof def === 'string' || !!def.selector;
 
 /**
  * @param {!AmpElementPropDef} def
@@ -985,20 +975,6 @@ PreactBaseElement['delegatesFocus'] = false;
 PreactBaseElement['props'] = {};
 
 /**
- * @param {null|string} attributeName
- * @param {string|undefined} attributePrefix
- * @return {boolean}
- */
-function matchesAttrPrefix(attributeName, attributePrefix) {
-  return (
-    attributeName !== null &&
-    attributePrefix !== undefined &&
-    attributeName.startsWith(attributePrefix) &&
-    attributeName !== attributePrefix
-  );
-}
-
-/**
  * @param {!NodeList} nodeList
  * @return {boolean}
  */
@@ -1043,7 +1019,7 @@ function shouldMutationBeRerendered(Ctor, m) {
       if (
         m.attributeName == def.attr ||
         (def.attrs && def.attrs.includes(devAssert(m.attributeName))) ||
-        matchesAttrPrefix(m.attributeName, def.attrPrefix)
+        def.attrMatches?.(m.attributeName)
       ) {
         return true;
       }

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -79,8 +79,7 @@ const RENDERED_PROP = '__AMP_RENDERED';
 const childIdGenerator = sequentialIdGenerator();
 
 const ONE_OF_ERROR_MESSAGE =
-  'Only one of "attr", "attrs", "attrMatches", "attrPrefix", "passthrough", ' +
-  '"passthroughNonEmpty", or "selector" must be given';
+  'Only one of "attr", "attrs", "attrMatches", "passthrough", "passthroughNonEmpty", or "selector" must be given';
 
 /**
  * @param {!Object<string, !AmpElementPropDef>} propDefs

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -105,20 +105,6 @@ const IS_EMPTY_TEXT_NODE = (node) =>
   node.nodeType === /* TEXT_NODE */ 3 && node.nodeValue.trim().length === 0;
 
 /**
- * @param {null|string} attributeName
- * @param {string|undefined} attributePrefix
- * @return {boolean}
- */
-function matchesAttrPrefix(attributeName, attributePrefix) {
-  return (
-    attributeName !== null &&
-    attributePrefix !== undefined &&
-    attributeName.startsWith(attributePrefix) &&
-    attributeName !== attributePrefix
-  );
-}
-
-/**
  * @param {typeof PreactBaseElement} Ctor
  * @param {!AmpElement} element
  * @param {{current: ?}} ref
@@ -329,11 +315,11 @@ function matchChild(element, defs) {
 /**
  * Maps multiple attributes with the same prefix to a single prop object.
  * The prefix cannot equal the attribute name.
- * @param {string} attrPrefix
+ * @param {string} prefix
  * @return {{attrMatches: function(string):boolean, parseAttrs: function(!Element):(undefined|Object<string, string>)}}
  */
-export function createParseAttrsWithPrefix(attrPrefix) {
-  const attrMatches = (name) => matchesAttrPrefix(name, attrPrefix);
+export function createParseAttrsWithPrefix(prefix) {
+  const attrMatches = (name) => name?.startsWith(prefix) && name !== prefix;
   const parseAttrs = (element) => {
     let currObj;
     const attrs = element.attributes;
@@ -343,7 +329,7 @@ export function createParseAttrsWithPrefix(attrPrefix) {
         if (!currObj) {
           currObj = {};
         }
-        currObj[dashToCamelCase(attrib.name.slice(attrPrefix.length))] =
+        currObj[dashToCamelCase(attrib.name.slice(prefix.length))] =
           attrib.value;
       }
     }

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -330,7 +330,7 @@ function matchChild(element, defs) {
  * Maps multiple attributes with the same prefix to a single prop object.
  * The prefix cannot equal the attribute name.
  * @param {string} attrPrefix
- * @return {{attrMatches: function(string):boolean, parseAttrs: function(!Element):undefined|Object<string, string>}}
+ * @return {{attrMatches: function(string):boolean, parseAttrs: function(!Element):(undefined|Object<string, string>)}}
  */
 export function createParseAttrsWithPrefix(attrPrefix) {
   const attrMatches = (name) => matchesAttrPrefix(name, attrPrefix);

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -316,7 +316,7 @@ function matchChild(element, defs) {
  * Maps multiple attributes with the same prefix to a single prop object.
  * The prefix cannot equal the attribute name.
  * @param {string} prefix
- * @return {{attrMatches: function(string):boolean, parseAttrs: function(!Element):(undefined|Object<string, string>)}}
+ * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(!Element):(undefined|Object<string, string>)}}
  */
 export function createParseAttrsWithPrefix(prefix) {
   const attrMatches = (name) => name?.startsWith(prefix) && name !== prefix;

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -312,7 +312,7 @@ function matchChild(element, defs) {
 /**
  * @param {string} name
  * @param {function(string): T} parse
- * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(!Element):(?T|undefined)}}
+ * @return {{attrs: Array<string>, parseAttrs: function(!Element):(?T|undefined)}}
  * @template T
  */
 export function createParseAttr(name, parse) {

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -264,8 +264,6 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
           ? parseFloat(value)
           : def.type == 'boolean'
           ? parseBooleanAttribute(/** @type {string} */ (value))
-          : def.type == 'date'
-          ? getDate(value)
           : value;
       props[name] = v;
     }
@@ -309,6 +307,32 @@ function matchChild(element, defs) {
     }
   }
   return null;
+}
+
+/**
+ * @param {string} name
+ * @param {function(string): T} parse
+ * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(!Element):(?T|undefined)}}
+ * @template T
+ */
+export function createParseAttr(name, parse) {
+  const attrs = [name];
+  const parseAttrs = (element) => {
+    const attr = element.getAttribute(name);
+    return attr && parse(attr);
+  };
+  return {
+    'attrs': attrs,
+    'parseAttrs': parseAttrs,
+  };
+}
+
+/**
+ * @param {string} name
+ * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(!Element):(?number|undefined)}}
+ */
+export function createParseDateAttr(name) {
+  return createParseAttr(name, getDate);
 }
 
 /**

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -16,8 +16,8 @@ import {Slot, createSlot} from './slot';
  *   an attribute maps to a component prop 1:1.
  * - `attrs` and `parseAttrs` can be specified when multiple attributes map
  *   to a single prop.
- * - `attrPrefix` can be specified when multiple attributes with the same prefix
- *   map to a single prop object. The prefix cannot equal the attribute name.
+ * - `attrMatches` and `parseAttrs` can be specified when multiple attributes
+ *   map to a single prop.
  * - `selector` can be specified for children of a certain shape and structure
  *   according to ChildDef.
  * - `passthrough` can be specified to slot children using a single
@@ -31,7 +31,7 @@ import {Slot, createSlot} from './slot';
  * @typedef {{
  *   attr: (string|undefined),
  *   type: (string|undefined),
- *   attrPrefix: (string|undefined),
+ *   attrMatches: (function(string):boolean|undefined),
  *   attrs: (!Array<string>|undefined),
  *   parseAttrs: ((function(!Element):*)|undefined),
  *   media: (boolean|undefined),
@@ -79,7 +79,7 @@ const RENDERED_PROP = '__AMP_RENDERED';
 const childIdGenerator = sequentialIdGenerator();
 
 const ONE_OF_ERROR_MESSAGE =
-  'Only one of "attr", "attrs", "attrPrefix", "passthrough", ' +
+  'Only one of "attr", "attrs", "attrMatches", "attrPrefix", "passthrough", ' +
   '"passthroughNonEmpty", or "selector" must be given';
 
 /**
@@ -87,7 +87,7 @@ const ONE_OF_ERROR_MESSAGE =
  * @param {function(!AmpElementPropDef):boolean} cb
  * @return {boolean}
  */
-function checkPropsFor(propDefs, cb) {
+export function checkPropsFor(propDefs, cb) {
   return Object.values(propDefs).some(cb);
 }
 
@@ -95,7 +95,7 @@ function checkPropsFor(propDefs, cb) {
  * @param {!AmpElementPropDef} def
  * @return {boolean}
  */
-const HAS_SELECTOR = (def) => typeof def === 'string' || !!def.selector;
+export const HAS_SELECTOR = (def) => typeof def === 'string' || !!def.selector;
 
 /**
  * @param {Node} node
@@ -240,7 +240,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
     devAssert(
       !!def.attr +
         !!def.attrs +
-        !!def.attrPrefix +
+        !!def.attrMatches +
         !!def.selector +
         !!def.passthrough +
         !!def.passthroughNonEmpty <=
@@ -266,23 +266,8 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
         value = mediaQueryProps.resolveListQuery(String(value));
       }
     } else if (def.parseAttrs) {
-      devAssert(def.attrs);
+      devAssert(def.attrs || def.attrMatches);
       value = def.parseAttrs(element);
-    } else if (def.attrPrefix) {
-      const currObj = {};
-      let objContains = false;
-      const attrs = element.attributes;
-      for (let i = 0; i < attrs.length; i++) {
-        const attrib = attrs[i];
-        if (matchesAttrPrefix(attrib.name, def.attrPrefix)) {
-          currObj[dashToCamelCase(attrib.name.slice(def.attrPrefix.length))] =
-            attrib.value;
-          objContains = true;
-        }
-      }
-      if (objContains) {
-        value = currObj;
-      }
     }
     if (value == null) {
       if (def.default != null) {
@@ -339,4 +324,33 @@ function matchChild(element, defs) {
     }
   }
   return null;
+}
+
+/**
+ * Maps multiple attributes with the same prefix to a single prop object.
+ * The prefix cannot equal the attribute name.
+ * @param {string} attrPrefix
+ * @return {{attrMatches: function(string):boolean, parseAttrs: function(!Element):undefined|Object<string, string>}}
+ */
+export function createParseAttrsWithPrefix(attrPrefix) {
+  const attrMatches = (name) => matchesAttrPrefix(name, attrPrefix);
+  const parseAttrs = (element) => {
+    let currObj;
+    const attrs = element.attributes;
+    for (let i = 0; i < attrs.length; i++) {
+      const attrib = attrs[i];
+      if (attrMatches(attrib.name)) {
+        if (!currObj) {
+          currObj = {};
+        }
+        currObj[dashToCamelCase(attrib.name.slice(attrPrefix.length))] =
+          attrib.value;
+      }
+    }
+    return currObj;
+  };
+  return {
+    'attrMatches': attrMatches,
+    'parseAttrs': parseAttrs,
+  };
 }

--- a/test/fixtures/e2e/amp-fit-text/1.0/amp-fit-text.html
+++ b/test/fixtures/e2e/amp-fit-text/1.0/amp-fit-text.html
@@ -29,7 +29,7 @@
  <h1>FitText</h1>
 
  <h3>Scale up to cover</h3>
- <amp-fit-text id="test1" width="300" height="200" class="ft">
+ <amp-fit-text id="test1" width="300" height="200" layout="responsive" class="ft">
   Lorem <i>ips</i>um dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
  </amp-fit-text>
 

--- a/test/fixtures/e2e/amp-fit-text/1.0/amp-fit-text.html
+++ b/test/fixtures/e2e/amp-fit-text/1.0/amp-fit-text.html
@@ -29,7 +29,7 @@
  <h1>FitText</h1>
 
  <h3>Scale up to cover</h3>
- <amp-fit-text id="test1" width="300" height="200" layout="responsive" class="ft">
+ <amp-fit-text id="test1" width="300" height="200" class="ft">
   Lorem <i>ips</i>um dolor sit amet, has nisl nihil convenire et, vim at aeque inermis reprehendunt.
  </amp-fit-text>
 

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -516,7 +516,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(lightDom.querySelector(':scope > #component')).to.be.ok;
       expect(lightDom.className).to.equal('i-amphtml-fill-content');
       expect(lightDom.hasAttribute('i-amphtml-rendered')).to.be.true;
-      expect(lastProps.className).to.equal('i-amphtml-fill-content');
+      expect(lastProps.class).to.equal('i-amphtml-fill-content');
       expect(lastProps.as).to.equal('time');
       await waitFor(
         () => updateEventSpy.callCount > 0,
@@ -536,7 +536,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
       expect(element.querySelector(':scope > time')).to.equal(existing);
       expect(existing.querySelector(':scope > #component')).to.be.ok;
       expect(existing.className).to.equal('i-amphtml-fill-content');
-      expect(lastProps.className).to.equal('i-amphtml-fill-content');
+      expect(lastProps.class).to.equal('i-amphtml-fill-content');
       expect(lastProps.as).to.equal('time');
       await waitFor(
         () => updateEventSpy.callCount > 0,

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -4,7 +4,10 @@ import {omit} from '#core/types/object';
 
 import * as Preact from '#preact';
 import {PreactBaseElement} from '#preact/base-element';
-import {createParseAttrsWithPrefix} from '#preact/parse-props';
+import {
+  createParseAttrsWithPrefix,
+  createParseDateAttr,
+} from '#preact/parse-props';
 import {Slot} from '#preact/slot';
 
 import {upgradeOrRegisterElement} from '#service/custom-element-registry';
@@ -107,7 +110,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
         'valueWithDef': {attr: 'value-with-def', default: 'DEFAULT'},
         'propA': {attr: 'prop-a'},
         'minFontSize': {attr: 'min-font-size', type: 'number'},
-        'aDate': {attr: 'a-date', type: 'date'},
+        'aDate': createParseDateAttr('a-date'),
         'disabled': {attr: 'disabled', type: 'boolean'},
         'enabled': {attr: 'enabled', type: 'boolean'},
         'boolDefTrue': {attr: 'bool-def-true', type: 'boolean', default: true},
@@ -565,7 +568,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
             'valueWithDef': {attr: 'value-with-def', default: 'DEFAULT'},
             'propA': {attr: 'prop-a'},
             'minFontSize': {attr: 'min-font-size', type: 'number'},
-            'aDate': {attr: 'a-date', type: 'date'},
+            'aDate': createParseDateAttr('a-date'),
             'disabled': {attr: 'disabled', type: 'boolean'},
             'enabled': {attr: 'enabled', type: 'boolean'},
           },
@@ -1152,7 +1155,7 @@ describes.realWin('PreactBaseElement', spec, (env) => {
             'valueWithDef': {attr: 'value-with-def', default: 'DEFAULT'},
             'propA': {attr: 'prop-a'},
             'minFontSize': {attr: 'min-font-size', type: 'number'},
-            'aDate': {attr: 'a-date', type: 'date'},
+            'aDate': createParseDateAttr('a-date'),
             'disabled': {attr: 'disabled', type: 'boolean'},
             'enabled': {attr: 'enabled', type: 'boolean'},
           },

--- a/test/unit/preact/test-base-element-mapping.js
+++ b/test/unit/preact/test-base-element-mapping.js
@@ -4,6 +4,7 @@ import {omit} from '#core/types/object';
 
 import * as Preact from '#preact';
 import {PreactBaseElement} from '#preact/base-element';
+import {createParseAttrsWithPrefix} from '#preact/parse-props';
 import {Slot} from '#preact/slot';
 
 import {upgradeOrRegisterElement} from '#service/custom-element-registry';
@@ -115,8 +116,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
           parseAttrs: (e) =>
             `${e.getAttribute('part-a')}+${e.getAttribute('part-b')}`,
         },
-        'params': {attrPrefix: 'data-param-'},
-        'prefix': {attrPrefix: 'prefix'},
+        'params': createParseAttrsWithPrefix('data-param-'),
+        'prefix': createParseAttrsWithPrefix('prefix'),
       };
       element = html`
         <amp-preact
@@ -600,8 +601,8 @@ describes.realWin('PreactBaseElement', spec, (env) => {
               parseAttrs: (e) =>
                 `${e.getAttribute('part-a')}+${e.getAttribute('part-b')}`,
             },
-            'params': {attrPrefix: 'data-param-'},
-            'prefix': {attrPrefix: 'prefix'},
+            'params': createParseAttrsWithPrefix('data-param-'),
+            'prefix': createParseAttrsWithPrefix('prefix'),
           },
           selector: '*', // This should be last as catch-all.
           single: false,


### PR DESCRIPTION
Partial for #36899

Refactor `{attrPrefix}` and `{type: 'date'}` so that they resolve to a `{parseAttrs}` config instead.

This allows extension bundles to include these parsing mechanisms independently, rather than sharing it as part of `PreactBaseElement`.

All Bento extensions are 0.03 kb to 0.25 kb smaller as a result. The `bento.js` binary should see similar savings once it includes shared dependencies.