### PR TITLE
Stable terser mangle via pre-generating mangling

### DIFF
--- a/build-system/pr-check/bundle-size-module-build.js
+++ b/build-system/pr-check/bundle-size-module-build.js
@@ -9,6 +9,7 @@ const {
   storeModuleBuildToWorkspace,
   timedExecOrDie,
 } = require('./utils');
+const {initializeMangleCache} = require('../tasks/helpers');
 const {runCiJob} = require('./ci-job');
 const {Targets, buildTargetsInclude} = require('./build-targets');
 
@@ -18,6 +19,7 @@ const jobName = 'bundle-size-module-build.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
+  initializeMangleCache();
   timedExecOrDie('amp dist --noconfig --esm --version_override 0000000000000');
   storeModuleBuildToWorkspace();
 }

--- a/build-system/pr-check/bundle-size-nomodule-build.js
+++ b/build-system/pr-check/bundle-size-nomodule-build.js
@@ -9,6 +9,7 @@ const {
   storeNomoduleBuildToWorkspace,
   timedExecOrDie,
 } = require('./utils');
+const {initializeMangleCache} = require('../tasks/helpers');
 const {runCiJob} = require('./ci-job');
 const {Targets, buildTargetsInclude} = require('./build-targets');
 
@@ -18,6 +19,7 @@ const jobName = 'bundle-size-nomodule-build.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
+  initializeMangleCache();
   timedExecOrDie('amp dist --noconfig --version_override 0000000000000');
   storeNomoduleBuildToWorkspace();
 }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -647,7 +647,6 @@ async function minify(code, map) {
   // Remove the local variable name cache which should not be reused between binaries.
   // See https://github.com/ampproject/amphtml/issues/36476
   /** @type {any}*/ (nameCache).vars = {};
-  console.log(nameCache);
 
   const minified = await terser.minify(code, terserOptions);
   return {code: minified.code ?? '', map: minified.map};


### PR DESCRIPTION
This is another attempt to solve #37014, this time by finding all mangleable keys and generating a mapping. This removes the build race (where a.js -> b.js and b.js -> a.js generate different name mangling).