### PR TITLE
🐛 Fix dispatch to promote script after cutting nightly by adding a `break;`

### DIFF
--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -195,9 +195,13 @@ async function promoteNightly(octokit, ampVersion) {
       break;
 
     default:
-      throw new Error(
-        `An uncaught status returned while attempting to create a promote workflow\n${response}`
+      log(
+        'Uncaught status',
+        cyan(response.status),
+        'returned while attempting to create a promote workflow:\n',
+        response
       );
+      throw new Error();
   }
 }
 

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -192,9 +192,11 @@ async function promoteNightly(octokit, ampVersion) {
         'created on',
         cyan('ampproject/cdn-configuration')
       );
+      break;
+
     default:
       throw new Error(
-        `An unaught status returned while attempting to create a promote workflow\n${response}`
+        `An uncaught status returned while attempting to create a promote workflow\n${response}`
       );
   }
 }


### PR DESCRIPTION
Promote workflow actually gets dispatched, but because I forgot a `break;` it continues to throw the default error 🙈

Also fixed a typo and logging issue

https://github.com/ampproject/amphtml/runs/4800286766?check_suite_focus=true#step:6:12
