### PR TITLE
amp-carousel-0.1: fast-followup fix for outdated merge

### DIFF
--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -402,12 +402,12 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
 
   /** Used by amp-lightbox-gallery */
   interactionNext() {
-    this.controls_.interactionNext();
+    this.controls_.handleNext();
   }
 
   /** Used by amp-lightbox-gallery */
   interactionPrev() {
-    this.controls_.interactionPrev();
+    this.controls_.handlePrev();
   }
 
   /**

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -339,12 +339,12 @@ export class AmpSlideScroll extends AMP.BaseElement {
 
   /** Used by amp-lightbox-gallery */
   interactionNext() {
-    this.controls_.interactionNext();
+    this.controls_.handleNext();
   }
 
   /** Used by amp-lightbox-gallery */
   interactionPrev() {
-    this.controls_.interactionPrev();
+    this.controls_.handlePrev();
   }
 
   /**


### PR DESCRIPTION
**summary**
I just merged in a pretty stale branch without realizing that I've also made a different change in the meantime which conflicts. Should have rebased. 

This is now caught by type checking!
Yay for type checking.

- Stale branch: https://github.com/ampproject/amphtml/pull/36602
- Conflict: https://github.com/ampproject/amphtml/pull/36869