### PR TITLE
Use a separate triple Mustache allowlist for email

### DIFF
--- a/extensions/amp-mustache/0.1/amp-mustache.js
+++ b/extensions/amp-mustache/0.1/amp-mustache.js
@@ -25,7 +25,9 @@ export class AmpMustache extends BaseTemplate {
     super(element, win);
 
     // Unescaped templating (triple mustache) has a special, strict sanitizer.
-    mustache.setUnescapedSanitizer(sanitizeTagsForTripleMustache);
+    mustache.setUnescapedSanitizer((html) =>
+      sanitizeTagsForTripleMustache(html, this.win.document)
+    );
 
     user().warn(
       TAG,

--- a/extensions/amp-mustache/amp-mustache.md
+++ b/extensions/amp-mustache/amp-mustache.md
@@ -74,7 +74,19 @@ that among other things, you can't use `amp-mustache` to:
 -   Calculate tag name. E.g. `<{{tagName}}>` is not allowed.
 -   Calculate attribute name. E.g. `<div {{attrName}}=something>` is not allowed.
 
-The output of "triple-mustache" is sanitized to only allow the following tags: `a`, `amp-img`, `article`, `aside`, `b`, `blockquote`, `br`, `caption`, `code`, `col`, `colgroup`, `dd`, `del`, `details`, `div`, `dl`, `dt`, `em`, `figcaption`, `figure`, `footer`, `h1`, `h2`, `h3`, `header`, `hr`, `i`, `ins`, `li`, `main`, `mark`, `nav`, `ol`, `p`, `pre`, `q`, `s`, `section`, `small`, `span`, `strong`, `sub`, `summary`, `sup`, `table`, `tbody`, `td`, `tfoot`, `th`, `thead`, `time`, `tr`, `u`, `ul`.
+The output of "triple-mustache" is sanitized to only allow the following tags:
+
+[filter formats="websites, ads"]
+
+`a`, `amp-img`, `article`, `aside`, `b`, `blockquote`, `br`, `caption`, `code`, `col`, `colgroup`, `dd`, `del`, `details`, `div`, `dl`, `dt`, `em`, `figcaption`, `figure`, `footer`, `h1`, `h2`, `h3`, `header`, `hr`, `i`, `ins`, `li`, `main`, `mark`, `nav`, `ol`, `p`, `pre`, `q`, `s`, `section`, `small`, `span`, `strong`, `sub`, `summary`, `sup`, `table`, `tbody`, `td`, `tfoot`, `th`, `thead`, `time`, `tr`, `u`, `ul`.
+
+[/filter]<!-- formats="websites, ads" -->
+
+[filter formats="email"]
+
+`a`, `article`, `aside`, `b`, `blockquote`, `br`, `caption`, `code`, `col`, `colgroup`, `dd`, `del`, `details`, `div`, `dl`, `dt`, `em`, `figcaption`, `figure`, `footer`, `h1`, `h2`, `h3`, `header`, `hr`, `i`, `ins`, `li`, `main`, `mark`, `nav`, `ol`, `p`, `pre`, `q`, `s`, `section`, `small`, `span`, `strong`, `sub`, `summary`, `sup`, `table`, `tbody`, `td`, `tfoot`, `th`, `thead`, `time`, `tr`, `u`, `ul`.
+
+[/filter]<!-- formats="email" -->
 
 ### Sanitization
 

--- a/src/purifier/index.js
+++ b/src/purifier/index.js
@@ -13,6 +13,7 @@ import {
   BIND_PREFIX,
   DENYLISTED_TAGS,
   EMAIL_ALLOWLISTED_AMP_TAGS,
+  EMAIL_TRIPLE_MUSTACHE_ALLOWLISTED_TAGS,
   TRIPLE_MUSTACHE_ALLOWLISTED_TAGS,
   isValidAttr,
   markElementForDiffing,
@@ -103,7 +104,9 @@ export class Purifier {
     // RETURN_DOM_FRAGMENT to keep the <template> and FORCE_BODY to prevent
     // reparenting. See https://github.com/cure53/DOMPurify/issues/285#issuecomment-397810671
     const fragment = this.domPurifyTriple_.sanitize(dirty, {
-      'ALLOWED_TAGS': TRIPLE_MUSTACHE_ALLOWLISTED_TAGS,
+      'ALLOWED_TAGS': isAmp4Email(this.doc_)
+        ? EMAIL_TRIPLE_MUSTACHE_ALLOWLISTED_TAGS
+        : TRIPLE_MUSTACHE_ALLOWLISTED_TAGS,
       'FORCE_BODY': true,
       'RETURN_DOM_FRAGMENT': true,
     });

--- a/src/purifier/sanitation.js
+++ b/src/purifier/sanitation.js
@@ -96,7 +96,8 @@ export const EMAIL_ALLOWLISTED_AMP_TAGS = {
 };
 
 /**
- * Allowlist of tags allowed in triple mustache e.g. {{{name}}}.
+ * Allowlist of tags allowed in triple mustache in non-email format, e.g.
+ * {{{name}}}.
  * Very restrictive by design since the triple mustache renders unescaped HTML
  * which, unlike double mustache, won't be processed by the AMP Validator.
  * @const {!Array<string>}
@@ -158,6 +159,68 @@ export const TRIPLE_MUSTACHE_ALLOWLISTED_TAGS = [
   'ul',
 ];
 
+/**
+ * Same as `TRIPLE_MUSTACHE_ALLOWLISTED_TAGS` except for the email format. The
+ * email format has a different threat model and needs to evolve the allowlist
+ * independently from other formats, as certain tags can be considered safe in
+ * other formats but not in the email format.
+ * @const {!Array<string>}
+ */
+export const EMAIL_TRIPLE_MUSTACHE_ALLOWLISTED_TAGS = [
+  'a',
+  'article',
+  'aside',
+  'b',
+  'blockquote',
+  'br',
+  'caption',
+  'code',
+  'col',
+  'colgroup',
+  'dd',
+  'del',
+  'details',
+  'div',
+  'dl',
+  'dt',
+  'em',
+  'figcaption',
+  'figure',
+  'footer',
+  'h1',
+  'h2',
+  'h3',
+  'header',
+  'hr',
+  'i',
+  'ins',
+  'li',
+  'main',
+  'mark',
+  'nav',
+  'ol',
+  'p',
+  'pre',
+  'q',
+  's',
+  'section',
+  'small',
+  'span',
+  'strong',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'tr',
+  'u',
+  'ul',
+];
 /**
  * Tag-agnostic attribute allowlisted used by both Caja and DOMPurify.
  * @const {!Array<string>}

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -8,6 +8,7 @@ import {
   BIND_PREFIX,
   DENYLISTED_TAGS,
   EMAIL_ALLOWLISTED_AMP_TAGS,
+  EMAIL_TRIPLE_MUSTACHE_ALLOWLISTED_TAGS,
   TRIPLE_MUSTACHE_ALLOWLISTED_TAGS,
   isValidAttr,
 } from '#purifier/sanitation';
@@ -243,19 +244,23 @@ export function sanitizeHtml(html, doc) {
  * We do so in sanitizeHtml which occurs after this initial sanitizing.
  *
  * @param {string} html
+ * @param {!Document} doc
  * @return {string}
  */
-export function sanitizeTagsForTripleMustache(html) {
-  return htmlSanitizer.sanitizeWithPolicy(html, tripleMustacheTagPolicy);
+export function sanitizeTagsForTripleMustache(html, doc) {
+  return htmlSanitizer.sanitizeWithPolicy(html, (tagName, attribs) =>
+    tripleMustacheTagPolicy(tagName, attribs, doc)
+  );
 }
 
 /**
  * Tag policy for handling what is valid html in templates.
  * @param {string} tagName
  * @param {!Array<string>} attribs
+ * @param {!Document} doc
  * @return {?{tagName: string, attribs: !Array<string>}}
  */
-function tripleMustacheTagPolicy(tagName, attribs) {
+function tripleMustacheTagPolicy(tagName, attribs, doc) {
   if (tagName == 'template') {
     for (let i = 0; i < attribs.length; i += 2) {
       if (attribs[i] == 'type' && attribs[i + 1] == 'amp-mustache') {
@@ -266,7 +271,11 @@ function tripleMustacheTagPolicy(tagName, attribs) {
       }
     }
   }
-  if (!TRIPLE_MUSTACHE_ALLOWLISTED_TAGS.includes(tagName)) {
+  if (isAmp4Email(doc)) {
+    if (!EMAIL_TRIPLE_MUSTACHE_ALLOWLISTED_TAGS.includes(tagName)) {
+      return null;
+    }
+  } else if (!TRIPLE_MUSTACHE_ALLOWLISTED_TAGS.includes(tagName)) {
     return null;
   }
   return {

--- a/test/unit/test-sanitizer.js
+++ b/test/unit/test-sanitizer.js
@@ -2,11 +2,12 @@ import {sanitizeHtml, sanitizeTagsForTripleMustache} from '../../src/sanitizer';
 
 let sanitize;
 let html;
+let documentEl;
 
 describes.sandboxed('Caja-based', {}, () => {
   beforeEach(() => {
     html = document.createElement('html');
-    const documentEl = {documentElement: html};
+    documentEl = {documentElement: html};
     sanitize = (html) => sanitizeHtml(html, documentEl);
   });
 
@@ -422,43 +423,54 @@ function runSanitizerTests() {
 
   describe('sanitizeTagsForTripleMustache', () => {
     it('should output basic text', () => {
-      expect(sanitizeTagsForTripleMustache('abc')).to.be.equal('abc');
+      expect(sanitizeTagsForTripleMustache('abc', documentEl)).to.be.equal(
+        'abc'
+      );
     });
 
     it('should output valid markup', () => {
-      expect(sanitizeTagsForTripleMustache('<b>abc</b>')).to.be.equal(
-        '<b>abc</b>'
-      );
-      expect(sanitizeTagsForTripleMustache('<b>ab<br>c</b>')).to.be.equal(
-        '<b>ab<br>c</b>'
-      );
-      expect(sanitizeTagsForTripleMustache('<b>a<i>b</i>c</b>')).to.be.equal(
-        '<b>a<i>b</i>c</b>'
-      );
+      expect(
+        sanitizeTagsForTripleMustache('<b>abc</b>', documentEl)
+      ).to.be.equal('<b>abc</b>');
+      expect(
+        sanitizeTagsForTripleMustache('<b>ab<br>c</b>', documentEl)
+      ).to.be.equal('<b>ab<br>c</b>');
+      expect(
+        sanitizeTagsForTripleMustache('<b>a<i>b</i>c</b>', documentEl)
+      ).to.be.equal('<b>a<i>b</i>c</b>');
       const markupWithClassAttribute = '<p class="some-class">heading</p>';
       expect(
-        sanitizeTagsForTripleMustache(markupWithClassAttribute)
+        sanitizeTagsForTripleMustache(markupWithClassAttribute, documentEl)
       ).to.be.equal(markupWithClassAttribute);
       const markupWithClassesAttribute =
         '<div class="some-class another"><span>heading</span></div>';
       expect(
-        sanitizeTagsForTripleMustache(markupWithClassesAttribute)
+        sanitizeTagsForTripleMustache(markupWithClassesAttribute, documentEl)
       ).to.be.equal(markupWithClassesAttribute);
       const markupParagraph = '<p class="valid-class">paragraph</p>';
-      expect(sanitizeTagsForTripleMustache(markupParagraph)).to.be.equal(
-        markupParagraph
-      );
+      expect(
+        sanitizeTagsForTripleMustache(markupParagraph, documentEl)
+      ).to.be.equal(markupParagraph);
     });
 
     it('should NOT output non-allowlisted markup', () => {
-      expect(sanitizeTagsForTripleMustache('a<style>b</style>c')).to.be.equal(
+      expect(
+        sanitizeTagsForTripleMustache('a<style>b</style>c', documentEl)
+      ).to.be.equal('ac');
+      expect(sanitizeTagsForTripleMustache('a<img>c', documentEl)).to.be.equal(
         'ac'
       );
-      expect(sanitizeTagsForTripleMustache('a<img>c')).to.be.equal('ac');
+    });
+
+    it('should not allowlist amp-img element for AMP4Email', () => {
+      html.setAttribute('amp4email', '');
+      expect(
+        sanitizeTagsForTripleMustache('a<amp-img></amp-img>c', documentEl)
+      ).to.be.equal('ac');
     });
 
     it('should compensate for broken markup', () => {
-      expect(sanitizeTagsForTripleMustache('<b>a<i>b')).to.be.equal(
+      expect(sanitizeTagsForTripleMustache('<b>a<i>b', documentEl)).to.be.equal(
         '<b>a<i>b</i></b>'
       );
     });


### PR DESCRIPTION
This allowlist of triple Mustache tags was shared with the email
format. triple-mustache is a pretty security sensitive feature in
the email format, and adding non-formatting tags like amp-img to
the allowlist requires a security review.

For some email clients (like Gmail) the Mustache is actually rendered
on the server side, and the server uses a different triple-mustache
allowlist. However, for consistency with email clients who don't
server-side render the template we should keep the client-side
sanitization consistent.

Using a separate list for email so we don't accidentally modify the
email format when there are requests to add new tags for the website
format (e.g., #32039). We can still add to the email allowlist on a
case-by-case basis.

/to @samouri 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
