### PR TITLE
build-system: cleanup esbuild options

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -678,9 +678,6 @@ async function maybeBuildBentoExtensionJs(dir, name, options) {
   const bentoName = getBentoName(name);
   return buildExtensionJs(dir, bentoName, {
     ...options,
-    // Use esbuild since Closure does not use a different babel config for
-    // Bento elements.
-    esbuild: true,
     wrapper: 'bento',
     babelCaller: options.minify
       ? 'bento-element-minified'

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -131,12 +131,7 @@ async function compileBentoRuntime(options) {
   const filename = `${srcDir}/${srcFilename}`;
   const fileSource = generateBentoRuntimeEntrypoint();
   await fs.outputFile(filename, fileSource);
-  await doBuildJs(jsBundles, 'bento.js', {
-    ...options,
-    // The pre-closure babel step wants the entry file to be generated earlier.
-    // Much simpler to generate it here and use esbuild instead.
-    esbuild: true,
-  });
+  await doBuildJs(jsBundles, 'bento.js', options);
 }
 
 /**


### PR DESCRIPTION
No longer necessary since the wholesale move to esbuild