### PR TITLE
♻️ Split Bento-specific `CustomElement` from `BaseElement`

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -768,7 +768,7 @@ async function getBentoBuildFilename(dir, name, mode, options) {
  */
 async function generateBentoEntryPointSource(name, toExport) {
   return dedent(`
-    import {defineBentoElement} from '../../../../src/preact/bento-ce';
+    import {defineBentoElement} from '#preact/bento-ce';
     import {BaseElement} from '../base-element';
 
     function defineElement() {

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -764,7 +764,7 @@ async function getBentoBuildFilename(dir, name, mode, options) {
 /**
  * @param {string} name
  * @param {string} toExport
- * @return {Promise<string>}
+ * @return {string}
  */
 function generateBentoEntryPointSource(name, toExport) {
   return dedent(`

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -768,13 +768,11 @@ async function getBentoBuildFilename(dir, name, mode, options) {
  */
 async function generateBentoEntryPointSource(name, toExport) {
   return dedent(`
+    import {defineBentoElement} from '../../../../src/preact/bento-ce';
     import {BaseElement} from '../base-element';
 
     function defineElement() {
-      customElements.define(
-        __name__,
-        BaseElement.CustomElement(BaseElement)
-      );
+      defineBentoElement(__name__, BaseElement);
     }
 
     ${toExport ? 'export {defineElement};' : 'defineElement();'}

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -755,7 +755,7 @@ async function getBentoBuildFilename(dir, name, mode, options) {
   if (await fs.pathExists(`${dir}/${filename}`)) {
     return filename;
   }
-  const generatedSource = await generateBentoEntryPointSource(name, toExport);
+  const generatedSource = generateBentoEntryPointSource(name, toExport);
   const generatedFilename = `build/${filename}`;
   await fs.outputFile(`${dir}/${generatedFilename}`, generatedSource);
   return generatedFilename;
@@ -766,7 +766,7 @@ async function getBentoBuildFilename(dir, name, mode, options) {
  * @param {string} toExport
  * @return {Promise<string>}
  */
-async function generateBentoEntryPointSource(name, toExport) {
+function generateBentoEntryPointSource(name, toExport) {
   return dedent(`
     import {defineBentoElement} from '#preact/bento-ce';
     import {BaseElement} from '../base-element';

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -768,7 +768,7 @@ async function getBentoBuildFilename(dir, name, mode, options) {
  */
 function generateBentoEntryPointSource(name, toExport) {
   return dedent(`
-    import {defineBentoElement} from '#preact/bento-ce';
+    import {defineBentoElement} from '../../../../src/preact/bento-ce';
     import {BaseElement} from '../base-element';
 
     function defineElement() {

--- a/extensions/amp-embedly-card/1.0/web-component.js
+++ b/extensions/amp-embedly-card/1.0/web-component.js
@@ -1,3 +1,5 @@
+import {defineBentoElement} from '#preact/bento-ce';
+
 import {BENTO_TAG, BaseElement} from './base-element';
 import {
   BENTO_TAG as EMBEDLY_KEY_BENTO_TAG,
@@ -8,7 +10,7 @@ import {
  * Registers `<bento-embedly-card> component to CustomElements registry
  */
 export function defineElement() {
-  customElements.define(BENTO_TAG, BaseElement.CustomElement(BaseElement));
+  defineBentoElement(BENTO_TAG, BaseElement);
   defineElementEmbedlyKey();
 }
 
@@ -16,8 +18,5 @@ export function defineElement() {
  * Registers <bento-embedly-key>` component to CustomElements registry
  */
 export function defineElementEmbedlyKey() {
-  customElements.define(
-    EMBEDLY_KEY_BENTO_TAG,
-    EmbedlyKeyBaseElement.CustomElement(EmbedlyKeyBaseElement)
-  );
+  defineBentoElement(EMBEDLY_KEY_BENTO_TAG, EmbedlyKeyBaseElement);
 }

--- a/extensions/amp-facebook/1.0/web-component.js
+++ b/extensions/amp-facebook/1.0/web-component.js
@@ -1,3 +1,4 @@
+import {defineBentoElement} from '#preact/bento-ce';
 import {
   BaseElement,
   COMMENTS_TAG,
@@ -13,7 +14,7 @@ import {
  *Register BentoFacebook component to CustomElements registry
  */
 export function defineElement() {
-  customElements.define(TAG, BaseElement.CustomElement(BaseElement));
+  defineBentoElement(TAG, BaseElement);
 
   defineCommentsElement();
   defineLikeElement();
@@ -24,28 +25,19 @@ export function defineElement() {
  * Register BentoFacebookComments component to CustomElements registry
  */
 export function defineCommentsElement() {
-  customElements.define(
-    COMMENTS_TAG,
-    CommentsBaseElement.CustomElement(CommentsBaseElement)
-  );
+  defineBentoElement(COMMENTS_TAG, CommentsBaseElement);
 }
 
 /**
  * Register BentoFacebook component to CustomElements registry
  */
 export function defineLikeElement() {
-  customElements.define(
-    LIKE_TAG,
-    LikeBaseElement.CustomElement(LikeBaseElement)
-  );
+  defineBentoElement(LIKE_TAG, LikeBaseElement);
 }
 
 /**
  * Register BentoFacebook component to CustomElements registry
  */
 export function definePageElement() {
-  customElements.define(
-    PAGE_TAG,
-    PageBaseElement.CustomElement(PageBaseElement)
-  );
+  defineBentoElement(PAGE_TAG, PageBaseElement);
 }

--- a/extensions/amp-inline-gallery/1.0/web-component.js
+++ b/extensions/amp-inline-gallery/1.0/web-component.js
@@ -8,11 +8,13 @@ import {
   PaginationBaseElement,
 } from './pagination-base-element';
 
+import {defineBentoElement} from '#preact/bento-ce';
+
 /**
  * Registers `<bento-inline-gallery> component to CustomElements registry
  */
 export function defineElement() {
-  customElements.define(TAG, BaseElement.CustomElement(BaseElement));
+  defineBentoElement(TAG, BaseElement);
   defineThumbnailsElement();
   definePaginationElement();
 }
@@ -21,18 +23,12 @@ export function defineElement() {
  * Registers `<bento-inline-gallery-pagination> component to CustomElements registry
  */
 export function definePaginationElement() {
-  customElements.define(
-    PAGINATION_TAG,
-    PaginationBaseElement.CustomElement(PaginationBaseElement)
-  );
+  defineBentoElement(PAGINATION_TAG, PaginationBaseElement);
 }
 
 /**
  * Registers `<bento-inline-gallery-thumbnails> component to CustomElements registry
  */
 export function defineThumbnailsElement() {
-  customElements.define(
-    THUMBNAIL_TAG,
-    ThumbnailsBaseElement.CustomElement(ThumbnailsBaseElement)
-  );
+  defineBentoElement(THUMBNAIL_TAG, ThumbnailsBaseElement);
 }

--- a/src/preact/bento-ce.js
+++ b/src/preact/bento-ce.js
@@ -33,7 +33,6 @@ let BaseElement;
 if (typeof AMP !== 'undefined' && AMP.BaseElement) {
   BaseElement = AMP.BaseElement;
 } else {
-  const ExtendableHTMLElement = maybeWrapNativeSuper(HTMLElement);
   class CeBaseElement {
     /**
      * @param {!Element} element
@@ -44,39 +43,6 @@ if (typeof AMP !== 'undefined' && AMP.BaseElement) {
 
       /** @const {!Window} */
       this.win = getWin(element);
-    }
-
-    /**
-     * @param {typeof CeBaseElement} BaseElement
-     * @return {typeof HTMLElement}
-     */
-    static 'CustomElement'(BaseElement) {
-      return class CustomElement extends ExtendableHTMLElement {
-        /** */
-        constructor() {
-          super();
-
-          /** @const {!CeBaseElement} */
-          this.implementation = new BaseElement(this);
-        }
-
-        /** */
-        connectedCallback() {
-          this.classList.add('i-amphtml-built');
-          this.implementation.mountCallback();
-          this.implementation.buildCallback();
-        }
-
-        /** */
-        disconnectedCallback() {
-          this.implementation.unmountCallback();
-        }
-
-        /** @return {Promise<*>} */
-        getApi() {
-          return this.implementation.getApi();
-        }
-      };
     }
 
     /**
@@ -105,3 +71,49 @@ if (typeof AMP !== 'undefined' && AMP.BaseElement) {
 }
 
 export {BaseElement};
+
+let ExtendableHTMLElement;
+
+/**
+ * @param {typeof CeBaseElement} BaseElement
+ * @return {typeof HTMLElement}
+ */
+function createBentoCustomElement(BaseElement) {
+  if (!ExtendableHTMLElement) {
+    ExtendableHTMLElement = maybeWrapNativeSuper(HTMLElement);
+  }
+  return class CustomElement extends ExtendableHTMLElement {
+    /** */
+    constructor() {
+      super();
+
+      /** @const {!CeBaseElement} */
+      this.implementation = new BaseElement(this);
+    }
+
+    /** */
+    connectedCallback() {
+      this.classList.add('i-amphtml-built');
+      this.implementation.mountCallback();
+      this.implementation.buildCallback();
+    }
+
+    /** */
+    disconnectedCallback() {
+      this.implementation.unmountCallback();
+    }
+
+    /** @return {Promise<*>} */
+    getApi() {
+      return this.implementation.getApi();
+    }
+  };
+}
+
+/**
+ * @param {string} tag
+ * @param {typeof BaseElement} BaseElement
+ */
+export function defineBentoElement(tag, BaseElement) {
+  customElements.define(tag, createBentoCustomElement(BaseElement));
+}


### PR DESCRIPTION
Untangles Bento-specific `CustomElement` from the barebones `BaseElement`.