### PR TITLE
🐛 [amp-lightbox] Set deferredMount to false for amp-lightbox

### DIFF
--- a/examples/bento/lightbox-bind.html
+++ b/examples/bento/lightbox-bind.html
@@ -14,7 +14,7 @@
       body {
         padding: 20px;
       }
-      amp-lightbox { 
+      amp-lightbox {
         background: wheat;
         color: black;
       }
@@ -35,7 +35,7 @@
       </blockquote>
       <button type="button" on="tap:AMP.setState({state:{open:false}})">Nice!</button>
     </amp-lightbox>
-    
+
     <button on="tap:quote-2">See Words</button>
     <amp-lightbox id="quote-2" layout="nodisplay">
       <blockquote>
@@ -43,9 +43,5 @@
       </blockquote>
       <button on="tap:quote-2.close">Nice!</button>
     </amp-lightbox>
-
-
-
-
   </body>
 </html>

--- a/examples/bento/lightbox-bind.html
+++ b/examples/bento/lightbox-bind.html
@@ -1,0 +1,51 @@
+
+<!DOCTYPE html>
+<html ⚡>
+  <head>
+    <meta charset="utf-8" />
+    <title>My AMP Page</title>
+    <link rel="canonical" href="self.html" />
+    <meta name="viewport" content="width=device-width" />
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-lightbox" src="https://cdn.ampproject.org/v0/amp-lightbox-1.0.js"></script>
+    <script async custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"></script>
+    <style amp-custom>
+      body {
+        padding: 20px;
+      }
+      amp-lightbox { 
+        background: wheat;
+        color: black;
+      }
+    </style>
+    <script>(self.AMP = self.AMP || []).push(function (AMP) { AMP.toggleExperiment("bento", true); });</script>
+  </head>
+  <body>
+    <amp-state id="state">
+      <script type="application/json">
+      {"open": false}
+      </script>
+    </amp-state>
+
+    <button on="tap:AMP.setState({state:{open:true}})">See Quote</button>
+    <amp-lightbox id="quote-lb" layout="nodisplay" data-amp-bind-open="state.open">
+      <blockquote>
+        "Don't talk to me about JavaScript fatigue" - Horse JS
+      </blockquote>
+      <button type="button" on="tap:AMP.setState({state:{open:false}})">Nice!</button>
+    </amp-lightbox>
+    
+    <button on="tap:quote-2">See Words</button>
+    <amp-lightbox id="quote-2" layout="nodisplay">
+      <blockquote>
+        "Don't talk to me about JavaScript fatigue" - Horse JS
+      </blockquote>
+      <button on="tap:quote-2.close">Nice!</button>
+    </amp-lightbox>
+
+
+
+
+  </body>
+</html>

--- a/extensions/amp-lightbox/1.0/base-element.js
+++ b/extensions/amp-lightbox/1.0/base-element.js
@@ -8,6 +8,11 @@ import {BentoLightbox} from './component';
 import {CSS as COMPONENT_CSS} from './component.jss';
 
 export class BaseElement extends PreactBaseElement {
+  /** @override */
+  static deferredMount(unusedElement) {
+    return false;
+  }
+
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);

--- a/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
+++ b/extensions/amp-lightbox/1.0/test/test-amp-lightbox.js
@@ -3,6 +3,7 @@ import {
   ActionTrust_Enum,
   DEFAULT_ACTION,
 } from '#core/constants/action-constants';
+import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
 import {htmlFor} from '#core/dom/static-template';
 
 import {toggleExperiment} from '#experiments';
@@ -12,8 +13,6 @@ import {ActionInvocation} from '#service/action-impl';
 
 import {whenCalled} from '#testing/helpers/service';
 import {poll} from '#testing/iframe';
-import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
-import {macroTask} from '#testing/helpers';
 
 describes.realWin(
   'amp-lightbox:1.0',
@@ -26,7 +25,6 @@ describes.realWin(
     let win;
     let html;
     let element;
-    let container;
     let historyPopSpy;
     let historyPushSpy;
 
@@ -76,22 +74,32 @@ describes.realWin(
 
     it('should open when `open` attribute is present', async () => {
       const {shadowRoot} = element;
-      const firstElementChild = shadowRoot.firstElementChild;
+      const {firstElementChild} = shadowRoot;
       expect(firstElementChild.firstElementChild).to.be.null;
 
       element.setAttribute('open', '');
-      await poll('element open updated', () => {
-       return element.getAttribute('hidden') == null; 
-      }, undefined, 500);
+      await poll(
+        'element open updated',
+        () => {
+          return element.getAttribute('hidden') == null;
+        },
+        undefined,
+        500
+      );
 
       expect(firstElementChild.firstElementChild).to.not.be.null;
 
       element.removeAttribute('open');
 
-      await poll('element open updated', () => {
-       return element.getAttribute('hidden') != null; 
-      }, undefined, 500);
-      
+      await poll(
+        'element open updated',
+        () => {
+          return element.getAttribute('hidden') != null;
+        },
+        undefined,
+        500
+      );
+
       expect(firstElementChild.firstElementChild).to.be.null;
     });
 


### PR DESCRIPTION
Currently deferredMount is true for all bento components, because amp-lightbox does not display on load its mounting is deferred and the mutationObserver is never registered. 

This change fixes #37400. 
amp-bind fails to work here because the mutationObserver does not recognize the addition of the `open` attribute.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
