### PR TITLE
typecheck: merge new-server check with the rest.

### DIFF
--- a/build-system/server/typescript-compile.js
+++ b/build-system/server/typescript-compile.js
@@ -4,7 +4,6 @@ const path = require('path');
 const {accessSync} = require('fs-extra');
 const {cyan, green} = require('kleur/colors');
 const {endBuildStep} = require('../tasks/helpers');
-const {exec} = require('../common/exec');
 const {log} = require('../common/logging');
 
 const SERVER_TRANSFORM_PATH = 'build-system/server/new-server/transforms';
@@ -41,18 +40,6 @@ async function buildNewServer() {
 }
 
 /**
- * Checks all types in the generated output after running server transforms.
- */
-function typecheckNewServer() {
-  const cmd = `npx -p typescript tsc --noEmit -p ${CONFIG_PATH}`;
-  const result = exec(cmd, {'stdio': ['inherit', 'inherit', 'pipe']});
-
-  if (result.status != 0) {
-    throw new Error(`Typechecking AMP Server failed.`);
-  }
-}
-
-/**
  * Requires a module output from `./new-server/transforms`.
  * If all of `new-server` was built, this simply imports an existing module.
  * Otherwise, it builds the required module only, then imports it
@@ -79,7 +66,6 @@ function requireNewServerModule(modulePath) {
 
 module.exports = {
   buildNewServer,
-  typecheckNewServer,
   requireNewServerModule,
   SERVER_TRANSFORM_PATH,
 };

--- a/build-system/tasks/check-types.js
+++ b/build-system/tasks/check-types.js
@@ -8,7 +8,6 @@ const {compileJison} = require('./compile-jison');
 const {cyan, green} = require('kleur/colors');
 const {execOrThrow} = require('../common/exec');
 const {log} = require('../common/logging');
-const {typecheckNewServer} = require('../server/typescript-compile');
 
 /**
  * Object of targets to check with TypeScript.
@@ -21,6 +20,7 @@ const TSC_TYPECHECK_TARGETS = {
   'core': 'src/core',
   'experiments': 'src/experiments',
   'preact': 'src/preact',
+  'new-server': 'build-system/server/new-server/transforms',
 };
 
 /**
@@ -45,7 +45,6 @@ async function checkTypes() {
 
   // Prepare build environment
   process.env.NODE_ENV = 'production';
-  typecheckNewServer();
   await Promise.all([compileCss(), compileJison()]);
 
   // Use the list of targets if provided, otherwise check all targets


### PR DESCRIPTION
**summary**
We've always had a command `amp check-types`. Historically we'd call `tsc` to typecheck the new-server and then closure compiler to check binary code.

Now that we use `tsc` for both, might as well merge the logic.