### PR TITLE
Core Typechecking: enable noImplicitAny

### DIFF
--- a/3p/iframe-transport-client.js
+++ b/3p/iframe-transport-client.js
@@ -1,12 +1,11 @@
-import {
-  IframeTransportEventDef,
-  MessageType_Enum,
-} from '#core/3p-frame-messaging';
+import {MessageType_Enum} from '#core/3p-frame-messaging';
 import {tryParseJson} from '#core/types/object/json';
 
 import {dev, devAssert, user, userAssert} from '#utils/log';
 
 import {IframeMessagingClient} from './iframe-messaging-client';
+
+/** @typedef {import('#core/3p-frame-messaging').IframeTransportEventDef} IframeTransportDef */
 
 /** @private @const {string} */
 const TAG_ = 'iframe-transport-client';

--- a/ads/inabox/frame-overlay-helper.js
+++ b/ads/inabox/frame-overlay-helper.js
@@ -1,8 +1,4 @@
-import {
-  LayoutRectDef,
-  layoutRectFromDomRect,
-  layoutRectLtwh,
-} from '#core/dom/layout/rect';
+import {layoutRectFromDomRect, layoutRectLtwh} from '#core/dom/layout/rect';
 import {
   centerFrameUnderVsyncMutate,
   collapseFrameUnderVsyncMutate,

--- a/ads/inabox/position-observer.js
+++ b/ads/inabox/position-observer.js
@@ -1,5 +1,4 @@
 import {
-  LayoutRectDef,
   layoutRectFromDomRect,
   layoutRectLtwh,
   moveLayoutRect,
@@ -14,6 +13,8 @@ import {throttle} from '#core/types/function';
  * }}
  */
 let PositionEntryDef;
+
+/** @typedef {import('#core/dom/layout/rect').LayoutRectDef} LayoutRectDef */
 
 /** @const */
 const MIN_EVENT_INTERVAL_IN_MS = 100;

--- a/extensions/amp-analytics/0.1/iframe-transport-message-queue.js
+++ b/extensions/amp-analytics/0.1/iframe-transport-message-queue.js
@@ -1,7 +1,4 @@
-import {
-  IframeTransportEventDef,
-  MessageType_Enum,
-} from '#core/3p-frame-messaging';
+import {MessageType_Enum} from '#core/3p-frame-messaging';
 import {SubscriptionApi} from '../../../src/iframe-helper';
 import {dev, devAssert} from '#utils/log';
 
@@ -10,6 +7,8 @@ const TAG_ = 'amp-analytics/iframe-transport-message-queue';
 
 /** @private @const {number} */
 const MAX_QUEUE_SIZE_ = 100;
+
+/** @typedef {import('#core/3p-frame-messaging').IframeTransportEventDef} IframeTransportDef */
 
 /**
  * @visibleForTesting

--- a/extensions/amp-analytics/0.1/iframe-transport.js
+++ b/extensions/amp-analytics/0.1/iframe-transport.js
@@ -6,9 +6,11 @@ import {hasOwn} from '#core/types/object';
 import * as mode from '#core/mode';
 import {toggle} from '#core/dom/style';
 import {urls} from '../../../src/config';
-import {IframeTransportEventDef} from '#core/3p-frame-messaging';
 
-/** @private @const {string} */
+/**
+ * @type {string}
+ * @private @const
+ */
 const TAG_ = 'amp-analytics/iframe-transport';
 
 /** @private @const {number} */

--- a/extensions/amp-auto-ads/0.1/placement.js
+++ b/extensions/amp-auto-ads/0.1/placement.js
@@ -1,10 +1,6 @@
 import {createElementWithAttributes} from '#core/dom';
 import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
 import {
-  LayoutMarginsChangeDef,
-  cloneLayoutMarginsChangeDef,
-} from '#core/dom/layout/rect';
-import {
   closestAncestorElementBySelector,
   scopedQuerySelectorAll,
 } from '#core/dom/query';
@@ -16,6 +12,8 @@ import {dev, user} from '#utils/log';
 
 import {Attributes, getAttributesFromConfigObj} from './attributes';
 import {measurePageLayoutBox} from './measure-page-layout-box';
+
+/** @typedef {import('#core/dom/layout/rect').LayoutMarginsChangeDef} LayoutMarginsChangeDef */
 
 /** @const */
 const TAG = 'amp-auto-ads';

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -1,4 +1,4 @@
-import {LayoutRectDef, layoutRectLtwh} from '#core/dom/layout/rect';
+import {layoutRectLtwh} from '#core/dom/layout/rect';
 
 /**
  * @param {function():T} get
@@ -15,7 +15,7 @@ const readonlyGetterProp = (get) => ({
  * Returns a `LayoutRectDef`-like object whose values match the viewport's area
  * accoding to service.
  * @param {!../../../src/service/viewport/viewport-interface.ViewportInterface} viewport
- * @return {!LayoutRectDef} with dynamic getters
+ * @return {import('#core/dom/layout/rect').LayoutRectDef} with dynamic getters
  */
 export function createViewportRect(viewport) {
   const width = readonlyGetterProp(() => viewport.getSize().width);

--- a/extensions/amp-video-docking/0.1/viewport-rect.js
+++ b/extensions/amp-video-docking/0.1/viewport-rect.js
@@ -15,7 +15,7 @@ const readonlyGetterProp = (get) => ({
  * Returns a `LayoutRectDef`-like object whose values match the viewport's area
  * accoding to service.
  * @param {!../../../src/service/viewport/viewport-interface.ViewportInterface} viewport
- * @return {import('#core/dom/layout/rect').LayoutRectDef} with dynamic getters
+ * @return {import('./rect').LayoutRectDef} with dynamic getters
  */
 export function createViewportRect(viewport) {
   const width = readonlyGetterProp(() => viewport.getSize().width);

--- a/src/core/3p-frame-messaging.js
+++ b/src/core/3p-frame-messaging.js
@@ -128,8 +128,7 @@ export function isAmpMessage(message) {
   );
 }
 
-/** @typedef {{creativeId: string, message: string}} */
-export let IframeTransportEventDef;
+/** @typedef {{creativeId: string, message: string}} IframeTransportEventDef */
 // An event, and the transport ID of the amp-analytics tags that
 // generated it. For instance if the creative with transport
 // ID 2 sends "hi", then an IframeTransportEventDef would look like:

--- a/src/core/assert/base.js
+++ b/src/core/assert/base.js
@@ -100,7 +100,7 @@ function assertType_(
   if (isArray(opt_message)) {
     /** @type {AssertionFunctionArrayDef} */ (assertFn)(
       shouldBeTruthy,
-      /** @type {Array<any>} */ (opt_message).concat([subject])
+      /** @type {Array<*>} */ (opt_message).concat([subject])
     );
   } else {
     /** @type {AssertionFunctionStringDef} */ (assertFn)(

--- a/src/core/assert/base.js
+++ b/src/core/assert/base.js
@@ -100,7 +100,7 @@ function assertType_(
   if (isArray(opt_message)) {
     /** @type {AssertionFunctionArrayDef} */ (assertFn)(
       shouldBeTruthy,
-      /** @type {Array} */ (opt_message).concat([subject])
+      /** @type {Array<any>} */ (opt_message).concat([subject])
     );
   } else {
     /** @type {AssertionFunctionStringDef} */ (assertFn)(

--- a/src/core/constants/action-constants.js
+++ b/src/core/constants/action-constants.js
@@ -12,14 +12,14 @@ import {devAssert} from '#core/assert';
  * See ./service/action-impl.ActionInfoDef
  * TODO(rcebulko): Revert to @see once type is available
  *
- * @const {string}
+ * @type {string}
  */
 export const RAW_OBJECT_ARGS_KEY = '__AMP_OBJECT_STRING__';
 
 /**
  * Identifier for an element's default action.
  *
- * @const {string}
+ * @type {string}
  */
 export const DEFAULT_ACTION = 'activate';
 

--- a/src/core/constants/action-constants.js
+++ b/src/core/constants/action-constants.js
@@ -13,6 +13,7 @@ import {devAssert} from '#core/assert';
  * TODO(rcebulko): Revert to @see once type is available
  *
  * @type {string}
+ * @const
  */
 export const RAW_OBJECT_ARGS_KEY = '__AMP_OBJECT_STRING__';
 
@@ -20,6 +21,7 @@ export const RAW_OBJECT_ARGS_KEY = '__AMP_OBJECT_STRING__';
  * Identifier for an element's default action.
  *
  * @type {string}
+ * @const
  */
 export const DEFAULT_ACTION = 'activate';
 

--- a/src/core/constants/loading-instructions.js
+++ b/src/core/constants/loading-instructions.js
@@ -31,7 +31,10 @@ export const Loading_Enum = {
   UNLOAD: 'unload',
 };
 
-/** @const {Array<Loading_Enum>} */
+/**
+ * @type {Array<Loading_Enum>}
+ * @const
+ */
 const ORDER = [
   Loading_Enum.AUTO,
   Loading_Enum.LAZY,
@@ -39,7 +42,7 @@ const ORDER = [
   Loading_Enum.UNLOAD,
 ];
 
-/** @const {Object<string, number>} */
+/** @type {Object<string, number>} */
 const MAP = {
   [Loading_Enum.AUTO]: 0,
   [Loading_Enum.LAZY]: 1,

--- a/src/core/constants/loading-instructions.js
+++ b/src/core/constants/loading-instructions.js
@@ -42,7 +42,10 @@ const ORDER = [
   Loading_Enum.UNLOAD,
 ];
 
-/** @type {Object<string, number>} */
+/**
+ * @type {Object<string, number>}
+ * @const
+ */
 const MAP = {
   [Loading_Enum.AUTO]: 0,
   [Loading_Enum.LAZY]: 1,

--- a/src/core/context/node.js
+++ b/src/core/context/node.js
@@ -93,7 +93,7 @@ export class ContextNode {
       if (n != node || includeSelf) {
         if (n[NODE_PROP]) {
           // Already a discovered node.
-          return /** @type {!ContextNode<?>} */ (n[NODE_PROP]);
+          return /** @type {ContextNode<?>} */ (n[NODE_PROP]);
         }
         const {nodeType} = n;
         if (

--- a/src/core/context/node.js
+++ b/src/core/context/node.js
@@ -26,7 +26,7 @@ const FRAGMENT_NODE = 11;
  * The structure for a group of nodes.
  *
  * @typedef {{
- *   cn: ContextNode,
+ *   cn: ContextNode<?>,
  *   match: function(Node, Node):boolean,
  *   weight: number,
  * }} GroupDef
@@ -83,7 +83,7 @@ export class ContextNode {
    * @param {Node} node The node from which to perform the search.
    * @param {boolean=} includeSelf Whether the specified node itself should
    * be included in the search. Defaults to `true`.
-   * @return {?ContextNode}
+   * @return {?ContextNode<?>}
    */
   static closest(node, includeSelf = true) {
     /** @type {?Node} */
@@ -93,7 +93,7 @@ export class ContextNode {
       if (n != node || includeSelf) {
         if (n[NODE_PROP]) {
           // Already a discovered node.
-          return /** @type {!ContextNode} */ (n[NODE_PROP]);
+          return /** @type {!ContextNode<?>} */ (n[NODE_PROP]);
         }
         const {nodeType} = n;
         if (
@@ -112,6 +112,7 @@ export class ContextNode {
       }
       // Navigate up the DOM tree. Notice that we do not automatically go over
       // a root node boundary.
+      /** @type {Node|Element|undefined|null} */
       const assignedSlot =
         /** @type {?Node|undefined} */ (n[ASSIGNED_SLOT_PROP]) ||
         /** @type {Element} */ (n).assignedSlot;
@@ -164,7 +165,9 @@ export class ContextNode {
    * @param {Node} node
    */
   static rediscoverChildren(node) {
-    const contextNode = /** @type {ContextNode|undefined} */ (node[NODE_PROP]);
+    const contextNode = /** @type {ContextNode<?>|undefined} */ (
+      node[NODE_PROP]
+    );
     contextNode?.children?.forEach(discoverContextNode);
   }
 
@@ -203,7 +206,7 @@ export class ContextNode {
      * root node after the discovery phase.
      *
      * @package
-     * @type {?ContextNode}
+     * @type {?ContextNode<?>}
      */
     this.root = this.isRoot ? this : null;
 
@@ -215,7 +218,7 @@ export class ContextNode {
      * unobfuscated to avoid cross-binary issues.
      *
      * @package
-     * @type {?ContextNode}
+     * @type {?ContextNode<?>}
      */
     this.parent = null;
 
@@ -223,7 +226,7 @@ export class ContextNode {
      * See `parent` description.
      *
      * @package
-     * @type {?ContextNode[]}
+     * @type {?ContextNode<?>[]}
      */
     this.children = null;
 
@@ -241,7 +244,7 @@ export class ContextNode {
 
     /**
      * @private
-     * @type {?Map<SID, import('./subscriber').Subscriber>}
+     * @type {?Map<SID, import('./subscriber').Subscriber<?>>}
      */
     this.subscribers_ = null;
 
@@ -301,12 +304,12 @@ export class ContextNode {
    * Sets (or unsets) the direct parent. If the parent is set, the node will no
    * longer try to discover itself.
    *
-   * @param {?(ContextNode|Node)} parent
+   * @param {?(ContextNode<?>|Node)} parent
    */
   setParent(parent) {
     const parentContext = /** @type {*} */ (parent)?.nodeType
       ? ContextNode.get(/** @type {!Node} */ (parent))
-      : /** @type {?ContextNode} */ (parent);
+      : /** @type {?ContextNode<?>} */ (parent);
     this.updateTree_(parentContext, /* parentOverridden */ parent != null);
   }
 
@@ -323,7 +326,7 @@ export class ContextNode {
   }
 
   /**
-   * @param {?ContextNode} root
+   * @param {?ContextNode<?>} root
    * @protected Used cross-binary.
    */
   updateRoot(root) {
@@ -348,7 +351,7 @@ export class ContextNode {
    * @param {string} name
    * @param {function(Node):boolean} match
    * @param {number} weight
-   * @return {ContextNode}
+   * @return {ContextNode<?>}
    */
   addGroup(name, match, weight) {
     const groups = this.groups || (this.groups = new Map());
@@ -362,7 +365,7 @@ export class ContextNode {
 
   /**
    * @param {string} name
-   * @return {?ContextNode}
+   * @return {?ContextNode<?>}
    */
   group(name) {
     return this.groups?.get(name)?.cn || null;
@@ -370,7 +373,7 @@ export class ContextNode {
 
   /**
    * @param {Node} node
-   * @return {?ContextNode}
+   * @return {?ContextNode<?>}
    * @protected
    */
   findGroup(node) {
@@ -447,7 +450,7 @@ export class ContextNode {
   }
 
   /**
-   * @param {?ContextNode} parent
+   * @param {?ContextNode<?>} parent
    * @param {boolean} parentOverridden
    * @private
    */
@@ -494,7 +497,7 @@ export class ContextNode {
  * `node`. Only iterates over known context nodes.
  *
  * @param {Node} node
- * @param {function(ContextNode):void} callback
+ * @param {function(ContextNode<?>):void} callback
  * @param {boolean=} includeSelf
  */
 function forEachContained(node, callback, includeSelf = true) {
@@ -521,7 +524,7 @@ function discoverContained(node) {
 }
 
 /**
- * @param {ContextNode} cn
+ * @param {ContextNode<?>} cn
  */
 function discoverContextNode(cn) {
   cn.discover();

--- a/src/core/context/subscriber.js
+++ b/src/core/context/subscriber.js
@@ -14,7 +14,10 @@ import {throttleTail} from './scheduler';
  *          |(function(...DEP):(function():void))} SubscribeCallback
  */
 
+/** @type {Array<*>} */
 const EMPTY_ARRAY = [];
+
+/** @type {function():void} */
 const EMPTY_FUNC = () => {};
 
 /**

--- a/src/core/context/types.d.ts
+++ b/src/core/context/types.d.ts
@@ -1,3 +1,4 @@
+import {ContextNode} from './node'
 export interface IContextProp<T, DEP> {
   /**
    * A globally unique key. Extensions must use a fully qualified name such
@@ -77,4 +78,13 @@ export interface IContextPropUsed<T, DEP> {
   ping: (refreshParent: boolean) => void
   pingDep: ((dep: DEP) => void)[]
   pingParent: null | ((parentValue: T) => void)
+}
+declare global {
+  interface Node {
+    // Used to assign a ContextNode to a DOM Node.
+    __AMP_NODE?: ContextNode<any>;
+
+    // Used to map a Node to its assigned slot.
+    __AMP_ASSIGNED_SLOT?: Node;
+  }
 }

--- a/src/core/context/values.js
+++ b/src/core/context/values.js
@@ -1,4 +1,4 @@
-import {devAssert} from '#core/assert';
+import {devAssert, devAssertNumber} from '#core/assert';
 import {rethrowAsync} from '#core/error';
 import {pushIfNotExist, removeItem} from '#core/types/array';
 
@@ -480,7 +480,7 @@ export class Values {
             used.pending = Pending_Enum.NOT_PENDING;
             return;
           }
-          devAssert(updated);
+          devAssertNumber(updated);
           updated++;
           this.tryUpdate_(used);
         }

--- a/src/core/context/values.js
+++ b/src/core/context/values.js
@@ -390,7 +390,7 @@ export class Values {
         pingDep:
           deps.length > 0
             ? deps.map((dep, index) => {
-                /** @type {function(DEP):void} */
+                /** @param {DEP} value*/
                 return (value) => {
                   used.depValues[index] = value;
                   used.ping();
@@ -399,7 +399,7 @@ export class Values {
             : EMPTY_ARRAY,
         // Schedule the value recalculation due to the parent value change.
         pingParent: isRecursive(prop)
-          ? /** @type {(function(T):void)} */
+          ? /** @param {T} parentValue */
             (parentValue) => {
               used.parentValue = parentValue;
               used.ping();

--- a/src/core/context/values.js
+++ b/src/core/context/values.js
@@ -5,7 +5,10 @@ import {pushIfNotExist, removeItem} from '#core/types/array';
 import {deepScan, findParent} from './scan';
 import {throttleTail} from './scheduler';
 
+/** @type {Array<*>} */
 const EMPTY_ARRAY = [];
+
+/** @type {function():void} */
 const EMPTY_FUNC = () => {};
 
 /** @typedef {import('./node').ContextNode<?>} ContextNode */
@@ -316,6 +319,7 @@ export class Values {
    * @protected
    */
   scanAll(scheduled) {
+    /** @type {string[]?} */
     let newScheduled = null;
     const usedByKey = this.usedByKey_;
     if (usedByKey) {
@@ -372,6 +376,7 @@ export class Values {
         parentContextNode: null,
         // Schedule the value recalculation, optionally with the parent
         // refresh.
+        /** @type {function(boolean):void} */
         ping: (refreshParent) => {
           if (this.isConnected_()) {
             const pending = refreshParent
@@ -384,14 +389,18 @@ export class Values {
         // Schedule the value recalculation due to the dependency change.
         pingDep:
           deps.length > 0
-            ? deps.map((dep, index) => (value) => {
-                used.depValues[index] = value;
-                used.ping();
+            ? deps.map((dep, index) => {
+                /** @type {function(DEP):void} */
+                return (value) => {
+                  used.depValues[index] = value;
+                  used.ping();
+                };
               })
             : EMPTY_ARRAY,
         // Schedule the value recalculation due to the parent value change.
         pingParent: isRecursive(prop)
-          ? (parentValue) => {
+          ? /** @type {(function(T):void)} */
+            (parentValue) => {
               used.parentValue = parentValue;
               used.ping();
             }
@@ -457,6 +466,7 @@ export class Values {
 
     // Recompute all "pinged" values for this node. It checks if dependencies
     // are satisfied and recomputes values accordingly.
+    /** @type {number?} */
     let updated;
     do {
       updated = 0;
@@ -470,6 +480,7 @@ export class Values {
             used.pending = Pending_Enum.NOT_PENDING;
             return;
           }
+          devAssert(updated);
           updated++;
           this.tryUpdate_(used);
         }

--- a/src/core/data-structures/curve.js
+++ b/src/core/data-structures/curve.js
@@ -3,16 +3,14 @@ import {isString} from '#core/types';
 /**
  * Number between 0 and 1 that designates normalized time, as in "from start to
  * end".
- * @typedef {number}
+ * @typedef {number} NormTimeDef
  */
-export let NormTimeDef;
 
 /**
  * A CurveDef is a function that returns a normtime value (0 to 1) for another
  * normtime value.
- * @typedef {function(NormTimeDef): NormTimeDef}
+ * @typedef {function(NormTimeDef): NormTimeDef} CurveDef
  */
-export let CurveDef;
 
 /**
  * Returns a cubic bezier curve.
@@ -248,7 +246,8 @@ export const Curves_Enum = {
 };
 
 /**
- * @const {Object<string, CurveDef>}
+ * @const
+ * @type {Object<string, CurveDef>}
  */
 const NAME_MAP = {
   'linear': Curves_Enum.LINEAR,

--- a/src/core/data-structures/curve.js
+++ b/src/core/data-structures/curve.js
@@ -246,8 +246,8 @@ export const Curves_Enum = {
 };
 
 /**
- * @const
  * @type {Object<string, CurveDef>}
+ * @const
  */
 const NAME_MAP = {
   'linear': Curves_Enum.LINEAR,

--- a/src/core/data-structures/priority-queue.js
+++ b/src/core/data-structures/priority-queue.js
@@ -7,7 +7,10 @@ export class PriorityQueue {
    * Creates an instance of PriorityQueue.
    */
   constructor() {
-    /** @private @const {Array<{item: T, priority: number}>} */
+    /**
+     * @type {Array<{item: T, priority: number}>}
+     * @private
+     */
     this.queue_ = [];
   }
 
@@ -85,7 +88,7 @@ export class PriorityQueue {
     if (!this.length) {
       return null;
     }
-    return this.queue_.pop().item;
+    return /** @type {{item: T}} */ (this.queue_.pop()).item;
   }
 
   /**

--- a/src/core/data-structures/priority-queue.js
+++ b/src/core/data-structures/priority-queue.js
@@ -70,7 +70,7 @@ export class PriorityQueue {
   }
 
   /**
-   * @param {function(T):any} callback
+   * @param {function(T):*} callback
    */
   forEach(callback) {
     let index = this.length;

--- a/src/core/data-structures/priority-queue.js
+++ b/src/core/data-structures/priority-queue.js
@@ -85,10 +85,11 @@ export class PriorityQueue {
    * @return {?T}
    */
   dequeue() {
-    if (!this.length) {
+    const lastItem = this.queue_.pop();
+    if (!lastItem) {
       return null;
     }
-    return /** @type {{item: T}} */ (this.queue_.pop()).item;
+    return lastItem.item;
   }
 
   /**

--- a/src/core/data-structures/promise.js
+++ b/src/core/data-structures/promise.js
@@ -1,4 +1,4 @@
-/** @type {undefined|Promise<undefined>}| */
+/** @type {undefined|Promise<void>}| */
 let resolved;
 
 /**
@@ -6,7 +6,7 @@ let resolved;
  * Babel converts direct calls to Promise.resolve() (with no arguments) into
  * calls to this.
  *
- * @return {Promise<undefined>}
+ * @return {Promise<void>}
  */
 export function resolvedPromise() {
   if (resolved) {

--- a/src/core/data-structures/promise.js
+++ b/src/core/data-structures/promise.js
@@ -1,3 +1,4 @@
+/** @type {undefined|Promise<undefined>}| */
 let resolved;
 
 /**
@@ -69,7 +70,7 @@ export function tryResolve(fn) {
 
 /**
  * Resolves with the result of the last promise added.
- * @implements {PromiseLike}
+ * @implements {PromiseLike<T>}
  * @template T
  */
 export class LastAddedResolver {

--- a/src/core/data-structures/signals.js
+++ b/src/core/data-structures/signals.js
@@ -1,7 +1,8 @@
-import {TimestampDef} from '#core/types/date';
 import {map} from '#core/types/object';
 
 import {Deferred} from './promise';
+
+/** @typedef {import('#core/types/date').TimestampDef} TimestampDef */
 
 /**
  * This object tracts signals and allows blocking until a signal has been

--- a/src/core/document/visibility.js
+++ b/src/core/document/visibility.js
@@ -12,14 +12,16 @@ export function getDocumentVisibilityState(doc) {
     'visibilityState',
     true
   );
-  if (doc[visibilityStateProp]) {
-    return doc[visibilityStateProp];
+  const visibilityStateValue = /** @type {any} */ (doc)[visibilityStateProp];
+  if (visibilityStateValue) {
+    return visibilityStateValue;
   }
 
   // Old API: `document.hidden` property.
   const hiddenProp = getVendorJsPropertyName(doc, 'hidden', true);
-  if (doc[hiddenProp]) {
-    return doc[hiddenProp]
+  if (hiddenProp in doc) {
+    const hiddenValue = /** @type {any} */ (doc)[hiddenProp];
+    return hiddenValue
       ? VisibilityState_Enum.HIDDEN
       : VisibilityState_Enum.VISIBLE;
   }

--- a/src/core/document/visibility.js
+++ b/src/core/document/visibility.js
@@ -12,7 +12,7 @@ export function getDocumentVisibilityState(doc) {
     'visibilityState',
     true
   );
-  const visibilityStateValue = /** @type {any} */ (doc)[visibilityStateProp];
+  const visibilityStateValue = /** @type {*} */ (doc)[visibilityStateProp];
   if (visibilityStateValue) {
     return visibilityStateValue;
   }

--- a/src/core/document/visibility.js
+++ b/src/core/document/visibility.js
@@ -20,7 +20,7 @@ export function getDocumentVisibilityState(doc) {
   // Old API: `document.hidden` property.
   const hiddenProp = getVendorJsPropertyName(doc, 'hidden', true);
   if (hiddenProp in doc) {
-    const hiddenValue = /** @type {any} */ (doc)[hiddenProp];
+    const hiddenValue = /** @type {*} */ (doc)[hiddenProp];
     return hiddenValue
       ? VisibilityState_Enum.HIDDEN
       : VisibilityState_Enum.VISIBLE;

--- a/src/core/dom/amp-element-helpers.js
+++ b/src/core/dom/amp-element-helpers.js
@@ -43,5 +43,7 @@ export function whenUpgradedToCustomElement(element) {
     element[UPGRADE_TO_CUSTOMELEMENT_RESOLVER] = deferred.resolve;
   }
 
-  return element[UPGRADE_TO_CUSTOMELEMENT_PROMISE];
+  const upgradedPromise = element[UPGRADE_TO_CUSTOMELEMENT_PROMISE];
+  devAssert(upgradedPromise);
+  return upgradedPromise;
 }

--- a/src/core/dom/amp-element.d.ts
+++ b/src/core/dom/amp-element.d.ts
@@ -24,7 +24,7 @@ declare global {
   }
 
   interface HTMLElement {
-    '__AMP_UPG_PRM'?: Promise<AmpElement>,
-    '__AMP_UPG_RES'?: (res:Function) => void,
+    __AMP_UPG_PRM?: Promise<AmpElement>;
+    __AMP_UPG_RES?: (res: Function) => void;
   }
 }

--- a/src/core/dom/amp-element.d.ts
+++ b/src/core/dom/amp-element.d.ts
@@ -18,5 +18,13 @@ declare global {
     sizerElement?: HTMLElement;
 
     getPlaceholder: () => null | Element;
+
+    unmount: () => Promise<void>;
+    ensureLoaded: () => Promise<void>;
+  }
+
+  interface HTMLElement {
+    '__AMP_UPG_PRM'?: Promise<AmpElement>,
+    '__AMP_UPG_RES'?: (res:Function) => void,
   }
 }

--- a/src/core/dom/dom-globals.d.ts
+++ b/src/core/dom/dom-globals.d.ts
@@ -1,0 +1,11 @@
+export {};
+
+declare global {
+  interface HTMLElement {
+    // Used by modal.js to keep track of the saved tab on an element.
+    '__AMP_MODAL_SAVED_TAB_INDEX'?: string | null;
+
+    // Used by form.js
+    '__AMP_FORM': HTMLFormElement;
+  }
+}

--- a/src/core/dom/dom-globals.d.ts
+++ b/src/core/dom/dom-globals.d.ts
@@ -5,7 +5,10 @@ declare global {
     // Used by modal.js to keep track of the saved tab on an element.
     '__AMP_MODAL_SAVED_TAB_INDEX'?: string | null;
 
-    // Used by form.js
-    '__AMP_FORM': HTMLFormElement;
+    // Used by extensions/amp-form/0.1 and src/core/form.js.
+    // TODO: move to extensions/amp-form, as it is the only consumer.
+    '__AMP_FORM': AmpForm;
   }
+
+  interface AmpForm {}
 }

--- a/src/core/dom/dom-globals.d.ts
+++ b/src/core/dom/dom-globals.d.ts
@@ -3,11 +3,11 @@ export {};
 declare global {
   interface HTMLElement {
     // Used by modal.js to keep track of the saved tab on an element.
-    '__AMP_MODAL_SAVED_TAB_INDEX'?: string | null;
+    __AMP_MODAL_SAVED_TAB_INDEX?: string | null;
 
     // Used by extensions/amp-form/0.1 and src/core/form.js.
-    // TODO: move to extensions/amp-form, as it is the only consumer.
-    '__AMP_FORM': AmpForm;
+    // TODO(wg-performance): move to extensions/amp-form, as it is the only consumer.
+    __AMP_FORM: AmpForm;
   }
 
   interface AmpForm {}

--- a/src/core/dom/form.js
+++ b/src/core/dom/form.js
@@ -8,7 +8,7 @@ const FORM_PROP_ = '__AMP_FORM';
 
 /**
  * @param {HTMLElement} element
- * @return {HTMLFormElement}
+ * @return {AmpForm}
  */
 export function formOrNullForElement(element) {
   return element[FORM_PROP_] || null;
@@ -16,7 +16,7 @@ export function formOrNullForElement(element) {
 
 /**
  * @param {HTMLElement} element
- * @param {HTMLFormElement} form
+ * @param {AmpForm} form
  */
 export function setFormForElement(element, form) {
   element[FORM_PROP_] = form;

--- a/src/core/dom/form.js
+++ b/src/core/dom/form.js
@@ -3,27 +3,20 @@ import {ancestorElementsByTag} from '#core/dom/query';
 import {toArray} from '#core/types/array';
 import {dict} from '#core/types/object';
 
-/**
- * Stub type until an AmpForm interface is available in typechecked-land.
- * Should be satisfied by `#extensions/amp-form/0.1/amp-form.AmpForm`
- * @typedef {?}
- */
-let AmpFormDef;
-
 /** @const {string} */
 const FORM_PROP_ = '__AMP_FORM';
 
 /**
- * @param {Element} element
- * @return {AmpFormDef}
+ * @param {HTMLElement} element
+ * @return {HTMLFormElement}
  */
 export function formOrNullForElement(element) {
   return element[FORM_PROP_] || null;
 }
 
 /**
- * @param {Element} element
- * @param {AmpFormDef} form
+ * @param {HTMLElement} element
+ * @param {HTMLFormElement} form
  */
 export function setFormForElement(element, form) {
   element[FORM_PROP_] = form;

--- a/src/core/dom/fullscreen.d.ts
+++ b/src/core/dom/fullscreen.d.ts
@@ -7,28 +7,28 @@ export {};
 
 declare global {
   interface Element {
-    requestFullScreen;
-    exitFullscreen;
-    cancelFullScreen;
-    webkitRequestFullscreen;
-    webkitExitFullscreen;
-    webkitEnterFullscreen;
-    webkitCancelFullScreen;
-    webkitDisplayingFullscreen;
-    mozRequestFullScreen;
-    mozCancelFullScreen;
-    msRequestFullscreen;
-    msExitFullscreen;
+    requestFullScreen: any;
+    exitFullscreen: any;
+    cancelFullScreen: any;
+    webkitRequestFullscreen: any;
+    webkitExitFullscreen: any;
+    webkitEnterFullscreen: any;
+    webkitCancelFullScreen: any;
+    webkitDisplayingFullscreen: any;
+    mozRequestFullScreen: any;
+    mozCancelFullScreen: any;
+    msRequestFullscreen: any;
+    msExitFullscreen: any;
   }
 
   interface Document {
-    cancelFullScreen;
-    webkitCancelFullScreen;
-    webkitExitFullscreen;
-    webkitFullscreenElement;
-    webkitCurrentFullScreenElement;
-    msExitFullscreen;
-    mozFullScreenElement;
-    mozCancelFullScreen;
+    cancelFullScreen:any;
+    webkitCancelFullScreen:any;
+    webkitExitFullscreen:any;
+    webkitFullscreenElement:any;
+    webkitCurrentFullScreenElement:any;
+    msExitFullscreen:any;
+    mozFullScreenElement:any;
+    mozCancelFullScreen:any;
   }
 }

--- a/src/core/dom/get-html.js
+++ b/src/core/dom/get-html.js
@@ -44,7 +44,8 @@ const allowedAttributes = [
  */
 export function getHtml(win, selector, attrs) {
   const root = win.document.querySelector(selector);
-  const result = /** @type {string[]} */ ([]);
+  /** @type {string[]} */
+  const result = [];
 
   if (root) {
     appendToResult(root, attrs, result);

--- a/src/core/dom/get-html.js
+++ b/src/core/dom/get-html.js
@@ -44,7 +44,7 @@ const allowedAttributes = [
  */
 export function getHtml(win, selector, attrs) {
   const root = win.document.querySelector(selector);
-  const result = [];
+  const result = /** @type {string[]} */ ([]);
 
   if (root) {
     appendToResult(root, attrs, result);

--- a/src/core/dom/index.js
+++ b/src/core/dom/index.js
@@ -20,9 +20,8 @@ const HTML_ESCAPE_REGEX = /(&|<|>|"|'|`)/g;
  * @typedef {{
  *   bubbles: (boolean|undefined),
  *   cancelable: (boolean|undefined),
- * }}
+ * }} CustomEventOptionsDef;
  */
-export let CustomEventOptionsDef;
 
 /** @const {CustomEventOptionsDef} */
 const DEFAULT_CUSTOM_EVENT_OPTIONS = {bubbles: true, cancelable: true};
@@ -63,7 +62,7 @@ export function waitForChild(parent, checkFunc, callback) {
  * promise is resolved.
  * @param {Element} parent
  * @param {function(Element):boolean} checkFunc
- * @return {Promise}
+ * @return {Promise<void>}
  */
 export function waitForChildPromise(parent, checkFunc) {
   return new Promise((resolve) => {
@@ -83,7 +82,7 @@ export function waitForBodyOpen(doc, callback) {
 /**
  * Waits for document's body to be available.
  * @param {Document} doc
- * @return {Promise}
+ * @return {Promise<void>}
  */
 export function waitForBodyOpenPromise(doc) {
   return new Promise((resolve) =>
@@ -376,7 +375,7 @@ export function escapeHtml(text) {
 }
 
 /**
- * @param {string} c
+ * @param {keyof HTML_ESCAPE_CHARS} c
  * @return {string}
  */
 function escapeHtmlChar(c) {

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -75,8 +75,8 @@ function setAttribute(element, name, value) {
 }
 
 /**
- * @param {string| ((props:any) => Element)} tag
- * @param {any} props
+ * @param {string | function(*): Element} tag
+ * @param {Object<string, *>} props
  * @param {...*} children
  * @return {Element}
  */

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -75,7 +75,7 @@ function setAttribute(element, name, value) {
 }
 
 /**
- * @param {string | function(*): Element} tag
+ * @param {string | (function(*): Element)} tag
  * @param {Object<string, *>} props
  * @param {...*} children
  * @return {Element}

--- a/src/core/dom/jsx.js
+++ b/src/core/dom/jsx.js
@@ -75,11 +75,10 @@ function setAttribute(element, name, value) {
 }
 
 /**
- * @param {string|function(T):Element} tag
- * @param {T} props
+ * @param {string| ((props:any) => Element)} tag
+ * @param {any} props
  * @param {...*} children
  * @return {Element}
- * @template T
  */
 export function createElement(tag, props, ...children) {
   if (typeof tag !== 'string') {

--- a/src/core/dom/layout/index.js
+++ b/src/core/dom/layout/index.js
@@ -36,24 +36,22 @@ export const LayoutPriority_Enum = {
 
 /**
  * CSS Length type. E.g. "1px" or "20vh".
- * @typedef {string}
+ * @typedef {string} LengthDef;
  */
-export let LengthDef;
 
 /**
  * @typedef {{
  *   width: string,
  *   height: string
- * }}
+ * }} DimensionsDef;
  */
-export let DimensionsDef;
 
 /**
  * Elements that the progress can be shown for. This set has to be externalized
  * since the element's implementation may not be downloaded yet.
  * This list does not include video players which are found via regex later.
  * @enum {string}
- * @private  Visible for testing only
+ * @private Visible for testing only
  */
 export const LOADING_ELEMENTS_ENUM = {
   AMP_AD: 'AMP-AD',
@@ -190,11 +188,8 @@ export function assertLengthOrPercent(length) {
  */
 export function getLengthUnits(length) {
   assertLength(length);
-  const m = userAssert(
-    /[a-z]+/i.exec(length ?? ''),
-    'Failed to read units from %s',
-    length
-  );
+  const m = /[a-z]+/i.exec(length ?? '');
+  userAssert(m, 'Failed to read units from %s', length);
   return m[0];
 }
 

--- a/src/core/dom/layout/intersection.js
+++ b/src/core/dom/layout/intersection.js
@@ -3,7 +3,7 @@ import {Deferred} from '#core/data-structures/promise';
 import {dict} from '#core/types/object';
 import {getWin} from '#core/window';
 
-import {LayoutRectDef, layoutRectFromDomRect} from './rect';
+import {layoutRectFromDomRect} from './rect';
 import {createViewportObserver} from './viewport-observer';
 
 /** @type {undefined|WeakMap<Element, Deferred<IntersectionObserverEntry>>|undefined} */
@@ -91,7 +91,7 @@ export function intersectionEntryToJson(entry) {
 
 /**
  * @param {?} rect
- * @return {?LayoutRectDef}
+ * @return {?import('#core/dom/layout/rect').LayoutRectDef}
  */
 function safeLayoutRectFromDomRect(rect) {
   if (rect === null) {

--- a/src/core/dom/layout/intersection.js
+++ b/src/core/dom/layout/intersection.js
@@ -91,7 +91,7 @@ export function intersectionEntryToJson(entry) {
 
 /**
  * @param {?} rect
- * @return {?import('#core/dom/layout/rect').LayoutRectDef}
+ * @return {?import('./rect').LayoutRectDef}
  */
 function safeLayoutRectFromDomRect(rect) {
   if (rect === null) {

--- a/src/core/dom/layout/page-layout-box.js
+++ b/src/core/dom/layout/page-layout-box.js
@@ -1,8 +1,8 @@
-import {LayoutRectDef, layoutRectLtwh} from './rect';
+import {layoutRectLtwh} from './rect';
 
 /**
  * @param {HTMLElement} element
- * @return {LayoutRectDef}
+ * @return {import('./rect').LayoutRectDef}
  */
 export function getPageLayoutBoxBlocking(element) {
   const stop = element.ownerDocument.body;

--- a/src/core/dom/layout/rect.js
+++ b/src/core/dom/layout/rect.js
@@ -20,9 +20,8 @@ let ViewportInterfaceDef;
  *   height: number,
  *   x: number,
  *   y: number
- * }}
+ * }} LayoutRectDef;
  */
-export let LayoutRectDef;
 
 /**
  * The structure that contains the size for an element. The exact
@@ -31,9 +30,8 @@ export let LayoutRectDef;
  * @typedef {{
  *   width: number,
  *   height: number,
- * }}
+ * }} LayoutSizeDef;
  */
-export let LayoutSizeDef;
 
 /**
  * The structure that represents the margins of an Element.
@@ -43,9 +41,8 @@ export let LayoutSizeDef;
  *   right: number,
  *   bottom: number,
  *   left: number
- * }}
+ * }} LayoutMarginsDef;
  */
-export let LayoutMarginsDef;
 
 /**
  * The structure that represents a requested change to the margins of an
@@ -57,9 +54,8 @@ export let LayoutMarginsDef;
  *   right: (number|undefined),
  *   bottom: (number|undefined),
  *   left: (number|undefined)
- * }}
+ * }} LayoutMarginsChangeDef;
  */
-export let LayoutMarginsChangeDef;
 
 /**
  * RelativePositions_Enum

--- a/src/core/dom/layout/size-observer.js
+++ b/src/core/dom/layout/size-observer.js
@@ -64,7 +64,7 @@ export function unobserveContentSize(element, callback) {
  */
 export function measureContentSize(element) {
   return new Promise((resolve) => {
-    /** @type {function(LayoutSizeDef):void} */
+    /** @param {LayoutSizeDef} size */
     const onSize = (size) => {
       resolve(size);
       unobserveContentSize(element, onSize);
@@ -98,7 +98,7 @@ export function unobserveBorderBoxSize(element, callback) {
  */
 export function measureBorderBoxSize(element) {
   return new Promise((resolve) => {
-    /** @type {function(ResizeObserverSize): void} */
+    /** @param {ResizeObserverSize} size */
     const onSize = (size) => {
       resolve(size);
       unobserveBorderBoxSize(element, onSize);

--- a/src/core/dom/layout/size-observer.js
+++ b/src/core/dom/layout/size-observer.js
@@ -6,7 +6,7 @@ import {getWin} from '#core/window';
 /** @typedef {import('./rect').LayoutSizeDef} LayoutSizeDef */
 /** @typedef {LayoutSizeDef|ResizeObserverSize} TargetSize */
 /**
- * @typedef {(s: Size) => void} SizeCallback
+ * @typedef {function(Size): void} SizeCallback
  * @template {TargetSize} Size
  */
 
@@ -64,7 +64,7 @@ export function unobserveContentSize(element, callback) {
  */
 export function measureContentSize(element) {
   return new Promise((resolve) => {
-    /** @type {(size: LayoutSizeDef) => void} */
+    /** @type {function(LayoutSizeDef):void} */
     const onSize = (size) => {
       resolve(size);
       unobserveContentSize(element, onSize);
@@ -98,7 +98,7 @@ export function unobserveBorderBoxSize(element, callback) {
  */
 export function measureBorderBoxSize(element) {
   return new Promise((resolve) => {
-    /** @type {(size: ResizeObserverSize) => void} */
+    /** @type {function(ResizeObserverSize): void} */
     const onSize = (size) => {
       resolve(size);
       unobserveBorderBoxSize(element, onSize);

--- a/src/core/dom/layout/size-observer.js
+++ b/src/core/dom/layout/size-observer.js
@@ -3,12 +3,11 @@ import {tryCallback} from '#core/error';
 import {remove} from '#core/types/array';
 import {getWin} from '#core/window';
 
-import {LayoutSizeDef} from './rect';
-
+/** @typedef {import('./rect').LayoutSizeDef} LayoutSizeDef */
 /** @typedef {LayoutSizeDef|ResizeObserverSize} TargetSize */
 /**
+ * @typedef {(s: Size) => void} SizeCallback
  * @template {TargetSize} Size
- * @typedef {function(Size):void} SizeCallback
  */
 
 /** @enum {number} */
@@ -31,10 +30,12 @@ const VERTICAL_RE = /vertical/;
 const observers = /* #__PURE__ */ new WeakMap();
 
 /**
- * @const {WeakMap<Element, Array<{
- *   type: !Type_Enum,
- *   callback: !SizeCallback
+ * @type {WeakMap<Element, Array<{
+ *   type: Type_Enum,
+ *   callback: SizeCallback<TargetSize>
  * }>>}
+ *
+ * @const
  */
 const targetObserverMultimap = /* #__PURE__ */ new WeakMap();
 
@@ -63,6 +64,7 @@ export function unobserveContentSize(element, callback) {
  */
 export function measureContentSize(element) {
   return new Promise((resolve) => {
+    /** @type {(size: LayoutSizeDef) => void} */
     const onSize = (size) => {
       resolve(size);
       unobserveContentSize(element, onSize);
@@ -96,6 +98,7 @@ export function unobserveBorderBoxSize(element, callback) {
  */
 export function measureBorderBoxSize(element) {
   return new Promise((resolve) => {
+    /** @type {(size: ResizeObserverSize) => void} */
     const onSize = (size) => {
       resolve(size);
       unobserveBorderBoxSize(element, onSize);
@@ -222,7 +225,7 @@ function computeAndCall(type, callback, entry) {
       const {target} = entry;
       const win = getWin(target);
       const isVertical = VERTICAL_RE.test(
-        computedStyle(win, /** @type {HTMLElement} */ (target))['writing-mode']
+        computedStyle(win, /** @type {HTMLElement} */ (target)).writingMode
       );
       const {offsetHeight, offsetWidth} = /** @type {HTMLElement} */ (target);
       let inlineSize, blockSize;

--- a/src/core/dom/media-query-props.js
+++ b/src/core/dom/media-query-props.js
@@ -16,10 +16,16 @@ export class MediaQueryProps {
     /** @private @const */
     this.callback_ = callback;
 
-    /** @private {Object<string, ExprDef>} */
+    /**
+     * @type {Object<string, ExprDef>}
+     * @private
+     */
     this.exprMap_ = {};
 
-    /** @private {?Object<string, ExprDef>} */
+    /**
+     * @type {?Object<string, ExprDef>}
+     * @private
+     */
     this.prevExprMap_ = null;
   }
 
@@ -86,8 +92,11 @@ export class MediaQueryProps {
     if (!exprString.trim()) {
       return emptyExprValue;
     }
-    let expr =
-      this.exprMap_[exprString] || devAssert(this.prevExprMap_)[exprString];
+    let expr = this.exprMap_[exprString];
+    if (!expr) {
+      devAssert(this.prevExprMap_);
+      expr = this.prevExprMap_[exprString];
+    }
     if (!expr) {
       expr = parser(this.win_, exprString);
       toggleOnChange(expr, this.callback_, true);

--- a/src/core/dom/modal.js
+++ b/src/core/dom/modal.js
@@ -135,7 +135,7 @@ function getPotentiallyFocusableElements(element) {
  *
  * @param {HTMLElement} element The Element top operate on.
  * @param {string} attribute  The name of the attribute.
- * @param {?string|undefined} value The value of the attribute.
+ * @param {?string=} value The value of the attribute.
  */
 function restoreAttributeValue(element, attribute, value) {
   if (value === null || value == undefined) {

--- a/src/core/dom/modal.js
+++ b/src/core/dom/modal.js
@@ -42,7 +42,8 @@ const SAVED_TAB_INDEX = '__AMP_MODAL_SAVED_TAB_INDEX';
  * @package Visible for testing
  */
 export function getElementsToAriaHide(element) {
-  const arr = /** @type {HTMLElement[]} */ ([]);
+  /** @type {HTMLElement[]} */
+  const arr = [];
   const ancestors = getAncestors(element);
 
   for (let i = 0; i < ancestors.length; i++) {
@@ -90,10 +91,11 @@ function getAncestors(element) {
  * Note that some of these Elements may not be focusable (e.g. is a button
  * that is `disabled` or has an ancestor that is `display: none`).
  * @param {HTMLElement} element
- * @return {Array<HTMLElement>}
+ * @return {HTMLElement[]}
  */
 function getPotentiallyFocusableElements(element) {
-  const arr = /** @type {HTMLElement[]}*/ ([]);
+  /** @type {HTMLElement[]} */
+  const arr = [];
   let cur = element;
 
   while (cur) {

--- a/src/core/dom/modal.js
+++ b/src/core/dom/modal.js
@@ -42,7 +42,7 @@ const SAVED_TAB_INDEX = '__AMP_MODAL_SAVED_TAB_INDEX';
  * @package Visible for testing
  */
 export function getElementsToAriaHide(element) {
-  const arr = [];
+  const arr = /** @type {HTMLElement[]} */ ([]);
   const ancestors = getAncestors(element);
 
   for (let i = 0; i < ancestors.length; i++) {
@@ -54,7 +54,7 @@ export function getElementsToAriaHide(element) {
 
     toArray(/** @type {HTMLDocument|HTMLElement} */ (cur.parentNode).children)
       .filter((c) => c != cur)
-      .forEach((c) => arr.push(c));
+      .forEach((c) => arr.push(/** @type {HTMLElement} */ (c)));
   }
 
   return arr;
@@ -93,7 +93,7 @@ function getAncestors(element) {
  * @return {Array<HTMLElement>}
  */
 function getPotentiallyFocusableElements(element) {
-  const arr = [];
+  const arr = /** @type {HTMLElement[]}*/ ([]);
   let cur = element;
 
   while (cur) {
@@ -133,10 +133,10 @@ function getPotentiallyFocusableElements(element) {
  *
  * @param {HTMLElement} element The Element top operate on.
  * @param {string} attribute  The name of the attribute.
- * @param {?string} value The value of the attribute.
+ * @param {?string|undefined} value The value of the attribute.
  */
 function restoreAttributeValue(element, attribute, value) {
-  if (value === null) {
+  if (value === null || value == undefined) {
     element.removeAttribute(attribute);
   } else {
     element.setAttribute(attribute, value);

--- a/src/core/dom/parse-date-attributes.js
+++ b/src/core/dom/parse-date-attributes.js
@@ -2,7 +2,7 @@ import {devAssert, userAssert} from '#core/assert';
 import {parseDate} from '#core/types/date';
 
 /** @typedef {import('#core/types/date').TimestampDef} TimestampDef */
-/** @typedef {(s:string) => TimestampDef} DateParserDef */
+/** @typedef {function(string): TimestampDef} DateParserDef */
 
 /**
  * Map from attribute names to their parsers.

--- a/src/core/dom/parse-date-attributes.js
+++ b/src/core/dom/parse-date-attributes.js
@@ -1,7 +1,8 @@
 import {devAssert, userAssert} from '#core/assert';
-import {TimestampDef, parseDate} from '#core/types/date';
+import {parseDate} from '#core/types/date';
 
-/** @typedef {function(string):TimestampDef} DateParserDef */
+/** @typedef {import('#core/types/date').TimestampDef} TimestampDef */
+/** @typedef {(s:string) => TimestampDef} DateParserDef */
 
 /**
  * Map from attribute names to their parsers.

--- a/src/core/dom/resource-container-helper.js
+++ b/src/core/dom/resource-container-helper.js
@@ -4,13 +4,13 @@ import {arrayOrSingleItemToArray} from '#core/types/array';
 const AMP_CLASS = 'i-amphtml-element';
 const DEEP = true;
 
-/** @type {(e:AmpElement) => Promise<void>} */
+/** @type {function(AmpElement): Promise<void>} */
 const ensureLoaded = (element) => element.ensureLoaded();
 
-/** @type {(e:AmpElement) => void} */
+/** @type {function(AmpElement): void} */
 const pause = (element) => element.pause();
 
-/** @type {(e:AmpElement) => Promise<void>} */
+/** @type {function(AmpElement): Promise<void>} */
 const unmount = (element) => element.unmount();
 
 /**

--- a/src/core/dom/resource-container-helper.js
+++ b/src/core/dom/resource-container-helper.js
@@ -4,8 +4,13 @@ import {arrayOrSingleItemToArray} from '#core/types/array';
 const AMP_CLASS = 'i-amphtml-element';
 const DEEP = true;
 
+/** @type {(e:AmpElement) => Promise<void>} */
 const ensureLoaded = (element) => element.ensureLoaded();
+
+/** @type {(e:AmpElement) => void} */
 const pause = (element) => element.pause();
+
+/** @type {(e:AmpElement) => Promise<void>} */
 const unmount = (element) => element.unmount();
 
 /**

--- a/src/core/dom/srcset.js
+++ b/src/core/dom/srcset.js
@@ -19,7 +19,7 @@ const srcsetRegex = /(\S+)(?:\s+(?:(-?\d+(?:\.\d+)?)([a-zA-Z]*)))?\s*(?:,|$)/g;
 /**
  * Extracts `srcset` and fallbacks to `src` if not available.
  * @param {Element} element
- * @return {Srcset<*>}
+ * @return {Srcset<SrcsetSourceDef>}
  */
 export function srcsetFromElement(element) {
   const srcsetAttr = element.getAttribute('srcset');
@@ -41,7 +41,7 @@ export function srcsetFromElement(element) {
 /**
  * Creates a Srcset from a `src` attribute value.
  * @param {string} src
- * @return {Srcset<*>}
+ * @return {Srcset<SrcsetSourceDef>}
  */
 export function srcsetFromSrc(src) {
   return new Srcset([{url: src, width: undefined, dpr: 1}]);

--- a/src/core/dom/srcset.js
+++ b/src/core/dom/srcset.js
@@ -19,7 +19,7 @@ const srcsetRegex = /(\S+)(?:\s+(?:(-?\d+(?:\.\d+)?)([a-zA-Z]*)))?\s*(?:,|$)/g;
 /**
  * Extracts `srcset` and fallbacks to `src` if not available.
  * @param {Element} element
- * @return {Srcset}
+ * @return {Srcset<*>}
  */
 export function srcsetFromElement(element) {
   const srcsetAttr = element.getAttribute('srcset');
@@ -41,7 +41,7 @@ export function srcsetFromElement(element) {
 /**
  * Creates a Srcset from a `src` attribute value.
  * @param {string} src
- * @return {Srcset}
+ * @return {Srcset<*>}
  */
 export function srcsetFromSrc(src) {
   return new Srcset([{url: src, width: undefined, dpr: 1}]);
@@ -52,10 +52,9 @@ export function srcsetFromSrc(src) {
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Attributes.
  * See http://www.w3.org/html/wg/drafts/html/master/semantics.html#attr-img-srcset.
  * @param {string} s
- * @return {Srcset}
+ * @return {Srcset<SrcsetSourceDef>}
  */
 export function parseSrcset(s) {
-  /** @type {SrcsetSourceDef[]} */
   const sources = [];
   let match;
   while ((match = srcsetRegex.exec(s))) {

--- a/src/core/dom/static-template.js
+++ b/src/core/dom/static-template.js
@@ -1,7 +1,10 @@
 import {devAssert} from '#core/assert';
 import {map} from '#core/types/object';
 
+/** @type {HTMLElement} */
 let htmlContainer;
+
+/** @type {SVGSVGElement} */
 let svgContainer;
 
 /**
@@ -72,7 +75,7 @@ function html(strings) {
 
 /**
  * Helper used by html and svg string literal functions.
- * @param {HTMLElement} container
+ * @param {HTMLElement | SVGSVGElement} container
  * @param {readonly string[]} strings
  * @return {HTMLElement}
  */

--- a/src/core/dom/stream/response.js
+++ b/src/core/dom/stream/response.js
@@ -41,7 +41,8 @@ export function streamResponseToWriter(win, response, writer) {
       }
 
       if (!done) {
-        return reader.read().then(handleChunk);
+        reader.read().then(handleChunk);
+        return;
       }
 
       writer.close();

--- a/src/core/dom/style.js
+++ b/src/core/dom/style.js
@@ -31,7 +31,7 @@ export function camelCaseToTitleCase(camelCase) {
   Checks the style if a prefixed version of a property exists and returns
  * it or returns an empty string.
  * @private
- * @param {Object} style
+ * @param {Object<string, *>} style
  * @param {string} titleCase the title case version of a css property name
  * @return {string} the prefixed property name or null.
  */
@@ -49,7 +49,7 @@ function getVendorJsPropertyName_(style, titleCase) {
  * Returns the possibly prefixed JavaScript property name of a style property
  * (ex. WebkitTransitionDuration) given a camelCase'd version of the property
  * (ex. transitionDuration).
- * @param {Object} style
+ * @param {any} style
  * @param {string} camelCase the camel cased version of a css property name
  * @param {boolean=} opt_bypassCache bypass the memoized cache of property
  *   mapping
@@ -119,7 +119,7 @@ export function setStyle(element, property, value, opt_units, opt_bypassCache) {
   if (isVar(propertyName)) {
     element.style.setProperty(propertyName, styleValue);
   } else {
-    element.style[propertyName] = styleValue;
+    /** @type {any} */ (element.style)[propertyName] = styleValue;
   }
 }
 
@@ -142,7 +142,7 @@ export function getStyle(element, property, opt_bypassCache) {
   if (isVar(propertyName)) {
     return element.style.getPropertyValue(propertyName);
   }
-  return element.style[propertyName];
+  return /** @type {any} */ (element.style)[propertyName];
 }
 
 /**

--- a/src/core/dom/style.js
+++ b/src/core/dom/style.js
@@ -49,7 +49,7 @@ function getVendorJsPropertyName_(style, titleCase) {
  * Returns the possibly prefixed JavaScript property name of a style property
  * (ex. WebkitTransitionDuration) given a camelCase'd version of the property
  * (ex. transitionDuration).
- * @param {any} style
+ * @param {*} style
  * @param {string} camelCase the camel cased version of a css property name
  * @param {boolean=} opt_bypassCache bypass the memoized cache of property
  *   mapping
@@ -119,7 +119,7 @@ export function setStyle(element, property, value, opt_units, opt_bypassCache) {
   if (isVar(propertyName)) {
     element.style.setProperty(propertyName, styleValue);
   } else {
-    /** @type {any} */ (element.style)[propertyName] = styleValue;
+    /** @type {*} */ (element.style)[propertyName] = styleValue;
   }
 }
 
@@ -142,7 +142,7 @@ export function getStyle(element, property, opt_bypassCache) {
   if (isVar(propertyName)) {
     return element.style.getPropertyValue(propertyName);
   }
-  return /** @type {any} */ (element.style)[propertyName];
+  return /** @type {*} */ (element.style)[propertyName];
 }
 
 /**

--- a/src/core/dom/video/index.js
+++ b/src/core/dom/video/index.js
@@ -26,8 +26,8 @@ export function detectIsAutoplaySupported(win) {
 
   detectionElement.muted = true;
   detectionElement.playsInline = true;
-  /** @type {any} */ (detectionElement)['playsinline'] = true;
-  /** @type {any} */ (detectionElement)['webkitPlaysinline'] = true;
+  /** @type {*} */ (detectionElement)['playsinline'] = true;
+  /** @type {*} */ (detectionElement)['webkitPlaysinline'] = true;
 
   setStyles(detectionElement, {
     position: 'fixed',

--- a/src/core/dom/video/index.js
+++ b/src/core/dom/video/index.js
@@ -26,8 +26,8 @@ export function detectIsAutoplaySupported(win) {
 
   detectionElement.muted = true;
   detectionElement.playsInline = true;
-  detectionElement['playsinline'] = true;
-  detectionElement['webkitPlaysinline'] = true;
+  /** @type {any} */ (detectionElement)['playsinline'] = true;
+  /** @type {any} */ (detectionElement)['webkitPlaysinline'] = true;
 
   setStyles(detectionElement, {
     position: 'fixed',
@@ -59,7 +59,7 @@ export function isAutoplaySupported(win) {
   if (win[AUTOPLAY_SUPPORTED_WIN_PROP] == null) {
     win[AUTOPLAY_SUPPORTED_WIN_PROP] = detectIsAutoplaySupported(win);
   }
-  return win[AUTOPLAY_SUPPORTED_WIN_PROP];
+  return /** @type {Promise<boolean>} */ (win[AUTOPLAY_SUPPORTED_WIN_PROP]);
 }
 
 /**

--- a/src/core/dom/video/video-globals.d.ts
+++ b/src/core/dom/video/video-globals.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Window {
+    // Used for storing whether or not the browser supports autoplay.
+    '__AMP_AUTOPLAY'?: Promise<boolean>;
+  }
+}

--- a/src/core/dom/video/video-globals.d.ts
+++ b/src/core/dom/video/video-globals.d.ts
@@ -3,6 +3,6 @@ export {};
 declare global {
   interface Window {
     // Used for storing whether or not the browser supports autoplay.
-    '__AMP_AUTOPLAY'?: Promise<boolean>;
+    __AMP_AUTOPLAY?: Promise<boolean>;
   }
 }

--- a/src/core/dom/web-components.shame.d.ts
+++ b/src/core/dom/web-components.shame.d.ts
@@ -2,6 +2,6 @@ export {};
 
 declare global {
   interface Element {
-    createShadowRoot;
+    createShadowRoot: () => ShadowRoot;
   }
 }

--- a/src/core/error/index.js
+++ b/src/core/error/index.js
@@ -13,7 +13,7 @@ export function duplicateErrorIfNecessary(error) {
   const e = new Error(message);
   // Copy all the extraneous things we attach.
   for (const prop in error) {
-    e[prop] = error[prop];
+    /** @type {any} */ (e)[prop] = /** @type {any} */ (error)[prop];
   }
   // Ensure these are copied.
   e.stack = stack;

--- a/src/core/error/index.js
+++ b/src/core/error/index.js
@@ -13,7 +13,7 @@ export function duplicateErrorIfNecessary(error) {
   const e = new Error(message);
   // Copy all the extraneous things we attach.
   for (const prop in error) {
-    /** @type {any} */ (e)[prop] = /** @type {any} */ (error)[prop];
+    /** @type {*} */ (e)[prop] = /** @type {*} */ (error)[prop];
   }
   // Ensure these are copied.
   e.stack = stack;

--- a/src/core/static-layout.js
+++ b/src/core/static-layout.js
@@ -251,7 +251,10 @@ function getEffectiveLayoutInternal(element) {
     layoutAttr,
     element
   );
-  /** @type {string|null|undefined} */
+  /**
+   * @type {string|null|undefined}
+   * @const
+   */
   const inputWidth =
     widthAttr && widthAttr != 'auto' ? parseLength(widthAttr) : widthAttr;
   userAssert(
@@ -260,7 +263,10 @@ function getEffectiveLayoutInternal(element) {
     widthAttr,
     element
   );
-  /** @type {string|null|undefined} */
+  /**
+   * @type {string|null|undefined}
+   * @const
+   */
   const inputHeight =
     heightAttr && heightAttr != 'fluid' ? parseLength(heightAttr) : heightAttr;
   userAssert(

--- a/src/core/static-layout.js
+++ b/src/core/static-layout.js
@@ -251,7 +251,7 @@ function getEffectiveLayoutInternal(element) {
     layoutAttr,
     element
   );
-  /** @const {string|null|undefined} */
+  /** @type {string|null|undefined} */
   const inputWidth =
     widthAttr && widthAttr != 'auto' ? parseLength(widthAttr) : widthAttr;
   userAssert(
@@ -260,7 +260,7 @@ function getEffectiveLayoutInternal(element) {
     widthAttr,
     element
   );
-  /** @const {string|null|undefined} */
+  /** @type {string|null|undefined} */
   const inputHeight =
     heightAttr && heightAttr != 'fluid' ? parseLength(heightAttr) : heightAttr;
   userAssert(

--- a/src/core/tsconfig.json
+++ b/src/core/tsconfig.json
@@ -6,6 +6,7 @@
     "downlevelIteration": true,
     "target": "es5",
     "strictNullChecks": true,
+    "noImplicitAny": true,
     "lib": ["dom", "esnext", "es6"],
     "paths": {
       "#core": ["."],

--- a/src/core/types/date.js
+++ b/src/core/types/date.js
@@ -4,9 +4,8 @@ import {isString} from './string';
 
 /**
  * Absolute time in milliseconds.
- * @typedef {number}
+ * @typedef {number} TimestampDef
  */
-export let TimestampDef;
 
 /**
  * Parses the date using the `Date.parse()` rules. Additionally supports the

--- a/src/core/types/function/index.js
+++ b/src/core/types/function/index.js
@@ -1,3 +1,5 @@
+import {devAssert} from '#core/assert';
+
 /** @fileoverview Helpers to wrap functions. */
 
 /**
@@ -14,14 +16,17 @@
  */
 export function once(fn) {
   let evaluated = false;
+  /** @type {T?} */
   let retValue = null;
   let callback = fn;
+
   return (...args) => {
     if (!evaluated) {
       retValue = callback.apply(self, args);
       evaluated = true;
       /** @type {?} */ (callback) = null; // GC
     }
+    devAssert(retValue);
     return retValue;
   };
 }
@@ -40,10 +45,12 @@ export function once(fn) {
  */
 export function throttle(win, callback, minInterval) {
   let locker = 0;
+
+  /** @type {T[]?} */
   let nextCallArgs = null;
 
   /**
-   * @param {Object} args
+   * @param {T[]} args
    */
   function fire(args) {
     nextCallArgs = null;
@@ -88,10 +95,12 @@ export function throttle(win, callback, minInterval) {
 export function debounce(win, callback, minInterval) {
   let locker = 0;
   let timestamp = 0;
+
+  /** @type {T[]?} */
   let nextCallArgs = null;
 
   /**
-   * @param {?Array} args
+   * @param {T[]?} args
    */
   function fire(args) {
     nextCallArgs = null;

--- a/src/core/types/function/index.js
+++ b/src/core/types/function/index.js
@@ -1,5 +1,3 @@
-import {devAssert} from '#core/assert';
-
 /** @fileoverview Helpers to wrap functions. */
 
 /**
@@ -11,8 +9,8 @@ import {devAssert} from '#core/assert';
  * different.
  *
  * @template T
- * @param {(function(...any):T)} fn
- * @return {(function(...any):T)}
+ * @param {(function(...any):T?)} fn
+ * @return {(function(...any):T?)}
  */
 export function once(fn) {
   let evaluated = false;
@@ -26,7 +24,6 @@ export function once(fn) {
       evaluated = true;
       /** @type {?} */ (callback) = null; // GC
     }
-    devAssert(retValue);
     return retValue;
   };
 }

--- a/src/core/types/object/index.js
+++ b/src/core/types/object/index.js
@@ -59,9 +59,9 @@ export function hasOwn(obj, key) {
  * Returns obj[key] iff key is obj's own property (is not inherited).
  * Otherwise, returns undefined.
  *
- * @param {Object} obj
+ * @param {Object<string, any>} obj
  * @param {string} key
- * @return {*}
+ * @return {any}
  */
 export function ownProperty(obj, key) {
   if (hasOwn(obj, key)) {
@@ -86,6 +86,7 @@ export function ownProperty(obj, key) {
  */
 export function deepMerge(target, source, depth = 10) {
   // Keep track of seen objects to detect recursive references.
+  /** @type {Object[]} */
   const seen = [];
 
   /** @type {DeepMergeTuple[]} */
@@ -107,39 +108,39 @@ export function deepMerge(target, source, depth = 10) {
       continue;
     }
     for (const key of Object.keys(s)) {
-      const newValue = s[key];
+      const newValue = /** @type {any} */ (s)[key];
       // Perform a deep merge IFF both target and source have the same key
       // whose corresponding values are objects.
       if (hasOwn(t, key)) {
-        const oldValue = t[key];
+        const oldValue = /** @type {any} */ (t)[key];
         if (isObject(newValue) && isObject(oldValue)) {
           queue.push({t: oldValue, s: newValue, d: d + 1});
           continue;
         }
       }
-      t[key] = newValue;
+      /** @type {any} */ (t)[key] = newValue;
     }
   }
   return target;
 }
 
 /**
- * @param {Object} o An object to remove properties from
+ * @param {Object<string, any>} o An object to remove properties from
  * @param {Array<string>} props A list of properties to remove from the Object
- * @return {Object} An object with the given properties removed
+ * @return {Object<string, any>} An object with the given properties removed
  */
 export function omit(o, props) {
   return Object.keys(o).reduce((acc, key) => {
     if (!props.includes(key)) {
-      acc[key] = o[key];
+      /** @type {*} */ (acc)[key] = o[key];
     }
     return acc;
   }, {});
 }
 
 /**
- * @param {Object|null|undefined} o1
- * @param {Object|null|undefined} o2
+ * @param {any} o1
+ * @param {any} o2
  * @return {boolean}
  */
 export function objectsEqualShallow(o1, o2) {
@@ -163,19 +164,20 @@ export function objectsEqualShallow(o1, o2) {
 }
 
 /**
- * @param {T} obj
+ * @param {{[prop:string]: R|undefined}} obj
  * @param {string} prop
- * @param {function(T, string):R} factory
+ * @param {(obj:{[prop:string]:R|undefined}, str:string) => R} factory
  * @return {R}
- * @template T,R
+ *
+ * @template {any} R
  */
 export function memo(obj, prop, factory) {
-  let result = /** @type {undefined|R} */ (obj[prop]);
+  let result = obj[prop];
   if (result === undefined) {
     result = factory(obj, prop);
     obj[prop] = result;
   }
-  return /** @type {R} */ (result);
+  return result;
 }
 
 /**

--- a/src/core/types/object/index.js
+++ b/src/core/types/object/index.js
@@ -61,7 +61,7 @@ export function hasOwn(obj, key) {
  *
  * @param {Object<string, any>} obj
  * @param {string} key
- * @return {any}
+ * @return {*}
  */
 export function ownProperty(obj, key) {
   if (hasOwn(obj, key)) {
@@ -108,17 +108,17 @@ export function deepMerge(target, source, depth = 10) {
       continue;
     }
     for (const key of Object.keys(s)) {
-      const newValue = /** @type {any} */ (s)[key];
+      const newValue = /** @type {*} */ (s)[key];
       // Perform a deep merge IFF both target and source have the same key
       // whose corresponding values are objects.
       if (hasOwn(t, key)) {
-        const oldValue = /** @type {any} */ (t)[key];
+        const oldValue = /** @type {*} */ (t)[key];
         if (isObject(newValue) && isObject(oldValue)) {
           queue.push({t: oldValue, s: newValue, d: d + 1});
           continue;
         }
       }
-      /** @type {any} */ (t)[key] = newValue;
+      /** @type {*} */ (t)[key] = newValue;
     }
   }
   return target;
@@ -139,8 +139,8 @@ export function omit(o, props) {
 }
 
 /**
- * @param {any} o1
- * @param {any} o2
+ * @param {*} o1
+ * @param {*} o2
  * @return {boolean}
  */
 export function objectsEqualShallow(o1, o2) {
@@ -164,12 +164,12 @@ export function objectsEqualShallow(o1, o2) {
 }
 
 /**
- * @param {{[prop:string]: R|undefined}} obj
+ * @param {Object<string, R|undefined>} obj
  * @param {string} prop
- * @param {(obj:{[prop:string]:R|undefined}, str:string) => R} factory
+ * @param {function(Object<string, R|undefined>, string): R} factory
  * @return {R}
  *
- * @template {any} R
+ * @template R
  */
 export function memo(obj, prop, factory) {
   let result = obj[prop];

--- a/src/core/types/object/index.js
+++ b/src/core/types/object/index.js
@@ -59,7 +59,7 @@ export function hasOwn(obj, key) {
  * Returns obj[key] iff key is obj's own property (is not inherited).
  * Otherwise, returns undefined.
  *
- * @param {Object<string, any>} obj
+ * @param {Object<string, *>} obj
  * @param {string} key
  * @return {*}
  */
@@ -125,9 +125,9 @@ export function deepMerge(target, source, depth = 10) {
 }
 
 /**
- * @param {Object<string, any>} o An object to remove properties from
+ * @param {Object<string, *>} o An object to remove properties from
  * @param {Array<string>} props A list of properties to remove from the Object
- * @return {Object<string, any>} An object with the given properties removed
+ * @return {Object<string, *>} An object with the given properties removed
  */
 export function omit(o, props) {
   return Object.keys(o).reduce((acc, key) => {

--- a/src/core/types/object/json.js
+++ b/src/core/types/object/json.js
@@ -112,8 +112,8 @@ export function deepEquals(a, b, depth = 5) {
         }
         for (const k of keysA) {
           queue.push({
-            a: /** @type {any} */ (a)[k],
-            b: /** @type {any} */ (b)[k],
+            a: /** @type {*} */ (a)[k],
+            b: /** @type {*} */ (b)[k],
             depth: depth - 1,
           });
         }

--- a/src/core/types/object/json.js
+++ b/src/core/types/object/json.js
@@ -111,7 +111,11 @@ export function deepEquals(a, b, depth = 5) {
           return false;
         }
         for (const k of keysA) {
-          queue.push({a: a[k], b: b[k], depth: depth - 1});
+          queue.push({
+            a: /** @type {any} */ (a)[k],
+            b: /** @type {any} */ (b)[k],
+            depth: depth - 1,
+          });
         }
         continue;
       }

--- a/src/core/types/string/base64.js
+++ b/src/core/types/string/base64.js
@@ -2,13 +2,14 @@ import {bytesToString, stringToBytes, utf8Decode, utf8Encode} from './bytes';
 
 /**
  * Character mapping from base64url to base64.
- * @const {Object<string, string>}
+ * @type {Object<string, string>}
+ * @const
  */
 const base64UrlDecodeSubs = {'-': '+', '_': '/', '.': '='};
 
 /**
  * Character mapping from base64 to base64url.
- * @const {Object<string, string>}
+ * @type {Object<string, string>}
  */
 const base64UrlEncodeSubs = {'+': '-', '/': '_', '=': '.'};
 

--- a/src/core/types/string/base64.js
+++ b/src/core/types/string/base64.js
@@ -10,6 +10,7 @@ const base64UrlDecodeSubs = {'-': '+', '_': '/', '.': '='};
 /**
  * Character mapping from base64 to base64url.
  * @type {Object<string, string>}
+ * @const
  */
 const base64UrlEncodeSubs = {'+': '-', '/': '_', '=': '.'};
 

--- a/src/core/window/interface.js
+++ b/src/core/window/interface.js
@@ -55,7 +55,9 @@ export class WindowInterface {
    * @return {string}
    */
   static getUserLanguage(win) {
-    return win.navigator.language;
+    return (
+      /** @type {*} */ (win.navigator)['userLanguage'] || win.navigator.language
+    );
   }
 
   /**

--- a/src/core/window/interface.js
+++ b/src/core/window/interface.js
@@ -87,7 +87,7 @@ export class WindowInterface {
    * @return {typeof XMLHttpRequest}
    */
   static getXMLHttpRequest(win) {
-    return /** @type {any} */ (win).XMLHttpRequest;
+    return /** @type {*} */ (win).XMLHttpRequest;
   }
 
   /**
@@ -96,6 +96,6 @@ export class WindowInterface {
    * @return {typeof Image}
    */
   static getImage(win) {
-    return /** @type {any} */ (win).Image;
+    return /** @type {*} */ (win).Image;
   }
 }

--- a/src/core/window/location.d.ts
+++ b/src/core/window/location.d.ts
@@ -1,0 +1,8 @@
+export {};
+
+declare global {
+  interface Location {
+    // Set by a viewer when it removes the fragment.
+    originalHash?: string;
+  }
+}

--- a/src/core/window/window.d.ts
+++ b/src/core/window/window.d.ts
@@ -11,6 +11,9 @@ declare global {
     // Global property set by test some harnesses to signal a testing environment.
     __AMP_TEST?: boolean;
 
+    // Global property set by test some harnesses to signal karma testing environment.
+    __karma__?: boolean;
+
     // Counter for the DomBaseWeakRef polyfill.
     __AMP_WEAKREF_ID?: number;
 
@@ -19,5 +22,9 @@ declare global {
 
     // AMP Mode, used to force an override in tests.
     __AMP_MODE: {esm: boolean};
+  }
+  interface Location {
+    // Set by a viewer when it removes the fragment.
+    originalHash?: string;
   }
 }

--- a/src/core/window/window.d.ts
+++ b/src/core/window/window.d.ts
@@ -23,9 +23,4 @@ declare global {
     // AMP Mode, used to force an override in tests.
     __AMP_MODE: {esm: boolean};
   }
-
-  interface Location {
-    // Set by a viewer when it removes the fragment.
-    originalHash?: string;
-  }
 }

--- a/src/core/window/window.d.ts
+++ b/src/core/window/window.d.ts
@@ -23,6 +23,7 @@ declare global {
     // AMP Mode, used to force an override in tests.
     __AMP_MODE: {esm: boolean};
   }
+
   interface Location {
     // Set by a viewer when it removes the fragment.
     originalHash?: string;

--- a/src/polyfills/get-bounding-client-rect.js
+++ b/src/polyfills/get-bounding-client-rect.js
@@ -17,8 +17,8 @@ let nativeClientRect;
 
 /**
  * Polyfill for Node.getBoundingClientRect API.
- * @this {!Element}
- * @return {!ClientRect|LayoutRectDef}
+ * @this {Element}
+ * @return {ClientRect|LayoutRectDef}
  */
 function getBoundingClientRect() {
   // eslint-disable-next-line local/no-invalid-this

--- a/src/polyfills/get-bounding-client-rect.js
+++ b/src/polyfills/get-bounding-client-rect.js
@@ -6,7 +6,7 @@
  */
 
 import {isConnectedNode} from '#core/dom';
-import {LayoutRectDef, layoutRectLtwh} from '#core/dom/layout/rect';
+import {layoutRectLtwh} from '#core/dom/layout/rect';
 import * as mode from '#core/mode';
 
 /**
@@ -18,7 +18,7 @@ let nativeClientRect;
 /**
  * Polyfill for Node.getBoundingClientRect API.
  * @this {!Element}
- * @return {!ClientRect|!LayoutRectDef}
+ * @return {!ClientRect|LayoutRectDef}
  */
 function getBoundingClientRect() {
   // eslint-disable-next-line local/no-invalid-this

--- a/src/utils/animation.js
+++ b/src/utils/animation.js
@@ -1,6 +1,8 @@
-import {NormTimeDef, getCurve} from '#core/data-structures/curve';
+import {getCurve} from '#core/data-structures/curve';
 import {Deferred} from '#core/data-structures/promise';
-import {TimestampDef} from '#core/types/date';
+
+/** @typedef {import('#core/types/date').NormTimeDef} NormTimeDef */
+/** @typedef {import('#core/types/date').TimestampDef} TimestampDef */
 
 import {Services} from '#service';
 


### PR DESCRIPTION
**summary**
Enables the `noImplicitAny` option for core tsconfig. There were a few changes necessary, and I am happy to bikeshed any of them:

1. Typedefs needed to be defined in their jsdoc instead of as variables for TS to not label them `any`. This required I then remove all the explicit `import` statement of those types, since they are not JS values.
2. `@const` and `@private` shorthand cannot be used for declaring types, and I switched them to using `@type`.
3. HTMLElement and Window cannot be indexed via string, where we do this I added globals. Happy to 🚲 shed on where the global modifiers should live.
4. Anything indexing `Object` or `CSSStyleDeclarations` via a string needed casting to any. Some I was able to fix via restructure, others seemed like too deep a well to solve (i.e.`deepMerge`). The logic for leaving as-is in this PR as that this doesn't make things perfect, but better than they were before (explicit any > implicit any).