### PR TITLE
🏗 Mark nightly branch as a push build in CircleCI shell jobs

### DIFF
--- a/.circleci/check_config.sh
+++ b/.circleci/check_config.sh
@@ -11,8 +11,8 @@ RED() { echo -e "\033[0;31m$1\033[0m"; }
 YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
-# Push builds are only run against the main branch and amp-release branches.
-if [[ "$CIRCLE_BRANCH" == "main" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+# Push builds are only run against the main, nightly, and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "main" || "$CIRCLE_BRANCH" == "nightly" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
   echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
   exit 0
 fi

--- a/.circleci/get_pr_number.sh
+++ b/.circleci/get_pr_number.sh
@@ -9,8 +9,8 @@ err=0
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
 
-# Push builds are only run against the main branch and amp-release branches.
-if [[ "$CIRCLE_BRANCH" == "main" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
+# Push builds are only run against the main, nightly, and amp-release branches.
+if [[ "$CIRCLE_BRANCH" == "main" || "$CIRCLE_BRANCH" == "nightly" || "$CIRCLE_BRANCH" =~ ^amp-release-* ]]; then
   echo $(GREEN "Nothing to do because $CIRCLE_BRANCH is not a PR branch.")
   # Warn if the build is linked to a PR on a different repo (known CircleCI bug).
   if [[ -n "$CIRCLE_PULL_REQUEST" && ! "$CIRCLE_PULL_REQUEST" =~ ^https://github.com/ampproject/amphtml* ]]; then


### PR DESCRIPTION
e.g., this line shouldn't happen: https://app.circleci.com/pipelines/github/ampproject/amphtml/21409/workflows/eebc003a-45ab-4f88-8b28-0d7182dcafcc/jobs/417934?invite=true#step-104-114