### PR TITLE
🐛 Fix sourcemaps in local dev server

### DIFF
--- a/build-system/compile/helpers.js
+++ b/build-system/compile/helpers.js
@@ -7,15 +7,16 @@ const {VERSION: internalRuntimeVersion} = require('./internal-version');
  * Computes the base url for sourcemaps. Custom sourcemap URLs have placeholder
  * {version} that should be replaced with the actual version. Also, ensures
  * that a trailing slash exists.
+ * @param {Object} options
  * @return {string}
  */
-function getSourceRoot() {
+function getSourceRoot(options) {
   if (argv.sourcemap_url) {
     return String(argv.sourcemap_url)
       .replace(/\{version\}/g, internalRuntimeVersion)
       .replace(/([^/])$/, '$1/');
   }
-  if (!argv._.includes('dist')) {
+  if (options.fortesting || !argv._.includes('dist')) {
     return 'http://localhost:8000/';
   }
   return `https://raw.githubusercontent.com/ampproject/amphtml/${internalRuntimeVersion}/`;

--- a/build-system/compile/helpers.js
+++ b/build-system/compile/helpers.js
@@ -7,16 +7,15 @@ const {VERSION: internalRuntimeVersion} = require('./internal-version');
  * Computes the base url for sourcemaps. Custom sourcemap URLs have placeholder
  * {version} that should be replaced with the actual version. Also, ensures
  * that a trailing slash exists.
- * @param {Object} options
  * @return {string}
  */
-function getSourceRoot(options) {
+function getSourceRoot() {
   if (argv.sourcemap_url) {
     return String(argv.sourcemap_url)
       .replace(/\{version\}/g, internalRuntimeVersion)
       .replace(/([^/])$/, '$1/');
   }
-  if (options.fortesting) {
+  if (!argv._.includes('dist')) {
     return 'http://localhost:8000/';
   }
   return `https://raw.githubusercontent.com/ampproject/amphtml/${internalRuntimeVersion}/`;

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -366,9 +366,9 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     if (options.minify) {
       const {code: minified, map: minifiedMap} = await minify(code);
       code = minified;
-      map = await massageSourcemaps([minifiedMap, map], babelMaps);
+      map = await massageSourcemaps([minifiedMap, map], babelMaps, options);
     } else {
-      map = await massageSourcemaps([map], babelMaps);
+      map = await massageSourcemaps([map], babelMaps, options);
     }
 
     await Promise.all([
@@ -699,9 +699,10 @@ async function getDependencies(entryPoint, options) {
 /**
  * @param {!Array<string|object>} sourcemaps
  * @param {Map<string, string|object>} babelMaps
+ * @param {*} options
  * @return {string}
  */
-function massageSourcemaps(sourcemaps, babelMaps) {
+function massageSourcemaps(sourcemaps, babelMaps, options) {
   const root = process.cwd();
   const remapped = remapping(
     sourcemaps,
@@ -733,7 +734,7 @@ function massageSourcemaps(sourcemaps, babelMaps) {
     }
     return source;
   });
-  remapped.sourceRoot = getSourceRoot();
+  remapped.sourceRoot = getSourceRoot(options);
   if (remapped.file) {
     remapped.file = path.basename(remapped.file);
   }

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -366,9 +366,9 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
     if (options.minify) {
       const {code: minified, map: minifiedMap} = await minify(code);
       code = minified;
-      map = await massageSourcemaps([minifiedMap, map], babelMaps, options);
+      map = await massageSourcemaps([minifiedMap, map], babelMaps);
     } else {
-      map = await massageSourcemaps([map], babelMaps, options);
+      map = await massageSourcemaps([map], babelMaps);
     }
 
     await Promise.all([
@@ -699,10 +699,9 @@ async function getDependencies(entryPoint, options) {
 /**
  * @param {!Array<string|object>} sourcemaps
  * @param {Map<string, string|object>} babelMaps
- * @param {*} options
  * @return {string}
  */
-function massageSourcemaps(sourcemaps, babelMaps, options) {
+function massageSourcemaps(sourcemaps, babelMaps) {
   const root = process.cwd();
   const remapped = remapping(
     sourcemaps,
@@ -734,7 +733,7 @@ function massageSourcemaps(sourcemaps, babelMaps, options) {
     }
     return source;
   });
-  remapped.sourceRoot = getSourceRoot(options);
+  remapped.sourceRoot = getSourceRoot();
   if (remapped.file) {
     remapped.file = path.basename(remapped.file);
   }


### PR DESCRIPTION
Currently sourcemaps are being directed to a `raw.githubusercontent.com/ampproject/amphtml/${internalRuntimeVersion}` url which does not exist for the fake dev rtv, so it 404s.