### PR TITLE
✨ Add missing `aria-modal` to global attributes in validator spec

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -5160,6 +5160,7 @@ attr_lists: {
   attrs: { name: "aria-labelledby" }
   attrs: { name: "aria-level" }
   attrs: { name: "aria-live" }
+  attrs: { name: "aria-modal" }
   attrs: { name: "aria-multiline" }
   attrs: { name: "aria-multiselectable" }
   attrs: { name: "aria-orientation" }


### PR DESCRIPTION
In the documentation for [`amp-mega-menu`](https://amp.dev/documentation/components/amp-mega-menu/#styling), the example advises the use of the [`aria-modal` attribute](https://w3c.github.io/aria/#aria-modal):

```html
<li>
  <button aria-expanded aria-controls="unique_id" aria-haspopup="dialog">
    ...
  </button>
  <div role="dialog" aria-modal id="unique_id">
    ...
  </div>
</li>
```

Nevertheless, `aria-modal` is not in the validator spec so this is invalid. It's true that `amp-meta-menu` is still experimental, but it seems this attribute should still be allowed regardless.

This PR adds the missing attribute.