### PR TITLE
✨ Remove Bento experiments from `amp-wordpress-embed`

### DIFF
--- a/extensions/amp-wordpress-embed/1.0/amp-wordpress-embed.js
+++ b/extensions/amp-wordpress-embed/1.0/amp-wordpress-embed.js
@@ -1,9 +1,5 @@
 import {dict} from '#core/types/object';
 
-import {isExperimentOn} from '#experiments';
-
-import {userAssert} from '#utils/log';
-
 import {BaseElement} from './base-element';
 
 /** @const {string} */
@@ -12,11 +8,6 @@ const TAG = 'amp-wordpress-embed';
 class AmpWordPressEmbed extends BaseElement {
   /** @override */
   isLayoutSupported(layout) {
-    userAssert(
-      isExperimentOn(this.win, 'bento') ||
-        isExperimentOn(this.win, 'bento-wordpress-embed'),
-      'expected global "bento" or specific "bento-wordpress-embed" experiment to be enabled'
-    );
     return super.isLayoutSupported(layout);
   }
 


### PR DESCRIPTION
The `amp-wordpress-embed` component was created (in #34948) without any non-Bento version, so the Bento experiment is currently blocking it from being usable on valid AMP pages. This removes the experiment.