### PR TITLE
🏗 Apply Babel config to React Storybook

### DIFF
--- a/build-system/babel-config/react-config.js
+++ b/build-system/babel-config/react-config.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const {getMinifiedConfig} = require('./minified-config');
 const {getUnminifiedConfig} = require('./unminified-config');
 
@@ -7,12 +8,16 @@ const {getUnminifiedConfig} = require('./unminified-config');
  * @param {!Object} config
  * @return {Object}
  */
-function mergeWithConfig(config) {
+function mergeReactBabelConfig(config) {
+  const rootDir = path.join(__dirname, '../../');
   return {
     ...config,
     plugins: [
-      './build-system/babel-plugins/babel-plugin-react-style-props',
-      ...config.plugins,
+      path.join(
+        rootDir,
+        './build-system/babel-plugins/babel-plugin-react-style-props'
+      ),
+      ...(config.plugins || []),
     ],
   };
 }
@@ -21,17 +26,18 @@ function mergeWithConfig(config) {
  * @return {!Object}
  */
 function getReactUnminifiedConfig() {
-  return mergeWithConfig(getUnminifiedConfig());
+  return mergeReactBabelConfig(getUnminifiedConfig());
 }
 
 /**
  * @return {!Object}
  */
 function getReactMinifiedConfig() {
-  return mergeWithConfig(getMinifiedConfig());
+  return mergeReactBabelConfig(getMinifiedConfig());
 }
 
 module.exports = {
   getReactMinifiedConfig,
   getReactUnminifiedConfig,
+  mergeReactBabelConfig,
 };

--- a/build-system/tasks/storybook/env/react/webpack.config.js
+++ b/build-system/tasks/storybook/env/react/webpack.config.js
@@ -5,6 +5,9 @@ const {
   getRelativeAliasMap,
 } = require('../../../../babel-config/import-resolver');
 const {existsSync} = require('fs-extra');
+const {
+  mergeReactBabelConfig,
+} = require('../../../../babel-config/react-config');
 
 const rootDir = path.join(__dirname, '../../../../..');
 
@@ -82,7 +85,7 @@ module.exports = ({config}) => {
         test: /\.jsx?$/,
         loader: 'babel-loader',
         exclude: /node_modules/,
-        query: {
+        query: mergeReactBabelConfig({
           presets: [
             [
               '@babel/preset-env',
@@ -93,7 +96,7 @@ module.exports = ({config}) => {
             ],
             ['@babel/preset-react', {'runtime': 'automatic'}],
           ],
-        },
+        }),
       },
       {
         test: /\.css$/i,


### PR DESCRIPTION
Run the same React-specific transforms on Storybook files as we do on component bundles.

In effect, this maps Preact-style prop names to React-style. This prevents issues like ``Invalid DOM property `class`. Did you mean `className`?``

Note that we still get an error for using `tabindex` instead of `tabIndex`. This is because our prop mapping is erroneously flipped. See #37459