### PR TITLE
✨ Allowlist the usage of the amp-state tag within page attachments

### DIFF
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -1080,6 +1080,7 @@ descendant_tag_list {
   tag: "AMP-SOUNDCLOUD"
   tag: "AMP-SELECTOR"
   tag: "AMP-SPRINGBOARD-PLAYER"
+  tag: "AMP-STATE"
   tag: "AMP-TIMEAGO"
   tag: "AMP-TWITTER"
   tag: "AMP-VIDEO"


### PR DESCRIPTION
MakeStories is using `amp-bind` to show/hide certain form fields depending on user’s inputs. As seen in the `amp-bind` [documentation](https://amp.dev/documentation/components/amp-bind/#%3Camp-state%3E-specification), `amp-state` is generally used in conjunction with `amp-bind`, so we should allow `amp-state` within page attachments.