### PR TITLE
♻️ `AmpLightbox` no longer inherits a Bento `BaseElement`

### DIFF
--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -103,7 +103,7 @@ class AmpLightbox extends AmpPreactBaseElement {
   onAfterClose_() {
     setIsOpen(this.element, false);
     triggerAmpEvent(this.element, 'close');
-    this.removeAsContainer?.();
+    this.removeAsContainer();
 
     if (this.historyId_ != null) {
       this.history_.pop(this.historyId_);

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -10,10 +10,10 @@ import {getWin} from '#core/window';
 import {userAssert} from '#utils/log';
 import {
   Component,
-  isOpen,
   props,
   setIsOpen,
   shadowCss,
+  toggleOnMutation,
   usesShadowDom,
 } from './element';
 // AmpPreactBaseElement should be declared elsewhere and shared.
@@ -29,10 +29,7 @@ const TAG = 'amp-lightbox';
  * @param {string} eventName
  */
 function triggerAmpEvent(element, eventName) {
-  const event = createCustomEvent(
-    getWin(element),
-    `${element.localName}:${eventName}`
-  );
+  const event = createCustomEvent(getWin(element), eventName);
   Services.actionServiceForDoc(element).trigger(
     element,
     eventName,
@@ -52,6 +49,9 @@ class AmpLightbox extends AmpPreactBaseElement {
 
     /** @private {number|null} */
     this.historyId_ = null;
+
+    /** @private {boolean} */
+    this.open_ = false;
   }
 
   /** @override */
@@ -85,8 +85,8 @@ class AmpLightbox extends AmpPreactBaseElement {
 
   /** @private */
   onBeforeOpen_() {
-    setIsOpen(this.element, true);
-    triggerAmpEvent(this.element, 'open');
+    this.open_ = setIsOpen(this.element, true);
+    triggerAmpEvent(this.element, 'amp-lightbox:open');
   }
 
   /** @private */
@@ -101,8 +101,8 @@ class AmpLightbox extends AmpPreactBaseElement {
 
   /** @private */
   onAfterClose_() {
-    setIsOpen(this.element, false);
-    triggerAmpEvent(this.element, 'close');
+    this.open_ = setIsOpen(this.element, false);
+    triggerAmpEvent(this.element, 'amp-lightbox:close');
     this.removeAsContainer();
 
     if (this.historyId_ != null) {
@@ -118,7 +118,7 @@ class AmpLightbox extends AmpPreactBaseElement {
 
   /** @override */
   mutationObserverCallback() {
-    this.api().toggle(isOpen(this.element));
+    this.open_ = toggleOnMutation(this.element, this.open_);
   }
 }
 

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -29,7 +29,10 @@ const TAG = 'amp-lightbox';
  * @param {string} eventName
  */
 function triggerAmpEvent(element, eventName) {
-  const event = createCustomEvent(getWin(element), eventName);
+  const event = createCustomEvent(
+    getWin(element),
+    `${element.localName}:${eventName}`
+  );
   Services.actionServiceForDoc(element).trigger(
     element,
     eventName,

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -11,7 +11,7 @@ import {userAssert} from '#utils/log';
 import {
   Component,
   props,
-  setIsOpen,
+  setElementOpen,
   shadowCss,
   toggleOnMutation,
   usesShadowDom,
@@ -85,7 +85,7 @@ class AmpLightbox extends AmpPreactBaseElement {
 
   /** @private */
   onBeforeOpen_() {
-    this.open_ = setIsOpen(this.element, true);
+    this.open_ = setElementOpen(this.element, true);
     triggerAmpEvent(this.element, 'amp-lightbox:open');
   }
 
@@ -101,7 +101,7 @@ class AmpLightbox extends AmpPreactBaseElement {
 
   /** @private */
   onAfterClose_() {
-    this.open_ = setIsOpen(this.element, false);
+    this.open_ = setElementOpen(this.element, false);
     triggerAmpEvent(this.element, 'amp-lightbox:close');
     this.removeAsContainer();
 

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -89,7 +89,7 @@ class AmpLightbox extends AmpPreactBaseElement {
   /** @private */
   onAfterOpen_() {
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
-    this.setAsContainer?.(scroller);
+    this.setAsContainer(scroller);
 
     this.history_
       .push(() => this.api().close())

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -2,19 +2,44 @@ import {
   ActionTrust_Enum,
   DEFAULT_ACTION,
 } from '#core/constants/action-constants';
-import {BaseElement} from './base-element';
 import {CSS} from '../../../build/amp-lightbox-1.0.css';
 import {Services} from '#service';
 import {createCustomEvent} from '#utils/event-helper';
 import {isExperimentOn} from '#experiments';
 import {getWin} from '#core/window';
 import {userAssert} from '#utils/log';
+import {
+  Component,
+  isOpen,
+  props,
+  setIsOpen,
+  shadowCss,
+  usesShadowDom,
+} from './element';
+// AmpPreactBaseElement should be declared elsewhere and shared.
+// We define it here to get around rule restrict-this-access.
+import {PreactBaseElement as AmpPreactBaseElement} from '#preact/base-element';
+import {dict} from '#core/types/object';
 
 /** @const {string} */
 const TAG = 'amp-lightbox';
 
+/**
+ * @param {Element} element
+ * @param {string} eventName
+ */
+function triggerAmpEvent(element, eventName) {
+  const event = createCustomEvent(getWin(element), eventName);
+  Services.actionServiceForDoc(element).trigger(
+    element,
+    eventName,
+    event,
+    ActionTrust_Enum.HIGH
+  );
+}
+
 /** @extends {PreactBaseElement<LightboxDef.Api>} */
-class AmpLightbox extends BaseElement {
+class AmpLightbox extends AmpPreactBaseElement {
   /** @override */
   constructor(element) {
     super(element);
@@ -38,24 +63,11 @@ class AmpLightbox extends BaseElement {
     this.registerApiAction('open', (api) => api.open(), ActionTrust_Enum.LOW);
     this.registerApiAction('close', (api) => api.close(), ActionTrust_Enum.LOW);
 
-    return super.init();
-  }
-
-  /** @override */
-  triggerEvent(element, eventName, detail) {
-    const event = createCustomEvent(
-      getWin(element),
-      `amp-lightbox.${eventName}`,
-      detail
-    );
-    Services.actionServiceForDoc(element).trigger(
-      element,
-      eventName,
-      event,
-      ActionTrust_Enum.HIGH
-    );
-
-    super.triggerEvent(element, eventName, detail);
+    return dict({
+      'onBeforeOpen': () => this.onBeforeOpen_(),
+      'onAfterOpen': () => this.onAfterOpen_(),
+      'onAfterClose': () => this.onAfterClose_(),
+    });
   }
 
   /** @override */
@@ -68,9 +80,14 @@ class AmpLightbox extends BaseElement {
     return super.isLayoutSupported(layout);
   }
 
-  /** @override */
-  afterOpen() {
-    super.afterOpen();
+  /** @private */
+  onBeforeOpen_() {
+    setIsOpen(this.element, true);
+    triggerAmpEvent(this.element, 'open');
+  }
+
+  /** @private */
+  onAfterOpen_() {
     const scroller = this.element.shadowRoot.querySelector('[part=scroller]');
     this.setAsContainer?.(scroller);
 
@@ -79,9 +96,10 @@ class AmpLightbox extends BaseElement {
       .then((historyId) => (this.historyId_ = historyId));
   }
 
-  /** @override */
-  afterClose() {
-    super.afterClose();
+  /** @private */
+  onAfterClose_() {
+    setIsOpen(this.element, false);
+    triggerAmpEvent(this.element, 'close');
     this.removeAsContainer?.();
 
     if (this.historyId_ != null) {
@@ -94,7 +112,24 @@ class AmpLightbox extends BaseElement {
   unmountCallback() {
     this.removeAsContainer?.();
   }
+
+  /** @override */
+  mutationObserverCallback() {
+    this.api().toggle(isOpen(this.element));
+  }
 }
+
+/** @override */
+AmpLightbox['Component'] = Component;
+
+/** @override */
+AmpLightbox['props'] = props;
+
+/** @override */
+AmpLightbox['usesShadowDom'] = usesShadowDom;
+
+/** @override */
+AmpLightbox['shadowCss'] = shadowCss;
 
 AMP.extension(TAG, '1.0', (AMP) => {
   AMP.registerElement(TAG, AmpLightbox, CSS);

--- a/extensions/amp-lightbox/1.0/amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/amp-lightbox.js
@@ -110,7 +110,7 @@ class AmpLightbox extends AmpPreactBaseElement {
 
   /** @override */
   unmountCallback() {
-    this.removeAsContainer?.();
+    this.removeAsContainer();
   }
 
   /** @override */

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -2,14 +2,22 @@ import {PreactBaseElement} from '#preact/base-element';
 import {dict} from '#core/types/object';
 import {
   Component,
-  isOpen,
   props,
   setIsOpen,
   shadowCss,
+  toggleOnMutation,
   usesShadowDom,
 } from './element';
 
 export class BaseElement extends PreactBaseElement {
+  /** @override */
+  constructor(element) {
+    super(element);
+
+    /** @private {boolean} */
+    this.open_ = false;
+  }
+
   /** @override */
   init() {
     return dict({
@@ -20,17 +28,17 @@ export class BaseElement extends PreactBaseElement {
 
   /** @private */
   onBeforeOpen_() {
-    setIsOpen(this.element, true);
+    this.open_ = setIsOpen(this.element, true);
   }
 
   /** @private */
   onAfterClose_() {
-    setIsOpen(this.element, false);
+    this.open_ = setIsOpen(this.element, false);
   }
 
   /** @override */
   mutationObserverCallback() {
-    this.api().toggle(isOpen(this.element));
+    this.open_ = toggleOnMutation(this.element, this.open_);
   }
 }
 

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -3,7 +3,7 @@ import {dict} from '#core/types/object';
 import {
   Component,
   props,
-  setIsOpen,
+  setElementOpen,
   shadowCss,
   toggleOnMutation,
   usesShadowDom,
@@ -28,12 +28,12 @@ export class BaseElement extends PreactBaseElement {
 
   /** @private */
   onBeforeOpen_() {
-    this.open_ = setIsOpen(this.element, true);
+    this.open_ = setElementOpen(this.element, true);
   }
 
   /** @private */
   onAfterClose_() {
-    this.open_ = setIsOpen(this.element, false);
+    this.open_ = setElementOpen(this.element, false);
   }
 
   /** @override */

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -1,75 +1,47 @@
-import {CSS as COMPONENT_CSS} from './component.jss';
-import {BentoLightbox} from './component';
 import {PreactBaseElement} from '#preact/base-element';
 import {dict} from '#core/types/object';
-import {toggle} from '#core/dom/style';
-import {toggleAttribute} from '#core/dom';
-import {unmountAll} from '#core/dom/resource-container-helper';
+import {
+  Component,
+  isOpen,
+  props,
+  setIsOpen,
+  shadowCss,
+  usesShadowDom,
+} from './element';
 
 export class BaseElement extends PreactBaseElement {
-  /** @param {!AmpElement} element */
-  constructor(element) {
-    super(element);
-
-    /** @private {boolean} */
-    this.open_ = false;
-  }
-
   /** @override */
   init() {
     return dict({
-      'onBeforeOpen': () => this.beforeOpen(),
-      'onAfterOpen': () => this.afterOpen(),
-      'onAfterClose': () => this.afterClose(),
+      'onBeforeOpen': () => this.onBeforeOpen_(),
+      'onAfterClose': () => this.onAfterClose_(),
     });
   }
 
-  /** @protected */
-  beforeOpen() {
-    this.open_ = true;
-    toggleAttribute(this.element, 'open', true);
-    toggle(this.element, true);
-    this.triggerEvent(this.element, 'open');
+  /** @private */
+  onBeforeOpen_() {
+    setIsOpen(this.element, true);
   }
 
-  /** @protected */
-  afterOpen() {}
-
-  /** @protected */
-  afterClose() {
-    this.open_ = false;
-    toggleAttribute(this.element, 'open', false);
-    toggle(this.element, false);
-    this.triggerEvent(this.element, 'close');
-
-    // Unmount all children when the lightbox is closed. They will automatically
-    // remount when the lightbox is opened again.
-    unmountAll(this.element, /* includeSelf */ false);
+  /** @private */
+  onAfterClose_() {
+    setIsOpen(this.element, false);
   }
 
   /** @override */
   mutationObserverCallback() {
-    const open = this.element.hasAttribute('open');
-    if (open === this.open_) {
-      return;
-    }
-    this.open_ = open;
-    open ? this.api().open() : this.api().close();
+    this.api().toggle(isOpen(this.element));
   }
 }
 
 /** @override */
-BaseElement['Component'] = BentoLightbox;
+BaseElement['Component'] = Component;
 
 /** @override */
-BaseElement['props'] = {
-  'animation': {attr: 'animation', media: true, default: 'fade-in'},
-  'closeButtonAs': {selector: '[slot="close-button"]', single: true, as: true},
-  'children': {passthrough: true},
-};
+BaseElement['props'] = props;
 
 /** @override */
-BaseElement['usesShadowDom'] = true;
+BaseElement['usesShadowDom'] = usesShadowDom;
 
 /** @override */
-BaseElement['shadowCss'] = COMPONENT_CSS;
+BaseElement['shadowCss'] = shadowCss;

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -70,6 +70,7 @@ function BentoLightboxWithRef(
         setVisible(true);
       },
       close: () => setVisible(false),
+      toggle: (visible) => setVisible(visible),
     }),
     [onBeforeOpenRef]
   );

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -70,7 +70,6 @@ function BentoLightboxWithRef(
         setVisible(true);
       },
       close: () => setVisible(false),
-      toggle: (visible) => setVisible(visible),
     }),
     [onBeforeOpenRef]
   );
@@ -107,9 +106,7 @@ function BentoLightboxWithRef(
       const postInvisibleAnim = () => {
         setStyle(element, 'opacity', 0);
         setStyle(element, 'visibility', 'hidden');
-        if (onAfterCloseRef.current) {
-          onAfterCloseRef.current();
-        }
+        onAfterCloseRef.current?.();
         animation = null;
         setMounted(false);
       };

--- a/extensions/amp-lightbox/1.0/element.js
+++ b/extensions/amp-lightbox/1.0/element.js
@@ -1,0 +1,31 @@
+import {toggle} from '#core/dom/style';
+import {dispatchCustomEvent, toggleAttribute} from '#core/dom';
+import {unmountAll} from '#core/dom/resource-container-helper';
+
+export {CSS as shadowCss} from './component.jss';
+export {BentoLightbox as Component} from './component';
+
+export const usesShadowDom = true;
+export const props = {
+  'animation': {attr: 'animation', media: true, default: 'fade-in'},
+  'closeButtonAs': {selector: '[slot="close-button"]', single: true, as: true},
+  'children': {passthrough: true},
+};
+
+/**
+ * @param {Element} element
+ * @param {boolean} isOpen
+ */
+export function setIsOpen(element, isOpen) {
+  toggleAttribute(element, 'open', isOpen);
+  toggle(element, isOpen);
+  dispatchCustomEvent(element, isOpen ? 'open' : 'close');
+  if (!isOpen) {
+    // Unmount all children when the lightbox is closed. They will automatically
+    // remount when the lightbox is opened again.
+    // TODO(wg-bento): Investigate if this is only needed on the AMP layer.
+    unmountAll(element, /* includeSelf */ false);
+  }
+}
+
+export const isOpen = (element) => element.hasAttribute('open');

--- a/extensions/amp-lightbox/1.0/element.js
+++ b/extensions/amp-lightbox/1.0/element.js
@@ -17,7 +17,7 @@ export const props = {
  * @param {boolean} isOpen
  * @return {boolean}
  */
-export function setIsOpen(element, isOpen) {
+export function setElementOpen(element, isOpen) {
   toggleAttribute(element, 'open', isOpen);
   toggle(element, isOpen);
   dispatchCustomEvent(element, isOpen ? 'open' : 'close');

--- a/extensions/amp-lightbox/1.0/element.js
+++ b/extensions/amp-lightbox/1.0/element.js
@@ -7,7 +7,7 @@ export {BentoLightbox as Component} from './component';
 
 export const usesShadowDom = true;
 export const props = {
-  'animation': {attr: 'animation', media: true, default: 'fade-in'},
+  'animation': {attr: 'animation', media: true},
   'closeButtonAs': {selector: '[slot="close-button"]', single: true, as: true},
   'children': {passthrough: true},
 };
@@ -15,6 +15,7 @@ export const props = {
 /**
  * @param {Element} element
  * @param {boolean} isOpen
+ * @return {boolean}
  */
 export function setIsOpen(element, isOpen) {
   toggleAttribute(element, 'open', isOpen);
@@ -26,6 +27,24 @@ export function setIsOpen(element, isOpen) {
     // TODO(wg-bento): Investigate if this is only needed on the AMP layer.
     unmountAll(element, /* includeSelf */ false);
   }
+  return isOpen;
 }
 
-export const isOpen = (element) => element.hasAttribute('open');
+/**
+ * @param {!Element} element
+ * @param {boolean} wasOpen
+ * @return {boolean}
+ */
+export function toggleOnMutation(element, wasOpen) {
+  const isOpen = element.hasAttribute('open');
+  if (isOpen !== wasOpen) {
+    element.getApi().then((api) => {
+      if (isOpen) {
+        api.open();
+      } else {
+        api.close();
+      }
+    });
+  }
+  return isOpen;
+}

--- a/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
@@ -27,7 +27,7 @@ describes.realWin(
     async function waitForOpen(el, open) {
       const isOpenOrNot = () => el.hasAttribute('open') === open;
       // Extend timeout due to animation delay.
-      await poll('element open updated', isOpenOrNot, undefined, 500);
+      await poll(`element open updated (${open})`, isOpenOrNot, undefined, 500);
     }
 
     function getContent() {


### PR DESCRIPTION
Partial for #36950

Changes hierarchy from: 

![image](https://user-images.githubusercontent.com/254946/142697302-96cce973-f1be-4fd6-8a72-026ee5c936a7.png)

To:

![image](https://user-images.githubusercontent.com/254946/142697316-1538aa28-2226-4bc7-ae19-28470bc67465.png)

This allows us to eventually get here:

![image](https://user-images.githubusercontent.com/254946/142697328-015ae78a-7450-47ce-8ca6-84e4d151448e.png)
