### PR TITLE
📔 Bento: split code samples into static and dynamic version

### DIFF
--- a/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/amp-__component_name_hyphenated__.md
+++ b/build-system/tasks/make-extension/template/shared/extensions/amp-__component_name_hyphenated__/amp-__component_name_hyphenated__.md
@@ -92,7 +92,7 @@ The example below demonstrates `amp-__component_name_hyphenated__` component in 
 
 #### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
+Bento components are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
 
 The `amp-__component_name_hyphenated__` component API is accessible by including the following script tag in your document:
 

--- a/extensions/amp-accordion/1.0/README.md
+++ b/extensions/amp-accordion/1.0/README.md
@@ -81,6 +81,65 @@ defineBentoAccordion();
         <div>Content in section 3.</div>
       </section>
     </bento-accordion>
+  </body>
+</html>
+```
+
+### Interactivity and API usage
+
+Bento enabled components in standalone use are highly interactive through their API. The `bento-accordion` component API is accessible by including the following script tag in your document:
+
+```javascript
+await customElements.whenDefined('bento-accordion');
+const api = await accordion.getApi();
+```
+
+#### API Example
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-accordion-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-accordion-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-accordion-1.0.css"
+    />
+  </head>
+  <body>
+    <bento-accordion id="my-accordion">
+      <section>
+        <h2>Section 1</h2>
+        <div>Content in section 1.</div>
+      </section>
+      <section>
+        <h2>Section 2</h2>
+        <div>Content in section 2.</div>
+      </section>
+       <!-- Expanded on page load due to attribute: -->
+      <section expanded>
+        <h2>Section 3</h2>
+        <div>Content in section 3.</div>
+      </section>
+    </bento-accordion>
     <script>
       (async () => {
         const accordion = document.querySelector('#my-accordion');
@@ -95,15 +154,6 @@ defineBentoAccordion();
     </script>
   </body>
 </html>
-```
-
-### Interactivity and API usage
-
-Bento enabled components in standalone use are highly interactive through their API. The `bento-accordion` component API is accessible by including the following script tag in your document:
-
-```javascript
-await customElements.whenDefined('bento-accordion');
-const api = await accordion.getApi();
 ```
 
 #### Actions

--- a/extensions/amp-accordion/1.0/README.md
+++ b/extensions/amp-accordion/1.0/README.md
@@ -87,7 +87,7 @@ defineBentoAccordion();
 
 ### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API. The `bento-accordion` component API is accessible by including the following script tag in your document:
+Bento components are highly interactive through their API. The `bento-accordion` component API is accessible by including the following script tag in your document:
 
 ```javascript
 await customElements.whenDefined('bento-accordion');

--- a/extensions/amp-base-carousel/1.0/README.md
+++ b/extensions/amp-base-carousel/1.0/README.md
@@ -84,7 +84,7 @@ defineBentoBaseCarousel();
 
 ### Interactivity and API usage
 
-Bento enabled components used as a standalone web component are highly interactive through their API. The `bento-base-carousel` component API is accessible by including the following script tag in your document:
+Bento components are highly interactive through their API. The `bento-base-carousel` component API is accessible by including the following script tag in your document:
 
 <!--% example %-->
 

--- a/extensions/amp-base-carousel/1.0/README.md
+++ b/extensions/amp-base-carousel/1.0/README.md
@@ -78,6 +78,63 @@ defineBentoBaseCarousel();
       <div class="blue"></div>
       <div class="green"></div>
     </bento-base-carousel>
+  </body>
+</html>
+```
+
+### Interactivity and API usage
+
+Bento enabled components used as a standalone web component are highly interactive through their API. The `bento-base-carousel` component API is accessible by including the following script tag in your document:
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.css"
+    />
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-base-carousel-1.0.js"
+    ></script>
+    <style>
+      bento-base-carousel,
+      bento-base-carousel > div {
+        aspect-ratio: 4/1;
+      }
+      .red {
+        background: darkred;
+      }
+      .blue {
+        background: steelblue;
+      }
+      .green {
+        background: seagreen;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-base-carousel id="my-carousel">
+      <div class="red"></div>
+      <div class="blue"></div>
+      <div class="green"></div>
+    </bento-base-carousel>
     <div class="buttons" style="margin-top: 8px">
       <button id="prev-button">Go to previous slide</button>
       <button id="next-button">Go to next slide</button>
@@ -103,10 +160,6 @@ defineBentoBaseCarousel();
   </body>
 </html>
 ```
-
-### Interactivity and API usage
-
-Bento enabled components used as a standalone web component are highly interactive through their API. The `bento-base-carousel` component API is accessible by including the following script tag in your document:
 
 ```javascript
 await customElements.whenDefined('bento-base-carousel');

--- a/extensions/amp-embedly-card/1.0/README.md
+++ b/extensions/amp-embedly-card/1.0/README.md
@@ -83,25 +83,6 @@ defineBentoEmbedlyCard();
       data-url="https://www.youtube.com/watch?v=LZcKdHinUhE"
     >
     </bento-embedly-card>
-
-    <div class="buttons" style="margin-top: 8px">
-      <button id="change-url">Change embed</button>
-    </div>
-
-    <script>
-      (async () => {
-        const embedlyCard = document.querySelector('#my-url');
-        await customElements.whenDefined('bento-embedly-card');
-
-        // set up button actions
-        document.querySelector('#change-url').onclick = () => {
-          embedlyCard.setAttribute(
-            'data-url',
-            'https://www.youtube.com/watch?v=wcJSHR0US80'
-          );
-        };
-      })();
-    </script>
   </body>
 </html>
 ```
@@ -188,6 +169,83 @@ Allows settings the `dark` theme which changes the background color of the main 
 #### title (optional)
 
 Define a `title` attribute for the component to propagate to the underlying `<iframe>` element. The default value is `"Embedly card"`.
+
+#### API Example
+
+Programmatically changing any of the attribute values, will automatically update the element. For example, by changing the `data-url` value, you can switch to a different embed:
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-embedly-card-1.0.css"
+    />
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-embedly-card-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-embedly-card-1.0.js"
+    ></script>
+    <style>
+      bento-embedly-card {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-embedly-key value="12af2e3543ee432ca35ac30a4b4f656a">
+    </bento-embedly-key>
+
+    <bento-embedly-card
+      data-url="https://twitter.com/AMPhtml/status/986750295077040128"
+      data-card-theme="dark"
+      data-card-controls="0"
+    >
+    </bento-embedly-card>
+
+    <bento-embedly-card
+      id="my-url"
+      data-url="https://www.youtube.com/watch?v=LZcKdHinUhE"
+    >
+    </bento-embedly-card>
+
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-url">Change embed</button>
+    </div>
+
+    <script>
+      (async () => {
+        const embedlyCard = document.querySelector('#my-url');
+        await customElements.whenDefined('bento-embedly-card');
+
+        // set up button actions
+        document.querySelector('#change-url').onclick = () => {
+          embedlyCard.setAttribute(
+            'data-url',
+            'https://www.youtube.com/watch?v=wcJSHR0US80'
+          );
+        };
+      })();
+    </script>
+  </body>
+</html>
+```
 
 ---
 

--- a/extensions/amp-fit-text/1.0/README.md
+++ b/extensions/amp-fit-text/1.0/README.md
@@ -64,23 +64,6 @@ defineBentoFitText();
       Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
       inermis reprehendunt.
     </bento-fit-text>
-    <div class="buttons" style="margin-top: 8px">
-      <button id="font-button">Change max-font-size</button>
-      <button id="content-button">Change content</button>
-    </div>
-
-    <script>
-      (async () => {
-        const fitText = document.querySelector('#my-fit-text');
-        await customElements.whenDefined('bento-fit-text');
-
-        // set up button actions
-        document.querySelector('#font-button').onclick = () =>
-          fitText.setAttribute('max-font-size', '40');
-        document.querySelector('#content-button').onclick = () =>
-          (fitText.textContent = 'new content');
-      })();
-    </script>
   </body>
 </html>
 ```
@@ -153,6 +136,65 @@ Specifies the minimum font size in pixels as an integer that the `bento-fit-text
 #### `max-font-size`
 
 Specifies the maximum font size in pixels as an integer that the `bento-fit-text` can use.
+
+#### API Example
+
+Programmatically changing an attribute value will automatically update the element.
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-fit-text-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-fit-text-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-fit-text-1.0.css"
+    />
+  </head>
+  <body>
+    <bento-fit-text id="my-fit-text">
+      Lorem ipsum dolor sit amet, has nisl nihil convenire et, vim at aeque
+      inermis reprehendunt.
+    </bento-fit-text>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="font-button">Change max-font-size</button>
+      <button id="content-button">Change content</button>
+    </div>
+
+    <script>
+      (async () => {
+        const fitText = document.querySelector('#my-fit-text');
+        await customElements.whenDefined('bento-fit-text');
+
+        // set up button actions
+        document.querySelector('#font-button').onclick = () =>
+          fitText.setAttribute('max-font-size', '40');
+        document.querySelector('#content-button').onclick = () =>
+          (fitText.textContent = 'new content');
+      })();
+    </script>
+  </body>
+</html>
+```
+
 
 ---
 

--- a/extensions/amp-fit-text/1.0/README.md
+++ b/extensions/amp-fit-text/1.0/README.md
@@ -195,7 +195,6 @@ Programmatically changing an attribute value will automatically update the eleme
 </html>
 ```
 
-
 ---
 
 ## Preact/React Component

--- a/extensions/amp-instagram/1.0/README.md
+++ b/extensions/amp-instagram/1.0/README.md
@@ -67,19 +67,6 @@ defineBentoInstagram();
       style="height: 800px; width: 400px"
     >
     </bento-instagram>
-    <button id="change-shortcode">Change shortcode</button>
-
-    <script>
-      (async () => {
-        const instagram = document.querySelector('#my-instagram');
-        await customElements.whenDefined('bento-instagram');
-
-        // set up button actions
-        document.querySelector('#change-shortcode').onclick = () => {
-          instagram.dataset.shortcode = '1totVhIFXl';
-        };
-      })();
-    </script>
   </body>
 </html>
 ```
@@ -128,6 +115,65 @@ The instagram data-shortcode is found in every instagram photo URL. For example,
 #### `data-captioned`
 
 Include the Instagram caption. `bento-instagram` will attempt to resize to the correct height including the caption.
+
+#### API Example
+
+By programmatically changing the `data-shortcode` attribute value, you can dynamically switch to a different post:
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-instagram-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-instagram-1.0.js"
+    ></script>
+    <style>
+      bento-instagram {
+        display: block;
+        overflow: hidden;
+        position: relative;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-instagram
+      id="my-instagram"
+      data-shortcode="CKXYAzuj7TE"
+      data-captioned
+      style="height: 800px; width: 400px"
+    >
+    </bento-instagram>
+    <button id="change-shortcode">Change shortcode</button>
+
+    <script>
+      (async () => {
+        const instagram = document.querySelector('#my-instagram');
+        await customElements.whenDefined('bento-instagram');
+
+        // set up button actions
+        document.querySelector('#change-shortcode').onclick = () => {
+          instagram.dataset.shortcode = '1totVhIFXl';
+        };
+      })();
+    </script>
+  </body>
+</html>
+```
 
 ### Styling
 

--- a/extensions/amp-jwplayer/1.0/README.md
+++ b/extensions/amp-jwplayer/1.0/README.md
@@ -132,7 +132,6 @@ You can use the API to trigger the available actions (`play`, `pause`, `mute`, `
 </html>
 ```
 
-
 ### Layout and style
 
 Each Bento component has a small CSS library you must include to guarantee proper loading without [content shifts](https://web.dev/cls/). Because of order-based specificity, you must manually ensure that stylesheets are included before any custom styles.

--- a/extensions/amp-jwplayer/1.0/README.md
+++ b/extensions/amp-jwplayer/1.0/README.md
@@ -70,7 +70,7 @@ defineBentoJwplayer();
 
 ### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API. The `bento-jwplayer` component API is accessible by including the following script tag in your document:
+Bento components are highly interactive through their API. The `bento-jwplayer` component API is accessible by including the following script tag in your document:
 
 ```javascript
 await customElements.whenDefined('bento-jwplayer');

--- a/extensions/amp-jwplayer/1.0/README.md
+++ b/extensions/amp-jwplayer/1.0/README.md
@@ -64,6 +64,56 @@ defineBentoJwplayer();
       data-media-id="CtaIzmFs"
       style="width: 480px; height: 270px"
     ></bento-jwplayer>
+  </body>
+</html>
+```
+
+### Interactivity and API usage
+
+Bento enabled components in standalone use are highly interactive through their API. The `bento-jwplayer` component API is accessible by including the following script tag in your document:
+
+```javascript
+await customElements.whenDefined('bento-jwplayer');
+const jwplayerApi = await document.querySelector('bento-jwplayer').getApi();
+```
+
+You can use the API to trigger the available actions (`play`, `pause`, `mute`, `unmute`, `requestFullscreen`):
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-jwplayer-1.0.css"
+    />
+  </head>
+  <body>
+    <bento-jwplayer
+      id="jwplayer"
+      data-player-id="BjcwyK37"
+      data-media-id="CtaIzmFs"
+      style="width: 480px; height: 270px"
+    ></bento-jwplayer>
 
     <script>
       (async () => {
@@ -82,14 +132,6 @@ defineBentoJwplayer();
 </html>
 ```
 
-### Interactivity and API usage
-
-Bento enabled components in standalone use are highly interactive through their API. The `bento-jwplayer` component API is accessible by including the following script tag in your document:
-
-```javascript
-await customElements.whenDefined('bento-accordion');
-const api = await document.querySelector('bento-accordion').getApi();
-```
 
 ### Layout and style
 

--- a/extensions/amp-lightbox-gallery/1.0/README.md
+++ b/extensions/amp-lightbox-gallery/1.0/README.md
@@ -107,7 +107,7 @@ In the following example, `<bento-lightbox-gallery>` displays the `alt` value as
 
 ## Interactivity and API usage
 
-Bento enabled components used as a standalone web component are highly interactive through their API. The `bento-lightbox-gallery` component API is accessible by including the following script tag in your document:
+Bento components are highly interactive through their API. The `bento-lightbox-gallery` component API is accessible by including the following script tag in your document:
 
 ```javascript
 await customElements.whenDefined('bento-lightbox-gallery');

--- a/extensions/amp-lightbox/1.0/README.md
+++ b/extensions/amp-lightbox/1.0/README.md
@@ -70,7 +70,7 @@ defineBentoLightbox();
 
 ### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API. The `bento-lightbox` component API is accessible by including the following script tag in your document:
+Bento components are highly interactive through their API. The `bento-lightbox` component API is accessible by including the following script tag in your document:
 
 ```js
 await customElements.whenDefined('bento-lightbox');

--- a/extensions/amp-lightbox/1.0/README.md
+++ b/extensions/amp-lightbox/1.0/README.md
@@ -70,9 +70,7 @@ defineBentoLightbox();
 
 ### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API.
-
-The `bento-lightbox` component API is accessible by including the following script tag in your document:
+Bento enabled components in standalone use are highly interactive through their API.  The `bento-lightbox` component API is accessible by including the following script tag in your document:
 
 ```js
 await customElements.whenDefined('bento-lightbox');
@@ -158,6 +156,57 @@ Defines the style of animation for opening the lightbox. By default, this will b
 #### `scrollable`
 
 When the `scrollable` attribute is present, the content of the lightbox can scroll when overflowing the height of the lightbox.
+
+#### API Example
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-lightbox-1.0.css"
+    />
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-lightbox-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-lightbox-1.0.js"
+    ></script>
+  </head>
+  <body>
+    <bento-lightbox id="my-lightbox">
+      Lightboxed content
+      <button id="close-button">Close lightbox</button>
+    </bento-lightbox>
+    <button id="open-button">Open lightbox</button>
+    <script>
+      (async () => {
+        const lightbox = document.querySelector('#my-lightbox');
+        await customElements.whenDefined('bento-lightbox');
+        const api = await lightbox.getApi();
+
+        // set up button actions
+        document.querySelector('#open-button').onclick = () => api.open();
+        document.querySelector('#close-button').onclick = () => api.close();
+      })();
+    </script>
+  </body>
+</html>
+```
 
 ---
 

--- a/extensions/amp-lightbox/1.0/README.md
+++ b/extensions/amp-lightbox/1.0/README.md
@@ -70,7 +70,7 @@ defineBentoLightbox();
 
 ### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API.  The `bento-lightbox` component API is accessible by including the following script tag in your document:
+Bento enabled components in standalone use are highly interactive through their API. The `bento-lightbox` component API is accessible by including the following script tag in your document:
 
 ```js
 await customElements.whenDefined('bento-lightbox');

--- a/extensions/amp-sidebar/1.0/README.md
+++ b/extensions/amp-sidebar/1.0/README.md
@@ -89,7 +89,7 @@ defineBentoSidebar();
 
 ### Interactivity and API usage
 
-Bento enabled components used as a standalone web component are highly interactive through their API. The `bento-sidebar` component API is accessible by including the following script tag in your document:
+Bento components are highly interactive through their API. The `bento-sidebar` component API is accessible by including the following script tag in your document:
 
 ```javascript
 await customElements.whenDefined('bento-sidebar');

--- a/extensions/amp-social-share/1.0/README.md
+++ b/extensions/amp-social-share/1.0/README.md
@@ -392,7 +392,6 @@ Programmatically changing any of the attribute values will automatically update 
 </html>
 ```
 
-
 ---
 
 ## Preact/React Component

--- a/extensions/amp-social-share/1.0/README.md
+++ b/extensions/amp-social-share/1.0/README.md
@@ -333,6 +333,66 @@ All `data-param-*` prefixed attributes are turned into URL parameters and passed
 
 The description of the button for accessibility. A recommended label is "Share on \<type>".
 
+#### API Example
+
+Programmatically changing any of the attribute values will automatically update the element. For example, by changing the `type` attribute, you can switch between different share providers.
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-social-share-1.0.css"
+    />
+    <script
+      async
+      src="https://cdn.ampproject.org/v0/bento-social-share-1.0.js"
+    ></script>
+    <style>
+      bento-social-share {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-social-share
+      id="my-share"
+      type="twitter"
+      aria-label="Share on Twitter"
+    ></bento-social-share>
+
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-share">Change share button</button>
+    </div>
+
+    <script>
+      (async () => {
+        const socialShare = document.querySelector('#my-share');
+        await customElements.whenDefined('bento-social-share');
+
+        // set up button actions
+        document.querySelector('#change-share').onclick = () => {
+          socialShare.setAttribute('type', 'linkedin');
+          socialShare.setAttribute('aria-label', 'Share on LinkedIn');
+        };
+      })();
+    </script>
+  </body>
+</html>
+```
+
+
 ---
 
 ## Preact/React Component

--- a/extensions/amp-soundcloud/1.0/README.md
+++ b/extensions/amp-soundcloud/1.0/README.md
@@ -247,6 +247,7 @@ Or via `className`:
 ### Props
 
 ##### trackId
+
 This attribute is required if <code>data-playlistid</code> is not defined.
 The value for this attribute is the ID of a track, an integer.
 

--- a/extensions/amp-soundcloud/1.0/README.md
+++ b/extensions/amp-soundcloud/1.0/README.md
@@ -69,23 +69,6 @@ defineBentoSoundcloud();
       data-trackid="89299804"
       data-visual="true"
     ></bento-soundcloud>
-    <div class="buttons" style="margin-top: 8px">
-      <button id="change-track">Change track</button>
-    </div>
-
-    <script>
-      (async () => {
-        const soundcloud = document.querySelector('#my-track');
-        await customElements.whenDefined('bento-soundcloud');
-
-        // set up button actions
-        document.querySelector('#change-track').onclick = () => {
-          soundcloud.setAttribute('data-trackid', '243169232');
-          soundcloud.setAttribute('data-color', 'ff5500');
-          soundcloud.removeAttribute('data-visual');
-        };
-      })();
-    </script>
   </body>
 </html>
 ```
@@ -127,30 +110,88 @@ bento-soundcloud {
 
 ### Attributes
 
-<table>
-  <tr>
-    <td width="40%"><strong>data-trackid</strong></td>
-    <td>This attribute is required if <code>data-playlistid</code> is not defined.<br />
-The value for this attribute is the ID of a track, an integer.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>data-playlistid</strong></td>
-    <td>This attribute is required if <code>data-trackid</code> is not defined.
-The value for this attribute is the ID of a playlist, an integer.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>data-secret-token (optional)</strong></td>
-    <td>The secret token of the track, if it is private.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>data-visual (optional)</strong></td>
-    <td>If set to <code>true</code>, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is <code>false</code>.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>data-color (optional)</strong></td>
-    <td>This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., <code>data-color="e540ff"</code>).</td>
-  </tr>
-</table>
+Programmatically changing one of the attributes will result in the player being automatically updated.
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-soundcloud-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-soundcloud-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-soundcloud-1.0.css"
+    />
+    <style>
+      bento-soundcloud {
+        width: 300px;
+        height: 300px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-soundcloud
+      id="my-track"
+      data-trackid="89299804"
+      data-visual="true"
+    ></bento-soundcloud>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-track">Change track</button>
+    </div>
+
+    <script>
+      (async () => {
+        const soundcloud = document.querySelector('#my-track');
+        await customElements.whenDefined('bento-soundcloud');
+
+        // set up button actions
+        document.querySelector('#change-track').onclick = () => {
+          soundcloud.setAttribute('data-trackid', '243169232');
+          soundcloud.setAttribute('data-color', 'ff5500');
+          soundcloud.removeAttribute('data-visual');
+        };
+      })();
+    </script>
+  </body>
+</html>
+```
+
+##### data-track
+
+This attribute is required if <code>data-playlistid</code> is not defined. The value for this attribute is the ID of a track, an integer.
+
+##### data-playlistid
+
+This attribute is required if <code>data-trackid</code> is not defined. The value for this attribute is the ID of a playlist, an integer.
+
+##### data-secret-token (optional)
+
+The secret token of the track, if it is private.
+
+##### data-visual (optional)
+
+If set to <code>true</code>, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is <code>false</code>.
+
+##### data-color (optional)
+
+This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., <code>data-color="e540ff"</code>).
 
 ---
 
@@ -205,27 +246,23 @@ Or via `className`:
 
 ### Props
 
-<table>
-  <tr>
-    <td width="40%"><strong>trackId</strong></td>
-    <td>This attribute is required if <code>data-playlistid</code> is not defined.<br />
-The value for this attribute is the ID of a track, an integer.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>playlistId</strong></td>
-    <td>This attribute is required if <code>data-trackid</code> is not defined.
-The value for this attribute is the ID of a playlist, an integer.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>secretToken (optional)</strong></td>
-    <td>The secret token of the track, if it is private.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>visual (optional)</strong></td>
-    <td>If set to <code>true</code>, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is <code>false</code>.</td>
-  </tr>
-  <tr>
-    <td width="40%"><strong>color (optional)</strong></td>
-    <td>This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., <code>data-color="e540ff"</code>).</td>
-  </tr>
-</table>
+##### trackId
+This attribute is required if <code>data-playlistid</code> is not defined.
+The value for this attribute is the ID of a track, an integer.
+
+##### playlistId
+
+This attribute is required if <code>data-trackid</code> is not defined.
+The value for this attribute is the ID of a playlist, an integer.
+
+##### secretToken (optional)
+
+The secret token of the track, if it is private.
+
+##### visual (optional)
+
+If set to <code>true</code>, displays full-width "Visual" mode; otherwise, it displays as "Classic" mode. The default value is <code>false</code>.
+
+##### color (optional)
+
+This attribute is a custom color override for the "Classic" mode. The attribute is ignored in "Visual" mode. Specify a hexadecimal color value, without the leading # (e.g., <code>data-color="e540ff"</code>).

--- a/extensions/amp-stream-gallery/1.0/README.md
+++ b/extensions/amp-stream-gallery/1.0/README.md
@@ -69,20 +69,6 @@ defineBentoStreamGallery();
       <div style="height: 100px; background: orange;">F</div>
       <div style="height: 100px; background: fuchsia;">G</div>
     </bento-stream-gallery>
-    <script>
-      (async () => {
-        const streamGallery = document.querySelector('#my-stream-gallery');
-        await customElements.whenDefined('bento-stream-gallery');
-        const api = await streamGallery.getApi();
-
-        // programatically go to next slide
-        api.next();
-        // programatically go to prev slide
-        api.prev();
-        // programatically go to slide
-        api.goToSlide(4);
-      })();
-    </script>
   </body>
 </html>
 ```
@@ -159,6 +145,66 @@ Alternatively, you may also make the light-weight pre-upgrade styles available i
     position: relative;
   }
 </style>
+```
+
+#### API Example
+
+This example demonstrates how to programmatically switch to the next/previous slide and jump to specific slides.
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-stream-gallery-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-stream-gallery-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-stream-gallery-1.0.css"
+    />
+  </head>
+  <body>
+    <bento-stream-gallery id="my-stream-gallery" style="height: 150px;" min-item-width="75" max-item-width="100">
+      <div style="height: 100px; background: red;">A</div>
+      <div style="height: 100px; background: green;">B</div>
+      <div style="height: 100px; background: blue;">C</div>
+      <div style="height: 100px; background: yellow;">D</div>
+      <div style="height: 100px; background: purple;">E</div>
+      <div style="height: 100px; background: orange;">F</div>
+      <div style="height: 100px; background: fuchsia;">G</div>
+    </bento-stream-gallery>
+    <script>
+      (async () => {
+        const streamGallery = document.querySelector('#my-stream-gallery');
+        await customElements.whenDefined('bento-stream-gallery');
+        const api = await streamGallery.getApi();
+
+        // programatically go to next slide
+        api.next();
+        // programatically go to prev slide
+        api.prev();
+        // programatically go to slide
+        api.goToSlide(4);
+      })();
+    </script>
+  </body>
+</html>
 ```
 
 ### Attributes

--- a/extensions/amp-stream-gallery/1.0/README.md
+++ b/extensions/amp-stream-gallery/1.0/README.md
@@ -75,7 +75,7 @@ defineBentoStreamGallery();
 
 ### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API. The `bento-stream-gallery` component API is accessible by including the following script tag in your document:
+Bento components are highly interactive through their API. The `bento-stream-gallery` component API is accessible by including the following script tag in your document:
 
 ```javascript
 await customElements.whenDefined('bento-stream-gallery');

--- a/extensions/amp-timeago/1.0/README.md
+++ b/extensions/amp-timeago/1.0/README.md
@@ -17,7 +17,33 @@ import {defineElement as defineBentoTimeago} from '@bentoproject/timeago';
 defineBentoTimeago();
 ```
 
-### Import via `<script>`
+### Include via `<script>`
+
+```html
+<script
+  type="module"
+  async
+  src="https://cdn.ampproject.org/bento.mjs"
+></script>
+<script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+<script
+  type="module"
+  async
+  src="https://cdn.ampproject.org/v0/bento-timeago-1.0.mjs"
+></script>
+<script
+  nomodule
+  async
+  src="https://cdn.ampproject.org/v0/bento-timeago-1.0.js"
+></script>
+<link
+  rel="stylesheet"
+  type="text/css"
+  href="https://cdn.ampproject.org/v0/bento-timeago-1.0.css"
+/>
+```
+
+### Example
 
 <!--% example %-->
 
@@ -165,6 +191,70 @@ Add the `locale` attribute to specify one of the following values to change the 
 #### `cutoff`
 
 Add the `cutoff` attribute to display the date specified in the `datatime` attribute after passing the specified date in seconds.
+
+#### API Example
+
+By programmatically changing attribute values, you can dynamically change the text or locale:
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-timeago-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-timeago-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-timeago-1.0.css"
+    />
+  </head>
+  <body>
+    <bento-timeago
+      id="my-timeago"
+      datetime="2017-04-11T00:37:33.809Z"
+      locale="en"
+      style="height: 30px"
+    >
+      Saturday 11 April 2017 00.37
+    </bento-timeago>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="ar-button">Change locale to Arabic</button>
+      <button id="en-button">Change locale to English</button>
+      <button id="now-button">Change time to now</button>
+    </div>
+
+    <script>
+      (async () => {
+        const timeago = document.querySelector('#my-timeago');
+
+        // set up button actions
+        document.querySelector('#ar-button').onclick = () =>
+          timeago.setAttribute('locale', 'ar');
+        document.querySelector('#en-button').onclick = () =>
+          timeago.setAttribute('locale', 'en');
+        document.querySelector('#now-button').onclick = () =>
+          timeago.setAttribute('datetime', 'now');
+      })();
+    </script>
+  </body>
+</html>
+```
 
 ---
 

--- a/extensions/amp-twitter/1.0/README.md
+++ b/extensions/amp-twitter/1.0/README.md
@@ -64,23 +64,7 @@ defineBentoTwitters();
     </style>
   </head>
   <body>
-    <bento-twitter id="my-tweet" data-tweetid="885634330868850689">
-    </bento-twitter>
-    <div class="buttons" style="margin-top: 8px">
-      <button id="change-tweet">Change tweet</button>
-    </div>
-
-    <script>
-      (async () => {
-        const twitter = document.querySelector('#my-tweet');
-        await customElements.whenDefined('bento-twitter');
-
-        // set up button actions
-        document.querySelector('#change-tweet').onclick = () => {
-          twitter.setAttribute('data-tweetid', '495719809695621121');
-        };
-      })();
-    </script>
+    <bento-twitter id="my-tweet" data-tweetid="885634330868850689"></bento-twitter>
   </body>
 </html>
 ```
@@ -145,6 +129,66 @@ For details on the available options, see Twitter's docs <a href="https://develo
     <td>Define a <code>title</code> attribute for the component. The default is <code>Twitter</code>.</td>
   </tr>
 </table>
+
+### Interactivity and API usage
+
+Programmatically changing any of the attribute values will automatically update the element. For example, changing the tweet id via `data-tweetid` will automatically load the new tweet:
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-twitter-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-twitter-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-twitter-1.0.css"
+    />
+    <style>
+      bento-twitter {
+        width: 375px;
+        height: 472px;
+      }
+    </style>
+  </head>
+  <body>
+    <bento-twitter id="my-tweet" data-tweetid="885634330868850689">
+    </bento-twitter>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="change-tweet">Change tweet</button>
+    </div>
+
+    <script>
+      (async () => {
+        const twitter = document.querySelector('#my-tweet');
+
+        // set up button actions
+        document.querySelector('#change-tweet').onclick = () => {
+          twitter.setAttribute('data-tweetid', '495719809695621121');
+        };
+      })();
+    </script>
+  </body>
+</html>
+```
+
 
 ---
 

--- a/extensions/amp-twitter/1.0/README.md
+++ b/extensions/amp-twitter/1.0/README.md
@@ -189,7 +189,6 @@ Programmatically changing any of the attribute values will automatically update 
 </html>
 ```
 
-
 ---
 
 ## Preact/React Component

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -54,7 +54,7 @@ To find the standalone version of `amp-video`, see [**`bento-video`**](./1.0/REA
 
 #### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
+Bento components are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
 
 The `amp-video` component API is accessible by including the following script tag in your document:
 

--- a/extensions/amp-video/amp-video.md
+++ b/extensions/amp-video/amp-video.md
@@ -50,8 +50,6 @@ to commit to fully valid AMP. You can take these components and place them
 in implementations with frameworks and CMSs that don't support AMP. Read
 more in our guide [Use AMP components in non-AMP pages](https://amp.dev/documentation/guides-and-tutorials/start/bento_guide/).
 
-To find the standalone version of `amp-video`, see [**`bento-video`**](./1.0/README.md).
-
 #### Interactivity and API usage
 
 Bento components are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).

--- a/extensions/amp-wordpress-embed/1.0/README.md
+++ b/extensions/amp-wordpress-embed/1.0/README.md
@@ -63,23 +63,6 @@ defineBentoWordpressEmbed();
       style="width: 300px; height: 400px"
       data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
     ></bento-wordpress-embed>
-    <div class="buttons" style="margin-top: 8px">
-      <button id="switch-button">Switch embed</button>
-    </div>
-
-    <script>
-      (async () => {
-        const embed = document.querySelector('#my-embed');
-        await customElements.whenDefined('bento-wordpress-embed');
-
-        // set up button actions
-        document.querySelector('#switch-button').onclick = () =>
-          embed.setAttribute(
-            'data-url',
-            'https://make.wordpress.org/core/2021/09/09/core-editor-improvement-cascading-impact-of-improvements-to-featured-images/'
-          );
-      })();
-    </script>
   </body>
 </html>
 ```
@@ -123,7 +106,62 @@ bento-wordpress-embed {
 
 #### data-url (required)
 
-The URL of the post to embed.
+The URL of the post to embed. Programmatically changing the attribute value will automatically update the embedded content.
+
+<!--% example %-->
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/bento.mjs"
+    ></script>
+    <script nomodule src="https://cdn.ampproject.org/bento.js"></script>
+    <script
+      type="module"
+      async
+      src="https://cdn.ampproject.org/v0/bento-wordpress-embed-1.0.mjs"
+    ></script>
+    <script
+      nomodule
+      async
+      src="https://cdn.ampproject.org/v0/bento-wordpress-embed-1.0.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.ampproject.org/v0/bento-wordpress-embed-1.0.css"
+    />
+  </head>
+  <body>
+    <bento-wordpress-embed
+      id="my-embed"
+      style="width: 300px; height: 400px"
+      data-url="https://make.wordpress.org/core/2015/10/28/new-embeds-feature-in-wordpress-4-4/"
+    ></bento-wordpress-embed>
+    <div class="buttons" style="margin-top: 8px">
+      <button id="switch-button">Switch embed</button>
+    </div>
+
+    <script>
+      (async () => {
+        const embed = document.querySelector('#my-embed');
+        await customElements.whenDefined('bento-wordpress-embed');
+
+        // set up button actions
+        document.querySelector('#switch-button').onclick = () =>
+          embed.setAttribute(
+            'data-url',
+            'https://make.wordpress.org/core/2021/09/09/core-editor-improvement-cascading-impact-of-improvements-to-featured-images/'
+          );
+      })();
+    </script>
+  </body>
+</html>
+```
 
 ---
 

--- a/extensions/amp-youtube/amp-youtube.md
+++ b/extensions/amp-youtube/amp-youtube.md
@@ -89,7 +89,7 @@ Bento AMP allows you to use AMP components in non-AMP pages without needing to c
 
 #### Interactivity and API usage
 
-Bento enabled components in standalone use are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
+Bento are highly interactive through their API. In Bento standalone use, the element's API replaces AMP Actions and events and [`amp-bind`](https://amp.dev/documentation/components/amp-bind/?format=websites).
 
 The `amp-youtube` component API is accessible by including the following script tag in your document:
 


### PR DESCRIPTION
This is to keep the first example simple.
