### PR TITLE
♻️🚀 Remove side-effect bloat from `amp-story` bundle

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -1,4 +1,5 @@
 import * as Preact from '#core/dom/jsx';
+import {AMP_STORY_PLAYER_EVENT} from '../../../src/amp-story-player/event';
 import {
   Action,
   StateProperty,
@@ -869,7 +870,7 @@ export class SystemLayer {
       this.viewerMessagingHandler_.send(
         'documentStateUpdate',
         dict({
-          'state': 'AMP_STORY_PLAYER_EVENT',
+          'state': AMP_STORY_PLAYER_EVENT,
           'value': eventName,
         })
       );

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -1,5 +1,4 @@
 import * as Preact from '#core/dom/jsx';
-import {AMP_STORY_PLAYER_EVENT} from '../../../src/amp-story-player/amp-story-player-impl';
 import {
   Action,
   StateProperty,
@@ -870,7 +869,7 @@ export class SystemLayer {
       this.viewerMessagingHandler_.send(
         'documentStateUpdate',
         dict({
-          'state': AMP_STORY_PLAYER_EVENT,
+          'state': 'AMP_STORY_PLAYER_EVENT',
           'value': eventName,
         })
       );

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -16,6 +16,7 @@ import {parseQueryString} from '#core/types/string/url';
 import {createCustomEvent, listenOnce} from '#utils/event-helper';
 
 import {AmpStoryPlayerViewportObserver} from './amp-story-player-viewport-observer';
+import {AMP_STORY_PLAYER_EVENT} from './event';
 import {PageScroller} from './page-scroller';
 
 import {cssText} from '../../build/amp-story-player-shadow.css';
@@ -102,9 +103,6 @@ const STORY_MESSAGE_STATE_TYPE_ENUM = {
   CURRENT_PAGE_ID: 'CURRENT_PAGE_ID',
   STORY_PROGRESS: 'STORY_PROGRESS',
 };
-
-/** @const {string} */
-export const AMP_STORY_PLAYER_EVENT = 'AMP_STORY_PLAYER_EVENT';
 
 /** @const {string} */
 const CLASS_NO_NAVIGATION_TRANSITION =

--- a/src/amp-story-player/event.js
+++ b/src/amp-story-player/event.js
@@ -1,0 +1,2 @@
+/** @const {string} */
+export const AMP_STORY_PLAYER_EVENT = 'AMP_STORY_PLAYER_EVENT';


### PR DESCRIPTION
By importing `AMP_STORY_PLAYER_EVENT` (whose value equals its name), we're accidentally bundling all of `@ampproject/toolbox-cache-url`. It's equivalent to `2.30 kb` compressed (!!!)

Closure knew how to remove this code, but esbuild does not. We move the string to a standalone file.
