### PR TITLE
Flush LCP metric once it's received

### DIFF
--- a/src/service/performance-impl.js
+++ b/src/service/performance-impl.js
@@ -649,6 +649,11 @@ export class Performance {
 
   /**
    * Tick the largest contentful paint metrics.
+   * Uses entry.startTime, which equates to: `renderTime ?? loadTime`. We can't
+   * always use one or the other because:
+   * - loadTime is 0 for non-remote resources (text)
+   * - renderTime is undefined for crossorigin resources
+   *
    * @param {!LargestContentfulPaint} entry
    */
   tickLargestContentfulPaint_(entry) {

--- a/test/unit/test-performance.js
+++ b/test/unit/test-performance.js
@@ -1042,7 +1042,11 @@ describes.realWin('PeformanceObserver metrics', {amp: true}, (env) => {
       toggleVisibility(perf, false);
 
       const lcpEvents = perf.events_.filter(({label}) => label === 'lcp');
-      expect(lcpEvents.length).to.equal(1);
+      expect(lcpEvents.length).to.equal(2);
+      expect(lcpEvents).deep.include({
+        label: 'lcp',
+        delta: 12,
+      });
       expect(lcpEvents).deep.include({
         label: 'lcp',
         delta: 23,


### PR DESCRIPTION
LCP isn't a cumulative metric (later entries don't change the value of the first), so it makes no sense to wait for more metrics to come in. This may be the final reason our CSI metrics don't align with UKM data. LCP pass rate appears low, but it's just because we're not receiving the metric at all even though the LCP already fired.