### PR TITLE
🐛  🏗 Copy jwplayer css to `src/bento`

### DIFF
--- a/build-system/compile/bundles.config.bento.json
+++ b/build-system/compile/bundles.config.bento.json
@@ -2,6 +2,8 @@
   {
     "name": "jwplayer",
     "version": "1.0",
-    "options": {}
+    "options": {
+      "hasCss": true
+    }
   }
 ]

--- a/src/bento/components/jwplayer/1.0/bento-jwplayer.css
+++ b/src/bento/components/jwplayer/1.0/bento-jwplayer.css
@@ -1,0 +1,17 @@
+/*
+ * Pre-upgrade:
+ * - display:block element
+ * - size-defined element
+ */
+ bento-jwplayer {
+  display: block;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Pre-upgrade: size-defining element - hide children. */
+bento-jwplayer:not(.i-amphtml-built)
+  > :not([placeholder]):not([slot='i-amphtml-svc']) {
+  display: none;
+  content-visibility: hidden;
+}


### PR DESCRIPTION
When creating #36639 I didn't realize that `amp-jwplayer.css` was being used by the Bento code as well. As a result I did not move it with the rest of the code. This resulted in `bento-jwplayer-1.0.css.js` not being generated during build. Unfortunately this file is not imported during any of the tests and thus the build showed as green. The fastest fix for this is to copy the file over (and also clean up some naming). 

Before moving more components over I will do the following:
1) Come up with a test to detect this sort of issue.
2) Explore reversing the logic used to replace `amp` in the css files with `bento` and import the Bento css file from the AMP component. To reduce duplicate code.


<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
