### PR TITLE
Fix remapping esbuild output on Windows

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -341,7 +341,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
         entryPoints: [entryPoint],
         bundle: true,
         sourcemap: true,
-        sourceRoot: path.join(process.cwd(), path.dirname(destFile)),
+        sourceRoot: path.dirname(destFile),
         sourcesContent: !!argv.full_sourcemaps,
         outfile: destFile,
         define: experimentDefines,
@@ -710,21 +710,19 @@ function massageSourcemaps(sourcemaps, babelMaps, options) {
       if (f.includes('__SOURCE__')) {
         return null;
       }
+      const file = path.join(root, f);
       // The Babel tranformed file and the original file have the same path,
       // which makes it difficult to distinguish during remapping's load phase.
       // We perform some manual path mangling to destingish the babel files
       // (which have a sourcemap) from the actual source file by pretending the
       // source file exists in the '__SOURCE__' root directory.
-      const map = babelMaps.get(f);
+      const map = babelMaps.get(file);
       if (!map) {
         throw new Error(`failed to find sourcemap for babel file "${f}"`);
       }
       return {
         ...map,
-        sourceRoot: path.join(
-          '/__SOURCE__/',
-          path.relative(root, path.dirname(f))
-        ),
+        sourceRoot: path.posix.join('/__SOURCE__/', f),
       };
     },
     !argv.full_sourcemaps

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -707,6 +707,7 @@ function massageSourcemaps(sourcemaps, babelMaps, options) {
   const remapped = remapping(
     sourcemaps,
     (f) => {
+      console.log(f);
       if (f.includes('__SOURCE__')) {
         return null;
       }
@@ -722,7 +723,7 @@ function massageSourcemaps(sourcemaps, babelMaps, options) {
       }
       return {
         ...map,
-        sourceRoot: path.posix.join('/__SOURCE__/', f),
+        sourceRoot: path.posix.join('/__SOURCE__/', path.dirname(f)),
       };
     },
     !argv.full_sourcemaps

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -707,7 +707,6 @@ function massageSourcemaps(sourcemaps, babelMaps, options) {
   const remapped = remapping(
     sourcemaps,
     (f) => {
-      console.log(f);
       if (f.includes('__SOURCE__')) {
         return null;
       }


### PR DESCRIPTION
There's a clash between sourcemap's files (which are always interpreted using POSIX `/foo/bar`) and Windows' files (which use `D:\foo\bar` paths). By not including the absolute `process.cwd()` in the `sourceRoot`, we can avoid joining POSIX and Windows filepaths during the sourcemap remapping load phase.