### PR TITLE
Use CloseWatcher API in amp-lightbox 0.1

### DIFF
--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -261,6 +261,7 @@ class AmpLightbox extends AMP.BaseElement {
   /**
    * @param {!ActionTrust_Enum} trust
    * @param {?Element} openerElement
+   * @return {!Promise}
    * @private
    */
   open_(trust, openerElement) {
@@ -281,7 +282,7 @@ class AmpLightbox extends AMP.BaseElement {
     }
 
     const {promise, resolve} = new Deferred();
-    this.getViewport()
+    return this.getViewport()
       .enterLightboxMode(this.element, promise)
       .then(() => this.finalizeOpen_(resolve, trust));
   }

--- a/extensions/amp-lightbox/0.1/amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/amp-lightbox.js
@@ -28,6 +28,7 @@ import {realChildElements} from '#core/dom/query';
 import {toArray} from '#core/types/array';
 import {tryFocus} from '#core/dom';
 import {unmountAll} from '#core/dom/resource-container-helper';
+import {CloseWatcherImpl} from '#utils/close-watcher-impl';
 
 /** @const {string} */
 const TAG = 'amp-lightbox';
@@ -99,14 +100,11 @@ class AmpLightbox extends AMP.BaseElement {
     /** @private {?../../../src/service/action-impl.ActionService} */
     this.action_ = null;
 
-    /** @private {number} */
-    this.historyId_ = -1;
+    /** @private {?CloseWatcherImpl} */
+    this.closeWatcher_ = null;
 
     /** @private {boolean} */
     this.active_ = false;
-
-    /**  @private {?function(this:AmpLightbox, Event)}*/
-    this.boundCloseOnEscape_ = null;
 
     /**  @private {?function(this:AmpLightbox, Event)}*/
     this.boundCloseOnEnter_ = null;
@@ -270,14 +268,6 @@ class AmpLightbox extends AMP.BaseElement {
       return;
     }
     this.initialize_();
-    this.boundCloseOnEscape_ =
-      /** @type {?function(this:AmpLightbox, Event)} */ (
-        this.closeOnEscape_.bind(this)
-      );
-    this.document_.documentElement.addEventListener(
-      'keydown',
-      this.boundCloseOnEscape_
-    );
     this.boundFocusin_ = /** @type {?function(this:AmpLightbox)} */ (
       this.onFocusin_.bind(this)
     );
@@ -385,11 +375,9 @@ class AmpLightbox extends AMP.BaseElement {
     owners.scheduleResume(this.element, container);
     this.triggerEvent_(LightboxEvents.OPEN, trust);
 
-    this.getHistory_()
-      .push((unused) => this.close(trust))
-      .then((historyId) => {
-        this.historyId_ = historyId;
-      });
+    this.closeWatcher_ = new CloseWatcherImpl(this.getAmpDoc(), () =>
+      this.close(ActionTrust_Enum.HIGH)
+    );
 
     this.maybeRenderCloseButtonHeader_();
     this.focusInModal_();
@@ -510,19 +498,6 @@ class AmpLightbox extends AMP.BaseElement {
   }
 
   /**
-   * Handles closing the lightbox when the ESC key is pressed.
-   * @param {!Event} event
-   * @private
-   */
-  closeOnEscape_(event) {
-    if (event.key == Keys_Enum.ESCAPE) {
-      event.preventDefault();
-      // Keypress gesture is high trust.
-      this.close(ActionTrust_Enum.HIGH);
-    }
-  }
-
-  /**
    * Handles closing the lightbox when the enter key is pressed.
    * Need it for i-amphtml-ad-close-header
    * @param {!Event} event
@@ -587,14 +562,10 @@ class AmpLightbox extends AMP.BaseElement {
       assertDoesNotContainDisplay(this.getAnimationPresetDef_().closedStyle)
     );
 
-    if (this.historyId_ != -1) {
-      this.getHistory_().pop(this.historyId_);
+    if (this.closeWatcher_) {
+      this.closeWatcher_.destroy();
+      this.closeWatcher_ = null;
     }
-    this.document_.documentElement.removeEventListener(
-      'keydown',
-      this.boundCloseOnEscape_
-    );
-    this.boundCloseOnEscape_ = null;
 
     this.document_.documentElement.removeEventListener(
       'focusin',
@@ -860,15 +831,6 @@ class AmpLightbox extends AMP.BaseElement {
       };
     }
     return this.size_;
-  }
-
-  /**
-   * Returns the history for the ampdoc.
-   *
-   * @return {!../../../src/service/history-impl.History}
-   */
-  getHistory_() {
-    return Services.historyForDoc(this.getAmpDoc());
   }
 
   /**

--- a/extensions/amp-lightbox/0.1/test/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/0.1/test/test-amp-lightbox.js
@@ -2,7 +2,6 @@ import '../amp-lightbox';
 import * as dom from '#core/dom';
 import {ActionService} from '#service/action-impl';
 import {ActionTrust_Enum} from '#core/constants/action-constants';
-import {Keys_Enum} from '#core/constants/key-codes';
 import {Services} from '#service';
 import {whenCalled} from '#testing/helpers/service';
 import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
@@ -104,25 +103,16 @@ describes.realWin(
       });
     });
 
-    it('should close on ESC', async () => {
+    it('should close on close-watcher signal', async () => {
       const lightbox = createLightbox();
       const impl = await lightbox.getImpl(true);
-      impl.getHistory_ = () => {
-        return {
-          pop: () => {},
-          push: () => Promise.resolve(11),
-        };
-      };
 
       const sourceElement = createOpeningButton('openBtn');
       const setupCloseSpy = env.sandbox.spy(impl, 'close');
 
-      impl.open_({caller: sourceElement});
-      impl.closeOnEscape_(new KeyboardEvent('keydown', {key: Keys_Enum.ENTER}));
-      impl.closeOnEscape_(
-        new KeyboardEvent('keydown', {key: Keys_Enum.ESCAPE})
-      );
-      expect(setupCloseSpy).to.be.calledOnce;
+      await impl.open_({caller: sourceElement});
+      impl.closeWatcher_.signalClosed();
+      expect(setupCloseSpy).to.be.called;
     });
 
     it('should not change focus or create a button if a focus has been made in the modal', async () => {

--- a/src/utils/close-watcher-impl.js
+++ b/src/utils/close-watcher-impl.js
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Support for the CloseWatcher API that fallbacks to the
+ * history service.
+ * See https://github.com/WICG/close-watcher.
+ */
+
+import {Keys_Enum} from '#core/constants/key-codes';
+
+import {Services} from '#service';
+
+import {dev, devAssert} from '#utils/log';
+
+const TAG = 'CloseWatcherImpl';
+
+export class CloseWatcherImpl {
+  /**
+   * @param {!../service/ampdoc-impl.AmpDoc} ampdoc
+   * @param {function()} handler
+   */
+  constructor(ampdoc, handler) {
+    const {win} = ampdoc;
+
+    /** @private @const */
+    this.win_ = win;
+
+    /** @private @const */
+    this.handler_ = handler;
+
+    /** @private {?CloseWatcher} */
+    this.watcher_ = null;
+
+    /** @private {?../service/history-impl.History} */
+    this.history_ = null;
+
+    /** @private {number} */
+    this.historyId_ = -1;
+
+    /** @private {?function()} */
+    this.boundCloseOnEscape_ = null;
+
+    if (typeof win.CloseWatcher === 'function') {
+      try {
+        this.watcher_ = new win.CloseWatcher();
+      } catch (e) {
+        dev().error(TAG, 'CloseWatcher failed:', e);
+      }
+    }
+    if (this.watcher_) {
+      this.watcher_.onclose = () => {
+        handler();
+        this.destroy();
+      };
+    } else {
+      this.history_ = Services.historyForDoc(ampdoc);
+      this.history_
+        .push(() => handler())
+        .then((historyId) => {
+          this.historyId_ = historyId;
+        });
+      this.boundCloseOnEscape_ = this.closeOnEscape_.bind(this);
+      win.document.documentElement.addEventListener(
+        'keydown',
+        this.boundCloseOnEscape_
+      );
+    }
+  }
+
+  /**
+   * Signals to the close watcher to close the modal.
+   * See `CloseWatcher.signalClosed`.
+   */
+  signalClosed() {
+    if (this.watcher_) {
+      this.watcher_.signalClosed();
+    } else if (this.handler_) {
+      const handler = this.handler_;
+      handler();
+      this.destroy();
+    }
+  }
+
+  /**
+   * Destroys the watcher.
+   * See `CloseWatcher.destroy`.
+   */
+  destroy() {
+    this.handler_ = null;
+    if (this.watcher_) {
+      this.watcher_.destroy();
+      this.watcher_ = null;
+    } else if (this.historyId_ != -1) {
+      devAssert(this.history_).pop(this.historyId_);
+      this.historyId_ = -1;
+      this.history_ = null;
+      this.win_.document.documentElement.removeEventListener(
+        'keydown',
+        this.boundCloseOnEscape_
+      );
+    }
+  }
+
+  /**
+   * @param {!Event} event
+   * @private
+   */
+  closeOnEscape_(event) {
+    if (event.key == Keys_Enum.ESCAPE) {
+      event.preventDefault();
+      this.signalClosed();
+    }
+  }
+}

--- a/src/utils/close-watcher.extern.js
+++ b/src/utils/close-watcher.extern.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Externs for CloseWatcher class.
+ * See https://github.com/WICG/close-watcher.
+ *
+ * TODO(dvoytenko): remove CloseWatcher once it's added in Closure externs.
+ *
+ * @externs
+ */
+
+/** @constructor */
+function CloseWatcher() {}
+
+CloseWatcher.prototype.destroy = function () {};
+
+CloseWatcher.prototype.signalClosed = function () {};
+
+/** @type {?function(!Event)} */
+CloseWatcher.prototype.onclose;
+
+/** @type {?function(!Event)} */
+CloseWatcher.prototype.oncancel;

--- a/test/unit/utils/test-close-watcher-impl.js
+++ b/test/unit/utils/test-close-watcher-impl.js
@@ -1,6 +1,8 @@
-import {CloseWatcherImpl} from '#utils/close-watcher-impl';
-import {Services} from '#service';
 import {Keys_Enum} from '#core/constants/key-codes';
+
+import {Services} from '#service';
+
+import {CloseWatcherImpl} from '#utils/close-watcher-impl';
 
 describes.realWin('#CloseWatcherImpl', {amp: true}, (env) => {
   let doc, win, ampdoc;
@@ -23,14 +25,8 @@ describes.realWin('#CloseWatcherImpl', {amp: true}, (env) => {
   });
 
   it('should push and pop history state', async () => {
-    historyMock
-      .expects('push')
-      .resolves('H1')
-      .once();
-    historyMock
-      .expects('pop')
-      .withArgs('H1')
-      .once();
+    historyMock.expects('push').resolves('H1').once();
+    historyMock.expects('pop').withArgs('H1').once();
     const watcher = new CloseWatcherImpl(ampdoc, handler);
     await Promise.resolve('H1');
     watcher.signalClosed();
@@ -41,13 +37,15 @@ describes.realWin('#CloseWatcherImpl', {amp: true}, (env) => {
     let popHandler;
     historyMock
       .expects('push')
-      .withArgs(sinon.match((a) => {
-        popHandler = a;
-        return true;
-      }))
+      .withArgs(
+        env.sandbox.match((a) => {
+          popHandler = a;
+          return true;
+        })
+      )
       .resolves('H1')
       .once();
-    const watcher = new CloseWatcherImpl(ampdoc, handler);
+    new CloseWatcherImpl(ampdoc, handler);
     await Promise.resolve('H1');
     expect(popHandler).to.exist;
     popHandler();
@@ -55,15 +53,9 @@ describes.realWin('#CloseWatcherImpl', {amp: true}, (env) => {
   });
 
   it('should trigger on ESC key', async () => {
-    historyMock
-      .expects('push')
-      .resolves('H1')
-      .once();
-    historyMock
-      .expects('pop')
-      .withArgs('H1')
-      .once();
-    const watcher = new CloseWatcherImpl(ampdoc, handler);
+    historyMock.expects('push').resolves('H1').once();
+    historyMock.expects('pop').withArgs('H1').once();
+    new CloseWatcherImpl(ampdoc, handler);
     await Promise.resolve('H1');
 
     doc.documentElement.dispatchEvent(

--- a/test/unit/utils/test-close-watcher-impl.js
+++ b/test/unit/utils/test-close-watcher-impl.js
@@ -1,0 +1,74 @@
+import {CloseWatcherImpl} from '#utils/close-watcher-impl';
+import {Services} from '#service';
+import {Keys_Enum} from '#core/constants/key-codes';
+
+describes.realWin('#CloseWatcherImpl', {amp: true}, (env) => {
+  let doc, win, ampdoc;
+  let historyMock;
+  let handler;
+
+  beforeEach(() => {
+    win = env.win;
+    doc = win.document;
+    ampdoc = env.ampdoc;
+
+    const history = Services.historyForDoc(ampdoc);
+    historyMock = env.sandbox.mock(history);
+
+    handler = env.sandbox.spy();
+  });
+
+  afterEach(() => {
+    historyMock.verify();
+  });
+
+  it('should push and pop history state', async () => {
+    historyMock
+      .expects('push')
+      .resolves('H1')
+      .once();
+    historyMock
+      .expects('pop')
+      .withArgs('H1')
+      .once();
+    const watcher = new CloseWatcherImpl(ampdoc, handler);
+    await Promise.resolve('H1');
+    watcher.signalClosed();
+    expect(handler).to.be.calledOnce;
+  });
+
+  it('should trigger on history pop', async () => {
+    let popHandler;
+    historyMock
+      .expects('push')
+      .withArgs(sinon.match((a) => {
+        popHandler = a;
+        return true;
+      }))
+      .resolves('H1')
+      .once();
+    const watcher = new CloseWatcherImpl(ampdoc, handler);
+    await Promise.resolve('H1');
+    expect(popHandler).to.exist;
+    popHandler();
+    expect(handler).to.be.calledOnce;
+  });
+
+  it('should trigger on ESC key', async () => {
+    historyMock
+      .expects('push')
+      .resolves('H1')
+      .once();
+    historyMock
+      .expects('pop')
+      .withArgs('H1')
+      .once();
+    const watcher = new CloseWatcherImpl(ampdoc, handler);
+    await Promise.resolve('H1');
+
+    doc.documentElement.dispatchEvent(
+      new KeyboardEvent('keydown', {key: Keys_Enum.ESCAPE})
+    );
+    expect(handler).to.be.calledOnce;
+  });
+});


### PR DESCRIPTION
Use [CloseWatcher API](https://wicg.github.io/close-watcher/) for amp-lightbox 0.1. It's supposed to be launched in Chrome 98. Some key benefits of this new API:

1. Reduces reliance on a global `window.history`.
2. Provides cleaner per-platform behavior. For instance, if platform has its own "close" gesture, then it's channeled via this API.

TODO:

- [x] Tests
