### PR TITLE
 🐛 Initialization onResize fix for the amp-story-store service

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -915,6 +915,18 @@ export class AmpStory extends AMP.BaseElement {
    * @private
    */
   layoutStory_() {
+    const needsDvhPolyfill =
+      !this.win.CSS?.supports?.('height: 1dvh') &&
+      !getStyle(this.win.document.documentElement, '--story-dvh');
+
+    const onResize = (size) => {
+      needsDvhPolyfill && this.polyfillDvh_(size);
+      this.onViewportResize_();
+    };
+
+    this.getViewport().onResize(onResize);
+
+    onResize(this.getViewport().getSize());
     const initialPageId = this.getInitialPageId_();
 
     this.buildSystemLayer_(initialPageId);


### PR DESCRIPTION
Fixes on-resize events to store the page width data for the amp-story-page store service on initialization.
Acts as an accompanying PR to #37195 and #37435