### PR TITLE
tsc: Remove some exclaimation points, since not nullable by default.

### DIFF
--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -41,7 +41,7 @@ function assertDomQueryResults() {
 
 /**
  * Builds a carousel button for next/prev.
- * @param {!Element} element
+ * @param {Element} element
  * @param {{className: string, title: string, enabled: boolean}} options
  * @return {?HTMLDivElement}
  */
@@ -67,7 +67,7 @@ function buildButton(element, {className, enabled, title}) {
 
 /**
  *
- * @param {!HTMLDivElement} button
+ * @param {HTMLDivElement} button
  * @param {boolean} enabled
  */
 export function setButtonState(button, enabled) {
@@ -78,11 +78,11 @@ export function setButtonState(button, enabled) {
 
 /**
  * Builds the DOM necessary for amp-carousel.
- * @param {!Element} element
+ * @param {Element} element
  * @param {number} slideCount
  * @return {{
- *   prevButton: !HTMLDivElement,
- *   nextButton: !HTMLDivElement
+ *   prevButton: HTMLDivElement,
+ *   nextButton: HTMLDivElement
  * }}
  */
 export function buildCarouselControls(element, slideCount) {
@@ -119,17 +119,17 @@ export function buildCarouselControls(element, slideCount) {
 
 /**
  * Queries for all of the necessary DOM Elements to assign to ivars
- * @param {!Element} element
+ * @param {Element} element
  * @return {{
- *   prevButton: !HTMLDivElement,
- *   nextButton: !HTMLDivElement
+ *   prevButton: HTMLDivElement,
+ *   nextButton: HTMLDivElement
  * }}
  */
 export function queryCarouselControls(element) {
-  const prevButton = /** @type {!HTMLDivElement} */ (
+  const prevButton = /** @type {HTMLDivElement} */ (
     element.querySelector(`.${escapeCssSelectorIdent(ClassNames.PREV_BUTTON)}`)
   );
-  const nextButton = /** @type {!HTMLDivElement} */ (
+  const nextButton = /** @type {HTMLDivElement} */ (
     element.querySelector(`.${escapeCssSelectorIdent(ClassNames.NEXT_BUTTON)}`)
   );
   assertDomQueryResults(prevButton, nextButton);
@@ -138,10 +138,10 @@ export function queryCarouselControls(element) {
 
 /**
  * Builds the DOM necessary for scrollable carousel.
- * @param {!Element} element
+ * @param {Element} element
  * @return {{
- *   container: !HTMLDivElement
- *   cells: !HTMLDivElement[]
+ *   container: HTMLDivElement
+ *   cells: HTMLDivElement[]
  * }}
  */
 function buildScrollableCarousel(element) {
@@ -167,19 +167,19 @@ function buildScrollableCarousel(element) {
 
 /**
  * Queries for ivars for scrollable carousel.
- * @param {!Element} element
+ * @param {Element} element
  * @return {{
- *   container: !HTMLDivElement
- *   cells: !HTMLDivElement[]
+ *   container: HTMLDivElement
+ *   cells: HTMLDivElement[]
  * }}
  */
 function queryScrollableCarousel(element) {
-  const container = /** @type {!HTMLDivElement} */ (
+  const container = /** @type {HTMLDivElement} */ (
     element.querySelector(
       `.${escapeCssSelectorIdent(ClassNames.SCROLLABLE_CONTAINER)}`
     )
   );
-  const cells = /** @type {!HTMLDivElement[]} */ (
+  const cells = /** @type {HTMLDivElement[]} */ (
     Array.from(
       element.querySelectorAll(`.${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
     )
@@ -190,11 +190,11 @@ function queryScrollableCarousel(element) {
 
 /**
  * Builds the DOM necessary for slidescroll carousel.
- * @param {!Element} element
+ * @param {Element} element
  * @return {{
- *   slides: !HTMLDivElement[]
- *   slidesContainer: !HTMLDivElement
- *   slideWrappers: !HTMLDivElement[]
+ *   slides: HTMLDivElement[]
+ *   slidesContainer: HTMLDivElement
+ *   slideWrappers: HTMLDivElement[]
  * }}
  */
 function buildSlideScrollCarousel(element) {
@@ -234,27 +234,27 @@ function buildSlideScrollCarousel(element) {
 
 /**
  * Queries for ivars for slidescroll.
- * @param {!Element} element
+ * @param {Element} element
  * @return {{
- *   slides: !HTMLDivElement[]
- *   slidesContainer: !HTMLDivElement
- *   slideWrappers: !HTMLDivElement[]
+ *   slides: HTMLDivElement[]
+ *   slidesContainer: HTMLDivElement
+ *   slideWrappers: HTMLDivElement[]
  * }}
  */
 function querySlideScrollCarousel(element) {
-  const slidesContainer = /** @type {!HTMLDivElement} */ (
+  const slidesContainer = /** @type {HTMLDivElement} */ (
     element.querySelector(
       `.${escapeCssSelectorIdent(ClassNames.SLIDES_CONTAINER)}`
     )
   );
-  const slideWrappers = /** @type {!HTMLDivElement[]} */ (
+  const slideWrappers = /** @type {HTMLDivElement[]} */ (
     Array.from(
       element.querySelectorAll(
         `.${escapeCssSelectorIdent(ClassNames.SLIDE_WRAPPER)}`
       )
     )
   );
-  const slides = /** @type {!HTMLDivElement[]} */ (
+  const slides = /** @type {HTMLDivElement[]} */ (
     Array.from(
       element.querySelectorAll(`.${escapeCssSelectorIdent(ClassNames.SLIDE)}`)
     )
@@ -265,15 +265,15 @@ function querySlideScrollCarousel(element) {
 
 /**
  * Builds the DOM necessary for slidescroll carousel.
- * @param {!Element} element
+ * @param {Element} element
  * @return {{
- *   prevButton: !HTMLDivElement,
- *   nextButton: !HTMLDivElement
- *   container?: !HTMLDivElement
- *   cells?: !HTMLDivElement[]
- *   slides?: !HTMLDivElement[]
- *   slidesContainer?: !HTMLDivElement
- *   slideWrappers?: !HTMLDivElement[]
+ *   prevButton: HTMLDivElement,
+ *   nextButton: HTMLDivElement
+ *   container?: HTMLDivElement
+ *   cells?: HTMLDivElement[]
+ *   slides?: HTMLDivElement[]
+ *   slidesContainer?: HTMLDivElement
+ *   slideWrappers?: HTMLDivElement[]
  * }}
  */
 export function buildDom(element) {
@@ -287,7 +287,7 @@ export function buildDom(element) {
 }
 
 /**
- * @param {!Element} element
+ * @param {Element} element
  * @return {string} The default title to use for the next button.
  * @param {{index?: string, total?: string}} options - The default title to use for the previous button.
  */
@@ -300,7 +300,7 @@ export function getNextButtonTitle(element, options = {}) {
 }
 
 /**
- * @param {!Element} element
+ * @param {Element} element
  * @param {{index?: string, total?: string}} options - The default title to use for the previous button.
  * @return {string} The default title to use for the previous button.
  */
@@ -341,7 +341,7 @@ function getButtonTitle(element, {index, prefix, total}) {
 
 /**
  * Returns true if the carousel is a Scrollable Carousel.
- * @param {!Element} element
+ * @param {Element} element
  * @return {boolean}
  */
 export function isScrollable(element) {

--- a/extensions/amp-fit-text/0.1/build-dom.js
+++ b/extensions/amp-fit-text/0.1/build-dom.js
@@ -10,8 +10,8 @@ const CONTENT_WRAPPER_CLASS = 'i-amphtml-fit-text-content-wrapper';
 /**
  * @see amphtml/compiler/types.js for full description
  *
- * @param {!Element} element
- * @return {{content: !Element, contentWrapper: !Element, measurer: !Element}}
+ * @param {HTMLElement} element
+ * @return {{content: Element, contentWrapper: Element, measurer: Element}}
  */
 export function buildDom(element) {
   if (isServerRendered(element)) {
@@ -40,8 +40,8 @@ export function buildDom(element) {
 
 /**
  * Returns all of the needed ivars from a server rendered element.
- * @param {!Element} element
- * @return {{content: !Element, contentWrapper: !Element, measurer: !Element}}
+ * @param {HTMLElement} element
+ * @return {{content: Element, contentWrapper: Element, measurer: Element}}
  */
 export function queryDom(element) {
   const content = element.querySelector(

--- a/src/builtins/amp-layout/build-dom.js
+++ b/src/builtins/amp-layout/build-dom.js
@@ -6,7 +6,7 @@ import {getEffectiveLayout} from '#core/static-layout';
 /**
  * @see amphtml/compiler/types.js for full description
  *
- * @param {!Element} element
+ * @param {HTMLElement} element
  */
 export function buildDom(element) {
   if (isServerRendered(element)) {


### PR DESCRIPTION
**summary**
In closure typed code, everything was assumed to be nullable unless it had an exclamation point. In TypeScript items are never considered nullable unless they have a `?`, i.e. `SomeType?`.

This PR just removes exclamation points now that they are noops.