### PR TITLE
🏗♻️ Replace `fs.rmdir` with `fs.rm` in build-system

### DIFF
--- a/build-system/tasks/e2e/index.js
+++ b/build-system/tasks/e2e/index.js
@@ -110,7 +110,7 @@ async function fetchCoverage_(outDir) {
   // it can be accessed separately.
 
   // Clear out previous coverage data.
-  fs.rmdirSync(outDir, {recursive: true});
+  fs.rmSync(outDir, {recursive: true});
   fs.mkdirSync(outDir);
 
   const zipFilename = path.join(outDir, 'coverage.zip');

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -518,7 +518,7 @@ async function populateNetWildcard_(tempDir, outputDir) {
  * @return {Promise<void>}
  */
 async function cleanup_(tempDir) {
-  await fs.rmdir(tempDir, {recursive: true});
+  await fs.rm(tempDir, {recursive: true});
 
   logSeparator_();
 }


### PR DESCRIPTION
Following NodeJS deprecation notice [DEP0147](https://nodejs.org/api/deprecations.html#DEP0147)