### PR TITLE
Fix GoToDefinition in IDEs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
     "checkJs": false
   },
 
-  "include": ["src", "3p", "ads", "extensions", "test", "testing"]
+  "include": ["src", "3p", "ads", "extensions", "test", "testing"],
+  "exclude": ["**/*shame.d.ts"]
 }


### PR DESCRIPTION
**summary**
There is a bug in in that the root `tsconfig.json` includes `shame.d.ts` files. The module definitions end up overriding the correct files in the "Go To Definition" feature, even outside of the files that the shame file is relevant.

cc @calebcordry who alerted me to the issue :)