### PR TITLE
tslint: ban non-standard ecmascript features

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -252,6 +252,32 @@ module.exports = {
     'no-native-reassign': 2,
     'no-redeclare': 2,
     'no-restricted-globals': [2, 'error', 'event', 'Animation'],
+    'no-restricted-syntax': [
+      2,
+      // Ban all TS features that don't have a direct ECMAScript equivalent.
+      {
+        'selector': 'TSEnumDeclaration',
+        'message': 'Enums are banned.',
+      },
+      {
+        'selector': 'TSModuleDeclaration',
+        'message': 'Namespaces are banned.',
+      },
+      {
+        'selector': 'TSParameterProperty',
+        'message': 'Parameter properties are banned.',
+      },
+      {
+        'selector': 'Decorator',
+        'message': 'Decorators are banned.',
+      },
+      {
+        'selector': 'PropertyDefinition[declare="false"]:not([value])',
+        'message':
+          'Class properties should be declared or initialized. ' +
+          'See https://github.com/ampproject/amphtml/pull/37387#discussion_r791232943',
+      },
+    ],
     'no-script-url': 2,
     'no-self-compare': 2,
     'no-sequences': 2,

--- a/build-system/server/new-server/transforms/utilities/lazy.ts
+++ b/build-system/server/new-server/transforms/utilities/lazy.ts
@@ -1,15 +1,15 @@
 export class Lazy<T> {
-  #value: T | undefined;
-  #initializer: () => T;
+  private declare initializer_: () => T;
+  private declare value_: T | undefined;
 
   constructor(initializer: () => T) {
-    this.#initializer = initializer;
+    this.initializer_ = initializer;
   }
 
   public get value(): T {
-    if (!this.#value) {
-      this.#value = this.#initializer();
+    if (this.value_ == undefined) {
+      this.value_ = this.initializer_();
     }
-    return this.#value;
+    return this.value_;
   }
 }

--- a/build-system/tasks/performance/print-report.js
+++ b/build-system/tasks/performance/print-report.js
@@ -69,9 +69,6 @@ function printReport(urls) {
  * Organizes a page's metrics for getReport()
  */
 class PageMetrics {
-  url;
-  metrics;
-
   /**
    * @param {string} url
    */


### PR DESCRIPTION
**summary**
Some inspo from https://www.executeprogram.com/blog/typescript-features-to-avoid.
The tldlr: is that we'd like to restrict ourselves to just "JS with types". This makes TS --> JS conversion significantly simpler and less error prone.