### PR TITLE
🐛 [amp story page attachment] reopen attachment on refresh

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -946,7 +946,12 @@ export class AmpStory extends AMP.BaseElement {
         );
 
         if (shouldReOpenAttachmentForPageId === this.activePage_.element.id) {
-          this.activePage_.openAttachment(false /** shouldAnimate */);
+          this.activePage_.element
+            .querySelector(
+              'amp-story-page-attachment, amp-story-page-outlink, amp-story-shopping-attachment'
+            )
+            ?.getImpl()
+            .then((attachment) => attachment.open(false /** shouldAnimate */));
         }
 
         if (


### PR DESCRIPTION
Re-open the active page's attachment if it was previously open.

Context / Fixes #37430