### PR TITLE
Update OWNERS for tsconfig and compiler

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -48,8 +48,12 @@
     },
     {
       // Locked down to minimize new import aliases being added
-      pattern: '**/tsconfig{,.base}.json',
+      pattern: 'tsconfig{,.base}.json',
       owners: [{name: 'ampproject/wg-performance', required: true}],
+    },
+    {
+      pattern: '**/tsconfig.json',
+      owners: [{name: 'ampproject/wg-performance'}],
     },
     {
       pattern: '**/*.d.ts',

--- a/OWNERS
+++ b/OWNERS
@@ -48,7 +48,7 @@
     },
     {
       // Locked down to minimize new import aliases being added
-      pattern: 'tsconfig{,.base}.json',
+      pattern: '**/tsconfig{,.base}.json',
       owners: [{name: 'ampproject/wg-performance', required: true}],
     },
     {

--- a/src/compiler/OWNERS
+++ b/src/compiler/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/main/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{name: 'ampproject/wg-performance'}],
+    }
+  ]
+}

--- a/src/compiler/OWNERS
+++ b/src/compiler/OWNERS
@@ -5,6 +5,6 @@
   rules: [
     {
       owners: [{name: 'ampproject/wg-performance'}],
-    }
-  ]
+    },
+  ],
 }


### PR DESCRIPTION
**summary**
Marks `wg-performance` as owners of `src/compiler` and `**/tsconfig.json` as we are the authors/maintainers of both.