### PR TITLE
🏗🐛 Lazy-load built files in the built-in server's CSS transformer

### DIFF
--- a/build-system/server/new-server/transforms/css/css-transform.ts
+++ b/build-system/server/new-server/transforms/css/css-transform.ts
@@ -1,9 +1,8 @@
-
-
 import minimist from 'minimist';
 import posthtml from 'posthtml';
 import {readFileSync} from 'fs';
 import {OptionSet} from '../utilities/option-set';
+import {Lazy} from '../utilities/lazy';
 
 const argv = minimist(process.argv.slice(2));
 const isTestMode: boolean = argv._.includes('server-tests');
@@ -14,24 +13,29 @@ const cwd = process.cwd();
 const cssPath = isTestMode
   ? `${cwd}/${testDir}/css.txt`
   : `${cwd}/build/css/v0.css`;
-const versionPath = `${cwd}/${testDir}/version.txt`
+const versionPath = `${cwd}/${testDir}/version.txt`;
 
-const css = readFileSync(cssPath, 'utf8').toString().trim();
-const version = readFileSync(versionPath, 'utf8').toString().trim();
+const css = new Lazy(() => readFileSync(cssPath, 'utf8').toString().trim());
+const version = new Lazy(() =>
+  readFileSync(versionPath, 'utf8').toString().trim()
+);
 
 interface StyleNode extends posthtml.Node {
-  tag: 'style',
+  tag: 'style';
   attrs: {
-    [key: string]: string | undefined
-    'amp-runtime': string,
-    'i-amphtml-version': string,
-  },
-  content: string[]
+    [key: string]: string | undefined;
+    'amp-runtime': string;
+    'i-amphtml-version': string;
+  };
+  content: string[];
 }
 
 function isStyleNode(node: posthtml.Node | string): node is StyleNode {
-  return node !== undefined && typeof node !== 'string' &&
-    (node as StyleNode).tag === 'style';
+  return (
+    node !== undefined &&
+    typeof node !== 'string' &&
+    (node as StyleNode).tag === 'style'
+  );
 }
 
 function prependAmpStyles(head: posthtml.Node): posthtml.Node {
@@ -51,9 +55,9 @@ function prependAmpStyles(head: posthtml.Node): posthtml.Node {
     attrs: {
       'amp-runtime': '',
       // Prefix 01 to simulate stable/prod version RTV prefix.
-      'i-amphtml-version': `01${version}`,
+      'i-amphtml-version': `01${version.value}`,
     },
-    content: [css]
+    content: [css.value],
   };
   content.unshift(styleNode);
   return {...head, content};
@@ -62,17 +66,19 @@ function prependAmpStyles(head: posthtml.Node): posthtml.Node {
 /**
  * Replace the src for every stories script tag.
  */
-export default function (_options: OptionSet = {}): (tree: posthtml.Node) => void {
+export default function (
+  _options: OptionSet = {}
+): (tree: posthtml.Node) => void {
   return function (tree: posthtml.Node) {
     let isAmp = false;
-      tree.match({tag: 'html'}, function(html: posthtml.Node): posthtml.Node {
-        if (html.attrs && ('amp' in html.attrs || '⚡' in html.attrs)) {
-          isAmp = true;
-        }
-        return html;
-      });
+    tree.match({tag: 'html'}, function (html: posthtml.Node): posthtml.Node {
+      if (html.attrs && ('amp' in html.attrs || '⚡' in html.attrs)) {
+        isAmp = true;
+      }
+      return html;
+    });
     if (isAmp) {
       tree.match({tag: 'head'}, prependAmpStyles);
     }
-  }
+  };
 }

--- a/build-system/server/new-server/transforms/utilities/lazy.ts
+++ b/build-system/server/new-server/transforms/utilities/lazy.ts
@@ -1,0 +1,15 @@
+export class Lazy<T> {
+  #value: T | undefined;
+  #initializer: () => T;
+
+  constructor(initializer: () => T) {
+    this.#initializer = initializer;
+  }
+
+  public get value(): T {
+    if (!this.#value) {
+      this.#value = this.#initializer();
+    }
+    return this.#value;
+  }
+}


### PR DESCRIPTION
This fixes the crash that happens when calling `amp visual-diff --empty` without building the runtime first: https://app.circleci.com/pipelines/github/ampproject/amphtml/20371/workflows/a8e75693-6c6b-4870-8433-38280f5e1b04/jobs/391367?invite=true#step-113-45