### PR TITLE
🐛 [Amp story page attachment] Prevent "Opening" text from shrinking 

### DIFF
--- a/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.css
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.css
@@ -81,6 +81,7 @@ amp-story[desktop] .i-amphtml-story-page-attachment-remote  {
 }
 
 .i-amphtml-story-page-attachment-remote-title :first-child {
+  flex-shrink: 0 !important;
   font-weight: bold !important;
 }
 


### PR DESCRIPTION
This prevents a potential line-break in remote attachments.

<img width="651" alt="Screen Shot 2022-01-04 at 9 41 17 AM" src="https://user-images.githubusercontent.com/3860311/148084614-d42438f8-5265-48f9-b8cc-0517a80086cc.png">

Fixes #37250