### PR TITLE
Fix forwardRef in react builds

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -651,7 +651,7 @@ async function buildNpmBinaries(extDir, name, options) {
         external: ['react', 'react-dom'],
         remap: {
           'preact': 'react',
-          'preact/compat': 'react',
+          '.*/preact/compat': 'react',
           'preact/hooks': 'react',
           'preact/dom': 'react-dom',
         },

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -484,9 +484,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
    */
   function remapDependenciesPlugin() {
     const remaps = Object.entries(options.remapDependencies).map(
-      ([path, value]) => {
-        return [new RegExp(`^${path}$`), value];
-      }
+      ([path, value]) => ({regex: new RegExp(`^${path}$`), value})
     );
     const external = options.externalDependencies;
     return {
@@ -497,8 +495,8 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
           const dep = importPath.startsWith('.')
             ? path.posix.join(resolveDir, importPath)
             : importPath;
-          for (const [key, value] of remaps) {
-            if (!key.test(dep)) {
+          for (const {regex, value} of remaps) {
+            if (!regex.test(dep)) {
               continue;
             }
             const isExternal = external.includes(value);


### PR DESCRIPTION
In #36976, we changed our implementation of `forwardRef` from being a simple wrapper around `preact/compat` to a custom-written implementation. There a bunch of side-effects in `preact/compat` that we don't want in addition to the `forwardRef` side-effect that we do want. This means that the side-effect now lives in `src/preact/comapt.js`.

When building React binaries, we do a simple dependency remapping that swaps literal `import ... from 'preact/compat'` into `import ... from 'react'`. This worked perfectly when we were wrapping `preact/compat`, because the side-effect import would be remapped directly to `react`. But now that we moved our side-effect into `src/preact/compat.js`, we need to update our remapping logic to handle this. Now, when a component imports from `src/preact/compat.js` (or `#preact/compat` using absolute shorthand), we'll correctly remap that import into `react`, skipping the side-effect in `src/preact/compat.js`.

Fixes https://github.com/swissspidy/gutenberg-bento/issues/36
Fixes #37111