### PR TITLE
♿ Flip `tabindex` prop mapping

### DIFF
--- a/build-system/common/preact-prop-names.js
+++ b/build-system/common/preact-prop-names.js
@@ -19,8 +19,7 @@ function objectFlip(obj) {
 
 const DOM_ATTRIBUTES_REACT_TO_PREACT = {
   className: 'class',
-  // TODO(wg-bento): Revert tabIndex with tabindex
-  tabindex: 'tabIndex',
+  tabIndex: 'tabindex',
 };
 
 /**

--- a/build-system/eslint-rules/no-import-rename.js
+++ b/build-system/eslint-rules/no-import-rename.js
@@ -31,6 +31,7 @@ const imports = {
   ],
   '#experiments': ['isExperimentOn'],
   '#utils/log': ['user', 'dev'],
+  '#preact/utils': ['propName', 'tabindexFromProps'],
   'src/mode': ['getMode'],
 };
 

--- a/build-system/eslint-rules/preact-preferred-props.js
+++ b/build-system/eslint-rules/preact-preferred-props.js
@@ -51,7 +51,7 @@ module.exports = {
         }
         const property = prop.key.name || prop.key.value;
 
-        if (property?.toLowerCase() === 'tabindex') {
+        if (property?.toLowerCase?.() === 'tabindex') {
           context.report({
             node: prop,
             message:
@@ -118,7 +118,7 @@ module.exports = {
       MemberExpression(node) {
         const property = node.property.name || node.property.value;
 
-        if (property?.toLowerCase() === 'tabindex') {
+        if (property?.toLowerCase?.() === 'tabindex') {
           context.report({
             node: node.property,
             message:

--- a/build-system/eslint-rules/preact-preferred-props.js
+++ b/build-system/eslint-rules/preact-preferred-props.js
@@ -7,7 +7,7 @@
 // function foo({'class': className}) {}
 // const {'class': className} = props;
 //
-// <div tabIndex="0" />
+// <div tabindex="0" />
 // <path stroke-linecap />
 //
 // Bad
@@ -16,7 +16,7 @@
 // const {'className': className'} = props;
 // const {className} = props;
 //
-// <div tabindex="0" />
+// <div tabIndex="0" />
 // <path strokeLinecap />
 
 const {ATTRIBUTES_REACT_TO_PREACT} = require('../common/preact-prop-names');
@@ -50,6 +50,18 @@ module.exports = {
           return;
         }
         const property = prop.key.name || prop.key.value;
+
+        if (property?.toLowerCase() === 'tabindex') {
+          context.report({
+            node: prop,
+            message:
+              '`tabindex` and `tabIndex` should be supported equally.' +
+              ' Instead of destructuring, use:' +
+              `\n\timport {tabindexFromProps} from '#preact/utils';` +
+              `\n\t<... tabindex={tabindexFromProps(rest)}>`,
+          });
+          return;
+        }
 
         let preferred = ATTRIBUTES_REACT_TO_PREACT[property];
         let message = `Prefer \`${preferred}\` property access to \`${property}\`.`;
@@ -103,6 +115,21 @@ module.exports = {
         }
       },
 
+      MemberExpression(node) {
+        const property = node.property.name || node.property.value;
+
+        if (property?.toLowerCase() === 'tabindex') {
+          context.report({
+            node: node.property,
+            message:
+              '`tabindex` and `tabIndex` should be supported equally.' +
+              ' Instead of property access, use:' +
+              `\n\timport {tabindexFromProps} from '#preact/utils';` +
+              `\n\t<... tabindex={tabindexFromProps(rest)}>`,
+          });
+        }
+      },
+
       [`CallExpression[callee.name="${propNameFn}"]`]: function (node) {
         if (
           node.arguments.length !== 1 ||
@@ -116,6 +143,17 @@ module.exports = {
           return;
         }
         const name = node.arguments[0].value;
+        if (name.toLowerCase() === 'tabindex') {
+          context.report({
+            node,
+            message:
+              '`tabindex` and `tabIndex` should be supported equally.' +
+              ` Instead of ${propNameFn}('tabindex'), use:` +
+              `\n\timport {tabindexFromProps} from '#preact/utils';` +
+              `\n\t<... tabindex={tabindexFromProps(rest)}>`,
+          });
+          return;
+        }
         if (ATTRIBUTES_REACT_TO_PREACT[name]) {
           context.report({
             node,

--- a/extensions/amp-accordion/1.0/component.js
+++ b/extensions/amp-accordion/1.0/component.js
@@ -19,7 +19,7 @@ import {
 } from '#preact';
 import {forwardRef} from '#preact/compat';
 import {WithAmpContext} from '#preact/context';
-import {propName} from '#preact/utils';
+import {propName, tabindexFromProps} from '#preact/utils';
 
 import {animateCollapse, animateExpand} from './animations';
 import {useStyles} from './component.jss';
@@ -342,8 +342,8 @@ export function BentoAccordionHeader({
   children,
   id,
   role = 'button',
+  tabindex: foo,
   [propName('class')]: className = '',
-  [propName('tabIndex')]: tabIndex = 0,
   ...rest
 }) {
   const {contentId, expanded, headerId, setHeaderId, toggleHandler} =
@@ -362,7 +362,7 @@ export function BentoAccordionHeader({
       id={headerId}
       role={role}
       class={`${className} ${classes.sectionChild} ${classes.header}`}
-      tabIndex={tabIndex}
+      tabindex={tabindexFromProps(rest)}
       aria-controls={contentId}
       onClick={() => toggleHandler()}
       aria-expanded={String(expanded)}

--- a/extensions/amp-accordion/1.0/component.js
+++ b/extensions/amp-accordion/1.0/component.js
@@ -342,7 +342,6 @@ export function BentoAccordionHeader({
   children,
   id,
   role = 'button',
-  tabindex: foo,
   [propName('class')]: className = '',
   ...rest
 }) {

--- a/extensions/amp-accordion/1.0/component.type.js
+++ b/extensions/amp-accordion/1.0/component.type.js
@@ -31,10 +31,12 @@ BentoAccordionDef.BentoAccordionSectionProps;
  *   as: (string|PreactDef.FunctionalComponent|undefined),
  *   role: (string|undefined),
  *   class: (string|undefined),
+ *   tabindex: (number|string|undefined),
  *   tabIndex: (number|string|undefined),
  *   id: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
+ * (We support tabindex and tabIndex equally, see tabindexFromProps())
  */
 BentoAccordionDef.BentoAccordionHeaderProps;
 

--- a/extensions/amp-base-carousel/1.0/component.js
+++ b/extensions/amp-base-carousel/1.0/component.js
@@ -311,7 +311,7 @@ function BentoBaseCarouselWithRef(
         }
         interaction.current = Interaction.TOUCH;
       }}
-      tabIndex="0"
+      tabindex="0"
       wrapperClassName={classes.carousel}
       contentRef={contentRef}
       {...rest}

--- a/extensions/amp-base-carousel/1.0/scroller.js
+++ b/extensions/amp-base-carousel/1.0/scroller.js
@@ -259,7 +259,7 @@ function ScrollerWithRef(
       class={`${classes.scrollContainer} ${classes.hideScrollbar} ${
         axis === Axis.X ? classes.horizontalScroll : classes.verticalScroll
       }`}
-      tabIndex={0}
+      tabindex={0}
     >
       {slides}
     </div>

--- a/extensions/amp-inline-gallery/1.0/thumbnails.js
+++ b/extensions/amp-inline-gallery/1.0/thumbnails.js
@@ -82,7 +82,7 @@ export function BentoInlineGalleryThumbnails({
                 height: px(height),
                 width: aspectRatio ? px(aspectRatio * height) : '',
               }}
-              tabIndex="0"
+              tabindex="0"
             />
           );
         })}

--- a/extensions/amp-lightbox-gallery/1.0/provider.js
+++ b/extensions/amp-lightbox-gallery/1.0/provider.js
@@ -283,7 +283,7 @@ function CloseButtonIcon({onClick}) {
       })}
       onClick={onClick}
       role="button"
-      tabIndex="0"
+      tabindex="0"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -315,7 +315,7 @@ function NavButtonIcon({'aria-disabled': ariaDisabled, by, disabled, onClick}) {
       disabled={disabled}
       onClick={onClick}
       role="button"
-      tabIndex="0"
+      tabindex="0"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -348,7 +348,7 @@ function ToggleViewIcon({onClick, showCarousel}) {
       })}
       onClick={onClick}
       role="button"
-      tabIndex="0"
+      tabindex="0"
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -394,7 +394,7 @@ function Thumbnail({onClick, render}) {
       class={classes.thumbnail}
       onClick={onClick}
       role="button"
-      tabIndex="0"
+      tabindex="0"
     >
       {render()}
     </div>

--- a/extensions/amp-lightbox/1.0/component.js
+++ b/extensions/amp-lightbox/1.0/component.js
@@ -145,7 +145,7 @@ function BentoLightboxWithRef(
         wrapperClassName={classes.wrapper}
         contentProps={CONTENT_PROPS}
         role="dialog"
-        tabIndex="0"
+        tabindex="0"
         onKeyDown={(event) => {
           if (event.key === Keys_Enum.ESCAPE) {
             setVisible(false);
@@ -192,7 +192,7 @@ function ScreenReaderCloseButton({'aria-label': ariaLabel, onClick}) {
       aria-label={ariaLabel}
       class={classes.closeButton}
       onClick={onClick}
-      tabIndex={-1}
+      tabindex={-1}
     />
   );
 }

--- a/extensions/amp-selector/1.0/base-element.js
+++ b/extensions/amp-selector/1.0/base-element.js
@@ -10,7 +10,7 @@ import {toArray} from '#core/types/array';
 import * as Preact from '#preact';
 import {useCallback, useLayoutEffect, useRef} from '#preact';
 import {PreactBaseElement} from '#preact/base-element';
-import {propName} from '#preact/utils';
+import {tabindexFromProps} from '#preact/utils';
 
 import {BentoSelector, BentoSelectorOption} from './component';
 
@@ -86,7 +86,6 @@ function getOptions(element, mu) {
       const option = child.getAttribute('option') || index.toString();
       const selected = child.hasAttribute('selected');
       const disabled = child.hasAttribute('disabled');
-      const tabIndex = child.getAttribute('tabindex');
       const props = {
         as: OptionShim,
         option,
@@ -102,12 +101,16 @@ function getOptions(element, mu) {
           mu.takeRecords();
         },
         selected,
-        tabIndex,
       };
       if (selected) {
         value.push(option);
       }
-      const optionChild = <BentoSelectorOption {...props} />;
+      const optionChild = (
+        <BentoSelectorOption
+          {...props}
+          tabindex={child.getAttribute('tabindex')}
+        />
+      );
       options.push(option);
       children.push(optionChild);
     });
@@ -126,8 +129,9 @@ export function OptionShim({
   role = 'option',
   selected,
   shimDomElement,
-  [propName('tabIndex')]: tabIndex,
+  ...rest
 }) {
+  const tabindex = tabindexFromProps(rest);
   const syncEvent = useCallback(
     (type, handler) => {
       if (!handler) {
@@ -160,10 +164,10 @@ export function OptionShim({
   }, [shimDomElement, role]);
 
   useLayoutEffect(() => {
-    if (tabIndex != undefined) {
-      shimDomElement.tabIndex = tabIndex;
+    if (tabindex != undefined) {
+      shimDomElement.setAttribute('tabindex', tabindex);
     }
-  }, [shimDomElement, tabIndex]);
+  }, [shimDomElement, tabindex]);
 
   return <div></div>;
 }
@@ -182,8 +186,9 @@ function SelectorShim({
   role = 'listbox',
   shimDomElement,
   value,
-  [propName('tabIndex')]: tabIndex,
+  ...rest
 }) {
+  const tabindex = tabindexFromProps(rest);
   const input = useRef(null);
   if (!input.current) {
     input.current = createElementWithAttributes(
@@ -237,10 +242,10 @@ function SelectorShim({
   }, [shimDomElement, role]);
 
   useLayoutEffect(() => {
-    if (tabIndex != undefined) {
-      shimDomElement.tabIndex = tabIndex;
+    if (tabindex != undefined) {
+      shimDomElement.setAttribute('tabindex', tabindex);
     }
-  }, [shimDomElement, tabIndex]);
+  }, [shimDomElement, tabindex]);
 
   return <div children={children} />;
 }

--- a/extensions/amp-selector/1.0/base-element.js
+++ b/extensions/amp-selector/1.0/base-element.js
@@ -263,6 +263,6 @@ BaseElement['props'] = {
   'multiple': {attr: 'multiple', type: 'boolean'},
   'name': {attr: 'name'},
   'role': {attr: 'role'},
-  'tabIndex': {attr: 'tabindex'},
+  'tabindex': {attr: 'tabindex'},
   'keyboardSelectMode': {attr: 'keyboard-select-mode', media: true},
 };

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -245,7 +245,7 @@ function SelectorWithRef(
       multiple={multiple}
       name={name}
       onKeyDown={onKeyDown}
-      tabIndex={
+      tabindex={
         tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? 0 : -1
       }
       value={selected}
@@ -361,7 +361,7 @@ export function BentoSelectorOption({
       ref={ref}
       role={role}
       selected={isSelected}
-      tabIndex={
+      tabindex={
         tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0
       }
       value={option}

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -16,7 +16,7 @@ import {
   useState,
 } from '#preact';
 import {forwardRef} from '#preact/compat';
-import {propName} from '#preact/utils';
+import {propName, tabindexFromProps} from '#preact/utils';
 
 import {useStyles} from './component.jss';
 
@@ -52,12 +52,15 @@ function SelectorWithRef(
     name,
     onChange,
     role = 'listbox',
-    [propName('tabIndex')]: tabIndex,
     children,
     ...rest
   },
   ref
 ) {
+  const tabindex = tabindexFromProps(
+    rest,
+    keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? 0 : -1
+  );
   const [selectedState, setSelectedState] = useState(value ?? defaultValue);
   const optionsRef = useRef([]);
   const focusRef = useRef({active: null, focusMap: {}});
@@ -245,9 +248,7 @@ function SelectorWithRef(
       multiple={multiple}
       name={name}
       onKeyDown={onKeyDown}
-      tabindex={
-        tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? 0 : -1
-      }
+      tabindex={tabindex}
       value={selected}
     >
       <input hidden defaultValue={selected} name={name} form={form} />
@@ -274,9 +275,12 @@ export function BentoSelectorOption({
   option,
   role = 'option',
   [propName('class')]: className = '',
-  [propName('tabIndex')]: tabIndex,
   ...rest
 }) {
+  const tabindex = tabindexFromProps(
+    rest,
+    keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0
+  );
   const classes = useStyles();
   const ref = useRef(null);
   const {
@@ -361,9 +365,7 @@ export function BentoSelectorOption({
       ref={ref}
       role={role}
       selected={isSelected}
-      tabindex={
-        tabIndex ?? keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0
-      }
+      tabindex={tabindex}
       value={option}
     />
   );

--- a/extensions/amp-selector/1.0/component.js
+++ b/extensions/amp-selector/1.0/component.js
@@ -277,10 +277,6 @@ export function BentoSelectorOption({
   [propName('class')]: className = '',
   ...rest
 }) {
-  const tabindex = tabindexFromProps(
-    rest,
-    keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0
-  );
   const classes = useStyles();
   const ref = useRef(null);
   const {
@@ -292,6 +288,11 @@ export function BentoSelectorOption({
     selectOption,
     selected,
   } = useContext(SelectorContext);
+
+  const tabindex = tabindexFromProps(
+    rest,
+    keyboardSelectMode === KEYBOARD_SELECT_MODE.SELECT ? -1 : 0
+  );
 
   const focus = useCallback(() => {
     customFocus?.();

--- a/extensions/amp-sidebar/1.0/component.js
+++ b/extensions/amp-sidebar/1.0/component.js
@@ -145,7 +145,7 @@ function BentoSidebarWithRef(
           [classes.right]: side !== Side.LEFT,
         })}
         role="menu"
-        tabIndex="-1"
+        tabindex="-1"
         hidden={!side}
         {...rest}
       >

--- a/extensions/amp-social-share/1.0/base-element.js
+++ b/extensions/amp-social-share/1.0/base-element.js
@@ -18,7 +18,7 @@ BaseElement['delegatesFocus'] = true;
 BaseElement['props'] = {
   'children': {passthroughNonEmpty: true},
   'height': {attr: 'height'},
-  'tabIndex': {attr: 'tabindex'},
+  'tabindex': {attr: 'tabindex'},
   'type': {attr: 'type'},
   'width': {attr: 'width'},
 };

--- a/extensions/amp-social-share/1.0/component.js
+++ b/extensions/amp-social-share/1.0/component.js
@@ -59,7 +59,7 @@ export function BentoSocialShare({
     <Wrapper
       {...rest}
       role="button"
-      tabIndex={tabIndex}
+      tabindex={tabIndex}
       onKeyDown={(e) => handleKeyPress(e, finalEndpoint, checkedTarget)}
       onClick={() => handleActivation(finalEndpoint, checkedTarget)}
       wrapperStyle={{

--- a/extensions/amp-social-share/1.0/component.js
+++ b/extensions/amp-social-share/1.0/component.js
@@ -3,7 +3,7 @@ import {parseQueryString} from '#core/types/string/url';
 
 import * as Preact from '#preact';
 import {Wrapper} from '#preact/component';
-import {propName, useResourcesNotify} from '#preact/utils';
+import {tabindexFromProps, useResourcesNotify} from '#preact/utils';
 
 import {useStyles} from './component.jss';
 import {getSocialConfig} from './social-share-config';
@@ -33,7 +33,6 @@ export function BentoSocialShare({
   target,
   type,
   width,
-  [propName('tabIndex')]: tabIndex = 0,
   ...rest
 }) {
   useResourcesNotify();
@@ -59,7 +58,7 @@ export function BentoSocialShare({
     <Wrapper
       {...rest}
       role="button"
-      tabindex={tabIndex}
+      tabindex={tabindexFromProps(rest)}
       onKeyDown={(e) => handleKeyPress(e, finalEndpoint, checkedTarget)}
       onClick={() => handleActivation(finalEndpoint, checkedTarget)}
       wrapperStyle={{

--- a/extensions/amp-social-share/1.0/component.type.js
+++ b/extensions/amp-social-share/1.0/component.type.js
@@ -13,9 +13,11 @@ var BentoSocialShareDef = {};
  *   height: (number|string|undefined),
  *   color: (string|undefined),
  *   background: (string|undefined),
+ *   tabindex: (number|string|undefined),
  *   tabIndex: (number|string|undefined),
  *   style: (string|undefined),
  *   children: (?PreactDef.Renderable|undefined),
  * }}
+ * (We support tabindex and tabIndex equally, see tabindexFromProps())
  */
 BentoSocialShareDef.Props;

--- a/extensions/amp-video/1.0/component.js
+++ b/extensions/amp-video/1.0/component.js
@@ -366,7 +366,7 @@ function Autoplay({
       {displayOverlay && (
         <button
           aria-label={(metadata && metadata.title) || 'Unmute video'}
-          tabIndex="0"
+          tabindex="0"
           class={objstr({
             [autoplayClasses.autoplayMaskButton]: true,
             [classes.fillContentOverlay]: true,

--- a/src/preact/utils.js
+++ b/src/preact/utils.js
@@ -59,3 +59,17 @@ export function useMergeRefs(refs) {
 export function propName(name) {
   return name;
 }
+
+/**
+ * Required to consume `tabindex` from props.
+ * We support taking both `tabIndex` and `tabindex` for backwards compatibility,
+ * so this takes either form.
+ * @param {{tabindex: string|number, tabIndex: string|number}} props
+ * @return {string|number}
+ */
+export function tabindexFromProps(props) {
+  // This tabindex property access is okay. Tabindex property access elsewhere
+  //  must use this function.
+  // eslint-disable-next-line local/preact-preferred-props
+  return props.tabindex || props.tabIndex || 0;
+}

--- a/src/preact/utils.js
+++ b/src/preact/utils.js
@@ -65,11 +65,12 @@ export function propName(name) {
  * We support taking both `tabIndex` and `tabindex` for backwards compatibility,
  * so this takes either form.
  * @param {{tabindex: string|number, tabIndex: string|number}} props
+ * @param {number=} fallback
  * @return {string|number}
  */
-export function tabindexFromProps(props) {
+export function tabindexFromProps(props, fallback = 0) {
   // This tabindex property access is okay. Tabindex property access elsewhere
   //  must use this function.
   // eslint-disable-next-line local/preact-preferred-props
-  return props.tabindex || props.tabIndex || 0;
+  return props.tabindex ?? props.tabIndex ?? fallback;
 }


### PR DESCRIPTION
We've been incorrectly mapping `tabIndex` as the Preact-style prop name and `tabindex` as the React-style prop name. This should be reversed.