### PR TITLE
🐛 [amp story shopping] shopping CTA label fix

### DIFF
--- a/extensions/amp-story-page-attachment/0.1/amp-story-open-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-open-page-attachment.js
@@ -99,7 +99,7 @@ const ctaLabelFromAttr = (element) =>
  */
 const openLabelOrFallback = (element, attachmentEl, label) => {
   const localizationService = Services.localizationForDoc(element);
-  if (attachmentEl.tagName === 'AMP-STORY-SHOPPING-ATTACHMENT') {
+  if (attachmentEl.parentElement.tagName === 'AMP-STORY-SHOPPING-ATTACHMENT') {
     return localizationService.getLocalizedString(
       LocalizedStringId_Enum.AMP_STORY_SHOPPING_CTA_LABEL
     );


### PR DESCRIPTION
Building the attachment was refactored as part of #37278 to be a separate component and introduced a regression which was not caught since Percy diffs were broken at the time of submitting the PR. `this.element` is now a reference to `amp-story-page-outlink` or `amp-story-page-attachment` and never `amp-story-shopping-attachment`.

This PR checks the parent element to see if it's an `amp-story-shopping-attachment` to create the appropriate label.