### PR TITLE
🚀  [Story video] Use the inlined video response instead of issuing an XHR request, for the 1st video of the 1st web story page

### DIFF
--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -74,7 +74,7 @@ export function fetchCachedSources(
         const responsePromise = Services.xhrFor(win).fetch(requestUrl, {
           prerenderSafe: true,
         });
-        jsonResponsePromise = responsePromise.json();
+        return responsePromise.json();
       });
   }
 

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -52,9 +52,13 @@ export function fetchCachedSources(
     const inlineResponseEl = win.document.getElementById(
       'amp-google-video-cache-response'
     );
-    const inlineResponseJson = JSON.parse(inlineResponseEl.textContent);
-    jsonResponsePromise = Promise.resolve(inlineResponseJson);
-  } else {
+    if (inlineResponseEl?.textContent) {
+      const inlineResponseJson = JSON.parse(inlineResponseEl.textContent);
+      jsonResponsePromise = Promise.resolve(inlineResponseJson);
+    }
+  }
+  
+  if (!jsonResponsePromise) {
     const {canonicalUrl, sourceUrl} = Services.documentInfoForDoc(win.document);
     maybeReplaceSrcWithSourceElement(videoEl, win);
     const videoUrl = resolveRelativeUrl(selectVideoSource(videoEl), sourceUrl);

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -71,10 +71,9 @@ export function fetchCachedSources(
               : null,
           }
         );
-        const responsePromise = Services.xhrFor(win).fetch(requestUrl, {
-          prerenderSafe: true,
-        });
-        return responsePromise.json();
+        return Services.xhrFor(win)
+          .fetch(requestUrl, {prerenderSafe: true})
+          .then((xhrResponse) => xhrResponse.json());
       });
   }
 

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -57,7 +57,7 @@ export function fetchCachedSources(
       jsonResponsePromise = Promise.resolve(inlineResponseJson);
     }
   }
-  
+
   if (!jsonResponsePromise) {
     const {canonicalUrl, sourceUrl} = Services.documentInfoForDoc(win.document);
     maybeReplaceSrcWithSourceElement(videoEl, win);


### PR DESCRIPTION
Monti will be inlining the 1st video in the 1st story page, removing the need for an XHR call. This PR prevents the XHR request for this video whenever the inlined response is present.

Fixes #37397
