### PR TITLE
📖 Mention that amp-state can contain a constant

### DIFF
--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -227,6 +227,17 @@ An `amp-state` element may contain either a child `<script>` element **OR** a `s
 <amp-state id="myRemoteState" src="https://data.com/articles.json"> </amp-state>
 ```
 
+As an `amp-state` element stores a JSON object literal, you can also initialize it with an object, as above, or with a constant.
+
+```html
+<amp-state id="singleton">
+  <script type="application/json">
+    {
+      'I am a string'
+    }
+  </script>
+</amp-state>
+```
 [/filter] <!-- formats="websites, ads" -->
 
 [filter formats="email"]

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -233,9 +233,7 @@ it with an object, as above, or with a constant.
 ```html
 <amp-state id="singleton">
   <script type="application/json">
-    {
-      'I am a string'
-    }
+    'I am a string'
   </script>
 </amp-state>
 ```

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -239,6 +239,7 @@ it with an object, as above, or with a constant.
   </script>
 </amp-state>
 ```
+
 [/filter] <!-- formats="websites, ads" -->
 
 [filter formats="email"]

--- a/extensions/amp-bind/amp-bind.md
+++ b/extensions/amp-bind/amp-bind.md
@@ -227,7 +227,8 @@ An `amp-state` element may contain either a child `<script>` element **OR** a `s
 <amp-state id="myRemoteState" src="https://data.com/articles.json"> </amp-state>
 ```
 
-As an `amp-state` element stores a JSON object literal, you can also initialize it with an object, as above, or with a constant.
+As an `amp-state` element stores a JSON object literal, you can also initialize
+it with an object, as above, or with a constant.
 
 ```html
 <amp-state id="singleton">


### PR DESCRIPTION
Add an example showing that it can be initialized to a constant, not just an object. (This is something I was never sure about when I first started using AMP.)

Note - I wasn't able to get the import to work on my local machine, so I tested this with an outdated version of the docs. It might be worth verifying this on a fully working build!