### PR TITLE
🖍 [amp story shopping] Prevent shopping tag dot and image from shrinking

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-shopping.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping.html
@@ -30,13 +30,13 @@
   <body>
     <amp-story
         standalone
-        title="Story Shopping Component Visual Diff Test"
+        title="Story Shopping Component"
         publisher="AMP Story Shopping"
         publisher-logo-src="example.com/logo.png"
         poster-portrait-src="example.com/poster.jpg">
       <amp-story-page id="inline-light-theme">
         <!--
-          Example of:
+          Example of
           Inline config.
           Multiple product tags with icon defined.
         -->
@@ -72,6 +72,8 @@
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-tag-id="hat" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-tag-id="sunglasses" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-tag-id="backpack" ></amp-story-shopping-tag>
         </amp-story-grid-layer>
         <amp-story-shopping-attachment></amp-story-shopping-attachment>
       </amp-story-page>
@@ -88,7 +90,7 @@
                    {
                     "product-tag-id": "city-pop",
                     "product-title": "Plastic Love",
-                    "product-price": "799"
+                    "product-price": "19"
                    }
                 ]
               }
@@ -99,8 +101,6 @@
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-tag-id="city-pop" ></amp-story-shopping-tag>
-          <amp-story-shopping-tag data-tag-id="k-pop" ></amp-story-shopping-tag>
-          <amp-story-shopping-tag data-tag-id="eurodance" ></amp-story-shopping-tag>
         </amp-story-grid-layer>
         <amp-story-shopping-attachment theme="dark"></amp-story-shopping-attachment>
       </amp-story-page>

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -30,6 +30,7 @@ amp-story-shopping-tag {
   align-items: center !important;
   justify-content: center !important;
   margin-inline-end: 4px !important;
+  flex-shrink: 0 !important;
   backdrop-filter: var(--i-amphtml-shopping-tag-backdrop-filter) !important;
 }
 
@@ -60,6 +61,7 @@ amp-story-shopping-tag {
   justify-content: center !important;
   background-color: rgba(0, 0, 0, 0.6) !important;
   border-radius: 100% !important;
+  flex-shrink: 0 !important;
   background-image: url('data:image/svg+xml;charset=utf-8,<svg width="12" height="12" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.49 5.755 6.24.505a1.16 1.16 0 0 0-.823-.338H1.334A1.17 1.17 0 0 0 .167 1.333v4.084c0 .32.128.612.344.828l5.25 5.25c.21.21.502.338.823.338.32 0 .612-.128.822-.344l4.083-4.083a1.14 1.14 0 0 0 .345-.823c0-.32-.134-.618-.345-.828ZM2.208 3.083a.874.874 0 1 1 0-1.75.874.874 0 1 1 0 1.75Z" fill="#fff"/></svg>') !important;
   background-repeat: no-repeat !important;
   background-position: center !important;


### PR DESCRIPTION
Prevents tag dot and image from shrinking when there is text. In the tag.

<img width="657" alt="Screen Shot 2021-12-08 at 10 27 10 AM" src="https://user-images.githubusercontent.com/3860311/145235319-8f91dbdf-1b95-4ca0-a36e-80c92f048641.png">

Related to #37112
Text formatting will be added in #37039


