### PR TITLE
Fix compiler link text

### DIFF
--- a/src/compiler/README.md
+++ b/src/compiler/README.md
@@ -35,6 +35,6 @@ function buildDom(element) {
 }
 ```
 
-Check out [<amp-layout>](../builtins/amp-layout/amp-layout.js) to see a simple example.
+Check out [`<amp-layout>`](../builtins/amp-layout/amp-layout.js) to see a simple example.
 
 <!-- TODO(samouri): Create Bento section when the details finalize. -->


### PR DESCRIPTION
It's currently empty because it's outputting a real `<amp-layout>` custom element, which can't render on GitHub.