### PR TITLE
🚀 [Story performance] Disable animations on first page if story is transformed

### DIFF
--- a/extensions/amp-story/1.0/animation.js
+++ b/extensions/amp-story/1.0/animation.js
@@ -27,7 +27,7 @@ import {
   scopedQuerySelector,
   scopedQuerySelectorAll,
 } from '#core/dom/query';
-import {timeStrToMillis, unscaledClientRect} from './utils';
+import {isTransformed, timeStrToMillis, unscaledClientRect} from './utils';
 import {isExperimentOn} from '#experiments';
 import {isPreviewMode} from './embed-mode';
 
@@ -548,7 +548,8 @@ export class AnimationManager {
 
     const firstPageAnimationDisabled =
       isExperimentOn(ampdoc.win, 'story-disable-animations-first-page') ||
-      isPreviewMode(ampdoc.win);
+      isPreviewMode(ampdoc.win) ||
+      isTransformed(ampdoc);
 
     /** @private @const {bool} */
     this.skipAnimations_ =

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -333,3 +333,12 @@ export const maybeMakeProxyUrl = (url, ampDoc) => {
   );
   return loc.origin + '/i/s/' + resolvedRelativeUrl.replace(/https?:\/\//, '');
 };
+
+/**
+ * Whether the document is transformed
+ * @param {!AmpDoc} ampdoc
+ * @return {boolean}
+ */
+export function isTransformed(ampdoc) {
+  return ampdoc.getRootNode().documentElement.hasAttribute('transformed');
+}


### PR DESCRIPTION
We want to disable the animations on the first page if the story is transformed, to prepare for the CSS split that would glitch (show + hide + animate in) animated elements on the first page.