### PR TITLE
minification: assume pure getters

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -77,6 +77,7 @@ function getMinifiedConfig() {
     assumptions: {
       constantSuper: true,
       noClassCalls: true,
+      pureGetters: true,
       setClassMethods: true,
     },
   };

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -570,6 +570,7 @@ async function minify(code, map) {
       // Settled on this count by incrementing number until there was no more
       // effect on minification quality.
       passes: 3,
+     'pure_getters': true,
     },
     output: {
       beautify: !!argv.pretty_print,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -570,7 +570,7 @@ async function minify(code, map) {
       // Settled on this count by incrementing number until there was no more
       // effect on minification quality.
       passes: 3,
-     'pure_getters': true,
+      'pure_getters': true,
     },
     output: {
       beautify: !!argv.pretty_print,


### PR DESCRIPTION
**summary**
Partial for https://github.com/ampproject/amphtml/issues/36453

Assume all of our getters are pure in both our babel transforms and terser minification.

```diff
-  ✔ dist/v0.mjs    60.68 kb   –          218.51 kb  
+  ✔ dist/v0.mjs    60.42 kb   –          217.73 kb  
```