### PR TITLE
Use stable identifier mangling for properties

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -540,7 +540,7 @@ const mangleIdentifier = {
     let base = 54;
     let id = '';
     do {
-      id += charset[num % base];
+      id = charset[num % base] + id;
       num = Math.floor(num / base);
       base = 64;
     } while (num > 0);


### PR DESCRIPTION
Part two of #36937, because apparently Terser doesn't share the mangler for both variables and properties.