### PR TITLE
Stable bundle size by disabling mangle cache

### DIFF
--- a/build-system/pr-check/bundle-size-module-build.js
+++ b/build-system/pr-check/bundle-size-module-build.js
@@ -18,7 +18,9 @@ const jobName = 'bundle-size-module-build.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp dist --noconfig --esm --version_override 0000000000000');
+  timedExecOrDie(
+    'amp dist --noconfig --esm --version_override 0000000000000 --nomanglecache'
+  );
   storeModuleBuildToWorkspace();
 }
 

--- a/build-system/pr-check/bundle-size-nomodule-build.js
+++ b/build-system/pr-check/bundle-size-nomodule-build.js
@@ -18,7 +18,9 @@ const jobName = 'bundle-size-nomodule-build.js';
  * Steps to run during push builds.
  */
 function pushBuildWorkflow() {
-  timedExecOrDie('amp dist --noconfig --version_override 0000000000000');
+  timedExecOrDie(
+    'amp dist --noconfig --version_override 0000000000000 --nomanglecache'
+  );
   storeNomoduleBuildToWorkspace();
 }
 

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -398,6 +398,8 @@ dist.flags = {
     'Output code with whitespace (useful while profiling / debugging production code)',
   fortesting: 'Compile production binaries for local testing',
   noconfig: 'Compile production binaries without applying AMP_CONFIG',
+  nomanglecache:
+    'Do not share the mangle cache between binaries, useful only in estimating size impatcs of code changes.',
   config: 'Set the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   coverage: 'Instrument code for collecting coverage information',
   extensions: 'Build only the listed extensions',

--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -399,7 +399,7 @@ dist.flags = {
   fortesting: 'Compile production binaries for local testing',
   noconfig: 'Compile production binaries without applying AMP_CONFIG',
   nomanglecache:
-    'Do not share the mangle cache between binaries, useful only in estimating size impatcs of code changes.',
+    'Do not share the mangle cache between binaries, useful only in estimating size impacts of code changes.',
   config: 'Set the runtime\'s AMP_CONFIG to one of "prod" or "canary"',
   coverage: 'Instrument code for collecting coverage information',
   extensions: 'Build only the listed extensions',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -536,7 +536,7 @@ const nameCache = {};
 const mangleIdentifier = {
   get(num) {
     const charset =
-      '$ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz0123456789';
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ$_0123456789';
     let base = 54;
     let id = '';
     do {
@@ -578,13 +578,13 @@ async function minify(code, map) {
     sourceMap: {content: map},
     toplevel: true,
     module: !!argv.esm,
-    nameCache,
+    nameCache: argv.nomanglecache ? undefined : nameCache,
   };
   /* eslint-enable local/camelcase */
 
   // Remove the local variable name cache which should not be reused between binaries.
   // See https://github.com/ampproject/amphtml/issues/36476
-  /** @type {any}*/ (nameCache).vars = {};
+  nameCache.vars = undefined;
 
   const minified = await terser.minify(code, terserOptions);
   return {code: minified.code ?? '', map: minified.map};


### PR DESCRIPTION
The mangle cache is necessary when generating multiple binaries which need to interact. However, our bundle size workflow doesn't actually run the code, it just needs to estimate the size impact a PR causes.

Hopefully fixes #37014.