### PR TITLE
♻️ Prevent `VideoInterface` class from being bundled

### DIFF
--- a/src/video-interface.js
+++ b/src/video-interface.js
@@ -18,6 +18,12 @@ export const MIN_VISIBILITY_RATIO_FOR_AUTOPLAY = 0.5;
  * @interface
  */
 export class VideoInterface {
+  /** @return {!AmpElement} */
+  get element() {}
+
+  /** @return {!Window} */
+  get win() {}
+
   /**
    * See `BaseElement`.
    * @return {!./utils/signals.Signals}
@@ -181,12 +187,6 @@ export class VideoInterface {
    */
   seekTo(unusedTimeSeconds) {}
 }
-
-/** @type {!AmpElement} */
-VideoInterface.prototype.element;
-
-/** @type {!Window} */
-VideoInterface.prototype.win;
 
 /**
  * Attributes


### PR DESCRIPTION
`esbuild` lacks the `@interface` concept from Closure. As a result, it believes that `VideoInterface.prototype.element;` could have side effects, and preserves the empty class. Bundles that import utilities from `src/video-interface.js` include this useless class.

We avoid this issue by defining dynamic getters instead. 
