### PR TITLE
✨ Add Denakop to RTC callout vendors

### DIFF
--- a/src/service/real-time-config/callout-vendors.js
+++ b/src/service/real-time-config/callout-vendors.js
@@ -189,6 +189,11 @@ const RTC_VENDORS = jsonConfiguration({
     macros: ['PLACEMENT_ID', 'CONSENT_STRING', 'ACCOUNT_ID'],
     disableKeyAppend: true,
   },
+  denakop: {
+    url: 'https://ib.adnxs.com/prebid/amp?tag_id=PLACEMENT_ID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&gdpr_consent=CONSENT_STRING&account=ACCOUNT_ID&gdpr_applies=CONSENT_METADATA(gdprApplies)&addtl_consent=CONSENT_METADATA(additionalConsent)&consent_type=CONSENT_METADATA(consentStringType)',
+    macros: ['PLACEMENT_ID', 'CONSENT_STRING', 'ACCOUNT_ID'],
+    disableKeyAppend: true,
+  },
   prebidflux: {
     url: 'https://prebid-server.flux-adserver.com/openrtb2/amp?tag_id=TAG_ID',
     macros: ['TAG_ID'],


### PR DESCRIPTION
Denakop (https://denakop.com/) has developed its own Prebid Server solution with AMP support to deliver Ads on AMP pages. With this Vendor's URL, any publisher will have the possibility of monetizing Ads on his site.

- Add Denakop as a vendor to RTC config