### PR TITLE
🐛[story-ads] Catch unsupported `playerExperiments` message

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -200,6 +200,13 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
             }
           });
         }
+      })
+      .catch((e) => {
+        dev().expectedError(
+          TAG,
+          'Player does not support `playerExperiments` message',
+          e
+        );
       });
   }
 


### PR DESCRIPTION
Story ads will ask embedded viewers for active player experiments. This is protected by an `isEmbedded()` check, but sometimes the story will be embedded in a player that does not support this message and throw an error. In that case we should catch the error and mark it as expected.

This does not have any effect on users.