### PR TITLE
🏗 Persist AMP version number between jobs in CircleCI release pipeline

### DIFF
--- a/build-system/release-workflows/upload-release.js
+++ b/build-system/release-workflows/upload-release.js
@@ -163,4 +163,10 @@ runReleaseJob(jobName, async () => {
 
   log('Archiving releases to', cyan(ARTIFACT_FILE_NAME));
   timedExecOrDie(`cd ${DEST_DIR} && tar -czf ${ARTIFACT_FILE_NAME} *`);
+
+  log('Persisting AMP version number to workspace');
+  const [versionsFile] = fastGlob.sync(
+    path.join(DEST_DIR, 'org-cdn/rtv/01*/version.txt')
+  );
+  fs.copySync(versionsFile, '/tmp/workspace/AMP_VERSION');
 });


### PR DESCRIPTION
Persisted file should be found in downstream jobs in the file `/tmp/restored-workspace/AMP_VERSION`