### PR TITLE
Fix the bottom sticky issue: amp-sticky-ad element contains amp-ad sticky

### DIFF
--- a/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/anchor-ad-strategy.js
@@ -119,6 +119,7 @@ export class AnchorAdStrategy {
         })
       )
     );
+    delete attributes.sticky; // To ensure that no sticky attribute will be wrapped inside an amp-sticky-ad element.
     const doc = this.ampdoc.win.document;
     const ampAd = createElementWithAttributes(doc, 'amp-ad', attributes);
     const stickyAd = createElementWithAttributes(


### PR DESCRIPTION
Rather than controlling this from the server side, we think it might be easier to do a client side change to filter out sticky attribute if the old amp-sticky-ad is being placed by amp-auto-ads. Once the switchover happens, we only need to do a client-side refactor.