### PR TITLE
bind-expression: bump max expression size.

### DIFF
--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -15,7 +15,7 @@ const TAG = 'amp-bind';
  * Maximum number of nodes in an expression AST.
  * @const @private {number}
  */
-const MAX_AST_SIZE = 200;
+const MAX_AST_SIZE = 250;
 
 /** @const @private {string} */
 const CUSTOM_FUNCTIONS = 'custom-functions';

--- a/extensions/amp-bind/0.1/bind-expression.js
+++ b/extensions/amp-bind/0.1/bind-expression.js
@@ -15,7 +15,7 @@ const TAG = 'amp-bind';
  * Maximum number of nodes in an expression AST.
  * @const @private {number}
  */
-const MAX_AST_SIZE = 100;
+const MAX_AST_SIZE = 200;
 
 /** @const @private {string} */
 const CUSTOM_FUNCTIONS = 'custom-functions';

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -532,7 +532,7 @@ Using `AMP.pushState()` sets the current state to the most recent pushed state.
 -   Only `amp-bind` [allowlisted functions](#allowlisted-functions) and operators are usable. are usable. Use of arrow functions are allowed as function parameters, e.g. `[1, 2, 3].map(x => x + 1)`.
     -   Custom functions, classes and loops are disallowed.
 -   Undefined variables and array-index-out-of-bounds return `null` instead of `undefined` or throwing errors.
--   A single expression is currently capped at 50 operands for performance. Please [contact us](https://github.com/ampproject/amphtml/issues/new/choose) if this is insufficient for your use case.
+-   A single expression is currently capped at 250 operands for performance. Please [contact us](https://github.com/ampproject/amphtml/issues/new/choose) if this is insufficient for your use case.
 
 The following are all valid expressions:
 


### PR DESCRIPTION
**summary**
`<amp-bind>` expression limits were last rebalanced on May 2018 https://github.com/ampproject/amphtml/pull/15517.
It has always been a relatively conservative, and median CPUs have also improved in the past 3 years. It makes sense to bump the number.

New AST size limit is 250.

**testing notes**
On my much-faster-than-median-phone 2018 MBP, with only a single run (this is nowhere near statistically valid):

```
200 nodes  eval took: 3ms
600 nodes  eval took: 3ms
1000 nodes eval took: 5ms
5000 nodes eval took: 9ms
```