### PR TITLE
🐛 copy react styles to root of each package before deploying

### DIFF
--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -8,10 +8,10 @@ const fastGlob = require('fast-glob');
 const marked = require('marked');
 const path = require('path');
 const posthtml = require('posthtml');
+const {copyFile, readFile} = require('fs-extra');
 const {getNameWithoutComponentPrefix} = require('../tasks/bento-helpers');
 const {getSemver} = require('./utils');
 const {log} = require('../common/logging');
-const {readFile} = require('fs-extra');
 const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
 
@@ -198,6 +198,26 @@ async function writeReactJs() {
 }
 
 /**
+ * todo(kvchari): temporarily copy styles to root of each package to support importing styles from root
+ * Remove when we begin properly proxying style imports.
+ * See issue from more information:
+ * @return {Promise<void>}
+ */
+async function copyCssToRoot() {
+  try {
+    const extDir = path.join('extension', extension, '1.0');
+    const preactCssDist = path.join(extDir, 'dist', 'styles.css');
+    const preactCssRoot = path.join(extDir, 'styles.css');
+    await copyFile(preactCssDist, preactCssRoot);
+    log('Copied', preactCssDist, 'to npm package root');
+  } catch (e) {
+    log(e);
+    process.exitCode = 1;
+    return;
+  }
+}
+
+/**
  * Main
  * @return {Promise<void>}
  */
@@ -205,8 +225,9 @@ async function main() {
   if (await shouldSkip()) {
     return;
   }
-  writePackageJson();
-  writeReactJs();
+  await writePackageJson();
+  await writeReactJs();
+  await copyCssToRoot();
 }
 
 main();


### PR DESCRIPTION
Copies the (p)react styles from an extension's package's `dist` folder to the root to support importing (p)react styles from the root of the package (e.g `import '@bentoproject/foo/styles.css'`).  

I could have also modified the `buildNpmCss` function in `extension-helpers.js` but that would generate a bunch of extensions/**/styles.css files that would need to be added to the gitignore and amp clean list. 

Couple questions I wanted to confirm:
 * is `extension` always only 1 extension or can it be a comma-separated list of multiple extensions. From the `publish-npm-package.yml` looks like it should only be called with 1 extension at a time?
 * is the version always 1.0? Looks like that should be the case, but please confirm

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
