### PR TITLE
🐛 [Story share] Fix revert of gplus share breaking

### DIFF
--- a/extensions/amp-story/1.0/amp-story-share.js
+++ b/extensions/amp-story/1.0/amp-story-share.js
@@ -93,10 +93,12 @@ function renderLinkShareItemElement(el, onClick) {
  * @return {!Element}
  */
 function buildProvider(doc, shareType) {
-  const shareProviderLocalizedStringId = devAssert(
-    SHARE_PROVIDER_LOCALIZED_STRING_ID[shareType],
-    `No localized string to display name for share type ${shareType}.`
-  );
+  const shareProviderLocalizedStringId =
+    SHARE_PROVIDER_LOCALIZED_STRING_ID[shareType];
+
+  if (!shareProviderLocalizedStringId) {
+    return;
+  }
 
   return (
     <amp-social-share


### PR DESCRIPTION
https://github.com/ampproject/amphtml/pull/36706/files#diff-1a75bd277e850aafaf99b8e6fde8d8d2dc44176907b94e91a70217216d26861cR96 introduced a bug where specifying the `gplus` sharing option (unsupported) will error, and not show the share options after it. When specifying an unsupported share option, we shouldn't break, just omit it.