### PR TITLE
Update nonce propagation to retrieve value via property

### DIFF
--- a/src/core/dom/element.nonce.extern.js
+++ b/src/core/dom/element.nonce.extern.js
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview Extern for the nonce attribute.
+ * @externs
+ */
+
+/** @type {undefined|string}| */
+Element.prototype.nonce;

--- a/src/core/dom/element.nonce.extern.js
+++ b/src/core/dom/element.nonce.extern.js
@@ -3,5 +3,5 @@
  * @externs
  */
 
-/** @type {undefined|string}| */
+/** @type {undefined|string} */
 Element.prototype.nonce;

--- a/src/core/dom/index.js
+++ b/src/core/dom/index.js
@@ -568,6 +568,6 @@ export function isServerRendered(element) {
 export function propagateNonce(doc, scriptEl) {
   const currentScript = doc.head.querySelector('script[nonce]');
   if (currentScript) {
-    scriptEl.nonce = currentScript.nonce ?? currentScript.getAttribute('nonce');
+    scriptEl.nonce = currentScript.nonce || currentScript.getAttribute('nonce');
   }
 }

--- a/src/core/dom/index.js
+++ b/src/core/dom/index.js
@@ -568,6 +568,7 @@ export function isServerRendered(element) {
 export function propagateNonce(doc, scriptEl) {
   const currentScript = doc.head.querySelector('script[nonce]');
   if (currentScript) {
-    scriptEl.nonce = currentScript.nonce || currentScript.getAttribute('nonce');
+    const nonce = currentScript.nonce || currentScript.getAttribute('nonce');
+    scriptEl.setAttribute('nonce', nonce);
   }
 }

--- a/src/core/dom/index.js
+++ b/src/core/dom/index.js
@@ -557,3 +557,17 @@ export function getChildJsonConfig(element) {
 export function isServerRendered(element) {
   return element.hasAttribute('i-amphtml-ssr');
 }
+
+/**
+ * Propagate the nonce found in <head> to a new script element.
+ * Recent browsers force nonce to be accessed via property instead of attribute.
+ *
+ * @param {Document} doc
+ * @param {HTMLScriptElement} scriptEl
+ */
+export function propagateNonce(doc, scriptEl) {
+  const currentScript = doc.head.querySelector('script[nonce]');
+  if (currentScript) {
+    scriptEl.nonce = currentScript.nonce ?? currentScript.getAttribute('nonce');
+  }
+}

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -1,3 +1,4 @@
+import {propagateNonce} from '#core/dom';
 import * as mode from '#core/mode';
 
 import {urls} from '../config';
@@ -120,14 +121,7 @@ export function createExtensionScript(win, extensionId, version) {
   if (mode.isEsm()) {
     scriptElement.setAttribute('type', 'module');
   }
-
-  // Propagate nonce to all generated script tags.
-  // In recent browsers the value is only accessible via property, not attribute.
-  const currentScript = win.document.head.querySelector('script[nonce]');
-  if (currentScript) {
-    scriptElement.nonce =
-      currentScript.nonce ?? currentScript.getAttribute('nonce');
-  }
+  propagateNonce(win.document, scriptElement);
 
   // Allow error information to be collected
   // https://github.com/ampproject/amphtml/issues/7353

--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -122,9 +122,11 @@ export function createExtensionScript(win, extensionId, version) {
   }
 
   // Propagate nonce to all generated script tags.
+  // In recent browsers the value is only accessible via property, not attribute.
   const currentScript = win.document.head.querySelector('script[nonce]');
   if (currentScript) {
-    scriptElement.setAttribute('nonce', currentScript.getAttribute('nonce'));
+    scriptElement.nonce =
+      currentScript.nonce ?? currentScript.getAttribute('nonce');
   }
 
   // Allow error information to be collected

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -46,9 +46,10 @@ export function loadScript(doc, url) {
   script.src = url;
 
   // Propagate nonce to all generated script tags.
+  // In recent browsers the value is only accessible via property, not attribute.
   const currentScript = doc.head.querySelector('script[nonce]');
   if (currentScript) {
-    script.setAttribute('nonce', currentScript.getAttribute('nonce'));
+    script.nonce = currentScript.nonce ?? currentScript.getAttribute('nonce');
   }
 
   const promise = loadPromise(script).then(

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -1,3 +1,4 @@
+import {propagateNonce} from '#core/dom';
 import {getHashParams} from '#core/types/string/url';
 
 import {loadPromise} from '#utils/event-helper';
@@ -44,13 +45,7 @@ export function loadScript(doc, url) {
     doc.createElement('script')
   );
   script.src = url;
-
-  // Propagate nonce to all generated script tags.
-  // In recent browsers the value is only accessible via property, not attribute.
-  const currentScript = doc.head.querySelector('script[nonce]');
-  if (currentScript) {
-    script.nonce = currentScript.nonce ?? currentScript.getAttribute('nonce');
-  }
+  propagateNonce(doc, script);
 
   const promise = loadPromise(script).then(
     () => {

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -63,8 +63,10 @@ describes.fakeWin('validator-integration', {}, (env) => {
   describe('loadScript', () => {
     it('should propagate pre-existing nonces', () => {
       const scriptEl = env.win.document.createElement('script');
-      scriptEl.setAttribute('nonce', '123');
+      scriptEl.setAttribute('nonce', '');
+      scriptEl.nonce = '123';
       win.document.head.append(scriptEl);
+
       loadScriptStub = env.sandbox
         .stub(eventHelper, 'loadPromise')
         .returns(Promise.resolve());
@@ -72,7 +74,7 @@ describes.fakeWin('validator-integration', {}, (env) => {
       loadScript(win.document, 'http://example.com');
 
       expect(loadScriptStub).calledWith(
-        env.sandbox.match((el) => el.getAttribute('nonce') === '123')
+        env.sandbox.match((el) => el.nonce === '123')
       );
     });
   });


### PR DESCRIPTION
**summary**
Related: `b/160931736`

Recently, browsers have updated their handling of the `nonce` s.t. it is only accessible via property access and not via attribute. This PR updates our handling to support the new recommendations. Notably, it seems that presence check still works via CSS Selector, just value retrieval fails (empty string is returned)

**testing done**
I verified that the nonce detection still works in Chrome/FF/Safari. 
- Both Chrome and FF follow new spec and automatically hide the nonce attribute value for scripts added to head.
- Safari hasn't implemented this yet.