### PR TITLE
Compiler: Add amp-carousel-0.1 to the builder map

### DIFF
--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -1,4 +1,3 @@
-import {devAssert} from '#core/assert';
 import {isAmp4Email} from '#core/document/format';
 import {isServerRendered} from '#core/dom';
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
@@ -289,9 +288,9 @@ export function buildDom(element) {
 /**
  * @param {Element} element
  * @return {string} The default title to use for the next button.
- * @param {{index?: string, total?: string}} options - The default title to use for the previous button.
+ * @param {{index: string, total: string}} options - The default title to use for the previous button.
  */
-export function getNextButtonTitle(element, options = {}) {
+export function getNextButtonTitle(element, options) {
   const prefix =
     element.getAttribute('data-next-button-aria-label') ||
     'Next item in carousel';
@@ -301,10 +300,10 @@ export function getNextButtonTitle(element, options = {}) {
 
 /**
  * @param {Element} element
- * @param {{index?: string, total?: string}} options - The default title to use for the previous button.
+ * @param {{index: string, total: string}} options - The default title to use for the previous button.
  * @return {string} The default title to use for the previous button.
  */
-export function getPrevButtonTitle(element, options = {}) {
+export function getPrevButtonTitle(element, options) {
   const prefix =
     element.getAttribute('data-prev-button-aria-label') ||
     'Previous item in carousel';
@@ -318,17 +317,14 @@ export function getPrevButtonTitle(element, options = {}) {
  * - Scrollable: "Next item in carousel"
  * - Slides    : "Next item in carousel (X of Y)"
  *
- * @param {*} element
- * @param {{prefix: string, index?: string, total?:string}} param1
+ * @param {Element} element
+ * @param {{prefix: string, index: string, total:string}} opts
  * @return {string}
  */
 function getButtonTitle(element, {index, prefix, total}) {
   if (isScrollable(element)) {
     return prefix;
   }
-  // Slides carousel should always have index/total provided.
-  devAssert(index);
-  devAssert(total);
 
   /**
    * A format string for the button label. Should be a string, containing two

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -1,3 +1,4 @@
+import {devAssert} from '#core/assert';
 import {isAmp4Email} from '#core/document/format';
 import {isServerRendered} from '#core/dom';
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
@@ -43,7 +44,7 @@ function assertDomQueryResults() {
  * Builds a carousel button for next/prev.
  * @param {Element} element
  * @param {{className: string, title: string, enabled: boolean}} options
- * @return {?HTMLDivElement}
+ * @return {HTMLDivElement}
  */
 function buildButton(element, {className, enabled, title}) {
   /*
@@ -218,6 +219,7 @@ function buildSlideScrollCarousel(element) {
   slidesContainer.setAttribute('aria-live', 'polite');
   element.appendChild(slidesContainer);
 
+  /** @type {HTMLDivElement[]} */
   const slideWrappers = [];
   slides.forEach((slide) => {
     slide.classList.add(ClassNames.SLIDE);
@@ -317,13 +319,16 @@ export function getPrevButtonTitle(element, options = {}) {
  * - Slides    : "Next item in carousel (X of Y)"
  *
  * @param {*} element
- * @param {{prefix: string, index: string, total:string}} param1
+ * @param {{prefix: string, index?: string, total?:string}} param1
  * @return {string}
  */
 function getButtonTitle(element, {index, prefix, total}) {
   if (isScrollable(element)) {
     return prefix;
   }
+  // Slides carousel should always have index/total provided.
+  devAssert(index);
+  devAssert(total);
 
   /**
    * A format string for the button label. Should be a string, containing two

--- a/src/compiler/builders.js
+++ b/src/compiler/builders.js
@@ -2,6 +2,7 @@ import {buildDom as ampLayoutClassic} from '#builtins/amp-layout/build-dom';
 
 import {applyStaticLayout} from '#core/static-layout';
 
+import {buildDom as ampCarouselClassic1} from '../../extensions/amp-carousel/0.1/build-dom';
 import {buildDom as ampFitTextClassic} from '../../extensions/amp-fit-text/0.1/build-dom';
 
 const versionedBuilderMap = {
@@ -10,6 +11,7 @@ const versionedBuilderMap = {
   },
   '0.1': {
     'amp-fit-text': ampFitTextClassic,
+    'amp-carousel': ampCarouselClassic1,
   },
 };
 


### PR DESCRIPTION
**summary**
A necessary step for ssring `amp-carousel` is adding it to the builder map.