### PR TITLE
babel: enable more assumptions

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -74,10 +74,31 @@ function getMinifiedConfig() {
     sourceMaps: 'inline',
     presets: [presetEnv],
     retainLines: true,
+    // Babel assumptions enables transformation optimizations.
+    // Full details at https://babeljs.io/docs/en/assumptions.
     assumptions: {
+      arrayLikeIsIterable: true,
+      constantReexports: true,
       constantSuper: true,
+      enumerableModuleMeta: true,
+      // TODO: determine if ignoreFunctionLength can be enabled
+      // https://babeljs.io/docs/en/assumptions#ignorefunctionlength
+      ignoreFunctionLength: false,
+      ignoreToPrimitiveHint: true,
+      iterableIsArray: false,
+      mutableTemplateObject: false,
       noClassCalls: true,
+      noDocumentAll: true,
+      noIncompleteNsImportDetection: true,
+      noNewArrows: true,
+      objectRestNoSymbols: true,
+      privateFieldsAsProperties: false,
+      pureGetters: true,
       setClassMethods: true,
+      setComputedProperties: true,
+      setPublicClassFields: true,
+      setSpreadProperties: true,
+      skipForOfIteratorClosing: true,
     },
   };
 }


### PR DESCRIPTION
**summary**
Partial for: https://github.com/ampproject/amphtml/issues/36453 and https://github.com/ampproject/amphtml/issues/36899

Enables more Babel assumptions.
To review, please go through the [assumptions](https://babeljs.io/docs/en/assumptions) one by one and ensure that you believe they are safe.

**why**
Enables creation of smaller/faster binaries.

**new assumptions**
- arrayLikeIsIterable,
- constantReexports,
- enumerableModuleMeta
- ignoreToPrimitiveHint
- noDocumentAll
- noIncompleteNsImportDetection
- noNewArrows
- objectRestNoSymbols
- pureGetters
- setComputedProperties
- setPublicClassFields
- setSpreadProperties
- skipForOfIteratorClosing

**note**
I am not confident about a few of these and would love to discuss.