### PR TITLE
root tsconfig: disable typecheck to save VS Code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
+    "checkJs": false,
 
     "paths": {
       "#3p/*": ["./3p/*"],


### PR DESCRIPTION
**summary**
An accidental side effect of https://github.com/ampproject/amphtml/pull/37215 was to enable `checkJs` for the root tsconfig.
This causes VS Code to get very angry as all of `src` becomes subject to red squigglies / IDE-driven type errors.

Thanks for spotting it @alanorozco!

**screenshot**
![image](https://user-images.githubusercontent.com/4656974/146259806-7243a5b3-4dc4-4e4d-a713-e12d86ff3cf8.png)

