### PR TITLE
🐛 [Amp story player] Remove active iframe translateZ

### DIFF
--- a/css/amp-story-player-shadow.css
+++ b/css/amp-story-player-shadow.css
@@ -32,7 +32,7 @@
 
 .i-amphtml-story-player-main-container iframe:nth-of-type(1),
 .i-amphtml-story-player-main-container .story-player-iframe[i-amphtml-iframe-position="0"] {
-  transform: translate3d(0, 0, 1px);
+  transform: translate3d(0, 0, 0);
 }
 
 .i-amphtml-story-player-main-container iframe:nth-of-type(2),


### PR DESCRIPTION
Fixes a [Safari bug](https://stackoverflow.com/questions/40895387/z-index-not-working-on-safari-fine-on-firefox-and-chrome) where translateZ overrides z-index, which is causing the previous and next story buttons to not be visible.

translateZ does not appear to be needed since translateX is being used to set position. 

Context / Fixes #37211