### PR TITLE
🐛 static-template: Fix FIE check for SVGs

### DIFF
--- a/src/core/dom/static-template.js
+++ b/src/core/dom/static-template.js
@@ -27,7 +27,7 @@ export function htmlFor(nodeOrDoc) {
  */
 export function svgFor(nodeOrDoc) {
   const doc = nodeOrDoc.ownerDocument || /** @type {Document} */ (nodeOrDoc);
-  if (!svgContainer || svgContainer.ownerDocument !== svgContainer) {
+  if (!svgContainer || svgContainer.ownerDocument !== doc) {
     svgContainer = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
   }
 


### PR DESCRIPTION
**summary**
Fixes old bug in our `svgFor` codepath.
Found while adding `noImplicitAny` to our tsconfig.