### PR TITLE
🐛 [amp-story] fix FIE media selector

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -757,7 +757,7 @@ export class AmpStoryPage extends AMP.BaseElement {
       iterateCursor(
         scopedQuerySelectorAll(
           fie.win.document.body,
-          Selectors.ALL_IFRAMED_MEDIA
+          selector.replace(/amp-story-grid-layer/g, '')
         ),
         (el) => mediaSet.push(el)
       );

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -80,7 +80,6 @@ export const Selectors = {
     'amp-story-grid-layer amp-video, amp-story-grid-layer amp-img, ' +
     'amp-story-grid-layer amp-anim',
   ALL_AMP_VIDEO: 'amp-story-grid-layer amp-video',
-  ALL_IFRAMED_MEDIA: 'audio, video',
   ALL_PLAYBACK_AMP_MEDIA:
     'amp-story-grid-layer amp-audio, amp-story-grid-layer amp-video',
   // TODO(gmajoulet): Refactor the way these selectors are used. They will be


### PR DESCRIPTION
Before this change we were ignoring the actual selector passed to `getMediaBySelector_` and always selecting video and audio elements if the page was an ad. 

This change respects the selector but removes the `amp-story-grid-layer` ancestor as these do not exists inside the FIE.