### PR TITLE
🐛 Allowlist amp-carousel 0.2 goToSlide for email

### DIFF
--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -63,6 +63,8 @@ class AmpCarousel extends AMP.BaseElement {
       },
       ActionTrust_Enum.LOW
     );
+    /** If the element is in an email document, allow its `goToSlide` action. */
+    this.action_.addToAllowlist('AMP-CAROUSEL', 'goToSlide', ['email']);
   }
 
   /** @param {!AmpElement} element */


### PR DESCRIPTION
The test code was copied from 0.1 tests:

https://github.com/ampproject/amphtml/blob/5df91d394d6e41a03dba8d3ceb950ed2ba4fe1ea/extensions/amp-carousel/0.1/test/test-slidescroll.js#L1543

/to @samouri 