### PR TITLE
♻️🚀 amp-story: Refactor service getters for size

### DIFF
--- a/extensions/amp-story/1.0/amp-story-affiliate-link.js
+++ b/extensions/amp-story/1.0/amp-story-affiliate-link.js
@@ -5,7 +5,10 @@ import * as Preact from '#core/dom/jsx';
 
 import {Services} from '#service';
 import {StateProperty, getStoreService} from './amp-story-store-service';
-import {StoryAnalyticsEvent, getAnalyticsService} from './story-analytics';
+import {
+  StoryAnalyticsEvent,
+  triggerStoryAnalyticsEvent,
+} from './story-analytics';
 import {getAmpdoc} from '../../../src/service-helpers';
 
 /**
@@ -46,9 +49,6 @@ export class AmpStoryAffiliateLink {
 
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
     this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win_.document));
-
-    /** @private @const {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, element);
   }
 
   /**
@@ -92,7 +92,8 @@ export class AmpStoryAffiliateLink {
         }
         if (expand) {
           this.element_.removeAttribute('pristine');
-          this.analyticsService_.triggerEvent(
+          triggerStoryAnalyticsEvent(
+            this.win_,
             StoryAnalyticsEvent.FOCUS,
             this.element_
           );
@@ -103,7 +104,8 @@ export class AmpStoryAffiliateLink {
     this.element_.addEventListener('click', (event) => {
       if (this.element_.hasAttribute('expanded')) {
         event.stopPropagation();
-        this.analyticsService_.triggerEvent(
+        triggerStoryAnalyticsEvent(
+          this.win_,
           StoryAnalyticsEvent.CLICK_THROUGH,
           this.element_
         );

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -10,7 +10,7 @@ import {
 import {
   AdvancementMode,
   StoryAnalyticsEvent,
-  getAnalyticsService,
+  triggerStoryAnalyticsEvent,
 } from './story-analytics';
 import {CSS} from '../../../build/amp-story-tooltip-1.0.css';
 import {EventType, dispatch} from './events';
@@ -179,9 +179,6 @@ export class AmpStoryEmbeddedComponent {
     /** @private @const {!../../../src/service/mutator-interface.MutatorInterface} */
     this.mutator_ = Services.mutatorForDoc(getAmpdoc(this.win_.document));
 
-    /** @private @const {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, storyEl);
-
     /** @private @const {!../../../src/service/timer-impl.Timer} */
     this.timer_ = Services.timerFor(this.win_);
 
@@ -254,7 +251,8 @@ export class AmpStoryEmbeddedComponent {
       case EmbeddedComponentState.FOCUSED:
         this.state_ = state;
         this.onFocusedStateUpdate_(component);
-        this.analyticsService_.triggerEvent(
+        triggerStoryAnalyticsEvent(
+          this.win_,
           StoryAnalyticsEvent.FOCUS,
           this.triggeringTarget_
         );
@@ -288,7 +286,8 @@ export class AmpStoryEmbeddedComponent {
       'click',
       (event) => {
         event.stopPropagation();
-        this.analyticsService_.triggerEvent(
+        triggerStoryAnalyticsEvent(
+          this.win_,
           StoryAnalyticsEvent.CLICK_THROUGH,
           this.triggeringTarget_
         );

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -2,7 +2,7 @@ import * as Preact from '#core/dom/jsx';
 import {
   ANALYTICS_TAG_NAME,
   StoryAnalyticsEvent,
-  getAnalyticsService,
+  triggerStoryAnalyticsEvent,
 } from './story-analytics';
 import {
   Action,
@@ -50,9 +50,6 @@ export class InfoDialog {
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(this.win_);
-
-    /** @private {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, parentEl);
 
     /** @private @const {!Element} */
     this.parentEl_ = parentEl;
@@ -147,7 +144,8 @@ export class InfoDialog {
     });
 
     this.element_[ANALYTICS_TAG_NAME] = 'amp-story-info-dialog';
-    this.analyticsService_.triggerEvent(
+    triggerStoryAnalyticsEvent(
+      this.win_,
       isOpen ? StoryAnalyticsEvent.OPEN : StoryAnalyticsEvent.CLOSE,
       this.element_
     );

--- a/extensions/amp-story/1.0/amp-story-page-attachment.js
+++ b/extensions/amp-story/1.0/amp-story-page-attachment.js
@@ -4,7 +4,10 @@ import {DraggableDrawer, DrawerState} from './amp-story-draggable-drawer';
 import {HistoryState, setHistoryState} from './history';
 import {LocalizedStringId_Enum} from '#service/localization/strings';
 import {Services} from '#service';
-import {StoryAnalyticsEvent, getAnalyticsService} from './story-analytics';
+import {
+  StoryAnalyticsEvent,
+  triggerStoryAnalyticsEvent,
+} from './story-analytics';
 import {renderOutlinkLinkIconElement} from './amp-story-open-page-attachment';
 import {closest} from '#core/dom/query';
 import {dev} from '#utils/log';
@@ -65,9 +68,6 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-
-    /** @private @const {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win, this.element);
 
     /** @private @const {!../../../src/service/history-impl.History} */
     this.historyService_ = Services.historyForDoc(this.element);
@@ -355,8 +355,13 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
       this.historyService_.push(() => this.closeInternal_(), historyState);
     }
 
-    this.analyticsService_.triggerEvent(StoryAnalyticsEvent.OPEN, this.element);
-    this.analyticsService_.triggerEvent(
+    triggerStoryAnalyticsEvent(
+      this.win,
+      StoryAnalyticsEvent.OPEN,
+      this.element
+    );
+    triggerStoryAnalyticsEvent(
+      this.win,
       StoryAnalyticsEvent.PAGE_ATTACHMENT_ENTER
     );
 
@@ -451,11 +456,13 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
 
     setHistoryState(this.win, HistoryState.ATTACHMENT_PAGE_ID, null);
 
-    this.analyticsService_.triggerEvent(
+    triggerStoryAnalyticsEvent(
+      this.win,
       StoryAnalyticsEvent.CLOSE,
       this.element
     );
-    this.analyticsService_.triggerEvent(
+    triggerStoryAnalyticsEvent(
+      this.win,
       StoryAnalyticsEvent.PAGE_ATTACHMENT_EXIT
     );
   }

--- a/extensions/amp-story/1.0/amp-story-request-service.js
+++ b/extensions/amp-story/1.0/amp-story-request-service.js
@@ -20,11 +20,10 @@ const TAG = 'amp-story-request-service';
 export class AmpStoryRequestService {
   /**
    * @param {!Window} win
-   * @param {!Element} storyElement
    */
-  constructor(win, storyElement) {
+  constructor(win) {
     /** @private @const {!Element} */
-    this.storyElement_ = storyElement;
+    this.storyElement_ = win.document.querySelector('amp-story');
 
     /** @private @const {!../../../src/service/xhr-impl.Xhr} */
     this.xhr_ = Services.xhrFor(win);
@@ -96,18 +95,9 @@ export class AmpStoryRequestService {
  * service synchronously from the amp-story codebase without running into race
  * conditions.
  * @param  {!Window} win
- * @param  {!Element} storyEl
  * @return {!AmpStoryRequestService}
  */
-export const getRequestService = (win, storyEl) => {
-  let service = Services.storyRequestService(win);
-
-  if (!service) {
-    service = new AmpStoryRequestService(win, storyEl);
-    registerServiceBuilder(win, 'story-request', function () {
-      return service;
-    });
-  }
-
-  return service;
-};
+export function getRequestService(win) {
+  registerServiceBuilder(win, 'story-request', AmpStoryRequestService);
+  return Services.storyRequestService(win);
+}

--- a/extensions/amp-story/1.0/amp-story-share-menu.js
+++ b/extensions/amp-story/1.0/amp-story-share-menu.js
@@ -2,7 +2,7 @@ import * as Preact from '#core/dom/jsx';
 import {
   ANALYTICS_TAG_NAME,
   StoryAnalyticsEvent,
-  getAnalyticsService,
+  triggerStoryAnalyticsEvent,
 } from './story-analytics';
 import {
   Action,
@@ -89,9 +89,6 @@ export class ShareMenu {
 
     /** @private @const {!./amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = getStoreService(this.win_);
-
-    /** @private {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win_, storyEl);
 
     /** @private @const {!Element} */
     this.parentEl_ = storyEl;
@@ -246,7 +243,8 @@ export class ShareMenu {
       });
     }
     this.element_[ANALYTICS_TAG_NAME] = 'amp-story-share-menu';
-    this.analyticsService_.triggerEvent(
+    triggerStoryAnalyticsEvent(
+      this.win_,
       isOpen ? StoryAnalyticsEvent.OPEN : StoryAnalyticsEvent.CLOSE,
       this.element_
     );

--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -175,9 +175,6 @@ export class ShareWidget {
 
     /** @protected {?Element} */
     this.root = null;
-
-    /** @private @const {!./amp-story-request-service.AmpStoryRequestService} */
-    this.requestService_ = getRequestService(this.win, storyEl);
   }
 
   /**
@@ -303,7 +300,8 @@ export class ShareWidget {
       'amp-story-social-share, amp-story-bookend'
     );
 
-    this.requestService_.loadShareConfig(shareEl).then((config) => {
+    const requestService = getRequestService(this.win);
+    requestService.loadShareConfig(shareEl).then((config) => {
       const providers =
         config &&
         (config[SHARE_PROVIDERS_KEY] || config[DEPRECATED_SHARE_PROVIDERS_KEY]);

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -16,18 +16,10 @@ const TAG = 'amp-story';
  * @param  {!Window} win
  * @return {!AmpStoryStoreService}
  */
-export const getStoreService = (win) => {
-  let service = Services.storyStoreService(win);
-
-  if (!service) {
-    service = new AmpStoryStoreService(win);
-    registerServiceBuilder(win, 'story-store', function () {
-      return service;
-    });
-  }
-
-  return service;
-};
+export function getStoreService(win) {
+  registerServiceBuilder(win, 'story-store', AmpStoryStoreService);
+  return Services.storyStoreService(win);
+}
 
 /**
  * Different UI experiences to display the story.

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -24,7 +24,7 @@ import {AdvancementConfig, TapNavigationDirection} from './page-advancement';
 import {
   AdvancementMode,
   StoryAnalyticsEvent,
-  getAnalyticsService,
+  triggerStoryAnalyticsEvent,
 } from './story-analytics';
 import {AmpEvents_Enum} from '#core/constants/amp-events';
 import {AmpStoryAccess} from './amp-story-access';
@@ -201,9 +201,6 @@ export class AmpStory extends AMP.BaseElement {
     if (isRTL(this.win.document)) {
       this.storeService_.dispatch(Action.TOGGLE_RTL, true);
     }
-
-    /** @private {!./story-analytics.StoryAnalyticsService} */
-    this.analyticsService_ = getAnalyticsService(this.win, this.element);
 
     /** @private @const {!AdvancementConfig} */
     this.advancement_ = AdvancementConfig.forElement(this.win, this.element);
@@ -580,7 +577,8 @@ export class AmpStory extends AMP.BaseElement {
       (isMuted) => {
         // We do not want to trigger an analytics event for the initialization of
         // the muted state.
-        this.analyticsService_.triggerEvent(
+        triggerStoryAnalyticsEvent(
+          this.win,
           isMuted
             ? StoryAnalyticsEvent.STORY_MUTED
             : StoryAnalyticsEvent.STORY_UNMUTED
@@ -1061,7 +1059,8 @@ export class AmpStory extends AMP.BaseElement {
     );
     this.viewerMessagingHandler_ &&
       this.viewerMessagingHandler_.send('storyContentLoaded', dict({}));
-    this.analyticsService_.triggerEvent(
+    triggerStoryAnalyticsEvent(
+      this.win,
       StoryAnalyticsEvent.STORY_CONTENT_LOADED
     );
     this.signals().signal(CommonSignals_Enum.INI_LOAD);

--- a/extensions/amp-story/1.0/media-performance-metrics-service.js
+++ b/extensions/amp-story/1.0/media-performance-metrics-service.js
@@ -5,6 +5,7 @@ import {dev} from '#utils/log';
 import {lastChildElement, matches} from '#core/dom/query';
 import {registerServiceBuilder} from '../../../src/service-helpers';
 import {toArray} from '#core/types/array';
+import {once} from '#core/types/function';
 
 /**
  * Media status.
@@ -83,18 +84,14 @@ const TAG = 'media-performance-metrics';
  * @param  {!Window} win
  * @return {!MediaPerformanceMetricsService}
  */
-export const getMediaPerformanceMetricsService = (win) => {
-  let service = Services.mediaPerformanceMetricsService(win);
-
-  if (!service) {
-    service = new MediaPerformanceMetricsService(win);
-    registerServiceBuilder(win, 'media-performance-metrics', function () {
-      return service;
-    });
-  }
-
-  return service;
-};
+export function getMediaPerformanceMetricsService(win) {
+  registerServiceBuilder(
+    win,
+    'media-performance-metrics',
+    MediaPerformanceMetricsService
+  );
+  return Services.mediaPerformanceMetricsService(win);
+}
 
 /**
  * Media performance metrics service.

--- a/extensions/amp-story/1.0/test/test-amp-story-request-service.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-request-service.js
@@ -14,14 +14,14 @@ describes.fakeWin('amp-story-request-service', {amp: true}, (env) => {
     shareElement = env.win.document.createElement('amp-story-social-share');
     storyElement.appendChild(shareElement);
     env.win.document.body.appendChild(storyElement);
-    requestService = new AmpStoryRequestService(env.win, storyElement);
+    requestService = new AmpStoryRequestService(env.win);
     xhrMock = env.sandbox.mock(requestService.xhr_);
   });
 
   it('should not load the config if no src or inline is set', async () => {
     xhrMock.expects('fetchJson').never();
 
-    const config = await requestService.loadConfig(shareElement);
+    const config = await requestService.loadConfig_(shareElement);
 
     expect(JSON.stringify(config)).to.equal('{}');
 
@@ -39,7 +39,7 @@ describes.fakeWin('amp-story-request-service', {amp: true}, (env) => {
     </script>
     `;
 
-    const config = await requestService.loadConfig(shareElement);
+    const config = await requestService.loadConfig_(shareElement);
 
     expect(JSON.stringify(config)).to.equal(JSON.stringify(configData));
     xhrMock.verify();
@@ -60,7 +60,7 @@ describes.fakeWin('amp-story-request-service', {amp: true}, (env) => {
       })
       .once();
 
-    await requestService.loadConfig(shareElement);
+    await requestService.loadConfig_(shareElement);
     xhrMock.verify();
   });
 
@@ -79,7 +79,7 @@ describes.fakeWin('amp-story-request-service', {amp: true}, (env) => {
       })
       .once();
 
-    const config = await requestService.loadConfig(shareElement);
+    const config = await requestService.loadConfig_(shareElement);
     expect(config).to.equal(fetchedConfig);
     xhrMock.verify();
   });
@@ -118,7 +118,7 @@ describes.fakeWin('amp-story-request-service', {amp: true}, (env) => {
       })
       .once();
 
-    const config = await requestService.loadConfig(shareElement);
+    const config = await requestService.loadConfig_(shareElement);
     expect(config).to.equal(fetchedConfig);
     xhrMock.verify();
   });

--- a/extensions/amp-story/1.0/test/test-analytics.js
+++ b/extensions/amp-story/1.0/test/test-analytics.js
@@ -11,9 +11,9 @@ describes.fakeWin('amp-story analytics', {}, (env) => {
     const {win} = env;
 
     rootEl = win.document.createElement('div');
-    storeService = getStoreService(win);
-    analytics = getAnalyticsService(win, rootEl);
     win.document.body.appendChild(rootEl);
+    storeService = getStoreService(win);
+    analytics = getAnalyticsService(rootEl);
     installDocService(win, true);
   });
 
@@ -54,7 +54,7 @@ describes.fakeWin('amp-story analytics', {}, (env) => {
 
     expect(trigger).to.have.been.calledOnceWith('story-page-visible');
 
-    const details = analytics.updateDetails('story-page-visible');
+    const details = analytics.updateDetails_('story-page-visible');
     expect(details.eventDetails).to.deep.equal({});
   });
 

--- a/extensions/amp-story/1.0/variable-service.js
+++ b/extensions/amp-story/1.0/variable-service.js
@@ -23,24 +23,13 @@ export const AnalyticsVariable = {
 };
 
 /**
- * Util function to retrieve the variable service. Ensures we can retrieve the
- * service synchronously from the amp-story codebase without running into race
- * conditions.
  * @param {!Window} win
  * @return {!AmpStoryVariableService}
  */
-export const getVariableService = (win) => {
-  let service = Services.storyVariableService(win);
-
-  if (!service) {
-    service = new AmpStoryVariableService(win);
-    registerServiceBuilder(win, 'story-variable', function () {
-      return service;
-    });
-  }
-
-  return service;
-};
+export function getVariableService(win) {
+  registerServiceBuilder(win, 'story-variable', AmpStoryVariableService);
+  return Services.storyVariableService(win);
+}
 
 /**
  * Variable service for amp-story.

--- a/extensions/amp-story/1.0/variable-service.js
+++ b/extensions/amp-story/1.0/variable-service.js
@@ -23,6 +23,9 @@ export const AnalyticsVariable = {
 };
 
 /**
+ * Util function to retrieve the variable service. Ensures we can retrieve the
+ * service synchronously from the amp-story codebase without running into race
+ * conditions.
  * @param {!Window} win
  * @return {!AmpStoryVariableService}
  */


### PR DESCRIPTION
Refactors service getters to minimize bundle size. 

All deltas compressed:

### `~0.40 kb` — `triggerStoryAnalyticsEvent` 

Wrapping `getAnalyticsService(win).triggerEvent` in a utility function has a large impact in since. It affects most users of this service and minifies into smaller syntax.

### `~0.15 kb` — `registerServiceBuilder`

- Registering a service a second time has no effect. Removes redundant short-circuit.
- Removes wrapper constructors by instantiating all classes only with `(win)`.

### `~0.05 kb` — Methods are private when possible

If a method was only used internally, make it private. This allows the method name to at worst be shortened, and at best fold-in its body into the callsite. 