### PR TITLE
Use remapping to remap minified sourcemap into source code

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -71,7 +71,7 @@ function getMinifiedConfig() {
   return {
     compact: false,
     plugins,
-    sourceMaps: 'inline',
+    sourceMaps: true,
     presets: [presetEnv],
     retainLines: true,
     assumptions: {

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -51,7 +51,7 @@ function getUnminifiedConfig() {
     compact: false,
     plugins: unminifiedPlugins,
     presets: unminifiedPresets,
-    sourceMaps: 'inline',
+    sourceMaps: true,
     assumptions: {
       constantSuper: true,
       noClassCalls: true,

--- a/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-rename-privates/index.js
@@ -28,15 +28,16 @@ module.exports = function (babel) {
         return;
       }
 
-      const {name} = key.node;
+      const {node} = key;
+      const {name} = node;
       if (name.endsWith('_AMP_PRIVATE_')) {
         return;
       }
 
-      if (!name.endsWith('_')) {
+      if (!name.endsWith('_') || name === '__proto__') {
         return;
       }
-      key.replaceWith(t.identifier(`${name}AMP_PRIVATE_`));
+      key.replaceWith(t.inherits(t.identifier(`${name}AMP_PRIVATE_`), node));
     };
   }
 

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -135,8 +135,6 @@ function getFileBabelOptions(babelOptions, filename) {
 
   return {
     ...babelOptions,
-    sourceMaps:
-      babelOptions.sourceMaps === 'inline' ? 'both' : babelOptions.sourceMaps,
     filename,
     filenameRelative,
   };

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -4,8 +4,17 @@ const {debug} = require('../compile/debug-compilation-lifecycle');
 const {TransformCache, batchedRead, md5} = require('./transform-cache');
 
 /**
+ * @typedef {{
+ *   filename: string,
+ *   code: string,
+ *   map: *,
+ * }}
+ */
+let CacheMessageDef;
+
+/**
  * Used to cache babel transforms done by esbuild.
- * @const {TransformCache}
+ * @type {TransformCache<!CacheMessageDef>}
  */
 let transformCache;
 
@@ -14,22 +23,24 @@ let transformCache;
  * caching to speed up transforms.
  * @param {string} callerName
  * @param {boolean} enableCache
- * @param {function(): void} preSetup
- * @param {function(): void} postLoad
+ * @param {{
+ *   preSetup?: function():void,
+ *   postLoad?: function():void,
+ *   babelMaps?: Map<string, *>,
+ * }} callbacks
  * @return {!Object}
  */
 function getEsbuildBabelPlugin(
   callerName,
   enableCache,
-  preSetup = () => {},
-  postLoad = () => {}
+  {preSetup = () => {}, postLoad = () => {}, babelMaps} = {}
 ) {
   /**
    * @param {string} filename
    * @param {string} contents
    * @param {string} hash
    * @param {Object} babelOptions
-   * @return {Promise}
+   * @return {!Promise<!CacheMessageDef>}
    */
   async function transformContents(filename, contents, hash, babelOptions) {
     if (enableCache) {
@@ -46,9 +57,9 @@ function getEsbuildBabelPlugin(
     const promise = babel
       .transformAsync(contents, babelOptions)
       .then((result) => {
-        const {code, map} = result || {};
+        const {code, map} = /** @type {!babel.BabelFileResult} */ (result);
         debug('post-babel', filename, code, map);
-        return code + `\n// ${filename}`;
+        return {filename, code: code || '', map};
       });
 
     if (enableCache) {
@@ -86,7 +97,8 @@ function getEsbuildBabelPlugin(
           rehash,
           getFileBabelOptions(babelOptions, filename)
         );
-        return {contents: transformed};
+        babelMaps?.set(filename, transformed.map);
+        return {contents: transformed.code};
       });
     },
   };
@@ -119,10 +131,14 @@ function getFileBabelOptions(babelOptions, filename) {
 
   // The amp runner automatically sets cwd to the `amphtml` directory.
   const root = process.cwd();
+  const filenameRelative = path.relative(root, filename);
+
   return {
     ...babelOptions,
+    sourceMaps:
+      babelOptions.sourceMaps === 'inline' ? 'both' : babelOptions.sourceMaps,
     filename,
-    filenameRelative: path.relative(root, filename),
+    filenameRelative,
   };
 }
 

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -34,7 +34,7 @@ function getEsbuildBabelPlugin(
   async function transformContents(filename, contents, hash, babelOptions) {
     if (enableCache) {
       if (!transformCache) {
-        transformCache = new TransformCache('.babel-cache', '.js');
+        transformCache = new TransformCache('.babel-cache');
       }
       const cached = transformCache.get(hash);
       if (cached) {

--- a/build-system/common/transform-cache.js
+++ b/build-system/common/transform-cache.js
@@ -3,22 +3,24 @@ const fs = require('fs-extra');
 const path = require('path');
 
 /**
+ * Used to bust caches when the TransformCache makes a breaking change to the API.
+ */
+const API_VERSION = 2;
+
+/**
  * Cache for storing transformed files on both memory and on disk.
+ * @template T
  */
 class TransformCache {
   /**
    * @param {string} cacheName
-   * @param {string} fileExtension
    */
-  constructor(cacheName, fileExtension) {
-    /** @type {string} */
-    this.fileExtension = fileExtension;
-
+  constructor(cacheName) {
     /** @type {string} */
     this.cacheDir = path.resolve(__dirname, '..', '..', cacheName);
     fs.ensureDirSync(this.cacheDir);
 
-    /** @type {Map<string, Promise<Buffer|string>>} */
+    /** @type {Map<string, Promise<T>>} */
     this.transformMap = new Map();
 
     /** @type {Set<string>} */
@@ -27,35 +29,45 @@ class TransformCache {
 
   /**
    * @param {string} hash
-   * @return {null|Promise<Buffer|string>}
+   * @return {null|Promise<T>}
    */
   get(hash) {
     const cached = this.transformMap.get(hash);
     if (cached) {
       return cached;
     }
-    const filename = hash + this.fileExtension;
+
+    const filename = this.key_(hash);
     if (this.fsCache.has(filename)) {
-      const transformedPromise = fs.readFile(
-        path.join(this.cacheDir, filename)
-      );
-      this.transformMap.set(hash, transformedPromise);
-      return transformedPromise;
+      const persisted = fs.readJson(path.join(this.cacheDir, filename));
+      this.transformMap.set(hash, persisted);
+      return persisted;
     }
+
     return null;
   }
 
   /**
    * @param {string} hash
-   * @param {Promise<string>} transformPromise
+   * @param {Promise<T>} transformPromise
    */
   set(hash, transformPromise) {
     if (this.transformMap.has(hash)) {
       throw new Error(`Read race: Attempting to transform ${hash} file twice.`);
     }
     this.transformMap.set(hash, transformPromise);
-    const filepath = path.join(this.cacheDir, hash) + this.fileExtension;
-    transformPromise.then((contents) => fs.outputFile(filepath, contents));
+
+    const filepath = path.join(this.cacheDir, this.key_(hash));
+    transformPromise.then((contents) => fs.outputJson(filepath, contents));
+  }
+
+  /**
+   * @param {string} hash
+   * @return {string}
+   * @private
+   */
+  key_(hash) {
+    return `${API_VERSION}_${hash}.json`;
   }
 }
 

--- a/build-system/tasks/css/jsify-css.js
+++ b/build-system/tasks/css/jsify-css.js
@@ -66,15 +66,15 @@ function getEnvironmentHash() {
 }
 
 /**
- * Used to cache css transforms done by postcss.
- * @const {TransformCache}
- */
-let transformCache;
-
-/**
  * @typedef {{css: string, warnings: string[]}}:
  */
 let CssTransformResultDef;
+
+/**
+ * Used to cache css transforms done by postcss.
+ * @type {TransformCache<CssTransformResultDef>}
+ */
+let transformCache;
 
 /**
  * Transform a css string using postcss.
@@ -139,18 +139,15 @@ async function getCssImports(cssFile) {
  */
 async function transformCss(contents, hash, opt_filename) {
   if (!transformCache) {
-    transformCache = new TransformCache('.css-cache', '.css');
+    transformCache = new TransformCache('.css-cache');
   }
   const cached = transformCache.get(hash);
   if (cached) {
-    return JSON.parse((await cached).toString());
+    return cached;
   }
 
   const transformed = transform(contents, opt_filename);
-  transformCache.set(
-    hash,
-    transformed.then((r) => JSON.stringify(r))
-  );
+  transformCache.set(hash, transformed);
   return transformed;
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -488,19 +488,19 @@ async function buildNpmCss(extDir, options) {
   endBuildStep('Wrote CSS', `${options.name} → styles.css`, startCssTime);
 }
 
-/** @type {TransformCache} */
+/** @type {TransformCache<string>} */
 let jssCache;
 
 /**
  * Returns the minified CSS for a .jss.js file.
  *
  * @param {string} jssFile
- * @return {Promise<string|Buffer>}
+ * @return {Promise<string>}
  */
 async function getCssForJssFile(jssFile) {
   // Lazily instantiate the TransformCache
   if (!jssCache) {
-    jssCache = new TransformCache('.jss-cache', '.css');
+    jssCache = new TransformCache('.jss-cache');
   }
 
   const {contents, hash} = await batchedRead(jssFile);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -335,6 +335,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
         entryPoints: [entryPoint],
         bundle: true,
         sourcemap: true,
+        sourcesContent: !argv.full_sourcemaps,
         outfile: destFile,
         define: experimentDefines,
         plugins,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -341,7 +341,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
         entryPoints: [entryPoint],
         bundle: true,
         sourcemap: true,
-        sourceRoot: path.join(process.cwd(), destDir),
+        sourceRoot: path.join(process.cwd(), path.dirname(destFile)),
         sourcesContent: !!argv.full_sourcemaps,
         outfile: destFile,
         define: experimentDefines,
@@ -716,6 +716,9 @@ function massageSourcemaps(sourcemaps, babelMaps, options) {
       // (which have a sourcemap) from the actual source file by pretending the
       // source file exists in the '__SOURCE__' root directory.
       const map = babelMaps.get(f);
+      if (!map) {
+        throw new Error(`failed to find sourcemap for babel file "${f}"`);
+      }
       return {
         ...map,
         sourceRoot: path.join(

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -6,6 +6,7 @@ const experimentDefines = require('../global-configs/experiments-const.json');
 const fs = require('fs-extra');
 const open = require('open');
 const path = require('path');
+const Remapping = require('@ampproject/remapping');
 const terser = require('terser');
 const wrappers = require('../compile/compile-wrappers');
 const {
@@ -21,6 +22,9 @@ const {jsBundles} = require('../compile/bundles.config');
 const {log, logLocalDev} = require('../common/logging');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {watch} = require('chokidar');
+
+/** @type {Remapping.default} */
+const remapping = /** @type {*} */ (Remapping);
 
 /**
  * Tasks that should print the `--nobuild` help text.

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -692,26 +692,23 @@ async function getDependencies(entryPoint, options) {
  * @return {string}
  */
 function massageSourcemaps(sourcemapsFile, minifiedMap, options) {
-  const sourcemaps = JSON.parse(sourcemapsFile);
-  sourcemaps.sources = sourcemaps.sources.map((source) => {
+  const remapped = remapping(
+    [minifiedMap, sourcemapsFile],
+    () => null,
+    !argv.full_sourcemaps
+  );
+  remapped.sources = remapped.sources.map((source) => {
     if (source.startsWith('../')) {
       return source.slice('../'.length);
     }
     return source;
   });
-  sourcemaps.sourceRoot = getSourceRoot(options);
-  if (sourcemaps.file) {
-    sourcemaps.file = path.basename(sourcemaps.file);
-  }
-  if (!argv.full_sourcemaps) {
-    delete sourcemaps.sourcesContent;
+  remapped.sourceRoot = getSourceRoot(options);
+  if (remapped.file) {
+    remapped.file = path.basename(remapped.file);
   }
 
-  return remapping(
-    [minifiedMap, sourcemaps],
-    () => null,
-    !argv.full_sourcemaps
-  ).toString();
+  return remapped.toString();
 }
 
 module.exports = {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -357,7 +357,8 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     let map = result.outputFiles.find(({path}) => path.endsWith('.map')).text;
 
     if (options.minify) {
-      ({code, map: minifiedMap} = await minify(code));
+      const {code: minified, map: minifiedMap} = await minify(code);
+      code = minified;
       map = await massageSourcemaps(map, minifiedMap, options);
     }
 

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -226,8 +226,10 @@ class RuntimeTestConfig {
     const babelPlugin = getEsbuildBabelPlugin(
       /* callerName */ 'test',
       /* enableCache */ true,
-      /* preSetup */ this.logBabelStart,
-      /* postLoad */ this.printBabelDot
+      {
+        preSetup: this.logBabelStart,
+        postLoad: this.printBabelDot,
+      }
     );
     this.esbuild = {
       target: 'es5',


### PR DESCRIPTION
For some reason, Terser is using the already changed property names instead of the original names (which exist inside the babel sourcemap). Instead of letting Terser do the remapping, we'll use our `remapping` library to remap our minified output maps into real source code.