### PR TITLE
🐛 Made currency symbol correct size and weight for amp-story-shopping-tag

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -18,7 +18,8 @@ amp-story-shopping-tag {
   font-family: 'Poppins', sans-serif !important;
   font-weight: 400 !important;
   font-size: 10px !important;
-  padding-right: 2px !important;
+  padding-right: 2px !important;  
+  line-height: 14px !important;
 }
 
 .amp-story-shopping-tag-inner {

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -13,6 +13,14 @@ amp-story-shopping-tag {
   --i-amphtml-shopping-tag-backdrop-filter: blur(20px);
 }
 
+
+.amp-story-shopping-tag-currency-symbol {
+  font-family: 'Poppins', sans-serif !important;
+  font-weight: 400 !important;
+  font-size: 10px !important;
+  padding-right: 2px !important;
+}
+
 .amp-story-shopping-tag-inner {
   height: 36px !important;
   display: flex !important;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -18,7 +18,7 @@ amp-story-shopping-tag {
   font-family: 'Poppins', sans-serif !important;
   font-weight: 400 !important;
   font-size: 10px !important;
-  padding-right: 2px !important;  
+  padding-right: 2px !important;
   line-height: 14px !important;
 }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -15,7 +15,6 @@ amp-story-shopping-tag {
 
 
 .amp-story-shopping-tag-currency-symbol {
-  font-family: 'Poppins', sans-serif !important;
   font-weight: 400 !important;
   font-size: 10px !important;
   padding-right: 2px !important;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -38,7 +38,10 @@ const renderShoppingTagTemplate = (tagData) => (
         }
       ></span>
       <span class="amp-story-shopping-tag-pill-text">
-        {tagData['product-tag-text'] || '$' + tagData['product-price']}
+        {!tagData['product-tag-text'] && (
+          <span class="amp-story-shopping-tag-currency-symbol">$</span>
+        )}
+        {tagData['product-tag-text'] || tagData['product-price']}
       </span>
     </span>
   </div>


### PR DESCRIPTION
fixes #37154

Currency symbol correct weight
<img width="124" alt="Screen Shot 2021-12-15 at 1 35 09 PM" src="https://user-images.githubusercontent.com/6364311/146268538-44953421-f471-4c93-9c91-f0434edda82c.png">

