### PR TITLE
small type cleanup: remove exclamation points

### DIFF
--- a/extensions/amp-carousel/0.1/carousel-controls.js
+++ b/extensions/amp-carousel/0.1/carousel-controls.js
@@ -19,19 +19,19 @@ export class CarouselControls {
    * }} param0
    */
   constructor({element, go, nextButton, prevButton}) {
-    /** @private @type {!AmpElement} */
+    /** @private @type {AmpElement} */
     this.element_ = element;
 
-    /** @private @type {!GoFunctionDef} */
+    /** @private @type {GoFunctionDef} */
     this.go_ = go;
 
-    /** @private @type {!Window} */
+    /** @private @type {Window} */
     this.win_ = getWin(element);
 
-    /** @private {!HTMLDivElement} */
+    /** @private {HTMLDivElement} */
     this.prevButton_ = prevButton;
 
-    /** @private {!HTMLDivElement} */
+    /** @private {HTMLDivElement} */
     this.nextButton_ = nextButton;
 
     /** @private {boolean} */
@@ -68,7 +68,7 @@ export class CarouselControls {
   }
 
   /**
-   * @param {!HTMLDivElement} button
+   * @param {HTMLDivElement} button
    * @param {*} onInteraction
    */
   setupButtonInteraction(button, onInteraction) {

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -14,7 +14,7 @@ import {buildDom} from './build-dom';
 const TAG = 'amp-scrollable-carousel';
 
 export class AmpScrollableCarousel extends AMP.BaseElement {
-  /** @param {!AmpElement} element */
+  /** @param {AmpElement} element */
   constructor(element) {
     super(element);
 
@@ -24,7 +24,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
     /** @private {number} */
     this.oldPos_ = 0;
 
-    /** @private {?Array<!Element>} */
+    /** @private {?Array<Element>} */
     this.cells_ = null;
 
     /** @private {?Element} */
@@ -153,7 +153,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
       this.commitSwitch_(newPos);
       this.container_./*OK*/ scrollLeft = newPos;
     } else {
-      /** @const {!TransitionDef<number>} */
+      /** @const {TransitionDef<number>} */
       const interpolate = numeric(oldPos, newPos);
       const duration = 200;
       const curve = 'ease-in-out';
@@ -194,7 +194,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
       if (newPos == oldPos) {
         return;
       }
-      /** @const {!TransitionDef<number>} */
+      /** @const {TransitionDef<number>} */
       const interpolate = numeric(oldPos, newPos);
       const duration = 200;
       const curve = 'ease-in-out';
@@ -242,7 +242,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
    * Escapes Left and Right arrow key events on the carousel container.
    * This is to prevent them from doubly interacting with surrounding viewer
    * contexts such as email clients when interacting with the amp-carousel.
-   * @param {!KeyboardEvent} event
+   * @param {KeyboardEvent} event
    * @private
    */
   keydownHandler_(event) {
@@ -321,7 +321,7 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
 
   /**
    * @param {number} pos
-   * @param {function(!Element):void} callback
+   * @param {function(Element):void} callback
    * @private
    */
   withinWindow_(pos, callback) {

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -58,7 +58,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
     /** @private {boolean} */
     this.hasNativeSnapPoints_ = false;
 
-    /** @private {!Array<Element>} */
+    /** @private {Array<Element>} */
     this.slides_ = [];
 
     /** @private {number} */
@@ -67,7 +67,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
     /** @private {?Element} */
     this.slidesContainer_ = null;
 
-    /** @private {!Array<Element>} */
+    /** @private {Array<Element>} */
     this.slideWrappers_ = [];
 
     /** @private {boolean} */

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -48,7 +48,7 @@ const CUSTOM_SNAP_TIMEOUT = 100;
 const TAG = 'AMP-CAROUSEL';
 
 export class AmpSlideScroll extends AMP.BaseElement {
-  /** @param {!AmpElement} element */
+  /** @param {AmpElement} element */
   constructor(element) {
     super(element);
 
@@ -58,7 +58,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
     /** @private {boolean} */
     this.hasNativeSnapPoints_ = false;
 
-    /** @private {!Array<!Element>} */
+    /** @private {!Array<Element>} */
     this.slides_ = [];
 
     /** @private {number} */
@@ -67,7 +67,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
     /** @private {?Element} */
     this.slidesContainer_ = null;
 
-    /** @private {!Array<!Element>} */
+    /** @private {!Array<Element>} */
     this.slideWrappers_ = [];
 
     /** @private {boolean} */
@@ -132,7 +132,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
     /** @private {number} */
     this.previousScrollLeft_ = 0;
 
-    /** @private {!Array<?string>} */
+    /** @private {Array<?string>} */
     this.dataSlideIdArr_ = [];
 
     const platform = Services.platformFor(this.win);
@@ -527,7 +527,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
    * Proceeds to the next slide in the desired direction.
    * @param {number} dir -1 or 1
    * @param {boolean} animate
-   * @param {!ActionTrust_Enum} trust
+   * @param {ActionTrust_Enum} trust
    */
   moveSlide(dir, animate, trust) {
     if (this.slideIndex_ !== null) {
@@ -552,7 +552,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
 
   /**
    * Handles scroll on the slides container.
-   * @param {!Event} unusedEvent Event object.
+   * @param {Event} unusedEvent Event object.
    * @private
    */
   scrollHandler_(unusedEvent) {
@@ -577,7 +577,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
    * Escapes Left and Right arrow key events on the carousel container.
    * This is to prevent them from doubly interacting with surrounding viewer
    * contexts such as email clients when interacting with the amp-carousel.
-   * @param {!KeyboardEvent} event
+   * @param {KeyboardEvent} event
    * @private
    */
   keydownHandler_(event) {
@@ -626,7 +626,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
    * @param {number=} opt_forceDir if a valid direction is given force it to
    * move 1 slide in that direction.
    * @param {ActionTrust_Enum=} opt_trust
-   * @return {!Promise}
+   * @return {Promise}
    */
   customSnap_(currentScrollLeft, opt_forceDir, opt_trust) {
     this.snappingInProgress_ = true;
@@ -748,7 +748,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
    * Parses given value as integer and shows the slide with that index value
    * when element has been laid out.
    * @param {*} value
-   * @param {!ActionTrust_Enum} trust
+   * @param {ActionTrust_Enum} trust
    */
   goToSlide(value, trust) {
     const index = parseInt(value, 10);
@@ -921,7 +921,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
 
   /**
    * Given an index, hides rest of the slides that are not needed.
-   * @param {!Array<number>} indexArr Array of indices that
+   * @param {Array<number>} indexArr Array of indices that
    *    should not be hidden.
    * @private
    */
@@ -955,14 +955,14 @@ export class AmpSlideScroll extends AMP.BaseElement {
    * Animate scrollLeft of the container.
    * @param {number} fromScrollLeft
    * @param {number} toScrollLeft
-   * @return {!Promise}
+   * @return {Promise}
    * @private
    */
   animateScrollLeft_(fromScrollLeft, toScrollLeft) {
     if (fromScrollLeft == toScrollLeft) {
       return Promise.resolve();
     }
-    /** @const {!TransitionDef<number>} */
+    /** @const {TransitionDef<number>} */
     const interpolate = numeric(fromScrollLeft, toScrollLeft);
     const curve = bezierCurve(0.8, 0, 0.6, 1); // ease-in
     const duration = 80;
@@ -1027,7 +1027,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
 
   /**
    * @param {string} eventType
-   * @param {!JsonObject} vars A map of vars and their values.
+   * @param {JsonObject} vars A map of vars and their values.
    * @private
    */
   analyticsEvent_(eventType, vars) {

--- a/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-hidden-controls.js
@@ -10,7 +10,7 @@ describes.endtoend(
      * A helper function for expecting an error from an async function since we
      * don't have ChaiAsExpected and we cannot wait for errors from
      * @param {function()} fn A function to run
-     * @param {!RegExp} regExp A regular expression to match the error message.
+     * @param {RegExp} regExp A regular expression to match the error message.
      */
     async function expectAysncError(fn, regExp) {
       let error;

--- a/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
+++ b/extensions/amp-carousel/0.1/test-e2e/test-slidescroll-autoplay.js
@@ -10,7 +10,7 @@ describes.endtoend(
     /**
      * Attach an event listener to page to capture the 'slideChange' event.
      * If given a selector, click on it to fire the event being listened for.
-     * @return {!Promise}
+     * @return {Promise}
      */
     function slideChangeEventAfterClicking(opt_selector) {
       return controller.evaluate((opt_selector) => {

--- a/extensions/amp-carousel/0.1/test/test-slidescroll.js
+++ b/extensions/amp-carousel/0.1/test/test-slidescroll.js
@@ -35,7 +35,7 @@ describes.realWin(
      * @param {boolean=} opt_attachToDom
      * @param {boolean=} opt_hasAutoplay
      * @param {boolean=} opt_autoplayLoops
-     * @return {!Element}
+     * @return {Element}
      */
     function getAmpSlideScroll(
       opt_hasLooping,

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -13,7 +13,7 @@ export class AmpFitText extends AMP.BaseElement {
     return true;
   }
 
-  /** @param {!AmpElement} element */
+  /** @param {AmpElement} element */
   constructor(element) {
     super(element);
 
@@ -150,7 +150,7 @@ export class AmpFitText extends AMP.BaseElement {
  * @param {number} minFontSize
  * @param {number} maxFontSize
  * @return {number}
- * @private  Visible for testing only!
+ * @private  Visible for testing only
  */
 export function calculateFontSize_(
   measurer,
@@ -181,7 +181,7 @@ export function calculateFontSize_(
  * @param {Element} measurer
  * @param {number} maxHeight
  * @param {number} fontSize
- * @private  Visible for testing only!
+ * @private  Visible for testing only
  */
 export function updateOverflow_(content, measurer, maxHeight, fontSize) {
   setStyle(measurer, 'fontSize', px(fontSize));

--- a/extensions/amp-fit-text/0.1/build-dom.js
+++ b/extensions/amp-fit-text/0.1/build-dom.js
@@ -64,8 +64,8 @@ export function queryDom(element) {
 /**
  * Make a destination node a clone of the source.
  *
- * @param {!Node} from
- * @param {!Node} to
+ * @param {Node} from
+ * @param {Node} to
  */
 export function mirrorNode(from, to) {
   // First clear out the destination node.

--- a/extensions/amp-fit-text/1.0/component.js
+++ b/extensions/amp-fit-text/1.0/component.js
@@ -6,7 +6,7 @@ import {getWin} from '#core/window';
 import {useCallback, useLayoutEffect, useRef} from '#preact';
 
 /**
- * @param {!BentoFitTextDef.Props} props
+ * @param {BentoFitTextDef.Props} props
  * @return {PreactDef.Renderable}
  */
 export function BentoFitText({

--- a/src/core/context/node.js
+++ b/src/core/context/node.js
@@ -238,7 +238,7 @@ export class ContextNode {
 
     /**
      * @package
-     * @type {!Values}
+     * @type {Values}
      */
     this.values = new Values(this);
 
@@ -267,7 +267,7 @@ export class ContextNode {
     // Shadow root: track slot changes.
     if (node.nodeType == FRAGMENT_NODE) {
       node.addEventListener('slotchange', (e) => {
-        const slot = /** @type {!HTMLSlotElement} */ (e.target);
+        const slot = /** @type {HTMLSlotElement} */ (e.target);
         // Rediscover newly assigned nodes.
         slot.assignedNodes().forEach(discoverContained);
         // Rediscover unassigned nodes.
@@ -308,7 +308,7 @@ export class ContextNode {
    */
   setParent(parent) {
     const parentContext = /** @type {*} */ (parent)?.nodeType
-      ? ContextNode.get(/** @type {!Node} */ (parent))
+      ? ContextNode.get(/** @type {Node} */ (parent))
       : /** @type {?ContextNode<?>} */ (parent);
     this.updateTree_(parentContext, /* parentOverridden */ parent != null);
   }

--- a/src/core/context/scheduler.js
+++ b/src/core/context/scheduler.js
@@ -14,7 +14,7 @@ export function throttleTail(handler, defaultScheduler) {
     scheduled = false;
     handler();
   };
-  /** @param {!SchedulerDef=} opt_scheduler */
+  /** @param {SchedulerDef=} opt_scheduler */
   const scheduleIfNotScheduled = (opt_scheduler) => {
     if (!scheduled) {
       scheduled = true;

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -509,7 +509,7 @@ export class PreactBaseElement extends BaseElement {
    * This has no effect on Bento documents, since they lack an Actions system.
    * Instead, they should use `(await element.getApi()).action()`
    * @param {string} alias
-   * @param {function(!API_TYPE, !../service/action-impl.ActionInvocation)} handler
+   * @param {function(!API_TYPE, ../service/action-impl.ActionInvocation)} handler
    * @param {../action-constants.ActionTrust_Enum} minTrust
    * @protected
    */

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -509,7 +509,7 @@ export class PreactBaseElement extends BaseElement {
    * This has no effect on Bento documents, since they lack an Actions system.
    * Instead, they should use `(await element.getApi()).action()`
    * @param {string} alias
-   * @param {function(!API_TYPE, ../service/action-impl.ActionInvocation)} handler
+   * @param {function(API_TYPE, ../service/action-impl.ActionInvocation)} handler
    * @param {../action-constants.ActionTrust_Enum} minTrust
    * @protected
    */

--- a/src/preact/bento-ce.js
+++ b/src/preact/bento-ce.js
@@ -36,13 +36,13 @@ if (typeof AMP !== 'undefined' && AMP.BaseElement) {
   let ExtendableHTMLElement;
   class CeBaseElement {
     /**
-     * @param {!Element} element
+     * @param {Element} element
      */
     constructor(element) {
-      /** @const {!Element} */
+      /** @const {Element} */
       this.element = element;
 
-      /** @const {!Window} */
+      /** @const {Window} */
       this.win = getWin(element);
     }
 
@@ -59,7 +59,7 @@ if (typeof AMP !== 'undefined' && AMP.BaseElement) {
         constructor() {
           super();
 
-          /** @const {!CeBaseElement} */
+          /** @const {CeBaseElement} */
           this.implementation = new BaseElement(this);
         }
 

--- a/src/preact/compat.js
+++ b/src/preact/compat.js
@@ -42,7 +42,7 @@ function newDiff(vnode) {
  */
 export function forwardRef(Component) {
   /**
-   * @param {!Object} props
+   * @param {Object} props
    * @return {R}
    */
   function Forward(props) {
@@ -75,7 +75,7 @@ export function forwardRef(Component) {
 
 /**
  * @param {PreactDef.Renderable} children
- * @return {!Array<PreactDef.Renderable>}
+ * @return {Array<PreactDef.Renderable>}
  */
 function toArray(children) {
   return toChildArray(children);
@@ -84,7 +84,7 @@ function toArray(children) {
 /**
  * @param {PreactDef.Renderable} children
  * @param {function(PreactDef.Renderable):R} fn
- * @return {!Array<R>}
+ * @return {Array<R>}
  * @template R
  */
 function map(children, fn) {

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -23,7 +23,7 @@ import {
 } from '../../3p-frame';
 import {parseUrlDeprecated} from '../../url';
 
-/** @type {!Object<string,function():void>} 3p frames for that type. */
+/** @type {Object<string,function():void>} 3p frames for that type. */
 export const countGenerators = {};
 
 // Block synchronous XHR in ad. These are very rare, but super bad for UX
@@ -40,8 +40,8 @@ const DEFAULT_SANDBOX =
 /**
  * Creates the iframe for the embed. Applies correct size and passes the embed
  * attributes to the frame via JSON inside the fragment.
- * @param {!IframeEmbedDef.Props} props
- * @param {{current: (!IframeEmbedDef.Api|null)}} ref
+ * @param {IframeEmbedDef.Props} props
+ * @param {{current: (IframeEmbedDef.Api|null)}} ref
  * @return {PreactDef.Renderable}
  */
 function ProxyIframeEmbedWithRef(

--- a/src/preact/component/component.type.js
+++ b/src/preact/component/component.type.js
@@ -2,7 +2,7 @@
 
 /**
  * @typedef {{
- *   as: (string|!Function|undefined),
+ *   as: (string|Function|undefined),
  *   wrapperClassName: (?string|undefined),
  *   wrapperStyle: (?Object|undefined),
  *   children: (?PreactDef.Renderable|undefined),
@@ -14,13 +14,13 @@ var WrapperComponentProps;
  * See https://developer.mozilla.org/en-US/docs/Web/CSS/contain
  *
  * @typedef {{
- *   as: (string|!Function|undefined),
+ *   as: (string|Function|undefined),
  *   size: (boolean|undefined),
  *   layout: (boolean|undefined),
  *   paint: (boolean|undefined),
  *   wrapperClassName: (?string|undefined),
  *   wrapperStyle: (?Object|undefined),
- *   contentRef: ({current: ?}|function(!Element)|undefined),
+ *   contentRef: ({current: ?}|function(Element)|undefined),
  *   contentClassName: (?string|undefined),
  *   contentStyle: (?Object|undefined),
  *   children: (?PreactDef.Renderable|undefined),
@@ -29,12 +29,12 @@ var WrapperComponentProps;
 var ContainWrapperComponentProps;
 
 /**
- * @typedef {!PreactDef.Renderable|!PreactDef.InnerHTML|null}
+ * @typedef {PreactDef.Renderable|PreactDef.InnerHTML|null}
  */
 var RendererFunctionResponseType;
 
 /**
- * @typedef {function(!JsonObject):(?RendererFunctionResponseType|!Promise<?RendererFunctionResponseType>)}
+ * @typedef {function(JsonObject):(?RendererFunctionResponseType|Promise<?RendererFunctionResponseType>)}
  */
 var RendererFunctionType;
 

--- a/src/preact/component/contain.js
+++ b/src/preact/component/contain.js
@@ -31,7 +31,7 @@ const SIZE_CONTENT_STYLE = {
  * - layout: nothing outside the element may affect its internal layout and
  * vice versa.
  * - paint: the element's content doesn't display outside the element's bounds.
- * @param {!ContainWrapperComponentProps} props
+ * @param {ContainWrapperComponentProps} props
  * @param {{current: ?Element}} ref
  * @return {PreactDef.Renderable}
  */

--- a/src/preact/component/iframe.js
+++ b/src/preact/component/iframe.js
@@ -26,7 +26,7 @@ const ABOUT_BLANK = 'about:blank';
 const canResetSrc = (src) => src && src != ABOUT_BLANK && !src.includes('#');
 
 /**
- * @param {!IframeEmbedDef.Props} props
+ * @param {IframeEmbedDef.Props} props
  * @param {{current: ?IframeEmbedDef.Api}} ref
  * @return {PreactDef.Renderable}
  */

--- a/src/preact/component/renderer.js
+++ b/src/preact/component/renderer.js
@@ -6,7 +6,7 @@ import {useLayoutEffect, useState} from '#preact';
  * in a layout effect and allows the result to be a promise.
  *
  * @param {?RendererFunctionType|undefined} renderer
- * @param {!JsonObject} data
+ * @param {JsonObject} data
  * @return {?RendererFunctionResponseType}
  */
 export function useRenderer(renderer, data) {

--- a/src/preact/component/wrapper.js
+++ b/src/preact/component/wrapper.js
@@ -6,7 +6,7 @@ import {propName} from '#preact/utils';
  * The wrapper component provides the canonical wrapper for components whose
  * size depends on the children. This is often the opposite of the
  * `ContainWrapper`.
- * @param {!WrapperComponentProps} props
+ * @param {WrapperComponentProps} props
  * @param {{current: ?Element}} ref
  * @return {PreactDef.Renderable}
  */

--- a/src/preact/context.js
+++ b/src/preact/context.js
@@ -18,7 +18,7 @@ let context;
  * - playable: whether the playback is allowed in this vDOM area. If playback
  *   is not allow, the component must immediately stop the playback.
  *
- * @return {!PreactDef.Context<AmpContextDef.ContextType>}
+ * @return {PreactDef.Context<AmpContextDef.ContextType>}
  */
 function getAmpContext() {
   return (
@@ -34,8 +34,8 @@ function getAmpContext() {
 /**
  * A wrapper-component that recalculates and propagates AmpContext properties.
  *
- * @param {!AmpContextDef.ProviderProps} props
- * @return {!PreactDef.VNode}
+ * @param {AmpContextDef.ProviderProps} props
+ * @return {PreactDef.VNode}
  */
 export function WithAmpContext({
   children,
@@ -54,7 +54,7 @@ export function WithAmpContext({
   const notify = notifyProp || parent.notify;
   const current = useMemo(
     () =>
-      /** @type {!AmpContextDef.ContextType} */ ({
+      /** @type {AmpContextDef.ContextType} */ ({
         renderable,
         playable,
         loading,
@@ -67,7 +67,7 @@ export function WithAmpContext({
 }
 
 /**
- * @return {!AmpContextDef.ContextType}
+ * @return {AmpContextDef.ContextType}
  */
 export function useAmpContext() {
   const AmpContext = getAmpContext();
@@ -77,7 +77,7 @@ export function useAmpContext() {
 /**
  * Whether the calling component should currently be in the loaded state.
  *
- * @param {!Loading_Enum|string} loadingProp
+ * @param {Loading_Enum|string} loadingProp
  * @return {boolean}
  */
 export function useLoading(loadingProp) {

--- a/src/preact/contextprops.js
+++ b/src/preact/contextprops.js
@@ -46,7 +46,7 @@ const CanPlay = contextProp('CanPlay', {
  *
  * Default is "auto".
  *
- * @const {!ContextPropDef<Loading_Enum, boolean>}
+ * @const {ContextPropDef<Loading_Enum, boolean>}
  */
 const LoadingProp = contextProp('Loading', {
   defaultValue: Loading_Enum.AUTO,

--- a/src/preact/contextprops.js
+++ b/src/preact/contextprops.js
@@ -12,7 +12,7 @@ import {contextProp} from '#core/context/prop';
  *
  * Default is `true`.
  *
- * @const {!ContextPropDef<boolean>}
+ * @const {ContextPropDef<boolean>}
  */
 const CanRender = contextProp('CanRender', {
   defaultValue: true,
@@ -29,7 +29,7 @@ const CanRender = contextProp('CanRender', {
  *
  * Default is `true`.
  *
- * @const {!ContextPropDef<boolean, boolean>}
+ * @const {ContextPropDef<boolean, boolean>}
  */
 const CanPlay = contextProp('CanPlay', {
   defaultValue: true,
@@ -46,7 +46,7 @@ const CanPlay = contextProp('CanPlay', {
  *
  * Default is "auto".
  *
- * @const {!ContextPropDef<!Loading_Enum, boolean>}
+ * @const {!ContextPropDef<Loading_Enum, boolean>}
  */
 const LoadingProp = contextProp('Loading', {
   defaultValue: Loading_Enum.AUTO,

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -56,7 +56,7 @@ const RENDERED_ATTR = 'i-amphtml-rendered';
 
 /**
  * The same as `applyFillContent`, but inside the shadow.
- * @const {!Object}
+ * @const {Object}
  */
 const SIZE_DEFINED_STYLE = {
   'position': 'absolute',
@@ -82,8 +82,8 @@ const ONE_OF_ERROR_MESSAGE =
   'Only one of "attr", "attrs", "attrMatches", "passthrough", "passthroughNonEmpty", or "selector" must be given';
 
 /**
- * @param {!Object<string, !AmpElementPropDef>} propDefs
- * @param {function(!AmpElementPropDef):boolean} cb
+ * @param {!Object<string, AmpElementPropDef>} propDefs
+ * @param {function(AmpElementPropDef):boolean} cb
  * @return {boolean}
  */
 export function checkPropsFor(propDefs, cb) {
@@ -91,7 +91,7 @@ export function checkPropsFor(propDefs, cb) {
 }
 
 /**
- * @param {!AmpElementPropDef} def
+ * @param {AmpElementPropDef} def
  * @return {boolean}
  */
 export const HAS_SELECTOR = (def) => typeof def === 'string' || !!def.selector;
@@ -105,11 +105,11 @@ const IS_EMPTY_TEXT_NODE = (node) =>
 
 /**
  * @param {typeof PreactBaseElement} Ctor
- * @param {!AmpElement} element
+ * @param {AmpElement} element
  * @param {{current: ?}} ref
- * @param {!JsonObject|null|undefined} defaultProps
+ * @param {JsonObject|null|undefined} defaultProps
  * @param {?MediaQueryProps} mediaQueryProps
- * @return {!JsonObject}
+ * @return {JsonObject}
  */
 export function collectProps(
   Ctor,
@@ -128,7 +128,7 @@ export function collectProps(
     mediaQueryProps.start();
   }
 
-  const props = /** @type {!JsonObject} */ ({...defaultProps, ref});
+  const props = /** @type {JsonObject} */ ({...defaultProps, ref});
 
   // Light DOM.
   if (lightDomTag) {
@@ -158,9 +158,9 @@ export function collectProps(
 
 /**
  * @param {typeof PreactBaseElement} Ctor
- * @param {!Object} props
- * @param {!Object} propDefs
- * @param {!Element} element
+ * @param {Object} props
+ * @param {Object} propDefs
+ * @param {Element} element
  * @param {?MediaQueryProps} mediaQueryProps
  */
 function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
@@ -221,7 +221,7 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
   }
 
   for (const name in propDefs) {
-    const def = /** @type {!AmpElementPropDef} */ (propDefs[name]);
+    const def = /** @type {AmpElementPropDef} */ (propDefs[name]);
     devAssert(
       !!def.attr +
         !!def.attrs +
@@ -273,8 +273,8 @@ function parsePropDefs(Ctor, props, propDefs, element, mediaQueryProps) {
 /**
  * Copies an Element into a VNode representation.
  * (Interpretation into VNode is not recursive, so it excludes children.)
- * @param {!Element} element
- * @return {!PreactDef.Renderable}
+ * @param {Element} element
+ * @return {PreactDef.Renderable}
  */
 function createShallowVNodeCopy(element) {
   const props = {
@@ -293,8 +293,8 @@ function createShallowVNodeCopy(element) {
 }
 
 /**
- * @param {!Element} element
- * @param {!Object} defs
+ * @param {Element} element
+ * @param {Object} defs
  * @return {?ChildDef}
  */
 function matchChild(element, defs) {
@@ -312,7 +312,7 @@ function matchChild(element, defs) {
 /**
  * @param {string} name
  * @param {function(string): T} parse
- * @return {{attrs: Array<string>, parseAttrs: function(!Element):(?T|undefined)}}
+ * @return {{attrs: Array<string>, parseAttrs: function(Element):(?T|undefined)}}
  * @template T
  */
 export function createParseAttr(name, parse) {
@@ -329,7 +329,7 @@ export function createParseAttr(name, parse) {
 
 /**
  * @param {string} name
- * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(!Element):(?number|undefined)}}
+ * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(Element):(?number|undefined)}}
  */
 export function createParseDateAttr(name) {
   return createParseAttr(name, getDate);
@@ -339,7 +339,7 @@ export function createParseDateAttr(name) {
  * Maps multiple attributes with the same prefix to a single prop object.
  * The prefix cannot equal the attribute name.
  * @param {string} prefix
- * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(!Element):(undefined|Object<string, string>)}}
+ * @return {{attrMatches: function(?string=):boolean, parseAttrs: function(Element):(undefined|Object<string, string>)}}
  */
 export function createParseAttrsWithPrefix(prefix) {
   const attrMatches = (name) => name?.startsWith(prefix) && name !== prefix;

--- a/src/preact/parse-props.js
+++ b/src/preact/parse-props.js
@@ -82,7 +82,7 @@ const ONE_OF_ERROR_MESSAGE =
   'Only one of "attr", "attrs", "attrMatches", "passthrough", "passthroughNonEmpty", or "selector" must be given';
 
 /**
- * @param {!Object<string, AmpElementPropDef>} propDefs
+ * @param {Object<string, AmpElementPropDef>} propDefs
  * @param {function(AmpElementPropDef):boolean} cb
  * @return {boolean}
  */

--- a/src/preact/slot.js
+++ b/src/preact/slot.js
@@ -17,15 +17,15 @@ import {CanPlay, CanRender, LoadingProp} from './contextprops';
 
 const EMPTY = {};
 
-/** @const {WeakMap<Element, {oldDefauls: (!Object|undefined), component: Component}>} */
+/** @const {WeakMap<Element, {oldDefauls: (Object|undefined), component: Component}>} */
 const cache = new WeakMap();
 
 /**
- * @param {!Element} element
+ * @param {Element} element
  * @param {string} name
- * @param {!Object|undefined} defaultProps
+ * @param {Object|undefined} defaultProps
  * @param {boolean|undefined} as
- * @return {!PreactDef.VNode|!PreactDef.FunctionalComponent}
+ * @return {PreactDef.VNode|PreactDef.FunctionalComponent}
  */
 export function createSlot(element, name, defaultProps, as = false) {
   element.setAttribute('slot', name);
@@ -39,8 +39,8 @@ export function createSlot(element, name, defaultProps, as = false) {
   }
 
   /**
-   * @param {!Object|undefined} props
-   * @return {!PreactDef.VNode}
+   * @param {Object|undefined} props
+   * @return {PreactDef.VNode}
    */
   function SlotWithProps(props) {
     return <Slot {...(defaultProps || EMPTY)} name={name} {...props} />;
@@ -53,8 +53,8 @@ export function createSlot(element, name, defaultProps, as = false) {
 /**
  * Slot component.
  *
- * @param {!JsonObject} props
- * @return {!PreactDef.VNode}
+ * @param {JsonObject} props
+ * @return {PreactDef.VNode}
  */
 export function Slot(props) {
   const ref = useRef(/** @type {?Element} */ (null));
@@ -73,7 +73,7 @@ export function Slot(props) {
 
 /**
  * @param {{current:?}} ref
- * @param {!JsonObject=} opt_props
+ * @param {JsonObject=} opt_props
  */
 export function useSlotContext(ref, opt_props) {
   const {'loading': loading} = opt_props || EMPTY;
@@ -90,7 +90,7 @@ export function useSlotContext(ref, opt_props) {
       slot,
       LoadingProp,
       Slot,
-      /** @type {!./core/constants/loading-instructions.Loading_Enum} */ (
+      /** @type {./core/constants/loading-instructions.Loading_Enum} */ (
         context.loading
       )
     );
@@ -129,8 +129,8 @@ export function useSlotContext(ref, opt_props) {
 }
 
 /**
- * @param {!Element} slot
- * @param {function(!AmpElement):void|function(!Array<!AmpElement>):void} action
+ * @param {Element} slot
+ * @param {function(AmpElement):void|function(Array<AmpElement>):void} action
  * @param {boolean} schedule
  */
 function execute(slot, action, schedule) {

--- a/src/preact/utils.js
+++ b/src/preact/utils.js
@@ -17,7 +17,7 @@ export function useResourcesNotify() {
 
 /**
  * @param {{current: ?}|function()} ref
- * @param {!Element} value
+ * @param {Element} value
  */
 function setRef(ref, value) {
   if (typeof ref === 'function') {
@@ -29,7 +29,7 @@ function setRef(ref, value) {
 
 /**
  * Combines refs to pass into `ref` prop.
- * @param {!Array<*>} refs
+ * @param {Array<*>} refs
  * @return {function(Element):function()}
  */
 export function useMergeRefs(refs) {


### PR DESCRIPTION
**summary**
In closure, most types are nullable by default and required `!` to mark them as NonNullable.
This is no longer necessary in TS. This PR applies @rcebulko 🧙 magic🧙   SublimeText regex to a couple of directories to remove the needless noise from future PRs. 

**regex**:
- Find `((?:^ *|\/\*)\* @\w+ (?:[^*\n]|\*(?!\/))*)!(.*?(?:\*\/|$))`
- Replace: `$1$2`

**directories**
- extensions/amp-carousel/0.1
- src/preact
- src/core