### PR TITLE
✅ [bento-sidebar] refactor e2e test to hopefully be less flaky

### DIFF
--- a/extensions/amp-sidebar/1.0/test-e2e/test-bento-sidebar.js
+++ b/extensions/amp-sidebar/1.0/test-e2e/test-bento-sidebar.js
@@ -14,22 +14,32 @@ describes.endtoend(
 
     it('should be able to open and close', async () => {
       // check if sidebar content is not visibile
-      const navLinkInSidebar = await controller.findElement('nav');
-      await expect(controller.isElementDisplayed(navLinkInSidebar)).to.be.false;
+      const navInLightDom = await controller.findElement('nav');
+      await expect(controller.isElementDisplayed(navInLightDom)).to.be.false;
 
       // Open sidebar
       const openButton = await controller.findElement('#open-sidebar');
       controller.click(openButton);
 
-      // check if sidebar content is visible
-      await expect(controller.isElementDisplayed(navLinkInSidebar)).to.be.true;
+      // wait for sidebar to finish open animation
+      const element = await controller.findElement('bento-sidebar');
+      await controller.switchToShadowRoot(element);
+      const navInShadowDom = await controller.findElement('[part="sidebar"]');
 
+      // check if sidebar content is visible
+      await expect(controller.isElementDisplayed(navInShadowDom)).to.be.true;
+      await expect(controller.getElementRect(navInShadowDom)).to.include({
+        width: 128,
+        right: 128,
+      });
+
+      await controller.switchToLight();
       // Close sidebar
       const closeButton = await controller.findElement('#close-sidebar');
       controller.click(closeButton);
 
       // check if sidebar content is not visible
-      await expect(controller.isElementDisplayed(navLinkInSidebar)).to.be.false;
+      await expect(controller.isElementDisplayed(navInShadowDom)).to.be.false;
     });
   }
 );


### PR DESCRIPTION
The bento-sidebar e2e test is rather flaky. I believe this may have something to do with animations. Seeing how the amp-sidebar e2e test is technically doing the same thing, but is not flaky. I will check the location of the sidebar to make sure the animation is done before doing anything else.
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
