### PR TITLE
🚀♻️  amp-story-shopping-config: no custom element

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -53,6 +53,8 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     this.localizationService_ = null;
 
     /** @private {?Promise<!KeyedShoppingConfigDef>}  */
+    // TODO(wg-stories): Remove temporary disable once private is used.
+    // eslint-disable-next-line local/unused-private-field
     this.shoppingConfig_ = null;
   }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -8,6 +8,7 @@ import {formatI18nNumber, loadFonts} from './amp-story-shopping';
 import {
   KeyedShoppingConfigDef,
   getShoppingConfig,
+  storeShoppingConfig,
 } from './amp-story-shopping-config';
 
 import {
@@ -51,11 +52,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
 
     /** @private {?../../../src/service/localization.LocalizationService} */
     this.localizationService_ = null;
-
-    /** @private {?Promise<!KeyedShoppingConfigDef>}  */
-    // TODO(wg-stories): Remove temporary disable once private is used.
-    // eslint-disable-next-line local/unused-private-field
-    this.shoppingConfig_ = null;
   }
 
   /** @override */
@@ -65,7 +61,9 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
       this.pageEl_.querySelectorAll('amp-story-shopping-tag')
     );
     loadFonts(this.win, FONTS_TO_LOAD);
-    this.shoppingConfig_ = getShoppingConfig(this.element.parentElement);
+
+    const pageElement = this.element.parentElement;
+    storeShoppingConfig(pageElement, getShoppingConfig(pageElement));
 
     this.attachmentEl_ = (
       <amp-story-page-attachment

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -6,7 +6,6 @@ import {LocalizedStringId_Enum} from '#service/localization/strings';
 
 import {formatI18nNumber, loadFonts} from './amp-story-shopping';
 import {
-  KeyedShoppingConfigDef,
   getShoppingConfig,
   storeShoppingConfig,
 } from './amp-story-shopping-config';

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -63,7 +63,9 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     loadFonts(this.win, FONTS_TO_LOAD);
 
     const pageElement = this.element.parentElement;
-    storeShoppingConfig(pageElement, getShoppingConfig(pageElement));
+    getShoppingConfig(pageElement).then((config) =>
+      storeShoppingConfig(pageElement, config)
+    );
 
     this.attachmentEl_ = (
       <amp-story-page-attachment

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -5,6 +5,7 @@ import {Services} from '#service';
 import {LocalizedStringId_Enum} from '#service/localization/strings';
 
 import {formatI18nNumber, loadFonts} from './amp-story-shopping';
+import {getShoppingConfig} from './amp-story-shopping-config';
 
 import {
   ShoppingConfigDataDef,
@@ -47,6 +48,9 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
 
     /** @private {?../../../src/service/localization.LocalizationService} */
     this.localizationService_ = null;
+
+    /** @private {?Promise<Object<!ShoppingConfigDataDef>>}  */
+    this.shoppingConfig_ = null;
   }
 
   /** @override */
@@ -54,6 +58,15 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     this.pageEl_ = this.element.closest('amp-story-page');
     this.shoppingTags_ = Array.from(
       this.pageEl_.querySelectorAll('amp-story-shopping-tag')
+    );
+    loadFonts(this.win, FONTS_TO_LOAD);
+    this.shoppingConfig_ = getShoppingConfig(this.element.parentElement);
+
+    this.attachmentEl_ = (
+      <amp-story-page-attachment
+        layout="nodisplay"
+        theme={this.element.getAttribute('theme')}
+      ></amp-story-page-attachment>
     );
     if (this.shoppingTags_.length === 0) {
       return;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -5,7 +5,10 @@ import {Services} from '#service';
 import {LocalizedStringId_Enum} from '#service/localization/strings';
 
 import {formatI18nNumber, loadFonts} from './amp-story-shopping';
-import {getShoppingConfig} from './amp-story-shopping-config';
+import {
+  KeyedShoppingConfigDef,
+  getShoppingConfig,
+} from './amp-story-shopping-config';
 
 import {
   ShoppingConfigDataDef,
@@ -49,7 +52,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     /** @private {?../../../src/service/localization.LocalizationService} */
     this.localizationService_ = null;
 
-    /** @private {?Promise<Object<!ShoppingConfigDataDef>>}  */
+    /** @private {?Promise<!KeyedShoppingConfigDef>}  */
     this.shoppingConfig_ = null;
   }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
@@ -37,8 +37,8 @@ export function getShoppingConfig(pageElement) {
  */
 function keyByProductTagId(config) {
   const keyed = {};
-  for (const item of config['items']) {
-    keyed[item['productId']] = item;
+  for (const item of config.items) {
+    keyed[item.productId] = item;
   }
   return keyed;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
@@ -12,9 +12,12 @@ import {
  *  items: !Array<!ShoppingConfigDataDef>,
  * }}
  */
-let ShoppingConfigDef;
+let ShoppingConfigResponseDef;
 
-/** @type {!WeakMap<!Element, !Promise<!ShoppingConfigDef>>} */
+/** @typedef {!Object<string, !ShoppingConfigDataDef> */
+export let KeyedShoppingConfigDef;
+
+/** @type {!WeakMap<!Element, !Promise<!KeyedShoppingConfigDef>>} */
 const cache = new WeakMap();
 
 /**
@@ -23,7 +26,7 @@ const cache = new WeakMap();
  * During the initial fetch, the config is: validated, keyed by 'product-tag-id',
  * and stored in service.
  * @param {!Element} pageElement <amp-story-page>
- * @return {!Promise<!ShoppingConfigDef>}
+ * @return {!Promise<!KeyedShoppingConfigDef>}
  */
 export function getShoppingConfig(pageElement) {
   if (!cache.has(pageElement)) {
@@ -34,7 +37,7 @@ export function getShoppingConfig(pageElement) {
 
 /**
  * @param {!Element} pageElement <amp-story-page>
- * @return {!Promise<!Object<string, ShoppingConfigDataDef>>}
+ * @return {!Promise<!KeyedShoppingConfigDef>>}
  */
 function getShoppingConfigUncached(pageElement) {
   const element = pageElement.querySelector('amp-story-shopping-config');
@@ -46,8 +49,8 @@ function getShoppingConfigUncached(pageElement) {
 }
 
 /**
- * @param {!ShoppingConfigDef} config
- * @return {!Object<string, ShoppingConfigDataDef>}
+ * @param {!ShoppingConfigResponseDef} config
+ * @return {!KeyedShoppingConfigDef}
  */
 function keyByProductTagId(config) {
   const keyed = {};
@@ -59,8 +62,8 @@ function keyByProductTagId(config) {
 
 /**
  * @param {!Element} element
- * @param {!Object<string, ShoppingConfigDataDef>} config
- * @return {!Promise<!ShoppingConfigDef>}
+ * @param {!KeyedShoppingConfigDef} config
+ * @return {!Promise<!ShoppingConfigResponseDef>}
  */
 function storeShoppingConfig(element, config) {
   const storeService = Services.storyStoreServiceForOrNull(element);

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
@@ -51,13 +51,6 @@ function keyByProductTagId(config) {
 export function storeShoppingConfig(pageElement, config) {
   const win = pageElement.ownerDocument.defaultView;
   return Services.storyStoreServiceForOrNull(win).then((storeService) => {
-    // TODO(wg-stories): Scope shopping data to page id:
-    // storeService?.dispatch(
-    //     Action.ADD_SHOPPING_DATA,
-    // -   config
-    // +   {[pageElement.id]: config}
-    //   )
-    // Consumer in AmpStoryShoppingTag must be updated symmetrically.
     storeService?.dispatch(Action.ADD_SHOPPING_DATA, config);
     return config;
   });

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
@@ -44,7 +44,7 @@ function getShoppingConfigUncached(pageElement) {
   return getElementConfig(element).then((config) => {
     //TODO(#36412): Add call to validate config here.
     const keyed = keyByProductTagId(config);
-    return storeShoppingConfig(element, keyed);
+    return storeShoppingConfig(pageElement, keyed);
   });
 }
 
@@ -66,7 +66,8 @@ function keyByProductTagId(config) {
  * @return {!Promise<!ShoppingConfigResponseDef>}
  */
 function storeShoppingConfig(element, config) {
-  const storeService = Services.storyStoreServiceForOrNull(element);
+  const win = element.ownerDocument.defaultView;
+  const storeService = Services.storyStoreServiceForOrNull(win);
   return storeService.then((storeService) => {
     storeService?.dispatch(Action.ADD_SHOPPING_DATA, config);
     return config;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping.js
@@ -1,5 +1,4 @@
 import {AmpStoryShoppingAttachment} from './amp-story-shopping-attachment';
-import {AmpStoryShoppingConfig} from './amp-story-shopping-config';
 import {AmpStoryShoppingTag} from './amp-story-shopping-tag';
 
 import {CSS as shoppingCSS} from '../../../build/amp-story-shopping-0.1.css';
@@ -40,7 +39,6 @@ export const loadFonts = (win, fontFaces) => {
 };
 
 AMP.extension('amp-story-shopping', '0.1', (AMP) => {
-  AMP.registerElement('amp-story-shopping-config', AmpStoryShoppingConfig);
   AMP.registerElement(
     'amp-story-shopping-tag',
     AmpStoryShoppingTag,

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
@@ -4,7 +4,10 @@ import {Services} from '#service';
 
 import * as defaultConfig from '../../../../examples/amp-story/shopping/remote.json';
 import {Action} from '../../../amp-story/1.0/amp-story-store-service';
-import {getShoppingConfig} from '../amp-story-shopping-config';
+import {
+  getShoppingConfig,
+  storeShoppingConfig,
+} from '../amp-story-shopping-config';
 
 describes.realWin(
   'amp-story-shopping-config-v0.1',
@@ -16,14 +19,8 @@ describes.realWin(
   },
   (env) => {
     let pageElement;
-    let storeService;
 
     beforeEach(async () => {
-      storeService = {dispatch: env.sandbox.spy()};
-      env.sandbox
-        .stub(Services, 'storyStoreServiceForOrNull')
-        .resolves(storeService);
-
       pageElement = <amp-story-page id="page1"></amp-story-page>;
       env.win.document.body.appendChild(pageElement);
     });
@@ -59,13 +56,6 @@ describes.realWin(
       );
 
       expect(result).to.deep.eql(expectedRemoteResult);
-
-      expect(
-        storeService.dispatch.withArgs(
-          Action.ADD_SHOPPING_DATA,
-          expectedRemoteResult
-        )
-      ).to.have.been.calledOnce;
     });
 
     it('does use remote config when src attribute is provided', async () => {
@@ -78,13 +68,6 @@ describes.realWin(
       );
 
       expect(result).to.deep.eql(expectedRemoteResult);
-
-      expect(
-        storeService.dispatch.withArgs(
-          Action.ADD_SHOPPING_DATA,
-          expectedRemoteResult
-        )
-      ).to.have.been.calledOnce;
     });
 
     it('does use inline config when remote src is invalid', async () => {
@@ -105,6 +88,27 @@ describes.realWin(
         expect(() => createAmpStoryShoppingConfig(exampleURL)).to.throw(
           /error determining if remote config is valid json: bad url or bad json/
         );
+      });
+    });
+
+    describe('storeShoppingConfig', () => {
+      let storeService;
+      let pageElement;
+
+      beforeEach(async () => {
+        storeService = {dispatch: env.sandbox.spy()};
+        env.sandbox
+          .stub(Services, 'storyStoreServiceForOrNull')
+          .resolves(storeService);
+      });
+
+      it('dispatches ADD_SHOPPING_DATA', async () => {
+        const config = {foo: {bar: true}};
+
+        await storeShoppingConfig(pageElement, config);
+
+        expect(storeService.dispatch.withArgs(Action.ADD_SHOPPING_DATA, config))
+          .to.have.been.calledOnce;
       });
     });
   }

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
@@ -1,13 +1,10 @@
-import {createElementWithAttributes} from '#core/dom';
-import {Layout_Enum} from '#core/dom/layout';
-import '../amp-story-shopping';
+import * as Preact from '#core/dom/jsx';
 
-import * as configData from '../../../../examples/amp-story/shopping/remote.json';
-import {registerServiceBuilder} from '../../../../src/service-helpers';
-import {
-  StateProperty,
-  getStoreService,
-} from '../../../amp-story/1.0/amp-story-store-service';
+import {Services} from '#service';
+
+import * as defaultConfig from '../../../../examples/amp-story/shopping/remote.json';
+import {Action} from '../../../amp-story/1.0/amp-story-store-service';
+import {getShoppingConfig} from '../amp-story-shopping-config';
 
 describes.realWin(
   'amp-story-shopping-config-v0.1',
@@ -18,90 +15,97 @@ describes.realWin(
     },
   },
   (env) => {
-    let win;
-    let element;
-    let shoppingConfig;
+    let pageElement;
     let storeService;
 
     beforeEach(async () => {
-      win = env.win;
-      storeService = getStoreService(win);
-      registerServiceBuilder(win, 'story-store', function () {
-        return storeService;
-      });
+      storeService = {dispatch: env.sandbox.spy()};
+      env.sandbox
+        .stub(Services, 'storyStoreServiceForOrNull')
+        .resolves(storeService);
 
-      await createAmpStoryShoppingConfig();
+      pageElement = <amp-story-page id="page1"></amp-story-page>;
+      env.win.document.body.appendChild(pageElement);
     });
 
-    async function createAmpStoryShoppingConfig() {
-      const pageEl = win.document.createElement('amp-story-page');
-      pageEl.id = 'page1';
-      element = createElementWithAttributes(
-        win.document,
-        'amp-story-shopping-config',
-        {'layout': 'nodisplay'}
+    async function createAmpStoryShoppingConfig(
+      src = null,
+      config = defaultConfig
+    ) {
+      pageElement.appendChild(
+        <amp-story-shopping-config layout="nodisplay" src={src}>
+          <script type="application/json">{JSON.stringify(config)}</script>
+        </amp-story-shopping-config>
       );
-
-      element.innerHTML = `
-        <script type="application/json">
-          ${JSON.stringify(configData)}
-        </script>
-      `;
-
-      pageEl.appendChild(element);
-      win.document.body.appendChild(pageEl);
-
-      shoppingConfig = await element.getImpl();
+      return getShoppingConfig(pageElement);
     }
-
-    it('should build shopping config component', () => {
-      expect(() => shoppingConfig.layoutCallback()).to.not.throw();
-    });
 
     it('throws on no config', async () => {
       expectAsyncConsoleError(async () => {
-        expect(async () => {
-          await shoppingConfig.buildCallback();
-        }).to.throw(
-          /The amp-story-auto-ads:config should be inside a <script> tag with type=\"application\/json\"​​​/
-        );
+        expect(() => {
+          pageElement.appendChild(<amp-story-shopping-config />);
+          return getShoppingConfig(pageElement);
+        }).to.throw(/<script> tag with type=\"application\/json\"​​​/);
       });
     });
 
-    it('does use remote config when src attribute is provided', async () => {
+    it('does use inline config', async () => {
       const exampleURL = 'foo.example';
-      element.setAttribute('src', exampleURL);
+
+      const result = await createAmpStoryShoppingConfig(exampleURL);
 
       const expectedRemoteResult = JSON.parse(
         '{"art":{"productId": "art","productTitle": "Abstract Art","productBrand": "V. Artsy","productPrice": 1200.0,"productPriceCurrency": "JPY","productImages": ["https://source.unsplash.com/BdVQU-NDtA8/500x500"]}}'
       );
 
-      expect(storeService.get(StateProperty.SHOPPING_DATA)).to.deep.eql(
-        expectedRemoteResult
+      expect(result).to.deep.eql(expectedRemoteResult);
+
+      expect(
+        storeService.dispatch.withArgs(
+          Action.ADD_SHOPPING_DATA,
+          expectedRemoteResult
+        )
+      ).to.have.been.calledOnce;
+    });
+
+    it('does use remote config when src attribute is provided', async () => {
+      const exampleURL = 'foo.example';
+
+      const result = await createAmpStoryShoppingConfig(exampleURL);
+
+      const expectedRemoteResult = JSON.parse(
+        '{"city-pop":{"product-tag-id":"city-pop","product-title":"Plastic Love","product-price": 19, "product-price-currency": "JPY"}}'
       );
+
+      expect(result).to.deep.eql(expectedRemoteResult);
+
+      expect(
+        storeService.dispatch.withArgs(
+          Action.ADD_SHOPPING_DATA,
+          expectedRemoteResult
+        )
+      ).to.have.been.calledOnce;
     });
 
     it('does use inline config when remote src is invalid', async () => {
       const exampleURL = 'invalidRemoteURL';
-      element.setAttribute('src', exampleURL);
+      const inlineConfig = {items: [{'product-tag-id': 'foo'}]};
 
-      shoppingConfig.buildCallback().then(async () => {
-        expect(await shoppingConfig.getInlineConfig_).to.be.called();
-      });
+      const result = await createAmpStoryShoppingConfig(
+        exampleURL,
+        inlineConfig
+      );
+
+      expect(result).to.deep.eql({foo: {'product-tag-id': 'foo'}});
     });
 
-    it('Test Invalid Remote Config URL', async () => {
+    it('errors with invalid remote config URL', async () => {
       const exampleURL = 'invalidRemoteURL';
-      element.setAttribute('src', exampleURL);
       expectAsyncConsoleError(async () => {
-        expect(async () => {
-          await shoppingConfig.buildCallback();
-        }).to.throw(
-          /'amp-story-auto-ads:config error determining if remote config is valid json: bad url or bad json'​​​/
+        expect(() => createAmpStoryShoppingConfig(exampleURL)).to.throw(
+          /error determining if remote config is valid json: bad url or bad json/
         );
       });
-      expect(shoppingConfig.isLayoutSupported(Layout_Enum.NODISPLAY)).to.be
-        .true;
     });
   }
 );

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
@@ -23,10 +23,10 @@ describes.realWin(
     const defaultInlineConfig = {
       items: [
         {
-          'product-tag-id': 'city-pop',
-          'product-title': 'Plastic Love',
-          'product-price': 19,
-          'product-price-currency': 'JPY',
+          'productId': 'city-pop',
+          'productTitle': 'Plastic Love',
+          'productPrice': 19,
+          'productPriceCurrency': 'JPY',
         },
       ],
     };
@@ -72,12 +72,12 @@ describes.realWin(
         // matches remote.json
         {
           'art': {
-            'product-tag-id': 'art',
-            'product-title': 'Abstract Art',
-            'product-brand': 'V. Artsy',
-            'product-price': 1200.0,
-            'product-price-currency': 'JPY',
-            'product-images': [
+            'productId': 'art',
+            'productTitle': 'Abstract Art',
+            'productBrand': 'V. Artsy',
+            'productPrice': 1200.0,
+            'productPriceCurrency': 'JPY',
+            'productImages': [
               'https://source.unsplash.com/BdVQU-NDtA8/500x500',
             ],
           },

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
@@ -93,7 +93,6 @@ describes.realWin(
 
     describe('storeShoppingConfig', () => {
       let storeService;
-      let pageElement;
 
       beforeEach(async () => {
         storeService = {dispatch: env.sandbox.spy()};

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
@@ -2,7 +2,7 @@ import * as Preact from '#core/dom/jsx';
 
 import {Services} from '#service';
 
-import * as defaultConfig from '../../../../examples/amp-story/shopping/remote.json';
+import * as remoteConfig from '../../../../examples/amp-story/shopping/remote.json';
 import {Action} from '../../../amp-story/1.0/amp-story-store-service';
 import {
   getShoppingConfig,
@@ -20,6 +20,21 @@ describes.realWin(
   (env) => {
     let pageElement;
 
+    const defaultInlineConfig = {
+      items: [
+        {
+          'product-tag-id': 'city-pop',
+          'product-title': 'Plastic Love',
+          'product-price': 19,
+          'product-price-currency': 'JPY',
+        },
+      ],
+    };
+
+    const keyedDefaultInlineConfig = {
+      'city-pop': defaultInlineConfig.items[0],
+    };
+
     beforeEach(async () => {
       pageElement = <amp-story-page id="page1"></amp-story-page>;
       env.win.document.body.appendChild(pageElement);
@@ -27,7 +42,7 @@ describes.realWin(
 
     async function createAmpStoryShoppingConfig(
       src = null,
-      config = defaultConfig
+      config = defaultInlineConfig
     ) {
       pageElement.appendChild(
         <amp-story-shopping-config layout="nodisplay" src={src}>
@@ -47,48 +62,48 @@ describes.realWin(
     });
 
     it('does use inline config', async () => {
-      const exampleURL = 'foo.example';
-
-      const result = await createAmpStoryShoppingConfig(exampleURL);
-
-      const expectedRemoteResult = JSON.parse(
-        '{"art":{"productId": "art","productTitle": "Abstract Art","productBrand": "V. Artsy","productPrice": 1200.0,"productPriceCurrency": "JPY","productImages": ["https://source.unsplash.com/BdVQU-NDtA8/500x500"]}}'
-      );
-
-      expect(result).to.deep.eql(expectedRemoteResult);
+      const result = await createAmpStoryShoppingConfig();
+      expect(result).to.deep.eql(keyedDefaultInlineConfig);
     });
 
     it('does use remote config when src attribute is provided', async () => {
-      const exampleURL = 'foo.example';
-
-      const result = await createAmpStoryShoppingConfig(exampleURL);
-
-      const expectedRemoteResult = JSON.parse(
-        '{"city-pop":{"product-tag-id":"city-pop","product-title":"Plastic Love","product-price": 19, "product-price-currency": "JPY"}}'
-      );
-
+      const remoteUrl = 'https://foo.example';
+      const expectedRemoteResult =
+        // matches remote.json
+        {
+          'art': {
+            'product-tag-id': 'art',
+            'product-title': 'Abstract Art',
+            'product-brand': 'V. Artsy',
+            'product-price': 1200.0,
+            'product-price-currency': 'JPY',
+            'product-images': [
+              'https://source.unsplash.com/BdVQU-NDtA8/500x500',
+            ],
+          },
+        };
+      env.sandbox.stub(Services, 'xhrFor').returns({
+        fetchJson(url) {
+          if (url === remoteUrl) {
+            return Promise.resolve({
+              ok: true,
+              json: () => remoteConfig,
+            });
+          }
+        },
+      });
+      const result = await createAmpStoryShoppingConfig(remoteUrl);
       expect(result).to.deep.eql(expectedRemoteResult);
     });
 
     it('does use inline config when remote src is invalid', async () => {
-      const exampleURL = 'invalidRemoteURL';
-      const inlineConfig = {items: [{'product-tag-id': 'foo'}]};
-
-      const result = await createAmpStoryShoppingConfig(
-        exampleURL,
-        inlineConfig
-      );
-
-      expect(result).to.deep.eql({foo: {'product-tag-id': 'foo'}});
-    });
-
-    it('errors with invalid remote config URL', async () => {
-      const exampleURL = 'invalidRemoteURL';
-      expectAsyncConsoleError(async () => {
-        expect(() => createAmpStoryShoppingConfig(exampleURL)).to.throw(
-          /error determining if remote config is valid json: bad url or bad json/
-        );
+      env.sandbox.stub(Services, 'xhrFor').returns({
+        fetchJson() {
+          throw new Error();
+        },
       });
+      const result = await createAmpStoryShoppingConfig('invalidRemoteUrl');
+      expect(result).to.deep.eql(keyedDefaultInlineConfig);
     });
 
     describe('storeShoppingConfig', () => {


### PR DESCRIPTION
Custom elements are heavy. `<amp-story-shopping-config>` does not render, or hold any state, so it does not need to be a component.

Instead of registering a custom element, use a parser function instead. 

(Note that this retains API and all other behavior).