### PR TITLE
🏗🐛 Fix uses of eslint `node.start/end` vs. `node.range`

### DIFF
--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -50,9 +50,10 @@ module.exports = {
       }
 
       const [nextComment] = context.getCommentsAfter(node);
+      const [nextCommentStart] = nextComment.range;
       if (
         nextComment &&
-        text.substr(end, nextComment.start - end).indexOf('\n') < 0
+        text.substr(end, nextCommentStart - end).indexOf('\n') < 0
       ) {
         yield fixer.remove(nextComment);
       }

--- a/build-system/eslint-rules/html-template.js
+++ b/build-system/eslint-rules/html-template.js
@@ -108,7 +108,7 @@ function create(context) {
 
     if (invalids.length) {
       const sourceCode = context.getSourceCode();
-      const {start} = template;
+      const [start] = template.range;
 
       for (const {offset, tag} of invalids) {
         const itemStart = start + offset;

--- a/build-system/eslint-rules/no-private-props.js
+++ b/build-system/eslint-rules/no-private-props.js
@@ -23,9 +23,10 @@ module.exports = {
           message:
             'Unquoted private properties are not allowed in BaseElement. Please use quotes',
           fix(fixer) {
-            const {object} = node;
+            const [, objectEnd] = node.object.range;
+            const [, nodeEnd] = node.range;
             return fixer.replaceTextRange(
-              [object.end, node.end],
+              [objectEnd, nodeEnd],
               `['${node.property.name}']`
             );
           },

--- a/build-system/eslint-rules/preact-preferred-props.js
+++ b/build-system/eslint-rules/preact-preferred-props.js
@@ -174,8 +174,9 @@ module.exports = {
               const replacement = `'${name}'`;
               if (node.parent.type === 'Property') {
                 // Remove brackets around ['computed'] prop keys
+                const [start, end] = node.parent.key.range;
                 return fixer.replaceTextRange(
-                  [node.parent.key.start - 1, node.parent.key.end + 1],
+                  [start - 1, end + 1],
                   replacement
                 );
               }


### PR DESCRIPTION
eslint changed the node API so that `.start/end` is no longer available, instead providing `.range`. 

This is the same change as #37422, but for the rest of the rules.