### PR TITLE
♿ [story-ads] Add aria-hidden for ad pages

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -301,6 +301,7 @@ export class StoryAdPage {
   createPageElement_() {
     const attributes = {
       'ad': '',
+      'aria-hidden': true,
       'distance': '2',
       'i-amphtml-loading': '',
       'id': this.id_,


### PR DESCRIPTION
So that they are not visible to screen readers until the ad itself is visible.

This works as expected with talkback, chromeOS & iOS. Voiceover appears to have a bug for mac only where it will read aloud the frame element even when `aria-hidden=true` is set on the parent `<amp-story-page>` element.