### PR TITLE
renovate: immediately bump deps from @amppproject

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -99,7 +99,8 @@
       "matchDepTypes": ["dependencies"],
       "labels": ["WG: bento", "WG: components", "WG: performance"],
       "rebaseWhen": "never",
-      "automerge": false
+      "automerge": false,
+      "schedule": null
     },
     {
       "groupName": "core dependencies",


### PR DESCRIPTION
**summary**
Updates Renovate Configuration to immediately create PRs for updates to `@ampproject`.
Does that by setting schedule to null, which equates to default settings, which equates to "at all times" ([docs](https://docs.renovatebot.com/configuration-options/#schedule))

**to test**
```
npm install -g renovate
renovate-config-validator .renovaterc.json
```