### PR TITLE
ssr: serialize event handlers for unit tests

### DIFF
--- a/extensions/amp-carousel/0.1/carousel-controls.js
+++ b/extensions/amp-carousel/0.1/carousel-controls.js
@@ -1,5 +1,6 @@
 import {Keys_Enum} from '#core/constants/key-codes';
 import {toggleAttribute} from '#core/dom';
+import {addSerializedEventListener} from '#core/dom/serialized-event-listener';
 import {getWin} from '#core/window';
 
 import {Services} from '#service';
@@ -47,8 +48,8 @@ export class CarouselControls {
    * Meant to be called during carousel's buildCallback().
    */
   setupBehaviors_() {
-    this.setupButtonInteraction(this.prevButton_, () => this.handlePrev());
-    this.setupButtonInteraction(this.nextButton_, () => this.handleNext());
+    this.setupButtonInteraction(this.prevButton_, this.handlePrev.bind(this));
+    this.setupButtonInteraction(this.nextButton_, this.handleNext.bind(this));
 
     if (this.element_.hasAttribute('controls')) {
       this.showControls_ = true;
@@ -74,8 +75,8 @@ export class CarouselControls {
    * @param {*} onInteraction
    */
   setupButtonInteraction(button, onInteraction) {
-    button.addEventListener('click', onInteraction);
-    button.addEventListener('keydown', (event) => {
+    /** @param {KeyboardEvent} event*/
+    function onKeyDown(event) {
       if (event.defaultPrevented) {
         return;
       }
@@ -84,7 +85,10 @@ export class CarouselControls {
         event.preventDefault();
         onInteraction();
       }
-    });
+    }
+
+    addSerializedEventListener(button, 'click', onInteraction);
+    addSerializedEventListener(button, 'keydown', onKeyDown);
   }
 
   /**

--- a/extensions/amp-carousel/0.1/scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/scrollable-carousel.js
@@ -2,6 +2,7 @@ import {ActionTrust_Enum} from '#core/constants/action-constants';
 import {Keys_Enum} from '#core/constants/key-codes';
 import {isLayoutSizeFixed} from '#core/dom/layout';
 import {observeIntersections} from '#core/dom/layout/viewport-observer';
+import {addSerializedEventListener} from '#core/dom/serialized-event-listener';
 import {numeric} from '#core/dom/transition';
 
 import {Services} from '#service';
@@ -60,10 +61,16 @@ export class AmpScrollableCarousel extends AMP.BaseElement {
   setupBehavior_() {
     this.cancelTouchEvents_();
 
-    this.container_.addEventListener('scroll', this.scrollHandler_.bind(this));
-    this.container_.addEventListener(
+    addSerializedEventListener(this.container_, 'scroll', () =>
+      this.scrollHandler_()
+    );
+    addSerializedEventListener(
+      this.container_,
       'keydown',
-      this.keydownHandler_.bind(this)
+      /** @param {KeyboardEvent} event*/
+      (event) => {
+        this.keydownHandler_(event);
+      }
     );
 
     this.cells_.forEach((cell) => {

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -9,6 +9,7 @@ import {
 } from '#core/dom/layout/size-observer';
 import {observeIntersections} from '#core/dom/layout/viewport-observer';
 import {closestAncestorElementBySelector} from '#core/dom/query';
+import {addSerializedEventListener} from '#core/dom/serialized-event-listener';
 import {getStyle, setStyle} from '#core/dom/style';
 import {numeric} from '#core/dom/transition';
 import {isFiniteNumber} from '#core/types';
@@ -257,13 +258,16 @@ export class AmpSlideScroll extends AMP.BaseElement {
 
     this.cancelTouchEvents_();
 
-    this.slidesContainer_.addEventListener(
-      'scroll',
-      this.scrollHandler_.bind(this)
+    addSerializedEventListener(this.slidesContainer_, 'scroll', () =>
+      this.scrollHandler_()
     );
-    this.slidesContainer_.addEventListener(
+    addSerializedEventListener(
+      this.slidesContainer_,
       'keydown',
-      this.keydownHandler_.bind(this)
+      /** @param {KeyboardEvent} event */
+      (event) => {
+        this.keydownHandler_(event);
+      }
     );
 
     listen(
@@ -555,10 +559,9 @@ export class AmpSlideScroll extends AMP.BaseElement {
 
   /**
    * Handles scroll on the slides container.
-   * @param {Event} unusedEvent Event object.
    * @private
    */
-  scrollHandler_(unusedEvent) {
+  scrollHandler_() {
     const currentScrollLeft = this.slidesContainer_./*OK*/ scrollLeft;
 
     if (!this.isIos_ && !this.isSafari_) {

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -289,12 +289,6 @@ describes.realWin(
           .stub(Services, 'inputFor')
           .returns({onMouseDetected: () => {}});
 
-        // Disables runtime bootstrapping of a component
-        const carouselCe = env.win.customElements.get('amp-carousel');
-        const imgCe = env.win.customElements.get('amp-img');
-        env.sandbox.stub(carouselCe.prototype, 'connectedCallbackInternal_');
-        env.sandbox.stub(imgCe.prototype, 'connectedCallbackInternal_');
-
         const el1 = await getAmpScrollableCarousel(/* addToDom */ false);
         const el2 = el1.cloneNode(/* deep */ true);
         const impl1 = new AmpScrollableCarousel(el1);
@@ -304,9 +298,9 @@ describes.realWin(
         await impl1.buildCallback();
 
         // impl2 server render + hydrate
+        doc.body.appendChild(el2);
         buildDom(el2);
         el2.setAttribute('i-amphtml-ssr', '');
-        doc.body.appendChild(el2);
         await impl2.buildCallback();
         el2.removeAttribute('i-amphtml-ssr');
 

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -293,6 +293,7 @@ describes.realWin(
         const el2 = el1.cloneNode(/* deep */ true);
         const impl1 = new AmpScrollableCarousel(el1);
         const impl2 = new AmpScrollableCarousel(el2);
+
         // impl1 client render
         doc.body.appendChild(el1);
         await impl1.buildCallback();

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -289,6 +289,12 @@ describes.realWin(
           .stub(Services, 'inputFor')
           .returns({onMouseDetected: () => {}});
 
+        // Disables runtime bootstrapping of a component
+        const carouselCe = env.win.customElements.get('amp-carousel');
+        const imgCe = env.win.customElements.get('amp-img');
+        env.sandbox.stub(carouselCe.prototype, 'connectedCallbackInternal_');
+        env.sandbox.stub(imgCe.prototype, 'connectedCallbackInternal_');
+
         const el1 = await getAmpScrollableCarousel(/* addToDom */ false);
         const el2 = el1.cloneNode(/* deep */ true);
         const impl1 = new AmpScrollableCarousel(el1);
@@ -298,9 +304,9 @@ describes.realWin(
         await impl1.buildCallback();
 
         // impl2 server render + hydrate
-        doc.body.appendChild(el2);
         buildDom(el2);
         el2.setAttribute('i-amphtml-ssr', '');
+        doc.body.appendChild(el2);
         await impl2.buildCallback();
         el2.removeAttribute('i-amphtml-ssr');
 

--- a/src/core/dom/serialized-event-listener.js
+++ b/src/core/dom/serialized-event-listener.js
@@ -1,0 +1,42 @@
+import * as mode from '#core/mode';
+
+let shouldSerialize = false;
+
+/**
+ * In any mode except test, this function behaves calls addEventListener and exits.
+ * In test mode, it provides the ability to toggle "serialization" mode on, which
+ * serializes the event listener as attributes on the node.
+ *
+ * @param {Element} element
+ * @param {string} event
+ * @param {function(T):void} handler
+ * @template {Event} T
+ */
+export function addSerializedEventListener(element, event, handler) {
+  element.addEventListener(event, handler);
+  if (!mode.isTest() || !shouldSerialize) {
+    return;
+  }
+
+  const onEvent = `data-test-on${event[0].toUpperCase()}${event.slice(1)}`;
+  let handlers = element.getAttribute(onEvent) ?? '';
+  if (handlers) {
+    handlers += ',';
+  }
+  handlers += handler.name;
+  element.setAttribute(onEvent, handlers);
+}
+
+/**
+ * Enables serialization of event handlers
+ */
+export function enableEventListenerSerialization() {
+  shouldSerialize = true;
+}
+
+/**
+ * Disables serialization of event handlers
+ */
+export function disableEventListenerSerialization() {
+  shouldSerialize = false;
+}

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1135,18 +1135,6 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
 
     /**
      * Called when the element is first connected to the DOM.
-     * Immediately calls internal version of the function.
-     * This extra layer of indirection exists because connectedCallback
-     * cannot be mocked by spec. The function is saved by the browser on initialization.
-     * The indirection allows us to mock out connectedCallbackInternal_ when necessary.
-     *
-     */
-    connectedCallback() {
-      this.connectedCallbackInternal_();
-    }
-
-    /**
-     * Called when the element is first connected to the DOM.
      *
      * This callback is guarded by checks to see if the element is still
      * connected.  Chrome and Safari can trigger connectedCallback even when
@@ -1155,8 +1143,9 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * connectedCallback will later be called when the disconnected root is
      * connected to the document tree.
      *
+     * @final
      */
-    connectedCallbackInternal_() {
+    connectedCallback() {
       if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
         this.isInTemplate_ = !!query.closestAncestorElementBySelector(
           this,

--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1135,6 +1135,18 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
 
     /**
      * Called when the element is first connected to the DOM.
+     * Immediately calls internal version of the function.
+     * This extra layer of indirection exists because connectedCallback
+     * cannot be mocked by spec. The function is saved by the browser on initialization.
+     * The indirection allows us to mock out connectedCallbackInternal_ when necessary.
+     *
+     */
+    connectedCallback() {
+      this.connectedCallbackInternal_();
+    }
+
+    /**
+     * Called when the element is first connected to the DOM.
      *
      * This callback is guarded by checks to see if the element is still
      * connected.  Chrome and Safari can trigger connectedCallback even when
@@ -1143,9 +1155,8 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
      * connectedCallback will later be called when the disconnected root is
      * connected to the document tree.
      *
-     * @final
      */
-    connectedCallback() {
+    connectedCallbackInternal_() {
       if (!isTemplateTagSupported() && this.isInTemplate_ === undefined) {
         this.isInTemplate_ = !!query.closestAncestorElementBySelector(
           this,


### PR DESCRIPTION
**summary**

While building out various `buildDom` functions, I've also written tests ensuring that the `outerHTML` of a component is identical after its buildCallback and buildDom. This ensures the HTML of an ssr is correct.

We also have hydration tests that ensure instance variables are set.
We don't have any tests for _interactivity_, notably event handlers.

This PR attempts to solve that issue by creating serializable event handlers. It isn't perfect, but should provide decent coverage. Event handler function names are added as attributes to their DOM Nodes. 

For example:
```html
<div
  data-test-onclick="bound handleNext"
  data-test-onkeydown="onKeyDown"
>
```

This allows us to compare outerHTML and get interaction tests for free.

--- 


**question for the reviewer**

There was one aspect of this solution I feel is uglier than necessary. The `connectedCallback` of the elements still fire when they are added to the DOM, therefore `i-amphtml-element` is added to the classList. The order in which buildDom and connectedCallback fire is different on client vs. server which results in a different order of class names.

A few ways to solve it:

1. (what I did): add the ssr node to the dom before calling buildDom even though this makes no sense.
2. create a new `outerHTML` dom serialization function that outputs class names in sorted order.
3. disable `connectedCallback` just for this test. This is similar to the existing `runtimeOn` flag, except that only disables buildCallback. In order to accomplish this we need to create an extra level of indirection in connectedCallbak so that we could mock it (https://github.com/ampproject/amphtml/pull/37389/commits/a7e8e20f63d1fd11961c80991d3407c094359b82).