### PR TITLE
🚀 [Story performance] Remove extra share CSS styles duplicated

### DIFF
--- a/extensions/amp-story/1.0/amp-story-info-dialog.css
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.css
@@ -15,7 +15,6 @@
 */
 
 @import './amp-story-shadow-reset.css';
-@import './amp-story-share.css';
 
 .i-amphtml-story-info-dialog {
   position: absolute !important;

--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -1,8 +1,3 @@
-
-
-@import './amp-story-share.css';
-
-
 .i-amphtml-story-system-layer {
   background: linear-gradient(to bottom, rgba(0, 0, 0, 0.32), transparent) !important;
   position: absolute !important;


### PR DESCRIPTION
Part of #37044

The share menu CSS gets bundled 3 times in the CSS file, making the uncompressed `amp-story.js` much larger than needed. In practice 2 of these are not necessary, and the compressed bundle is good at optimizing them, but we want to get rid of them for when we extract the share menu.