### PR TITLE
🐛 Add support for Wunderkind full width ads

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -1375,6 +1375,7 @@ const adConfig = jsonConfiguration({
   'wunderkind': {
     preconnect: ['https://tag.wknd.ai', 'https://api.bounceexchange.com'],
     renderStartImplemented: true,
+    fullWidthHeightRatio: 4 / 3,
   },
 
   'xlift': {

--- a/extensions/amp-auto-ads/0.1/test/test-wunderkind-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-wunderkind-network-config.js
@@ -64,8 +64,8 @@ describes.realWin(
           'type': 'wunderkind',
           'data-ad': 'wunderkind',
           'layout': 'responsive',
-          'height': '250',
-          'width': '250',
+          'height': '75vw',
+          'width': '100vw',
         });
       });
 
@@ -81,11 +81,8 @@ describes.realWin(
         const adNetwork = getAdNetworkConfig('wunderkind', ampAutoAdsElem);
         expect(adNetwork.getDefaultAdConstraints()).to.deep.equal({
           initialMinSpacing: 500,
-          subsequentMinSpacing: [
-            {adCount: 3, spacing: 1000},
-            {adCount: 6, spacing: 1500},
-          ],
-          maxAdCount: 8,
+          subsequentMinSpacing: [],
+          maxAdCount: 10,
         });
       });
 

--- a/extensions/amp-auto-ads/0.1/wunderkind-network-config.js
+++ b/extensions/amp-auto-ads/0.1/wunderkind-network-config.js
@@ -53,8 +53,8 @@ export class WunderkindNetworkConfig {
       'type': 'wunderkind',
       'data-ad': 'wunderkind',
       'layout': 'responsive',
-      'height': '250',
-      'width': '250',
+      'height': '75vw',
+      'width': '100vw',
     });
     return attributes;
   }
@@ -66,11 +66,8 @@ export class WunderkindNetworkConfig {
     ).getSize().height;
     return {
       initialMinSpacing: viewportHeight,
-      subsequentMinSpacing: [
-        {adCount: 3, spacing: viewportHeight * 2},
-        {adCount: 6, spacing: viewportHeight * 3},
-      ],
-      maxAdCount: 8,
+      subsequentMinSpacing: [],
+      maxAdCount: 10,
     };
   }
 


### PR DESCRIPTION
This PR updates the Wunderkind `amp-ad` and `amp-auto-ads` to support full-width ads.

It also updates spacing and ad count settings per our customers' requests.


Fixes #37068