### PR TITLE
bump bento-compiler for latest fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/animations": "0.2.2",
-        "@ampproject/bento-compiler": "0.0.11",
+        "@ampproject/bento-compiler": "0.0.12",
         "@ampproject/toolbox-cache-url": "2.8.0",
         "@ampproject/viewer-messaging": "1.1.2",
         "@ampproject/worker-dom": "0.32.1",
@@ -188,9 +188,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ampproject/bento-compiler": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.11.tgz",
-      "integrity": "sha512-FR6bw/EodR0hHJEw7hwTD+5YhxJQHx43vZxlWYef8Asn1wF5PmRmVV769+ZIMQlSM3leYV4et01YrAyrZL0Keg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.12.tgz",
+      "integrity": "sha512-9cMESvUspEIMn+Vc9ZZaeoEUgh+m3TlfdWH2AZlk5G9iVZjbXj+JBrhX1IXVe2I45sdq6J7P1XkdQhZMWv6Hgg==",
       "dependencies": {
         "@ampproject/worker-dom": "0.32.1"
       }
@@ -22890,9 +22890,9 @@
       "version": "0.2.2"
     },
     "@ampproject/bento-compiler": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.11.tgz",
-      "integrity": "sha512-FR6bw/EodR0hHJEw7hwTD+5YhxJQHx43vZxlWYef8Asn1wF5PmRmVV769+ZIMQlSM3leYV4et01YrAyrZL0Keg==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.12.tgz",
+      "integrity": "sha512-9cMESvUspEIMn+Vc9ZZaeoEUgh+m3TlfdWH2AZlk5G9iVZjbXj+JBrhX1IXVe2I45sdq6J7P1XkdQhZMWv6Hgg==",
       "requires": {
         "@ampproject/worker-dom": "0.32.1"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ampproject/animations": "0.2.2",
-    "@ampproject/bento-compiler": "0.0.11",
+    "@ampproject/bento-compiler": "0.0.12",
     "@ampproject/toolbox-cache-url": "2.8.0",
     "@ampproject/viewer-messaging": "1.1.2",
     "@ampproject/worker-dom": "0.32.1",


### PR DESCRIPTION
**summary**
Update: https://github.com/ampproject/bento-compiler/pull/31

Supports handling text nodes with no text.