### PR TITLE
esbuild: prioritize "module" over "browser"

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -456,6 +456,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
         incremental: !!options.watch,
         logLevel: 'silent',
         external: options.externalDependencies,
+        mainFields: ['module', 'browser', 'main'],
         write: false,
       });
     } else {

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -236,6 +236,7 @@ class RuntimeTestConfig {
         'process.env.NODE_ENV': '"test"',
       },
       plugins: [importPathPlugin, babelPlugin],
+      mainFields: ['module', 'browser', 'main'],
       sourcemap: 'inline',
     };
   }


### PR DESCRIPTION
**summary**
Partial for https://github.com/ampproject/amphtml/issues/36453

By default esbuild will utilize browser, module, main in that order ([docs]()). This PR swaps the priorities of module/browser for better tree shaking of our dependencies. In particular, this allows for the elision of the [cache-url](https://github.com/ampproject/amp-toolbox/tree/main/packages/cache-url) package.

**size diff**
```diff
- ✔ dist/v0/amp-story-0.1.mjs               73.40 kb   –          353.52 kb  
- ✔ dist/v0/amp-story-1.0.mjs               73.40 kb   –          353.52 kb 
+ ✔ dist/v0/amp-story-0.1.mjs               71.09 kb   –          347.51 kb  
+ ✔ dist/v0/amp-story-1.0.mjs               71.09 kb   –          347.51 kb  
```