### PR TITLE
Revert "Remove extraneous preact/compat code in bento.js bundle"

### DIFF
--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -12,9 +12,12 @@ import {CarouselContext} from './carousel-context';
 import {ContainWrapper} from '#preact/component';
 import {Scroller} from './scroller';
 import {WithAmpContext} from '#preact/context';
+import {forwardRef, toChildArray} from '#preact/compat';
+import {isRTL} from '#core/dom';
+import {sequentialIdGenerator} from '#core/data-structures/id-generator';
+import {getWin} from '#core/window';
 import {
   cloneElement,
-  toChildArray,
   useCallback,
   useContext,
   useEffect,
@@ -24,10 +27,6 @@ import {
   useRef,
   useState,
 } from '#preact';
-import {forwardRef} from '#preact/compat';
-import {isRTL} from '#core/dom';
-import {sequentialIdGenerator} from '#core/data-structures/id-generator';
-import {getWin} from '#core/window';
 import {useStyles} from './component.jss';
 import {mod} from '#core/math';
 

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -3,13 +3,13 @@ import {sequentialIdGenerator} from '#core/data-structures/id-generator';
 import * as Preact from '#preact';
 import {
   cloneElement,
-  toChildArray,
   useCallback,
   useContext,
   useLayoutEffect,
   useMemo,
   useState,
 } from '#preact';
+import {toChildArray} from '#preact/compat';
 
 import {BentoLightboxGalleryContext} from './context';
 

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -1,16 +1,15 @@
 import * as Preact from '#preact';
 import {BentoBaseCarousel} from '../../amp-base-carousel/1.0/component';
-import {forwardRef} from '#preact/compat';
+import {forwardRef, toChildArray} from '#preact/compat';
+import {setStyle} from '#core/dom/style';
+import {getWin} from '#core/window';
 import {
-  toChildArray,
   useCallback,
   useImperativeHandle,
   useLayoutEffect,
   useRef,
   useState,
 } from '#preact';
-import {setStyle} from '#core/dom/style';
-import {getWin} from '#core/window';
 import {useStyles} from './component.jss';
 import objstr from 'obj-str';
 import {propName} from '#preact/utils';

--- a/src/preact/compat.js
+++ b/src/preact/compat.js
@@ -1,31 +1,27 @@
-/**
- * todo(kvchari): replace with official solution from preact
- * copying forwardRef implementation from https://gist.github.com/developit/974b5e4e582df8e954c5a7981603cd37
- * preact contains a bug where importing forwardRef imports a lot of extraneous code due to side-effects.
- * see issue for more information https://github.com/preactjs/preact/issues/3295
- */
-import {options} from /*OK*/ 'preact';
+import * as compat from /*OK*/ 'preact/compat';
 
-options.__b = function (o, v) {
-  if (v.type && v.type._f && (v.props.ref = v.ref)) {
-    v.ref = null;
-  }
-  o && o(v);
-}.bind(0, options.__b);
 /**
  * @param {function(T, {current: (R|null)}):PreactDef.Renderable} fn
  * @return {function(T):PreactDef.Renderable}
  * @template T, R
  */
 export function forwardRef(fn) {
-  /**
-   * @param {*} p
-   * @return {*}
-   */
-  function F(p) {
-    const {ref} = p;
-    delete p.ref;
-    return fn(p, ref);
-  }
-  return (F._f = F);
+  return compat.forwardRef(fn);
+}
+
+/**
+ * @param {PreactDef.VNode} vnode
+ * @param {HTMLElement} container
+ * @return {PreactDef.VNode}
+ */
+export function createPortal(vnode, container) {
+  return compat.createPortal(vnode, container);
+}
+
+/**
+ * @param {...PreactDef.Renderable} unusedChildren
+ * @return {!Array<PreactDef.Renderable>}
+ */
+export function toChildArray(unusedChildren) {
+  return compat.Children.toArray.apply(undefined, arguments);
 }

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -145,5 +145,3 @@ export function useCallback(cb, opt_deps) {
 export function useImperativeHandle(ref, create, opt_deps) {
   return hooks.useImperativeHandle(ref, create, opt_deps);
 }
-
-export {toChildArray} from 'preact';


### PR DESCRIPTION
Reverts ampproject/amphtml#36901

Auto-merge strikes again.
Culprit: https://discuss.circleci.com/t/workflow-checking-showing-as-neutral-on-github-checks/41911/8

Action items: 
- [x] disable auto-merge until solved