### PR TITLE
🐛 [Amp story page attachment] Get reference to elements in buildCallback

### DIFF
--- a/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
@@ -72,15 +72,11 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
   constructor(element) {
     super(element);
 
-    /** @private @const {!Element} */
-    this.storyEl_ = devAssert(
-      closestAncestorElementBySelector(this.element, 'amp-story')
-    );
+    /** @private {?Element} */
+    this.storyEl_ = null;
 
-    /** @private @const {!Element} */
-    this.pageEl_ = devAssert(
-      closestAncestorElementBySelector(this.element, 'amp-story-page')
-    );
+    /** @private {?Element} */
+    this.pageEl_ = null;
 
     /** @private @const {!../../amp-story/1.0/story-analytics.StoryAnalyticsService} */
     this.analyticsService_ = Services.storyAnalyticsService(this.win);
@@ -97,6 +93,12 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    */
   buildCallback() {
     super.buildCallback();
+    this.storyEl_ = devAssert(
+      closestAncestorElementBySelector(this.element, 'amp-story')
+    );
+    this.pageEl_ = devAssert(
+      closestAncestorElementBySelector(this.element, 'amp-story-page')
+    );
     this.buildOpenAttachmentUI_();
     this.maybeSetDarkThemeForElement_(this.headerEl);
     this.maybeSetDarkThemeForElement_(this.element);


### PR DESCRIPTION
Moving the selectors to the buildCallback ensures amp story is ready before references to the elements are received.

The attachment has been moved to its own extension. 
Because of this in some contexts the extension can load before amp story is ready.
The [dependsOnStoryServices](https://github.com/ampproject/amphtml/pull/37335) has been implemented to fix this, however there were still elements being selected in the constructor which could cause race conditions. 

Fixes [#134](https://github.com/ampproject/error-reporting/issues/134)