### PR TITLE
src/preact: use URL instead of parseUrlDeprecated

### DIFF
--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -104,7 +104,7 @@ function ProxyIframeEmbedWithRef(
     };
     setNameAndSrc({
       name: JSON.stringify({
-        'host': new URL(src, win.location).hostname,
+        'host': new URL(src, win.location.toString()).hostname,
         'bootstrap': getBootstrapUrl(type),
         'type': type,
         // "name" must be unique across iframes, so we add a count.

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -20,7 +20,6 @@ import {
   getBootstrapUrl,
   getDefaultBootstrapBaseUrl,
 } from '../../3p-frame';
-import {parseUrlDeprecated} from '../../url';
 
 /** @type {Object<string,function():void>} 3p frames for that type. */
 export const countGenerators = {};
@@ -105,7 +104,7 @@ function ProxyIframeEmbedWithRef(
     };
     setNameAndSrc({
       name: JSON.stringify({
-        'host': parseUrlDeprecated(src).hostname,
+        'host': new URL(src).hostname,
         'bootstrap': getBootstrapUrl(type),
         'type': type,
         // "name" must be unique across iframes, so we add a count.

--- a/src/preact/component/3p-frame.js
+++ b/src/preact/component/3p-frame.js
@@ -104,7 +104,7 @@ function ProxyIframeEmbedWithRef(
     };
     setNameAndSrc({
       name: JSON.stringify({
-        'host': new URL(src).hostname,
+        'host': new URL(src, win.location).hostname,
         'bootstrap': getBootstrapUrl(type),
         'type': type,
         // "name" must be unique across iframes, so we add a count.


### PR DESCRIPTION
**summary**
We should not use the deprecated path in new code.
This breaks IE11 compat.


**bundle size diff**
```
extensions/amp-mathml/1.0/dist/component-react.js: Δ -0.41KB
dist/v0/bento-mathml-1.0.js: Δ -0.40KB
extensions/amp-embedly-card/1.0/dist/component-react.js: Δ -0.41KB
dist/v0/bento-embedly-card-1.0.js: Δ -0.40KB
extensions/amp-embedly-card/1.0/dist/component-preact.js: Δ -0.42KB
extensions/amp-twitter/1.0/dist/component-preact.js: Δ -0.40KB
extensions/amp-facebook/1.0/dist/component-react.js: Δ -0.42KB
extensions/amp-facebook/1.0/dist/component-preact.js: Δ -0.43KB
extensions/amp-mathml/1.0/dist/web-component.js: Δ -0.39KB
extensions/amp-embedly-card/1.0/dist/web-component.js: Δ -0.39KB
extensions/amp-twitter/1.0/dist/web-component.js: Δ -0.41KB
dist/v0/amp-twitter-1.0.mjs: Δ +0.02KB
extensions/amp-facebook/1.0/dist/web-component.js: Δ -0.37KB
dist/v0/amp-embedly-card-1.0.js: Δ -0.45KB
```

**notifications**
@ampproject/wg-bento 