### PR TITLE
Do not encode CSS SVGs

### DIFF
--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -41,7 +41,7 @@ const cssNanoDefaultOptions = {
   reduceInitial: false,
   zindex: false,
   svgo: {
-    encode: true,
+    encode: false,
   },
 };
 

--- a/extensions/amp-video-docking/0.1/amp-video-docking.css
+++ b/extensions/amp-video-docking/0.1/amp-video-docking.css
@@ -118,7 +118,7 @@
 }
 
 .amp-video-docked-pause {
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23000000'%3E%3Cpath d='M6 19h4V5H6v14zm8-14v14h4V5h-4z'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' width='24px' height='24px' viewBox='0 0 24 24' fill='%23000000'><path d='M6 19h4V5H6v14zm8-14v14h4V5h-4z'/><path d='M0 0h24v24H0z' fill='none'/></svg>");
 }
 
 .amp-video-docked-play {


### PR DESCRIPTION
This should save some bytes on SVGs that appear inside our CSS as `data:image/svg+xml`.