### PR TITLE
🐛 Add `hidden` attribute to `bento-lightbox` and `bento-sidebar` to prevent FOUC

### DIFF
--- a/extensions/amp-lightbox/1.0/README.md
+++ b/extensions/amp-lightbox/1.0/README.md
@@ -48,7 +48,7 @@ defineBentoLightbox();
     ></script>
   </head>
   <body>
-    <bento-lightbox id="my-lightbox">
+    <bento-lightbox id="my-lightbox" hidden>
       Lightboxed content
       <button id="close-button">Close lightbox</button>
     </bento-lightbox>
@@ -188,7 +188,7 @@ When the `scrollable` attribute is present, the content of the lightbox can scro
     ></script>
   </head>
   <body>
-    <bento-lightbox id="my-lightbox">
+    <bento-lightbox id="my-lightbox" hidden>
       Lightboxed content
       <button id="close-button">Close lightbox</button>
     </bento-lightbox>

--- a/extensions/amp-lightbox/1.0/example/index.html
+++ b/extensions/amp-lightbox/1.0/example/index.html
@@ -40,7 +40,7 @@
     </style>
   </head>
   <body>
-    <bento-lightbox id="my-lightbox">
+    <bento-lightbox id="my-lightbox" hidden>
       <div class="lightbox-content">
         <h1>Lightboxed content</h1>
         <button id="close-button">Close lightbox</button>

--- a/extensions/amp-sidebar/1.0/README.md
+++ b/extensions/amp-sidebar/1.0/README.md
@@ -58,7 +58,7 @@ defineBentoSidebar();
     />
   </head>
   <body>
-    <bento-sidebar id="sidebar1" side="right">
+    <bento-sidebar id="sidebar1" side="right" hidden>
       <ul>
         <li>Nav item 1</li>
         <li>Nav item 2</li>

--- a/extensions/amp-sidebar/1.0/example/index.html
+++ b/extensions/amp-sidebar/1.0/example/index.html
@@ -94,7 +94,7 @@
       </svg>
     </button>
 
-    <bento-sidebar id="sidebar1" side="left">
+    <bento-sidebar id="sidebar1" side="left" hidden>
       <button id="close-sidebar">
         <svg
           xmlns="http://www.w3.org/2000/svg"

--- a/test/fixtures/e2e/bento/lightbox.html
+++ b/test/fixtures/e2e/bento/lightbox.html
@@ -15,7 +15,7 @@
   <body>
     <button id="open-button">Open</button>
     <button id="close-button">Close</button>
-    <bento-lightbox id="my-lightbox">
+    <bento-lightbox id="my-lightbox" hidden>
       <p>Test</p>
       <button slot="close-button">Close</button>
     </bento-lightbox>


### PR DESCRIPTION
See https://github.com/ampproject/bento.dev/pull/131:

<blockquote cite="https://github.com/ampproject/bento.dev/pull/131">

Since `bento-lightbox` and `bento-sidebar` have these [style](https://github.com/ampproject/amphtml/blob/b78e8781ff3976b3bff1ba881cf66dd2609b5c07/extensions/amp-sidebar/1.0/amp-sidebar.css#L3-L6) [rules](https://github.com/ampproject/amphtml/blob/b78e8781ff3976b3bff1ba881cf66dd2609b5c07/extensions/amp-lightbox/1.0/amp-lightbox.css#L3-L6):

```css
/* Pre-upgrade: not displayed */
amp-sidebar[hidden] {
  display: none !important;
}
```

```css
/* Pre-upgrade: not displayed */
amp-lightbox[hidden] {
  display: none !important;
}
```

If the `amp-sidebar` or `amp-lightbox` does not initially have the `hidden` attribute, then there is a flash of unstyled content (FOUC):

https://user-images.githubusercontent.com/134745/143930228-3a1dc5d7-f97f-4190-8e4d-ccca50680de8.mov

https://user-images.githubusercontent.com/134745/143930232-2bd90a29-1ce0-4ed7-a5da-c34688d8d609.mov

So these elements should always have `hidden` supplied initially.

</blockquote>