### PR TITLE
🏗🐛 Fix range in `forbidden-terms-config`

### DIFF
--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -37,7 +37,7 @@ module.exports = {
     function* removeFromArray(fixer, node) {
       const {text} = context.getSourceCode();
       let [start] = node.range;
-      const [end] = node.range;
+      const [, end] = node.range;
       while (/\s/.test(text[start - 1])) {
         start--;
       }

--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -36,11 +36,12 @@ module.exports = {
      */
     function* removeFromArray(fixer, node) {
       const {text} = context.getSourceCode();
-      let {start} = node;
+      let [start] = node.range;
+      const [end] = node.range;
       while (/\s/.test(text[start - 1])) {
         start--;
       }
-      yield fixer.removeRange([start, node.end]);
+      yield fixer.removeRange([start, end]);
 
       const after = context.getTokenAfter(node);
       if (after.type === 'Punctuator' && after.value === ',') {
@@ -51,7 +52,7 @@ module.exports = {
       const [nextComment] = context.getCommentsAfter(node);
       if (
         nextComment &&
-        text.substr(node.end, nextComment.start - node.end).indexOf('\n') < 0
+        text.substr(end, nextComment.start - end).indexOf('\n') < 0
       ) {
         yield fixer.remove(nextComment);
       }


### PR DESCRIPTION
ESLint API changed so that `node.start/node.end` do not exist anymore. 

This makes the lint rule fail opaquely:

```
[13:02:52] AssertionError [ERR_ASSERTION]: Fix has invalid range: {
  "range": [
    null,
    null
  ],
  "text": ""
}
```

These values are now an array `node.range`. Correct errors after fix:

```
build-system/test-configs/forbidden-terms.js
  737:7  error  File does not exist  local/forbidden-terms-config
```