### PR TITLE
🐛 [amp story] Change toggleAttribute to set/removeAttribute

### DIFF
--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -810,6 +810,7 @@ const forbiddenTermsSrcInclusive = {
   '\\.pageXOffset(?!_)': bannedTermsHelpString,
   '\\.pageYOffset(?!_)': bannedTermsHelpString,
   '\\.innerWidth(?!_)': bannedTermsHelpString,
+  '\\.toggleAttribute(?!_)': 'please use `toggleAttribute()` from core/dom',
   '\\.innerHeight(?!_)': bannedTermsHelpString,
   '\\.scrollingElement(?!_)': bannedTermsHelpString,
   '\\.computeCTM(?!_)': bannedTermsHelpString,

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-preview.js
@@ -1,3 +1,4 @@
+import {toggleAttribute} from '#core/dom';
 import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
 import {observeContentSize} from '#core/dom/layout/size-observer';
 import {closest} from '#core/dom/query';
@@ -828,7 +829,7 @@ export class AmpStoryDevToolsTabPreview extends AMP.BaseElement {
       const isEnabled =
         (currentDeviceSpaces + spaces <= MAX_DEVICE_SPACES) |
         !chipEl.hasAttribute('inactive');
-      chipEl.toggleAttribute('disabled', !isEnabled);
+      toggleAttribute(chipEl, 'disabled', !isEnabled);
     });
   }
 }

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools.js
@@ -1,3 +1,4 @@
+import {toggleAttribute} from '#core/dom';
 import {htmlFor} from '#core/dom/static-template';
 import {toggle} from '#core/dom/style';
 import {parseQueryString} from '#core/types/string/url';
@@ -215,12 +216,13 @@ export class AmpStoryDevTools extends AMP.BaseElement {
     this.mutateElement(() => {
       toggle(this.tabContents_[this.currentTab_], false);
       toggle(this.tabContents_[tab], true);
-      this.tabSelectors_.forEach((tabSelector) => {
-        return tabSelector.toggleAttribute(
+      this.tabSelectors_.forEach((tabSelector) =>
+        toggleAttribute(
+          tabSelector,
           'active',
           tabSelector.getAttribute('data-tab') === tab
-        );
-      });
+        )
+      );
       this.currentTab_ = tab;
     });
   }

--- a/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
@@ -1,4 +1,5 @@
 import {devAssert} from '#core/assert';
+import {toggleAttribute} from '#core/dom';
 import {isAmpElement} from '#core/dom/amp-element-helpers';
 import * as Preact from '#core/dom/jsx';
 import {Layout_Enum} from '#core/dom/layout';
@@ -237,9 +238,7 @@ export class DraggableDrawer extends AMP.BaseElement {
       ? this.startListeningForTouchEvents_()
       : this.stopListeningForTouchEvents_();
 
-    isMobile
-      ? this.headerEl.removeAttribute('desktop')
-      : this.headerEl.setAttribute('desktop', '');
+    toggleAttribute(this.headerEl, 'desktop', !isMobile);
   }
 
   /**

--- a/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
@@ -237,7 +237,9 @@ export class DraggableDrawer extends AMP.BaseElement {
       ? this.startListeningForTouchEvents_()
       : this.stopListeningForTouchEvents_();
 
-    this.headerEl.toggleAttribute('desktop', !isMobile);
+    isMobile
+      ? this.headerEl.removeAttribute('desktop')
+      : this.headerEl.setAttribute('desktop', '');
   }
 
   /**

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -1,4 +1,4 @@
-import {tryFocus} from '#core/dom';
+import {toggleAttribute, tryFocus} from '#core/dom';
 import * as Preact from '#core/dom/jsx';
 import {closest, matches} from '#core/dom/query';
 import {resetStyles, setImportantStyles} from '#core/dom/style';
@@ -398,7 +398,7 @@ export class AmpStoryEmbeddedComponent {
           UIType.DESKTOP_FULLBLEED,
           UIType.DESKTOP_ONE_PANEL,
         ].includes(uiState);
-        this.focusedStateOverlay_.toggleAttribute('desktop', isDesktop);
+        toggleAttribute(this.focusedStateOverlay_, 'desktop', isDesktop);
       }
     );
   }

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -1,3 +1,4 @@
+import {toggleAttribute} from '#core/dom';
 import * as Preact from '#core/dom/jsx';
 
 import {Services} from '#service';
@@ -123,9 +124,7 @@ class PaginationButton {
         !isEnabled
       );
       const button = this.element.querySelector('button');
-      isEnabled
-        ? button.removeAttribute('disabled')
-        : button.setAttribute('disabled', '');
+      toggleAttribute(button, 'disabled', !isEnabled);
     });
   }
 

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -122,9 +122,10 @@ class PaginationButton {
         'i-amphtml-story-button-hidden',
         !isEnabled
       );
-      this.element
-        .querySelector('button')
-        ?.toggleAttribute('disabled', !isEnabled);
+      const button = this.element.querySelector('button');
+      isEnabled
+        ? button.removeAttribute('disabled')
+        : button.setAttribute('disabled', '');
     });
   }
 

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -5,7 +5,7 @@ import {Messaging} from '@ampproject/viewer-messaging';
 import {devAssertElement} from '#core/assert';
 import {VisibilityState_Enum} from '#core/constants/visibility-state';
 import {Deferred} from '#core/data-structures/promise';
-import {isJsonScriptTag, tryFocus} from '#core/dom';
+import {isJsonScriptTag, toggleAttribute, tryFocus} from '#core/dom';
 import {resetStyles, setStyle, setStyles} from '#core/dom/style';
 import {findIndex, toArray} from '#core/types/array';
 import {isEnumValue} from '#core/types/enum';
@@ -773,12 +773,14 @@ export class AmpStoryPlayer {
    * @private
    */
   checkButtonsDisabled_() {
-    this.prevButton_.toggleAttribute(
+    toggleAttribute(
+      this.prevButton_,
       'disabled',
       this.isIndexOutofBounds_(this.currentIdx_ - 1) &&
         !this.isCircularWrappingEnabled_
     );
-    this.nextButton_.toggleAttribute(
+    toggleAttribute(
+      this.nextButton_,
       'disabled',
       this.isIndexOutofBounds_(this.currentIdx_ + 1) &&
         !this.isCircularWrappingEnabled_


### PR DESCRIPTION
toggleAttribute is [not widely supported](https://caniuse.com/?search=toggleAttribute) so it fails on multiple platforms.

This PR uses the toggleAttribute utility function instead.

Fixes [#120](https://github.com/ampproject/error-reporting/issues/120), [#93](https://github.com/ampproject/error-reporting/issues/93) 