### PR TITLE
esbuild: dont transpile esm builds

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -350,7 +350,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
         banner,
         footer,
         // For es5 builds, ensure esbuild-injected code is transpiled.
-        target: argv.esm ? 'es6' : 'es5',
+        target: argv.esm ? 'esnext' : 'es5',
         incremental: !!options.watch,
         logLevel: 'silent',
         external: options.externalDependencies,


### PR DESCRIPTION
**summary**
Testing out a theory based on https://github.com/ampproject/amphtml/pull/37313.
If `esbuild` only uses up to es6 code within the runtime it injects, then it should be safe to include in our esm builds. 

In theory this should save us from any extra transpilation between esm-->es6 it may be performing.

See https://github.com/evanw/esbuild/blob/master/internal/runtime/runtime.go