### PR TITLE
🏗️ 🔥  Fix batchedReads being shared by different callers

### DIFF
--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -70,18 +70,19 @@ function getEsbuildBabelPlugin(
       build.onLoad({filter: /\.[cm]?js$/, namespace: ''}, async (file) => {
         const filename = file.path;
         const {contents, hash} = await batchedRead(filename);
+        const rehash = md5(
+          JSON.stringify({
+            callerName,
+            hash,
+            babelOptions,
+            argv: process.argv.slice(2),
+          })
+        );
 
         const transformed = await transformContents(
           filename,
           contents,
-          md5(
-            JSON.stringify({
-              callerName,
-              hash,
-              babelOptions,
-              argv: process.argv.slice(2),
-            })
-          ),
+          rehash,
           getFileBabelOptions(babelOptions, filename)
         );
         return {contents: transformed};

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -66,18 +66,22 @@ function getEsbuildBabelPlugin(
 
       const babelOptions =
         babel.loadOptions({caller: {name: callerName}}) || {};
-      const optionsHash = md5(
-        JSON.stringify({babelOptions, argv: process.argv.slice(2)})
-      );
 
       build.onLoad({filter: /\.[cm]?js$/, namespace: ''}, async (file) => {
         const filename = file.path;
-        const {contents, hash} = await batchedRead(filename, optionsHash);
+        const {contents, hash} = await batchedRead(filename);
 
         const transformed = await transformContents(
           filename,
           contents,
-          hash,
+          md5(
+            JSON.stringify({
+              callerName,
+              hash,
+              babelOptions,
+              argv: process.argv.slice(2),
+            })
+          ),
           getFileBabelOptions(babelOptions, filename)
         );
         return {contents: transformed};

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -73,6 +73,7 @@ function getEsbuildBabelPlugin(
         const rehash = md5(
           JSON.stringify({
             callerName,
+            filename,
             hash,
             babelOptions,
             argv: process.argv.slice(2),

--- a/build-system/common/transform-cache.js
+++ b/build-system/common/transform-cache.js
@@ -91,17 +91,16 @@ const readCache = new Map();
  * completed, the result will be reused.
  *
  * @param {string} path
- * @param {string=} optionsHash
  * @return {Promise<ReadResult>}
  */
-function batchedRead(path, optionsHash) {
+function batchedRead(path) {
   let read = readCache.get(path);
   if (!read) {
     read = fs
       .readFile(path)
       .then((contents) => ({
         contents,
-        hash: md5(contents, optionsHash ?? ''),
+        hash: md5(contents),
       }))
       .finally(() => {
         readCache.delete(path);

--- a/build-system/common/transform-cache.js
+++ b/build-system/common/transform-cache.js
@@ -51,7 +51,7 @@ class TransformCache {
    */
   set(hash, transformPromise) {
     if (this.transformMap.has(hash)) {
-      throw new Error('Read race: Attempting to transform a file twice.');
+      throw new Error(`Read race: Attempting to transform ${hash} file twice.`);
     }
     this.transformMap.set(hash, transformPromise);
     const filepath = path.join(this.cacheDir, hash) + this.fileExtension;

--- a/build-system/compile/pre-closure-babel.js
+++ b/build-system/compile/pre-closure-babel.js
@@ -91,16 +91,15 @@ async function preClosureBabel(file, outputFilename, options) {
     const callerName = 'pre-closure';
     const babelOptions = babel.loadOptions({caller: {name: callerName}}) || {};
     const {contents, hash} = await batchedRead(file);
-    const cachedPromise = transformCache.get(
-      md5(
-        JSON.stringify({
-          callerName,
-          hash,
-          babelOptions,
-          argv: process.argv.slice(2),
-        })
-      )
+    const rehash = md5(
+      JSON.stringify({
+        callerName,
+        hash,
+        babelOptions,
+        argv: process.argv.slice(2),
+      })
     );
+    const cachedPromise = transformCache.get(rehash);
     if (cachedPromise) {
       if (!(await fs.pathExists(transformedFile))) {
         await fs.outputFile(transformedFile, await cachedPromise);
@@ -114,7 +113,7 @@ async function preClosureBabel(file, outputFilename, options) {
           sourceFileName: path.relative(process.cwd(), file),
         })
         .then((result) => result?.code);
-      transformCache.set(hash, transformPromise);
+      transformCache.set(rehash, transformPromise);
       await fs.outputFile(transformedFile, await transformPromise);
       debug(CompilationLifecycles['pre-closure'], transformedFile);
     }


### PR DESCRIPTION
In the old code, `batchedRead` performed a file read, and hashed the contents with an input `optionsHash`. But `batchedRead` is designed to allow multiple callers to share the same file, and they may provide different `optionsHash`es. When this happened, only the first caller's read+`optionsHash` would be used, and the 2nd+ caller would receive the first caller's hashes!

This simple fix is to move this out of `batchedRead` and let that _just_ read and hash the file contents. If you want to rehash with options, do that afterwards.