### PR TITLE
♻️🚀 amp-story: Refactor unsupported browser layer for size

### DIFF
--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -109,7 +109,6 @@ export let ShoppingConfigDataDef;
  *    storyHasAudioState: boolean,
  *    storyHasPlaybackUiState: boolean,
  *    storyHasBackgroundAudioState: boolean,
- *    supportedBrowserState: boolean,
  *    systemUiIsVisibleState: boolean,
  *    uiState: !UIType,
  *    viewportWarningState: boolean,
@@ -159,7 +158,6 @@ export const StateProperty = {
   RTL_STATE: 'rtlState',
   SHARE_MENU_STATE: 'shareMenuState',
   SHOPPING_DATA: 'shoppingData',
-  SUPPORTED_BROWSER_STATE: 'supportedBrowserState',
   // Any page has audio, or amp-story has a `background-audio` attribute.
   STORY_HAS_AUDIO_STATE: 'storyHasAudioState',
   // amp-story has a `background-audio` attribute.
@@ -204,8 +202,11 @@ export const Action = {
   TOGGLE_PAUSED: 'togglePaused',
   TOGGLE_RTL: 'toggleRtl',
   TOGGLE_SHARE_MENU: 'toggleShareMenu',
+<<<<<<< HEAD
   ADD_SHOPPING_DATA: 'addShoppingData',
   TOGGLE_SUPPORTED_BROWSER: 'toggleSupportedBrowser',
+=======
+>>>>>>> 936240c3e5 (♻️🚀 amp-story: Refactor unsupported browser layer for size)
   TOGGLE_STORY_HAS_AUDIO: 'toggleStoryHasAudio',
   TOGGLE_STORY_HAS_BACKGROUND_AUDIO: 'toggleStoryHasBackgroundAudio',
   TOGGLE_STORY_HAS_PLAYBACK_UI: 'toggleStoryHasPlaybackUi',
@@ -392,11 +393,6 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ ({
         ...state,
         [StateProperty.KEYBOARD_ACTIVE_STATE]: !!data,
-      });
-    case Action.TOGGLE_SUPPORTED_BROWSER:
-      return /** @type {!State} */ ({
-        ...state,
-        [StateProperty.SUPPORTED_BROWSER_STATE]: !!data,
       });
     case Action.TOGGLE_SHARE_MENU:
       return /** @type {!State} */ ({
@@ -585,7 +581,6 @@ export class AmpStoryStoreService {
       [StateProperty.RTL_STATE]: false,
       [StateProperty.SHARE_MENU_STATE]: false,
       [StateProperty.SHOPPING_DATA]: {},
-      [StateProperty.SUPPORTED_BROWSER_STATE]: true,
       [StateProperty.STORY_HAS_AUDIO_STATE]: false,
       [StateProperty.STORY_HAS_BACKGROUND_AUDIO_STATE]: false,
       [StateProperty.STORY_HAS_PLAYBACK_UI_STATE]: false,

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -202,11 +202,7 @@ export const Action = {
   TOGGLE_PAUSED: 'togglePaused',
   TOGGLE_RTL: 'toggleRtl',
   TOGGLE_SHARE_MENU: 'toggleShareMenu',
-<<<<<<< HEAD
   ADD_SHOPPING_DATA: 'addShoppingData',
-  TOGGLE_SUPPORTED_BROWSER: 'toggleSupportedBrowser',
-=======
->>>>>>> 936240c3e5 (♻️🚀 amp-story: Refactor unsupported browser layer for size)
   TOGGLE_STORY_HAS_AUDIO: 'toggleStoryHasAudio',
   TOGGLE_STORY_HAS_BACKGROUND_AUDIO: 'toggleStoryHasBackgroundAudio',
   TOGGLE_STORY_HAS_PLAYBACK_UI: 'toggleStoryHasPlaybackUi',

--- a/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
+++ b/extensions/amp-story/1.0/amp-story-unsupported-browser-layer.js
@@ -1,37 +1,28 @@
 import * as Preact from '#core/dom/jsx';
-import {Action, getStoreService} from './amp-story-store-service';
 import {CSS} from '../../../build/amp-story-unsupported-browser-layer-1.0.css';
 import {LocalizedStringId_Enum} from '#service/localization/strings';
 import {createShadowRootWithStyle} from './utils';
-import {removeElement} from '#core/dom';
 import {localize} from './amp-story-localization-service';
-
-/** @const {string} Class for the continue anyway button */
-const CONTINUE_ANYWAY_BUTTON_CLASS = 'i-amphtml-continue-button';
 
 /**
  * Full viewport black layer indicating browser is not supported.
- * @param {!Element} element
+ * @param {!Element} context
+ * @param {string} continueAnyway
  * @return {!Element}
  */
-const renderUnsuportedBrowserLayerElement = (element) => (
+const renderContent = (context, continueAnyway) => (
   <div class="i-amphtml-story-unsupported-browser-overlay">
     <div class="i-amphtml-overlay-container">
       <div class="i-amphtml-gear-icon" />
       <div class="i-amphtml-story-overlay-text">
         {localize(
-          element,
+          context,
           LocalizedStringId_Enum.AMP_STORY_WARNING_UNSUPPORTED_BROWSER_TEXT
         )}
       </div>
-      <button
-        // The continue button functionality will only be present in the default
-        // layer. Publisher provided fallbacks will not provide users with the
-        // ability to continue with an unsupported browser
-        class="i-amphtml-continue-button"
-      >
+      <button class="i-amphtml-continue-button" onClick={continueAnyway}>
         {localize(
-          element,
+          context,
           LocalizedStringId_Enum.AMP_STORY_CONTINUE_ANYWAY_BUTTON_LABEL
         )}
       </button>
@@ -40,66 +31,11 @@ const renderUnsuportedBrowserLayerElement = (element) => (
 );
 
 /**
- * Unsupported browser layer UI.
+ * @param {!Element} context
+ * @param {function(Event):void} continueAnyway
+ * @return {!Element}
  */
-export class UnsupportedBrowserLayer {
-  /**
-   * @param {!Window} win
-   */
-  constructor(win) {
-    /** @private @const {!Window} */
-    this.win_ = win;
-
-    /** @private {?Element} */
-    this.root_ = null;
-
-    /** @private {?Element} */
-    this.element_ = null;
-
-    /** @private {?Element} */
-    this.continueButton_ = null;
-
-    /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = getStoreService(this.win_);
-  }
-
-  /**
-   * Builds and appends the component in the story.
-   * @return {*} TODO(#23582): Specify return type
-   */
-  build() {
-    if (this.root_) {
-      return this.root_;
-    }
-    this.root_ = this.win_.document.createElement('div');
-    this.element_ = renderUnsuportedBrowserLayerElement(this.win_.document);
-    createShadowRootWithStyle(this.root_, this.element_, CSS);
-    this.continueButton_ = this.element_./*OK*/ querySelector(
-      `.${CONTINUE_ANYWAY_BUTTON_CLASS}`
-    );
-    this.continueButton_.addEventListener('click', () => {
-      this.storeService_.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, true);
-    });
-    return this.root_;
-  }
-
-  /**
-   * Returns the unsupported browser componenet
-   * @return {?Element} The root element of the componenet
-   */
-  get() {
-    if (!this.root_) {
-      this.build();
-    }
-    return this.root_;
-  }
-
-  /**
-   * Removes the entire layer
-   */
-  removeLayer() {
-    if (this.root_) {
-      removeElement(this.root_);
-    }
-  }
+export function renderUnsupportedBrowserLayer(context, continueAnyway) {
+  const content = renderContent(context, continueAnyway);
+  return createShadowRootWithStyle(<div />, content, CSS);
 }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1791,8 +1791,8 @@ export class AmpStory extends AMP.BaseElement {
   /**
    * Displays the publisher [fallback] element if provided, or renders our own
    * unsupported browser layer.
-   * @private
    * @return {!Promise|undefined}
+   * @private
    */
   displayUnsupportedBrowser_() {
     this.setPausedStateToRestore_();

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -55,7 +55,7 @@ import {Services} from '#service';
 import {ShareMenu} from './amp-story-share-menu';
 import {SwipeXYRecognizer} from '../../../src/gesture-recognizers';
 import {SystemLayer} from './amp-story-system-layer';
-import {UnsupportedBrowserLayer} from './amp-story-unsupported-browser-layer';
+import {renderUnsupportedBrowserLayer} from './amp-story-unsupported-browser-layer';
 import {VisibilityState_Enum} from '#core/constants/visibility-state';
 import {
   childElement,
@@ -81,14 +81,19 @@ import {getLocalizationService} from './amp-story-localization-service';
 import {getMode, isModeDevelopment} from '../../../src/mode';
 import {getHistoryState as getWindowHistoryState} from '#core/window/history';
 import {isExperimentOn} from '#experiments';
+<<<<<<< HEAD
 import {isPreviewMode} from './embed-mode';
 import {isRTL} from '#core/dom';
+=======
+import {isRTL, removeElement} from '#core/dom';
+>>>>>>> 936240c3e5 (♻️🚀 amp-story: Refactor unsupported browser layer for size)
 import {parseQueryString} from '#core/types/string/url';
 import {
   removeAttributeInMutate,
   setAttributeInMutate,
   shouldShowStoryUrlInfo,
 } from './utils';
+import {isEsm} from '#core/mode';
 import {upgradeBackgroundAudio} from './audio';
 import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
 import LocalizedStringsAr from './_locales/ar.json' assert {type: 'json'}; // lgtm[js/syntax-error]
@@ -220,9 +225,6 @@ export class AmpStory extends AMP.BaseElement {
 
     /** Instantiate in case there are embedded components. */
     new AmpStoryEmbeddedComponent(this.win, this.element);
-
-    /** @private @const {!UnsupportedBrowserLayer} */
-    this.unsupportedBrowserLayer_ = new UnsupportedBrowserLayer(this.win);
 
     /** @private {!Array<!./amp-story-page.AmpStoryPage>} */
     this.pages_ = [];
@@ -430,14 +432,7 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   pause_() {
-    // Preserve if previously set. This method can be called several times when
-    // setting the visibilitystate to paused and then inactive.
-    if (this.pausedStateToRestore_ === null) {
-      this.pausedStateToRestore_ = !!this.storeService_.get(
-        StateProperty.PAUSED_STATE
-      );
-    }
-    this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+    this.setPausedStateToRestore_();
     if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
       this.pauseBackgroundAudio_();
     }
@@ -456,14 +451,31 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   resume_() {
+    this.restorePausedState_();
+    if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
+      this.playBackgroundAudio_();
+    }
+  }
+
+  /** @private */
+  setPausedStateToRestore_() {
+    // Preserve if previously set. This method can be called several times when
+    // setting the visibilitystate to paused and then inactive.
+    if (this.pausedStateToRestore_ === null) {
+      this.pausedStateToRestore_ = !!this.storeService_.get(
+        StateProperty.PAUSED_STATE
+      );
+    }
+    this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
+  }
+
+  /** @private */
+  restorePausedState_() {
     this.storeService_.dispatch(
       Action.TOGGLE_PAUSED,
       this.pausedStateToRestore_
     );
     this.pausedStateToRestore_ = null;
-    if (!this.storeService_.get(StateProperty.MUTED_STATE)) {
-      this.playBackgroundAudio_();
-    }
   }
 
   /**
@@ -587,13 +599,6 @@ export class AmpStory extends AMP.BaseElement {
         );
       },
       false /** callToInitialize */
-    );
-
-    this.storeService_.subscribe(
-      StateProperty.SUPPORTED_BROWSER_STATE,
-      (isBrowserSupported) => {
-        this.onSupportedBrowserStateUpdate_(isBrowserSupported);
-      }
     );
 
     this.storeService_.subscribe(StateProperty.ADVANCEMENT_MODE, (mode) => {
@@ -878,8 +883,7 @@ export class AmpStory extends AMP.BaseElement {
   /** @override */
   layoutCallback() {
     if (!AmpStory.isBrowserSupported(this.win) && !this.platform_.isBot()) {
-      this.storeService_.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, false);
-      return Promise.resolve();
+      return this.displayUnsupportedBrowser_();
     }
     return this.layoutStory_();
   }
@@ -1789,50 +1793,31 @@ export class AmpStory extends AMP.BaseElement {
   }
 
   /**
-   * If browser is supported, displays the story. Otherwise, shows either the
-   * default unsupported browser layer or the publisher fallback (if provided).
-   * @param {boolean} isBrowserSupported
+   * Displays the publisher [fallback] element if provided, or renders our own
+   * unsupported browser layer.
    * @private
+   * @return {!Promise|undefined}
    */
-  onSupportedBrowserStateUpdate_(isBrowserSupported) {
-    const fallbackEl = this.getFallback();
-    if (isBrowserSupported) {
-      // Removes the default unsupported browser layer or throws an error
-      // if the publisher has provided their own fallback.
-      if (fallbackEl) {
-        dev().error(
-          TAG,
-          'No handler to exit unsupported browser state on ' +
-            'publisher provided fallback.'
-        );
-      } else {
-        this.layoutStory_().then(() => {
-          this.storeService_.dispatch(
-            Action.TOGGLE_PAUSED,
-            this.pausedStateToRestore_
-          );
-          this.pausedStateToRestore_ = null;
-          this.mutateElement(() => {
-            this.unsupportedBrowserLayer_.removeLayer();
-          });
-        });
-      }
-    } else {
-      this.pausedStateToRestore_ = !!this.storeService_.get(
-        StateProperty.PAUSED_STATE
-      );
-      this.storeService_.dispatch(Action.TOGGLE_PAUSED, true);
-      // Displays the publisher provided fallback or fallbacks to the default
-      // unsupported browser layer.
-      if (fallbackEl) {
-        this.toggleFallback(true);
-      } else {
-        this.unsupportedBrowserLayer_.build();
-        this.mutateElement(() => {
-          this.element.appendChild(this.unsupportedBrowserLayer_.get());
-        });
-      }
+  displayUnsupportedBrowser_() {
+    this.setPausedStateToRestore_();
+    if (this.getFallback()) {
+      this.toggleFallback(true);
+      return;
     }
+    // Provide "continue anyway" button only when rendering our own layer.
+    // Publisher provided fallbacks do not allow users to continue.
+    const continueAnyway = () => {
+      this.layoutStory_().then(() => {
+        this.restorePausedState_();
+        this.mutateElement(() => {
+          removeElement(layer);
+        });
+      });
+    };
+    const layer = renderUnsupportedBrowserLayer(this.element, continueAnyway);
+    return this.mutateElement(() => {
+      this.element.appendChild(layer);
+    });
   }
 
   /**
@@ -2461,6 +2446,13 @@ export class AmpStory extends AMP.BaseElement {
    *     for amp-story.
    */
   static isBrowserSupported(win) {
+    if (isEsm()) {
+      // Browsers that run the ESM build are should support the features
+      // detected below.
+      // If the logic changes so that ESM browsers do not pass support detection,
+      // this optimization should be removed.
+      return true;
+    }
     return Boolean(
       win.CSS &&
         win.CSS.supports &&

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -81,12 +81,8 @@ import {getLocalizationService} from './amp-story-localization-service';
 import {getMode, isModeDevelopment} from '../../../src/mode';
 import {getHistoryState as getWindowHistoryState} from '#core/window/history';
 import {isExperimentOn} from '#experiments';
-<<<<<<< HEAD
 import {isPreviewMode} from './embed-mode';
-import {isRTL} from '#core/dom';
-=======
 import {isRTL, removeElement} from '#core/dom';
->>>>>>> 936240c3e5 (♻️🚀 amp-story: Refactor unsupported browser layer for size)
 import {parseQueryString} from '#core/types/string/url';
 import {
   removeAttributeInMutate,

--- a/extensions/amp-story/1.0/test/test-amp-story-store-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-store-service.js
@@ -106,14 +106,6 @@ describes.fakeWin('amp-story-store-service actions', {}, (env) => {
     expect(listenerSpy).to.have.been.calledWith(true);
   });
 
-  it('should toggle the supported browser state', () => {
-    const listenerSpy = env.sandbox.spy();
-    storeService.subscribe(StateProperty.SUPPORTED_BROWSER_STATE, listenerSpy);
-    storeService.dispatch(Action.TOGGLE_SUPPORTED_BROWSER, false);
-    expect(listenerSpy).to.have.been.calledOnce;
-    expect(listenerSpy).to.have.been.calledWith(false);
-  });
-
   it('should pause the story when displaying the share menu', () => {
     const pausedListenerSpy = env.sandbox.spy();
     storeService.subscribe(StateProperty.PAUSED_STATE, pausedListenerSpy);

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -809,14 +809,13 @@ describes.realWin(
           continueAnywayButton.click();
 
           await poll(
-            'TOGGLE_PAUSED with pausedStateToRestore_',
-            () => dispatchTogglePausedRestore.callCount > 0
+            '.i-amphtml-story-unsupported-browser-overlay is removed',
+            () =>
+              element.querySelector(
+                '.i-amphtml-story-unsupported-browser-overlay'
+              ) == null
           );
-          expect(
-            element.querySelector(
-              '.i-amphtml-story-unsupported-browser-overlay'
-            )
-          ).to.be.null;
+          expect(dispatchTogglePausedRestore).to.have.been.calledOnce;
         });
       });
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -23,6 +23,7 @@ import {registerServiceBuilder} from '../../../../src/service-helpers';
 import {toggleExperiment} from '#experiments';
 import {setImportantStyles} from '#core/dom/style';
 import {waitFor} from '#testing/helpers/service';
+import {poll} from '#testing/iframe';
 
 // Represents the correct value of KeyboardEvent.which for the Right Arrow
 const KEYBOARD_EVENT_WHICH_RIGHT_ARROW = 39;
@@ -768,12 +769,24 @@ describes.realWin(
           await createStoryWithPages(2, ['cover', 'page-4']);
           AmpStory.isBrowserSupported = () => false;
           story = new AmpStory(element);
-          const dispatchSpy = env.sandbox.spy(story.storeService_, 'dispatch');
+          expect(
+            element.querySelector(
+              '.i-amphtml-story-unsupported-browser-overlay'
+            )
+          ).to.be.null;
+          const dispatchTogglePaused = env.sandbox
+            .spy(story.storeService_, 'dispatch')
+            .withArgs(Action.TOGGLE_PAUSED, true);
           await story.layoutCallback();
-          expect(dispatchSpy).to.have.been.calledWith(
-            Action.TOGGLE_SUPPORTED_BROWSER,
-            false
+          await poll(
+            'TOGGLE_PAUSED true',
+            () => dispatchTogglePaused.callCount > 0
           );
+          expect(
+            element.querySelector(
+              '.i-amphtml-story-unsupported-browser-overlay'
+            )
+          ).to.not.be.null;
         });
 
         it('should display the story after clicking "continue" button', async () => {
@@ -781,19 +794,29 @@ describes.realWin(
 
           AmpStory.isBrowserSupported = () => false;
           story = new AmpStory(element);
-          const dispatchSpy = env.sandbox.spy(
-            story.unsupportedBrowserLayer_.storeService_,
-            'dispatch'
-          );
 
           story.buildCallback();
 
           await story.layoutCallback();
-          story.unsupportedBrowserLayer_.continueButton_.click();
-          expect(dispatchSpy).to.have.been.calledWith(
-            Action.TOGGLE_SUPPORTED_BROWSER,
-            true
+
+          const dispatchTogglePausedRestore = env.sandbox
+            .spy(story.storeService_, 'dispatch')
+            .withArgs(Action.TOGGLE_PAUSED, story.pausedStateToRestore_);
+
+          const continueAnywayButton = element.querySelector(
+            '.i-amphtml-story-unsupported-browser-overlay button'
           );
+          continueAnywayButton.click();
+
+          await poll(
+            'TOGGLE_PAUSED with pausedStateToRestore_',
+            () => dispatchTogglePausedRestore.callCount > 0
+          );
+          expect(
+            element.querySelector(
+              '.i-amphtml-story-unsupported-browser-overlay'
+            )
+          ).to.be.null;
         });
       });
 

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -84,6 +84,7 @@ export function ampMediaElementFor(el) {
  * @param  {!Element} container
  * @param  {!Element} element
  * @param  {string} css
+ * @return {!Element}
  */
 export function createShadowRootWithStyle(container, element, css) {
   const style = self.document.createElement('style');
@@ -95,6 +96,7 @@ export function createShadowRootWithStyle(container, element, css) {
 
   containerToUse.appendChild(style);
   containerToUse.appendChild(element);
+  return container;
 }
 
 /**


### PR DESCRIPTION
Refactors Unsupported Browser Layer to minimize bundle size and complexity.

These are compressed size deltas:

### amp-story-1.0.mjs `-0.67kb`

Browsers that run the `module` build support all detected features, so the unsupported browser layer is unnecessary. We strip it out completely.

### amp-story-1.0.js `-0.12kb`

We remove some complexity by encapsulating the layer so that it's cleanly stripped out from the `module` build. As a result, the size of the `nomodule` build also reduces.