### PR TITLE
🏗 Add `rsimha` as a root-level owner of `amphtml`

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,6 +9,7 @@
         {name: 'cramforce', requestReviews: false},
         {name: 'dvoytenko', requestReviews: false},
         {name: 'jridgewell', requestReviews: false},
+        {name: 'rsimha', requestReviews: false},
       ],
     },
     {


### PR DESCRIPTION
With the departure of @kristoferbaxter, we discussed adding an additional root-level owner of `amphtml` in https://github.com/ampproject/amphtml/pull/37504#pullrequestreview-865249169 so that @jridgewell isn't the only active contributor available to provide owners approval for root-level changes (e.g. base infra changes, large refactors, etc.).

This PR adds @rsimha (me) as an additional owner. Note that targeted changes affecting inner directories will continue to require reviews from their current owners, and this change only affects large scale changes that could use a single owners approval.
