### PR TITLE
core/window/interface: small ie support removal

### DIFF
--- a/src/core/window/interface.js
+++ b/src/core/window/interface.js
@@ -55,9 +55,7 @@ export class WindowInterface {
    * @return {string}
    */
   static getUserLanguage(win) {
-    // The `navigator.userLanguage` is only supported by IE. The standard is
-    // the `navigator.language`.
-    return win.navigator['userLanguage'] || win.navigator.language;
+    return win.navigator.language;
   }
 
   /**


### PR DESCRIPTION
**summary**
Noticed a little case where we explicitly have support for IE. Removing as we've since turned that down, no need to waste bytes.