### PR TITLE
Remove CEv1 polyfill from ESM binaries

### DIFF
--- a/src/friendly-iframe-embed.js
+++ b/src/friendly-iframe-embed.js
@@ -686,11 +686,11 @@ export class FriendlyIframeEmbed {
 function installPolyfillsInChildWindow(parentWin, childWin) {
   if (!mode.isEsm()) {
     installDocContains(childWin);
+    installCustomElements(childWin, class {});
   }
   // The anonymous class parameter allows us to detect native classes vs
   // transpiled classes.
   if (!IS_SXG) {
-    installCustomElements(childWin, class {});
     installIntersectionObserver(parentWin, childWin);
     installResizeObserver(parentWin, childWin);
     installAbortController(childWin);

--- a/src/polyfills/index.js
+++ b/src/polyfills/index.js
@@ -35,11 +35,11 @@ if (self.document) {
   if (!mode.isEsm()) {
     installDocContains(self);
     installGetBoundingClientRect(self);
+    installCustomElements(self, class {});
   }
   // The anonymous class parameter allows us to detect native classes vs
   // transpiled classes.
   if (!IS_SXG) {
-    installCustomElements(self, class {});
     installIntersectionObserver(self);
     installResizeObserver(self);
     installAbortController(self);


### PR DESCRIPTION
The only ESM browser that doesn't support CEv1 is Firefox 60-63, which we've now decided is not worth supporting.

Re: https://github.com/ampproject/amphtml/issues/36908
Fixes https://github.com/ampproject/amphtml/issues/36908