### PR TITLE
🐛 [amp story] Replay/next page button bug fix

### DIFF
--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -93,7 +93,6 @@ class PaginationButton {
     if (state === this.state_) {
       return;
     }
-    // console.log(state);
 
     this.mutator_.mutateElement(this.element, () => {
       this.element.classList.remove(this.state_.className);
@@ -231,12 +230,12 @@ export class PaginationButtons {
     if (pageIndex < totalPages - 1) {
       this.forwardButton_.updateState(ButtonStates.NEXT_PAGE);
     } else {
-      // const viewer = Services.viewerForDoc(this.ampStory_.element);
-      // if (viewer.hasCapability('swipe')) {
-      //   this.forwardButton_.updateState(ButtonStates.NEXT_STORY);
-      // } else {
-      this.forwardButton_.updateState(ButtonStates.REPLAY);
-      // }
+      const viewer = Services.viewerForDoc(this.ampStory_.element);
+      if (viewer.hasCapability('swipe')) {
+        this.forwardButton_.updateState(ButtonStates.NEXT_STORY);
+      } else {
+        this.forwardButton_.updateState(ButtonStates.REPLAY);
+      }
     }
   }
 

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -93,6 +93,8 @@ class PaginationButton {
     if (state === this.state_) {
       return;
     }
+    // console.log(state);
+
     this.mutator_.mutateElement(this.element, () => {
       this.element.classList.remove(this.state_.className);
       this.element.classList.add(state.className);
@@ -100,9 +102,8 @@ class PaginationButton {
         'aria-label',
         localize(this.win_.document, state.label)
       );
+      this.state_ = state;
     });
-
-    this.state_ = state;
   }
 
   /**
@@ -230,12 +231,12 @@ export class PaginationButtons {
     if (pageIndex < totalPages - 1) {
       this.forwardButton_.updateState(ButtonStates.NEXT_PAGE);
     } else {
-      const viewer = Services.viewerForDoc(this.ampStory_.element);
-      if (viewer.hasCapability('swipe')) {
-        this.forwardButton_.updateState(ButtonStates.NEXT_STORY);
-      } else {
-        this.forwardButton_.updateState(ButtonStates.REPLAY);
-      }
+      // const viewer = Services.viewerForDoc(this.ampStory_.element);
+      // if (viewer.hasCapability('swipe')) {
+      //   this.forwardButton_.updateState(ButtonStates.NEXT_STORY);
+      // } else {
+      this.forwardButton_.updateState(ButtonStates.REPLAY);
+      // }
     }
   }
 


### PR DESCRIPTION
Once the replay class was added, it was not being removed. Both classes were present resulting in always displaying the replay button 

Due to async between mutation and setting state the classList was not being updated properly.
This sets the state synchronously within the mutation.  

Fixes a regression from #37098