### PR TITLE
Remove 'version: "latest"'.

### DIFF
--- a/docs/component-validator-rules.md
+++ b/docs/component-validator-rules.md
@@ -76,7 +76,6 @@ tags: {  # amp-cat
   extension_spec: {
     name: "amp-cat"
     version: "0.1"
-    version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
@@ -153,12 +152,11 @@ as well as a link to documentation on ampproject.org for all error messages.
 
 ```js
     version: "0.1"
-    version: "latest"
   }
 ```
 
 These fields define a list of all allowed version numbers. Currently, almost all
-extended components are at version `0.1`, and we also allow `latest` to be specified.
+extended components are at version `0.1`.
 
 The combination of the `version` and `name` fields of the
 `extension_spec` define the allowed values of the `src` attribute in the


### PR DESCRIPTION
Remove `version: "latest"` as a suggestion for new components.