### PR TITLE
Validator Rollup

### DIFF
--- a/validator/testdata/feature_tests/img.html
+++ b/validator/testdata/feature_tests/img.html
@@ -104,5 +104,18 @@
        srcset="https://www.example.com/blah2.jpg 470w,
                https://www.example.com/blah3.jpg 800w,
                https://www.example.com/blah4.jpg 1200w">
+
+  <!-- Invalid inside amp-story -->
+  <amp-story standalone
+           title=""
+           publisher=""
+           publisher-logo-src="logo"
+           poster-portrait-src="portrait">
+    <amp-story-page id=page1>
+      <amp-story-grid-layer template="vertical">
+        <img src="http://www.example.com/blah.jpg#fragment" width=92 height=10>"
+      </amp-story-grid-layer>
+    </amp-story-page>
+  </amp-story>
 </body>
 </html>

--- a/validator/testdata/feature_tests/img.out
+++ b/validator/testdata/feature_tests/img.out
@@ -115,5 +115,26 @@ feature_tests/img.html:57:2 The attribute 'loading' in tag 'img' is set to the i
 |         srcset="https://www.example.com/blah2.jpg 470w,
 |                 https://www.example.com/blah3.jpg 800w,
 |                 https://www.example.com/blah4.jpg 1200w">
+|
+|    <!-- Invalid inside amp-story -->
+|    <amp-story standalone
+>>   ^~~~~~~~~
+feature_tests/img.html:109:2 Tag 'amp-story' is not allowed to have any sibling tags ('body' should only have 1 child). (see https://amp.dev/documentation/components/amp-story)
+>>   ^~~~~~~~~
+feature_tests/img.html:109:2 The tag 'amp-story' requires including the 'amp-story' extension JavaScript. (see https://amp.dev/documentation/components/amp-story)
+|             title=""
+|             publisher=""
+|             publisher-logo-src="logo"
+|             poster-portrait-src="portrait">
+|      <amp-story-page id=page1>
+>>     ^~~~~~~~~
+feature_tests/img.html:114:4 The tag 'amp-story-page' requires including the 'amp-story' extension JavaScript. (see https://amp.dev/documentation/components/amp-story)
+|        <amp-story-grid-layer template="vertical">
+|          <img src="http://www.example.com/blah.jpg#fragment" width=92 height=10>"
+>>         ^~~~~~~~~
+feature_tests/img.html:116:8 The tag 'img' may only appear as a descendant of tag 'noscript'. Did you mean 'amp-img'? (see https://amp.dev/documentation/components/amp-img/)
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|    </amp-story>
 |  </body>
 |  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1826,6 +1826,7 @@ tags: {
   spec_name: "Standard Img"
   descriptive_name: "img"
   disallowed_ancestor: "AMP-IMG"
+  disallowed_ancestor: "AMP-STORY"
   attrs: {
     name: "decoding"
     value_casei: "async"
@@ -1839,6 +1840,7 @@ tags: {
   spec_name: "Hero Img"
   descriptive_name: "img"
   disallowed_ancestor: "AMP-IMG"
+  disallowed_ancestor: "AMP-STORY"
   attrs: {
     name: "data-hero"
     mandatory: true
@@ -1857,6 +1859,7 @@ tags: {
   spec_name: "Img using srcset"
   descriptive_name: "img"
   disallowed_ancestor: "AMP-IMG"
+  disallowed_ancestor: "AMP-STORY"
   attrs: {
     name: "decoding"
     value_casei: "async"
@@ -1873,6 +1876,7 @@ tags: {
   spec_name: "Standard Image"
   descriptive_name: "img"
   disallowed_ancestor: "AMP-IMG"
+  disallowed_ancestor: "AMP-STORY"
   attrs: {
     name: "decoding"
     value_casei: "async"
@@ -1886,6 +1890,7 @@ tags: {
   spec_name: "Hero Image"
   descriptive_name: "img"
   disallowed_ancestor: "AMP-IMG"
+  disallowed_ancestor: "AMP-STORY"
   attrs: {
     name: "data-hero"
     mandatory: true
@@ -1903,6 +1908,7 @@ tags: {
   tag_name: "IMAGE"
   spec_name: "Image using srcset"
   disallowed_ancestor: "AMP-IMG"
+  disallowed_ancestor: "AMP-STORY"
   descriptive_name: "img"
   attrs: {
     name: "decoding"


### PR DESCRIPTION
- cl/415376510 Disallow amp-story as an ancestor for img tag. Per  https://github.com/ampproject/amphtml/issues/30442#issuecomment-702212525