### PR TITLE
Enable `attribution-reporting` API for inabox

### DIFF
--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -99,7 +99,7 @@ const CDN_PROXY_REGEXP =
   /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org((\/.*)|($))+/;
 
 /** @const {string} */
-export const TOKEN_VALUE =
+const TOKEN_VALUE_3P =
   'AxOH8+XUqIxXfDG7Bxf7YR6oBTF4f73xWZNTyqhrkvIEgEmpxrpX8rzEqe9/yOsCGW9ChT05U9t++yH/aCYKCAgAAACVeyJvcmlnaW4iOiJodHRwczovL2FtcHByb2plY3Qub3JnOjQ0MyIsImZlYXR1cmUiOiJDb252ZXJzaW9uTWVhc3VyZW1lbnQiLCJleHBpcnkiOjE2NDMxNTUxOTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWUsInVzYWdlIjoic3Vic2V0In0=';
 
 /**
@@ -108,12 +108,12 @@ export const TOKEN_VALUE =
  * @param {!Window} win
  */
 export function maybeInsertOriginTrialToken(win) {
-  if (win.document.head.querySelector(`meta[content='${TOKEN_VALUE}']`)) {
+  if (win.document.head.querySelector(`meta[content='${TOKEN_VALUE_3P}']`)) {
     return;
   }
   const metaEl = createElementWithAttributes(win.document, 'meta', {
     'http-equiv': 'origin-trial',
-    content: TOKEN_VALUE,
+    content: TOKEN_VALUE_3P,
   });
   win.document.head.appendChild(metaEl);
 }

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -3,6 +3,8 @@
  */
 
 import '#polyfills';
+import {maybeInsertOriginTrialToken} from '#ads/google/a4a/utils';
+
 import {TickLabel_Enum} from '#core/constants/enums';
 import * as mode from '#core/mode';
 
@@ -100,6 +102,7 @@ startupChunk(self.document, function initial() {
         self.document,
         function final() {
           Navigation.installAnchorClickInterceptor(ampdoc, self);
+          maybeInsertOriginTrialToken(self);
           maybeRenderInaboxAsStoryAd(ampdoc);
           maybeValidate(self);
           makeBodyVisible(self.document);


### PR DESCRIPTION
Inserts the origin trial token for inabox so that it is possible for partner ad networks to use this feature. 