### PR TITLE
small build cleanup: move closure devDep to validator folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
       },
       "devDependencies": {
         "@ampproject/filesize": "4.3.0",
-        "@ampproject/google-closure-compiler": "20210601.0.0",
         "@ampproject/remapping": "1.0.1",
         "@babel/core": "7.15.0",
         "@babel/eslint-parser": "7.15.0",
@@ -227,69 +226,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@ampproject/google-closure-compiler": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ampproject/google-closure-compiler-java": "20210601.0.0",
-        "kleur": "4.1.4",
-        "vinyl": "2.2.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      },
-      "bin": {
-        "google-closure-compiler": "cli.js"
-      },
-      "optionalDependencies": {
-        "@ampproject/google-closure-compiler-linux": "20210601.0.0",
-        "@ampproject/google-closure-compiler-osx": "20210601.0.0",
-        "@ampproject/google-closure-compiler-windows": "20210601.0.0"
-      }
-    },
-    "node_modules/@ampproject/google-closure-compiler-java": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@ampproject/google-closure-compiler-linux": {
-      "version": "20210601.0.0",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ampproject/google-closure-compiler-osx": {
-      "version": "20210601.0.0",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@ampproject/google-closure-compiler-windows": {
-      "version": "20210601.0.0",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@ampproject/remapping": {
       "version": "1.0.1",
@@ -22421,14 +22357,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/vinyl-sourcemaps-apply": {
-      "version": "0.2.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "source-map": "^0.5.1"
-      }
-    },
     "node_modules/void-elements": {
       "version": "2.0.1",
       "dev": true,
@@ -22912,38 +22840,6 @@
           }
         }
       }
-    },
-    "@ampproject/google-closure-compiler": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "requires": {
-        "@ampproject/google-closure-compiler-java": "20210601.0.0",
-        "@ampproject/google-closure-compiler-linux": "20210601.0.0",
-        "@ampproject/google-closure-compiler-osx": "20210601.0.0",
-        "@ampproject/google-closure-compiler-windows": "20210601.0.0",
-        "kleur": "4.1.4",
-        "vinyl": "2.2.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      }
-    },
-    "@ampproject/google-closure-compiler-java": {
-      "version": "20210601.0.0",
-      "dev": true
-    },
-    "@ampproject/google-closure-compiler-linux": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "optional": true
-    },
-    "@ampproject/google-closure-compiler-osx": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "optional": true
-    },
-    "@ampproject/google-closure-compiler-windows": {
-      "version": "20210601.0.0",
-      "dev": true,
-      "optional": true
     },
     "@ampproject/remapping": {
       "version": "1.0.1",
@@ -38305,13 +38201,6 @@
             "remove-trailing-separator": "^1.0.1"
           }
         }
-      }
-    },
-    "vinyl-sourcemaps-apply": {
-      "version": "0.2.1",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.5.1"
       }
     },
     "void-elements": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "@ampproject/filesize": "4.3.0",
-    "@ampproject/google-closure-compiler": "20210601.0.0",
     "@ampproject/remapping": "1.0.1",
     "@babel/core": "7.15.0",
     "@babel/eslint-parser": "7.15.0",

--- a/validator/build.py
+++ b/validator/build.py
@@ -273,7 +273,7 @@ def CompileWithClosure(js_files, definitions, entry_points, output_file):
 
   cmd = [
       'java', '-jar',
-      '../node_modules/@ampproject/google-closure-compiler-java/compiler.jar',
+      './node_modules/@ampproject/google-closure-compiler-java/compiler.jar',
       '--language_out=ES5_STRICT', '--dependency_mode=PRUNE',
       '--js_output_file=%s' % output_file
   ]

--- a/validator/build.py
+++ b/validator/build.py
@@ -273,7 +273,7 @@ def CompileWithClosure(js_files, definitions, entry_points, output_file):
 
   cmd = [
       'java', '-jar',
-      './node_modules/@ampproject/google-closure-compiler-java/compiler.jar',
+      './node_modules/google-closure-compiler-java/compiler.jar',
       '--language_out=ES5_STRICT', '--dependency_mode=PRUNE',
       '--js_output_file=%s' % output_file
   ]

--- a/validator/package-lock.json
+++ b/validator/package-lock.json
@@ -10,83 +10,10 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
-        "@ampproject/google-closure-compiler": "20210601.0.0",
+        "google-closure-compiler-java": "20210601.0.0",
         "jasmine": "3.10.0",
         "jasmine-console-reporter": "3.1.0"
       }
-    },
-    "node_modules/@ampproject/google-closure-compiler": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler/-/google-closure-compiler-20210601.0.0.tgz",
-      "integrity": "sha512-65Oizsyl4vpqqWCSzgSRb2baENB4Oi3brLK2tdIr7rhaqtwujrqcNvl28AmlIr3FxgVvKbqrl5g7IyodiUzRrw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "dependencies": {
-        "@ampproject/google-closure-compiler-java": "20210601.0.0",
-        "kleur": "4.1.4",
-        "vinyl": "2.2.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      },
-      "bin": {
-        "google-closure-compiler": "cli.js"
-      },
-      "optionalDependencies": {
-        "@ampproject/google-closure-compiler-linux": "20210601.0.0",
-        "@ampproject/google-closure-compiler-osx": "20210601.0.0",
-        "@ampproject/google-closure-compiler-windows": "20210601.0.0"
-      }
-    },
-    "node_modules/@ampproject/google-closure-compiler-java": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20210601.0.0.tgz",
-      "integrity": "sha512-E6ToLZEYDD+JojIlNXo6XyUl7HihKtsy4zRCIcFetA7EHz5aMuWx7+F/fUPQzS0t4TjdQ0CV74zuLhei6dxEeA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true
-    },
-    "node_modules/@ampproject/google-closure-compiler-linux": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20210601.0.0.tgz",
-      "integrity": "sha512-jizEZV+OtsU9k7iSw+B0v0jupo1qA+SHdcK8pSydL5hJuhKdS7jLe6JjgAohr3ACnp7JcjB+RPPcJqVi5uTo8Q==",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@ampproject/google-closure-compiler-osx": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20210601.0.0.tgz",
-      "integrity": "sha512-KFVGc+hKzsPtKWUx3pUMUt00f9lJfg8SfVhDpvXQmRkpK4TXhKcd8Lnxs0i3wR0ORXnp4s2ziZMZSA9D9LcBgg==",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@ampproject/google-closure-compiler-windows": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20210601.0.0.tgz",
-      "integrity": "sha512-rl0e35lg6F8wbNIPAN0ifxQB92XhOUOLNDzEVtuAa5SjpXgQPH3E77DWzV36jdgQDKvOjfw9URCKhJFdRb2lCQ==",
-      "cpu": [
-        "x64",
-        "x86"
-      ],
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/ansi-regex": {
       "version": "4.1.0",
@@ -178,32 +105,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/clone-stats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-      "dev": true
-    },
-    "node_modules/cloneable-readable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -223,12 +124,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "node_modules/defaults": {
@@ -275,6 +170,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/google-closure-compiler-java": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210601.0.0.tgz",
+      "integrity": "sha512-bH6nIwOmp4qDWvlbXx5/DE3XA2aDGQoCpmRYZJGONY1Sy6Xfbq0ioXRHH9eBDP9hxhCJ5Sd/K89A0NZ8Nz9RJA==",
+      "dev": true
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -298,12 +199,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "node_modules/jasmine": {
@@ -344,15 +239,6 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
       "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==",
       "dev": true
-    },
-    "node_modules/kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -455,42 +341,6 @@
       "integrity": "sha512-/ieVBpMaPTJf83YTUl2TImsSwMEJ23qGP2w27pE6aX+NrB/ZRGqOnQZpl7J719yFwd+ebDiHguPNFeMSamyK7w==",
       "dev": true
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "node_modules/replace-ext": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -504,35 +354,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "node_modules/signal-exit": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
-    },
-    "node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/strip-ansi": {
       "version": "5.2.0",
@@ -558,47 +384,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "node_modules/vinyl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
-      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
-      "dev": true,
-      "dependencies": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/vinyl-sourcemaps-apply": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.5.1"
-      }
-    },
-    "node_modules/vinyl/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -616,48 +401,6 @@
     }
   },
   "dependencies": {
-    "@ampproject/google-closure-compiler": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler/-/google-closure-compiler-20210601.0.0.tgz",
-      "integrity": "sha512-65Oizsyl4vpqqWCSzgSRb2baENB4Oi3brLK2tdIr7rhaqtwujrqcNvl28AmlIr3FxgVvKbqrl5g7IyodiUzRrw==",
-      "dev": true,
-      "requires": {
-        "@ampproject/google-closure-compiler-java": "20210601.0.0",
-        "@ampproject/google-closure-compiler-linux": "20210601.0.0",
-        "@ampproject/google-closure-compiler-osx": "20210601.0.0",
-        "@ampproject/google-closure-compiler-windows": "20210601.0.0",
-        "kleur": "4.1.4",
-        "vinyl": "2.2.1",
-        "vinyl-sourcemaps-apply": "0.2.1"
-      }
-    },
-    "@ampproject/google-closure-compiler-java": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20210601.0.0.tgz",
-      "integrity": "sha512-E6ToLZEYDD+JojIlNXo6XyUl7HihKtsy4zRCIcFetA7EHz5aMuWx7+F/fUPQzS0t4TjdQ0CV74zuLhei6dxEeA==",
-      "dev": true
-    },
-    "@ampproject/google-closure-compiler-linux": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20210601.0.0.tgz",
-      "integrity": "sha512-jizEZV+OtsU9k7iSw+B0v0jupo1qA+SHdcK8pSydL5hJuhKdS7jLe6JjgAohr3ACnp7JcjB+RPPcJqVi5uTo8Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@ampproject/google-closure-compiler-osx": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20210601.0.0.tgz",
-      "integrity": "sha512-KFVGc+hKzsPtKWUx3pUMUt00f9lJfg8SfVhDpvXQmRkpK4TXhKcd8Lnxs0i3wR0ORXnp4s2ziZMZSA9D9LcBgg==",
-      "dev": true,
-      "optional": true
-    },
-    "@ampproject/google-closure-compiler-windows": {
-      "version": "20210601.0.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20210601.0.0.tgz",
-      "integrity": "sha512-rl0e35lg6F8wbNIPAN0ifxQB92XhOUOLNDzEVtuAa5SjpXgQPH3E77DWzV36jdgQDKvOjfw9URCKhJFdRb2lCQ==",
-      "dev": true,
-      "optional": true
-    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -727,29 +470,6 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-      "dev": true
-    },
-    "clone-stats": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-      "dev": true
-    },
-    "cloneable-readable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
-      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "process-nextick-args": "^2.0.0",
-        "readable-stream": "^2.3.5"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -769,12 +489,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "defaults": {
@@ -812,6 +526,12 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "google-closure-compiler-java": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20210601.0.0.tgz",
+      "integrity": "sha512-bH6nIwOmp4qDWvlbXx5/DE3XA2aDGQoCpmRYZJGONY1Sy6Xfbq0ioXRHH9eBDP9hxhCJ5Sd/K89A0NZ8Nz9RJA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -832,12 +552,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
     "jasmine": {
@@ -868,12 +582,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
       "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==",
-      "dev": true
-    },
-    "kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "dev": true
     },
     "lodash": {
@@ -959,39 +667,6 @@
       "integrity": "sha512-/ieVBpMaPTJf83YTUl2TImsSwMEJ23qGP2w27pE6aX+NrB/ZRGqOnQZpl7J719yFwd+ebDiHguPNFeMSamyK7w==",
       "dev": true
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
-    },
-    "replace-ext": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
-      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
-      "dev": true
-    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -1002,32 +677,11 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "strip-ansi": {
       "version": "5.2.0",
@@ -1045,43 +699,6 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "vinyl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
-      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
-      "dev": true,
-      "requires": {
-        "clone": "^2.1.1",
-        "clone-buffer": "^1.0.0",
-        "clone-stats": "^1.0.0",
-        "cloneable-readable": "^1.0.0",
-        "remove-trailing-separator": "^1.0.1",
-        "replace-ext": "^1.0.0"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        }
-      }
-    },
-    "vinyl-sourcemaps-apply": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.5.1"
       }
     },
     "wcwidth": {

--- a/validator/package-lock.json
+++ b/validator/package-lock.json
@@ -10,9 +10,83 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
+        "@ampproject/google-closure-compiler": "20210601.0.0",
         "jasmine": "3.10.0",
         "jasmine-console-reporter": "3.1.0"
       }
+    },
+    "node_modules/@ampproject/google-closure-compiler": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler/-/google-closure-compiler-20210601.0.0.tgz",
+      "integrity": "sha512-65Oizsyl4vpqqWCSzgSRb2baENB4Oi3brLK2tdIr7rhaqtwujrqcNvl28AmlIr3FxgVvKbqrl5g7IyodiUzRrw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/google-closure-compiler-java": "20210601.0.0",
+        "kleur": "4.1.4",
+        "vinyl": "2.2.1",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      },
+      "bin": {
+        "google-closure-compiler": "cli.js"
+      },
+      "optionalDependencies": {
+        "@ampproject/google-closure-compiler-linux": "20210601.0.0",
+        "@ampproject/google-closure-compiler-osx": "20210601.0.0",
+        "@ampproject/google-closure-compiler-windows": "20210601.0.0"
+      }
+    },
+    "node_modules/@ampproject/google-closure-compiler-java": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20210601.0.0.tgz",
+      "integrity": "sha512-E6ToLZEYDD+JojIlNXo6XyUl7HihKtsy4zRCIcFetA7EHz5aMuWx7+F/fUPQzS0t4TjdQ0CV74zuLhei6dxEeA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true
+    },
+    "node_modules/@ampproject/google-closure-compiler-linux": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20210601.0.0.tgz",
+      "integrity": "sha512-jizEZV+OtsU9k7iSw+B0v0jupo1qA+SHdcK8pSydL5hJuhKdS7jLe6JjgAohr3ACnp7JcjB+RPPcJqVi5uTo8Q==",
+      "cpu": [
+        "x64",
+        "x86"
+      ],
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ampproject/google-closure-compiler-osx": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20210601.0.0.tgz",
+      "integrity": "sha512-KFVGc+hKzsPtKWUx3pUMUt00f9lJfg8SfVhDpvXQmRkpK4TXhKcd8Lnxs0i3wR0ORXnp4s2ziZMZSA9D9LcBgg==",
+      "cpu": [
+        "x64",
+        "x86"
+      ],
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ampproject/google-closure-compiler-windows": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20210601.0.0.tgz",
+      "integrity": "sha512-rl0e35lg6F8wbNIPAN0ifxQB92XhOUOLNDzEVtuAa5SjpXgQPH3E77DWzV36jdgQDKvOjfw9URCKhJFdRb2lCQ==",
+      "cpu": [
+        "x64",
+        "x86"
+      ],
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/ansi-regex": {
       "version": "4.1.0",
@@ -104,6 +178,32 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "node_modules/cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -123,6 +223,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "node_modules/defaults": {
@@ -194,6 +300,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "node_modules/jasmine": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.10.0.tgz",
@@ -232,6 +344,15 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
       "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==",
       "dev": true
+    },
+    "node_modules/kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -334,6 +455,42 @@
       "integrity": "sha512-/ieVBpMaPTJf83YTUl2TImsSwMEJ23qGP2w27pE6aX+NrB/ZRGqOnQZpl7J719yFwd+ebDiHguPNFeMSamyK7w==",
       "dev": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "node_modules/replace-ext": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -347,11 +504,35 @@
         "node": ">=4"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/strip-ansi": {
       "version": "5.2.0",
@@ -377,6 +558,47 @@
         "node": ">=4"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/vinyl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.5.1"
+      }
+    },
+    "node_modules/vinyl/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -394,6 +616,48 @@
     }
   },
   "dependencies": {
+    "@ampproject/google-closure-compiler": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler/-/google-closure-compiler-20210601.0.0.tgz",
+      "integrity": "sha512-65Oizsyl4vpqqWCSzgSRb2baENB4Oi3brLK2tdIr7rhaqtwujrqcNvl28AmlIr3FxgVvKbqrl5g7IyodiUzRrw==",
+      "dev": true,
+      "requires": {
+        "@ampproject/google-closure-compiler-java": "20210601.0.0",
+        "@ampproject/google-closure-compiler-linux": "20210601.0.0",
+        "@ampproject/google-closure-compiler-osx": "20210601.0.0",
+        "@ampproject/google-closure-compiler-windows": "20210601.0.0",
+        "kleur": "4.1.4",
+        "vinyl": "2.2.1",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "@ampproject/google-closure-compiler-java": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-java/-/google-closure-compiler-java-20210601.0.0.tgz",
+      "integrity": "sha512-E6ToLZEYDD+JojIlNXo6XyUl7HihKtsy4zRCIcFetA7EHz5aMuWx7+F/fUPQzS0t4TjdQ0CV74zuLhei6dxEeA==",
+      "dev": true
+    },
+    "@ampproject/google-closure-compiler-linux": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-linux/-/google-closure-compiler-linux-20210601.0.0.tgz",
+      "integrity": "sha512-jizEZV+OtsU9k7iSw+B0v0jupo1qA+SHdcK8pSydL5hJuhKdS7jLe6JjgAohr3ACnp7JcjB+RPPcJqVi5uTo8Q==",
+      "dev": true,
+      "optional": true
+    },
+    "@ampproject/google-closure-compiler-osx": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-osx/-/google-closure-compiler-osx-20210601.0.0.tgz",
+      "integrity": "sha512-KFVGc+hKzsPtKWUx3pUMUt00f9lJfg8SfVhDpvXQmRkpK4TXhKcd8Lnxs0i3wR0ORXnp4s2ziZMZSA9D9LcBgg==",
+      "dev": true,
+      "optional": true
+    },
+    "@ampproject/google-closure-compiler-windows": {
+      "version": "20210601.0.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/google-closure-compiler-windows/-/google-closure-compiler-windows-20210601.0.0.tgz",
+      "integrity": "sha512-rl0e35lg6F8wbNIPAN0ifxQB92XhOUOLNDzEVtuAa5SjpXgQPH3E77DWzV36jdgQDKvOjfw9URCKhJFdRb2lCQ==",
+      "dev": true,
+      "optional": true
+    },
     "ansi-regex": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -463,6 +727,29 @@
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+      "dev": true
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+      "dev": true
+    },
+    "cloneable-readable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+      "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "process-nextick-args": "^2.0.0",
+        "readable-stream": "^2.3.5"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -482,6 +769,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "defaults": {
@@ -541,6 +834,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "jasmine": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.10.0.tgz",
@@ -569,6 +868,12 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.10.1.tgz",
       "integrity": "sha512-ooZWSDVAdh79Rrj4/nnfklL3NQVra0BcuhcuWoAwwi+znLDoUeH87AFfeX8s+YeYi6xlv5nveRyaA1v7CintfA==",
+      "dev": true
+    },
+    "kleur": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
       "dev": true
     },
     "lodash": {
@@ -654,6 +959,39 @@
       "integrity": "sha512-/ieVBpMaPTJf83YTUl2TImsSwMEJ23qGP2w27pE6aX+NrB/ZRGqOnQZpl7J719yFwd+ebDiHguPNFeMSamyK7w==",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "replace-ext": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+      "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -664,11 +1002,32 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "strip-ansi": {
       "version": "5.2.0",
@@ -686,6 +1045,43 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "vinyl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+      "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.1",
+        "clone-buffer": "^1.0.0",
+        "clone-stats": "^1.0.0",
+        "cloneable-readable": "^1.0.0",
+        "remove-trailing-separator": "^1.0.1",
+        "replace-ext": "^1.0.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+          "dev": true
+        }
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.1"
       }
     },
     "wcwidth": {

--- a/validator/package.json
+++ b/validator/package.json
@@ -12,6 +12,7 @@
     "preinstall": "node ../build-system/common/check-package-manager.js"
   },
   "devDependencies": {
+    "@ampproject/google-closure-compiler": "20210601.0.0",
     "jasmine": "3.10.0",
     "jasmine-console-reporter": "3.1.0"
   }

--- a/validator/package.json
+++ b/validator/package.json
@@ -12,7 +12,7 @@
     "preinstall": "node ../build-system/common/check-package-manager.js"
   },
   "devDependencies": {
-    "@ampproject/google-closure-compiler": "20210601.0.0",
+    "google-closure-compiler-java": "20210601.0.0",
     "jasmine": "3.10.0",
     "jasmine-console-reporter": "3.1.0"
   }


### PR DESCRIPTION
**summary**
Since `validator` is the only piece still needing closure compiler, moves the dep to its folder.