### PR TITLE
📖 - Update building a bento component build configuration docs

### DIFF
--- a/docs/building-a-bento-amp-extension.md
+++ b/docs/building-a-bento-amp-extension.md
@@ -129,7 +129,7 @@ exports.extensionBundles = [
 ];
 ```
 
-The entry for your component must have `options.wrapper = "bento"`. It may optionally include `options.npm = true` to publish the Preact component portion on npm automatically, following AMP's [release schedule](./release-schedule.md).
+The entry for your component must have `options.bento = true`. It may optionally include `options.npm = true` to publish the Preact component portion on npm automatically, following AMP's [release schedule](./release-schedule.md).
 
 ```diff
 exports.extensionBundles = [
@@ -140,7 +140,7 @@ exports.extensionBundles = [
     "latestVersion": "1.0",
     "options": {
 +     "npm": true,
-+     "wrapper": "bento"
++     "bento": true
     }
   },
 ...


### PR DESCRIPTION
Update documentation around modifying the build config to reference setting the "bento" option key set to `true` instead of using `"wrapper": "bento"` which appears to no longer be correct procedure

