### PR TITLE
tsconfig: enable isolatedModules

### DIFF
--- a/src/compiler/polyfills.js
+++ b/src/compiler/polyfills.js
@@ -22,3 +22,5 @@ globalObject['Node'] = {
   DOCUMENT_TYPE_NODE: 10,
   DOCUMENT_FRAGMENT_NODE: 11,
 };
+
+export {};

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "strictNullChecks": true,
     "noImplicitAny": true,
+    "isolatedModules": true,
     "lib": ["dom", "esnext", "es6"],
 
     "paths": {


### PR DESCRIPTION
**summary**
We should enable this feature to ensure we don't begin using features which require multi-file transpilation (would break compat with esbuild, babel, swc, etc).

See https://www.typescriptlang.org/tsconfig#isolatedModules