### PR TITLE
Implement Children interface in Preact

### DIFF
--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -14,7 +14,6 @@ import {Scroller} from './scroller';
 import {WithAmpContext} from '#preact/context';
 import {
   cloneElement,
-  toChildArray,
   useCallback,
   useContext,
   useEffect,
@@ -24,7 +23,7 @@ import {
   useRef,
   useState,
 } from '#preact';
-import {forwardRef} from '#preact/compat';
+import {Children, forwardRef} from '#preact/compat';
 import {isRTL} from '#core/dom';
 import {sequentialIdGenerator} from '#core/data-structures/id-generator';
 import {getWin} from '#core/window';
@@ -102,7 +101,7 @@ function BentoBaseCarouselWithRef(
   ref
 ) {
   const classes = useStyles();
-  const childrenArray = useMemo(() => toChildArray(children), [children]);
+  const childrenArray = useMemo(() => Children.toArray(children), [children]);
   const {length} = childrenArray;
   const carouselContext = useContext(CarouselContext);
   const [currentSlideState, setCurrentSlideState] = useState(

--- a/extensions/amp-lightbox-gallery/1.0/consumer.js
+++ b/extensions/amp-lightbox-gallery/1.0/consumer.js
@@ -3,13 +3,13 @@ import {sequentialIdGenerator} from '#core/data-structures/id-generator';
 import * as Preact from '#preact';
 import {
   cloneElement,
-  toChildArray,
   useCallback,
   useContext,
   useLayoutEffect,
   useMemo,
   useState,
 } from '#preact';
+import {Children} from '#preact/compat';
 
 import {BentoLightboxGalleryContext} from './context';
 
@@ -56,7 +56,7 @@ export function WithBentoLightboxGallery({
       return renderProp();
     }
     if (children) {
-      return toChildArray(children).map(CLONE_CHILD);
+      return Children.map(children, CLONE_CHILD);
     }
     return <Comp srcset={srcset} />;
   }, [children, renderProp, srcset]);

--- a/extensions/amp-stream-gallery/1.0/component.js
+++ b/extensions/amp-stream-gallery/1.0/component.js
@@ -1,8 +1,7 @@
 import * as Preact from '#preact';
 import {BentoBaseCarousel} from '../../amp-base-carousel/1.0/component';
-import {forwardRef} from '#preact/compat';
+import {Children, forwardRef} from '#preact/compat';
 import {
-  toChildArray,
   useCallback,
   useImperativeHandle,
   useLayoutEffect,
@@ -42,7 +41,7 @@ function BentoStreamGalleryWithRef(props, ref) {
   const classes = useStyles();
   const carouselRef = useRef(null);
   const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT);
-  const {length} = toChildArray(children);
+  const length = Children.count(children);
   const measure = useCallback(
     (containerWidth) =>
       getVisibleCount(

--- a/src/preact/compat.js
+++ b/src/preact/compat.js
@@ -82,8 +82,8 @@ function toArray(children) {
 }
 
 /**
- * @param {...PreactDef.Renderable} children
- * @param {functional(PreactDef.Renderable):R} fn
+ * @param {PreactDef.Renderable} children
+ * @param {function(PreactDef.Renderable):R} fn
  * @return {!Array<R>}
  * @template R
  */
@@ -92,7 +92,7 @@ function map(children, fn) {
 }
 
 /**
- * @param {...PreactDef.Renderable} children
+ * @param {PreactDef.Renderable} children
  * @return {number}
  */
 function count(children) {

--- a/src/preact/compat.js
+++ b/src/preact/compat.js
@@ -1,4 +1,4 @@
-import {options} from /*OK*/ 'preact';
+import {options, toChildArray} from /*OK*/ 'preact';
 
 import * as mode from '#core/mode';
 
@@ -72,3 +72,35 @@ export function forwardRef(Component) {
 
   return Forward;
 }
+
+/**
+ * @param {PreactDef.Renderable} children
+ * @return {!Array<PreactDef.Renderable>}
+ */
+function toArray(children) {
+  return toChildArray(children);
+}
+
+/**
+ * @param {...PreactDef.Renderable} children
+ * @param {functional(PreactDef.Renderable):R} fn
+ * @return {!Array<R>}
+ * @template R
+ */
+function map(children, fn) {
+  return toChildArray(children).map(fn);
+}
+
+/**
+ * @param {...PreactDef.Renderable} children
+ * @return {number}
+ */
+function count(children) {
+  return toChildArray(children).length;
+}
+
+export const Children = {
+  toArray,
+  map,
+  count,
+};

--- a/src/preact/index.js
+++ b/src/preact/index.js
@@ -69,14 +69,6 @@ export function createContext(value) {
   return preact.createContext(value, undefined);
 }
 
-/**
- * @param {...PreactDef.Renderable} unusedChildren
- * @return {!Array<PreactDef.Renderable>}
- */
-export function toChildArray(unusedChildren) {
-  return preact.toChildArray.apply(undefined, arguments);
-}
-
 // Defines the type interfaces for the approved Preact Hooks APIs.
 // TODO: useReducer, useDebugValue, useErrorBoundary
 


### PR DESCRIPTION
Because `import {Children} from '#preact/compat'` is automatically remapped to `import {Children} from 'react'`, we need to use the official interface for interacting with renderable children.

Fixes https://github.com/ampproject/amphtml/issues/37111#issuecomment-987078671