### PR TITLE
Start building cherry-pick-* branches on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ commands:
       - when:
           condition:
             matches:
-              pattern: ^main|amp-release-.*$
+              pattern: ^main|amp-release-.*$|cherry-pick-.*$
               value: << pipeline.git.branch >>
           steps:
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,14 @@ push_and_pr_builds: &push_and_pr_builds
       ignore:
         - nightly
 
+# TODO(estherkim): remove amp-release-* branches in favor of cherry-pick-*
 push_builds_only: &push_builds_only
   filters:
     branches:
       only:
         - main
         - /^amp-release-.*$/
+        - /^cherry-pick-.*$/
 
 release_builds_only: &release_builds_only
   filters:
@@ -23,6 +25,7 @@ release_builds_only: &release_builds_only
       only:
         - nightly
         - /^amp-release-.*$/
+        - /^cherry-pick-.*$/
 
 pr_builds_only: &pr_builds_only
   filters:
@@ -30,6 +33,7 @@ pr_builds_only: &pr_builds_only
       ignore:
         - main
         - /^amp-release-.*$/
+        - /^cherry-pick-.*$/
         - nightly
 
 experiment_job: &experiment_job
@@ -489,7 +493,7 @@ jobs:
       - setup_vm
       - run:
           name: '⭐ Trigger Promote Workflow ⭐'
-          command: node --unhandled-rejections=strict build-system/release-workflows/trigger-promote.js
+          command: node --unhandled-rejections=strict build-system/release-workflows/trigger-promote.js --branch=${CIRCLE_BRANCH}
       - teardown_vm
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ jobs:
       - setup_vm
       - run:
           name: '⭐ Trigger Promote Workflow ⭐'
-          command: node --unhandled-rejections=strict build-system/release-workflows/trigger-promote.js --branch=${CIRCLE_BRANCH}
+          command: node --unhandled-rejections=strict build-system/release-workflows/trigger-promote.js
       - teardown_vm
 
 workflows:

--- a/build-system/release-workflows/trigger-promote.js
+++ b/build-system/release-workflows/trigger-promote.js
@@ -14,8 +14,10 @@ const jobName = 'trigger-promote.js';
 const cdnConfigurationParams = {
   owner: 'ampproject',
   repo: 'cdn-configuration',
-  // TODO(estherkim): set to promote-nightly or promote-amp-version
-  'workflow_id': 'promote-nightly.yml',
+  'workflow_id':
+    process.env.CIRCLE_BRANCH == 'nightly'
+      ? 'promote-nightly.yml'
+      : 'promote-cherry-picks.yml',
   ref: 'main',
 };
 


### PR DESCRIPTION
The new cherry-pick github action will create branches called `cherry-pick-${AMP_VERSION_TO_BE_CHERRYPICKED}`. This will replace the existing `amp cherry-pick` task that creates `amp-release-${AMP_VERSION}`