### PR TITLE
lint/testing: support typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -348,6 +348,8 @@ module.exports = {
         'jsdoc/require-param': 0,
         'jsdoc/require-param-type': 0,
         'jsdoc/require-returns': 0,
+        'no-undef': 0,
+        'import/no-unresolved': 0
       },
     },
     {

--- a/build-system/babel-config/import-resolver.js
+++ b/build-system/babel-config/import-resolver.js
@@ -42,12 +42,13 @@ function readJsconfigPaths() {
 
 /**
  * Import map configuration.
- * @return {!Object}
+ * @return {Object}
  */
 function getImportResolver() {
   return {
     root: ['.'],
     alias: readJsconfigPaths(),
+    extensions: ['.js', '.jsx', '.ts', 'tsx'],
     babelOptions: {
       caller: {
         name: 'import-resolver',

--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -232,7 +232,7 @@ class RuntimeTestConfig {
       }
     );
     this.esbuild = {
-      target: 'es5',
+      target: 'esnext', // We use babel for transpilation.
       define: {
         'process.env.NODE_DEBUG': 'false',
         'process.env.NODE_ENV': '"test"',


### PR DESCRIPTION
**summary**
Extracted from https://github.com/ampproject/amphtml/pull/37370.

1. We no longer need `import/resolver` on `ts` files, since TypeScript does a significantly better job at it.
2. For JS files where `import/resolver` still applies, it need to know about the `.ts` and `.tsx` extensions.
3. Tests should not tell esbuild to transpile. Babel is already doing that. And esbuild throws when it encounters a TS->JS transformation that includes features it doesn't know how to downlevel.

These were the only issues that came up when integrating `*.ts` files.


cc @ampproject/wg-infra 