### PR TITLE
🏗🚮 Clean up closure compiler code paths no longer used by `amp dist`

### DIFF
--- a/build-system/tasks/dist.js
+++ b/build-system/tasks/dist.js
@@ -14,10 +14,6 @@ const {
   printNobuildHelp,
 } = require('./helpers');
 const {
-  cleanupBuildDir,
-  printClosureConcurrency,
-} = require('../compile/compile');
-const {
   createCtrlcHandler,
   exitCtrlcHandler,
 } = require('../common/ctrlcHandler');
@@ -30,6 +26,7 @@ const {
 const {buildCompiler} = require('../compile/build-compiler');
 const {buildExtensions, parseExtensionFlags} = require('./extension-helpers');
 const {buildVendorConfigs} = require('./3p-vendor-helpers');
+const {cleanupBuildDir} = require('../compile/compile');
 const {compileCss, copyCss} = require('./css');
 const {compileJison} = require('./compile-jison');
 const {formatExtractedMessages} = require('../compile/log-messages');
@@ -112,7 +109,6 @@ async function dist() {
     minify: true,
     watch: argv.watch,
   };
-  printClosureConcurrency();
   printNobuildHelp();
   printDistHelp(options);
   await runPreDistSteps(options);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -4,16 +4,13 @@ const esbuild = require('esbuild');
 /** @type {Object} */
 const experimentDefines = require('../global-configs/experiments-const.json');
 const fs = require('fs-extra');
-const magicstring = require('magic-string');
 const open = require('open');
 const path = require('path');
-const Remapping = require('@ampproject/remapping');
 const terser = require('terser');
 const wrappers = require('../compile/compile-wrappers');
 const {
   VERSION: internalRuntimeVersion,
 } = require('../compile/internal-version');
-const {closureCompile} = require('../compile/compile');
 const {cyan, green, red} = require('kleur/colors');
 const {generateBentoRuntimeEntrypoint} = require('../compile/generate/bento');
 const {getAmpConfigForFile} = require('./prepend-global');
@@ -25,22 +22,11 @@ const {log, logLocalDev} = require('../common/logging');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {watch} = require('chokidar');
 
-/** @type {Remapping.default} */
-const remapping = /** @type {*} */ (Remapping);
-
-/** @type {magicstring.default} */
-const MagicString = /** @type {*} */ (magicstring);
-
 /**
  * Tasks that should print the `--nobuild` help text.
  * @private @const {!Set<string>}
  */
 const NOBUILD_HELP_TASKS = new Set(['e2e', 'integration', 'visual-diff']);
-
-/**
- * Used during minification to concatenate modules
- */
-const MODULE_SEPARATOR = ';';
 
 /**
  * Used during minification to concatenate extension bundles
@@ -206,82 +192,6 @@ async function getCompiledFile(srcFilename) {
 }
 
 /**
- * Allows pending inside the compile wrapper to the already minified JS file.
- * @param {string} srcFilename Name of the JS source file
- * @param {string} destFilePath File path to the minified JS file
- * @param {?Object} options
- */
-function combineWithCompiledFile(srcFilename, destFilePath, options) {
-  const bundleFiles = EXTENSION_BUNDLE_MAP[srcFilename];
-  if (!bundleFiles) {
-    return;
-  }
-  const bundle = new MagicString.Bundle({
-    separator: '\n',
-  });
-  // We need to inject the code _inside_ the extension wrapper
-  const destFileName = path.basename(destFilePath);
-  /**
-   * TODO (rileyajones) This should be import('magic-string').MagicStringOptions but
-   * is invalid until https://github.com/Rich-Harris/magic-string/pull/183
-   * is merged.
-   * @type {Object}
-   */
-  const mapMagicStringOptions = {filename: destFileName};
-  const contents = new MagicString(
-    fs.readFileSync(destFilePath, 'utf8'),
-    mapMagicStringOptions
-  );
-  const map = JSON.parse(fs.readFileSync(`${destFilePath}.map`, 'utf8'));
-  const {sourceRoot} = map;
-  map.sourceRoot = undefined;
-
-  // The wrapper may have been minified further. Search backwards from the
-  // expected <%=contents%> location to find the start of the `{` in the
-  // wrapping function.
-  const wrapperIndex = options.wrapper.indexOf('<%= contents %>');
-  const index = contents.original.lastIndexOf('{', wrapperIndex) + 1;
-
-  const wrapperOpen = contents.snip(0, index);
-  const remainingContents = contents.snip(index, contents.length());
-
-  bundle.addSource(wrapperOpen);
-  for (const bundleFile of bundleFiles) {
-    const contents = fs.readFileSync(bundleFile, 'utf8');
-    /**
-     * TODO (rileyajones) This should be import('magic-string').MagicStringOptions but
-     * is invalid until https://github.com/Rich-Harris/magic-string/pull/183
-     * is merged.
-     * @type {Object}
-     */
-    const bundleMagicStringOptions = {filename: bundleFile};
-    bundle.addSource(new MagicString(contents, bundleMagicStringOptions));
-    bundle.append(MODULE_SEPARATOR);
-  }
-  bundle.addSource(remainingContents);
-
-  const bundledMap = bundle.generateDecodedMap({
-    file: destFileName,
-    hires: true,
-  });
-
-  const remapped = remapping(
-    bundledMap,
-    (file) => {
-      if (file === destFileName) {
-        return map;
-      }
-      return null;
-    },
-    !argv.full_sourcemaps
-  );
-  remapped.sourceRoot = sourceRoot;
-
-  fs.writeFileSync(destFilePath, bundle.toString(), 'utf8');
-  fs.writeFileSync(`${destFilePath}.map`, remapped.toString(), 'utf8');
-}
-
-/**
  * @param {string} name
  * @return {string}
  */
@@ -307,42 +217,6 @@ function maybeToEsmName(name) {
  */
 function maybeToNpmEsmName(name) {
   return argv.esm ? name.replace(/\.js$/, '.module.js') : name;
-}
-
-/**
- * Minifies a given JavaScript file entry point.
- * @param {string} srcDir
- * @param {string} srcFilename
- * @param {string} destDir
- * @param {?Object} options
- * @return {!Promise}
- */
-async function compileMinifiedJs(srcDir, srcFilename, destDir, options) {
-  const timeInfo = {};
-  const entryPoint = path.join(srcDir, srcFilename);
-  const minifiedName = maybeToEsmName(options.minifiedName);
-
-  options.errored = false;
-  await closureCompile(entryPoint, destDir, minifiedName, options, timeInfo);
-  // If an incremental watch build fails, simply return.
-  if (options.watch && options.errored) {
-    return;
-  }
-
-  const destPath = path.join(destDir, minifiedName);
-  combineWithCompiledFile(srcFilename, destPath, options);
-  if (options.aliasName) {
-    fs.copySync(
-      destPath,
-      path.join(destDir, maybeToEsmName(options.aliasName))
-    );
-  }
-
-  let name = minifiedName;
-  if (options.aliasName) {
-    name += ` → ${maybeToEsmName(options.aliasName)}`;
-  }
-  endBuildStep('Minified', name, timeInfo.startTime);
 }
 
 /**
@@ -651,10 +525,7 @@ async function compileJs(srcDir, srcFilename, destDir, options) {
    * @return {Promise<void>}
    */
   async function doCompileJs(options) {
-    const buildResult =
-      options.minify && shouldUseClosure()
-        ? compileMinifiedJs(srcDir, srcFilename, destDir, options)
-        : esbuildCompile(srcDir, srcFilename, destDir, options);
+    const buildResult = esbuildCompile(srcDir, srcFilename, destDir, options);
     if (options.onWatchBuild) {
       options.onWatchBuild(buildResult);
     }
@@ -841,16 +712,6 @@ function massageSourcemaps(sourcemapsFile, options) {
   return JSON.stringify(sourcemaps);
 }
 
-/**
- * Returns whether or not we should compile with Closure Compiler.
- * @return {boolean}
- */
-function shouldUseClosure() {
-  // TODO(samouri): cleanup closure build pipeline.
-  // If restoring, ensure that it continues returning false if options.bento
-  return false;
-}
-
 module.exports = {
   bootstrapThirdPartyFrames,
   compileAllJs,
@@ -867,6 +728,5 @@ module.exports = {
   printConfigHelp,
   printNobuildHelp,
   watchDebounceDelay,
-  shouldUseClosure,
   mangleIdentifier,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
         "kleur": "4.1.4",
         "list-imports-exports": "0.1.2",
         "lodash.debounce": "4.0.8",
-        "magic-string": "0.25.7",
         "markdown-link-check": "3.8.7",
         "markdown-toc": "1.2.0",
         "marked": "3.0.8",
@@ -16323,14 +16322,6 @@
       "optional": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.25.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.4"
       }
     },
     "node_modules/make-dir": {
@@ -34243,13 +34234,6 @@
     "luxon": {
       "version": "1.26.0",
       "optional": true
-    },
-    "magic-string": {
-      "version": "0.25.7",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "kleur": "4.1.4",
     "list-imports-exports": "0.1.2",
     "lodash.debounce": "4.0.8",
-    "magic-string": "0.25.7",
     "markdown-link-check": "3.8.7",
     "markdown-toc": "1.2.0",
     "marked": "3.0.8",


### PR DESCRIPTION
The coast is clear to delete all the closure compilation code paths used during minification. The guts of the actual compilation still remain because they're used during type checking. They can be cleaned up after type checking moves to TS.

Related to #35264

