### PR TITLE
🏗 Use locally built validator during `amp validate-html-fixtures`

### DIFF
--- a/build-system/pr-check/checks.js
+++ b/build-system/pr-check/checks.js
@@ -16,7 +16,6 @@ const jobName = 'checks.js';
 function pushBuildWorkflow() {
   timedExecOrDie('amp presubmit');
   timedExecOrDie('amp check-invalid-whitespaces');
-  timedExecOrDie('amp validate-html-fixtures');
   timedExecOrDie('amp lint');
   timedExecOrDie('amp prettify');
   timedExecOrDie('amp check-json-schemas');
@@ -53,10 +52,6 @@ function prBuildWorkflow() {
 
   if (buildTargetsInclude(Targets.IGNORE_LIST)) {
     timedExecOrDie(`amp check-ignore-lists`);
-  }
-
-  if (buildTargetsInclude(Targets.HTML_FIXTURES)) {
-    timedExecOrDie('amp validate-html-fixtures');
   }
 
   if (buildTargetsInclude(Targets.LINT_RULES)) {

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -43,11 +43,17 @@ function prBuildWorkflow() {
     timedExecOrDie('amp validator-webui');
   }
 
-  if (buildTargetsInclude(Targets.RUNTIME, Targets.VALIDATOR)) {
+  if (
+    buildTargetsInclude(
+      Targets.HTML_FIXTURES,
+      Targets.RUNTIME,
+      Targets.VALIDATOR
+    )
+  ) {
     timedExecOrDie('amp validator');
   }
 
-  if (buildTargetsInclude(Targets.HTML_FIXTURES, Targets.VALIDATOR)) {
+  if (buildTargetsInclude(Targets.VALIDATOR)) {
     timedExecOrDie('amp validator-cpp');
   }
 

--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -17,6 +17,7 @@ function pushBuildWorkflow() {
   timedExecOrDie('amp validator-webui');
   timedExecOrDie('amp validator');
   timedExecOrDie('amp validator-cpp');
+  timedExecOrDie('amp validate-html-fixtures');
 }
 
 /**
@@ -25,6 +26,7 @@ function pushBuildWorkflow() {
 function prBuildWorkflow() {
   if (
     !buildTargetsInclude(
+      Targets.HTML_FIXTURES,
       Targets.RUNTIME,
       Targets.VALIDATOR,
       Targets.VALIDATOR_WEBUI
@@ -32,7 +34,7 @@ function prBuildWorkflow() {
   ) {
     skipDependentJobs(
       jobName,
-      'this PR does not affect the runtime, validator, or validator web UI'
+      'this PR does not affect the runtime, HTML fixtures, validator, or validator web UI'
     );
     return;
   }
@@ -45,8 +47,12 @@ function prBuildWorkflow() {
     timedExecOrDie('amp validator');
   }
 
-  if (buildTargetsInclude(Targets.VALIDATOR)) {
+  if (buildTargetsInclude(Targets.HTML_FIXTURES, Targets.VALIDATOR)) {
     timedExecOrDie('amp validator-cpp');
+  }
+
+  if (buildTargetsInclude(Targets.HTML_FIXTURES)) {
+    timedExecOrDie('amp validate-html-fixtures');
   }
 }
 

--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -12,7 +12,7 @@ const {cyan, green, red} = require('kleur/colors');
 const {getFilesToCheck} = require('../common/utils');
 const {getOutput} = require('../common/process');
 const {htmlFixtureGlobs} = require('../test-configs/config');
-const {readFile} = require('fs-extra');
+const {pathExists, readFile} = require('fs-extra');
 
 const defaultFormat = 'AMP';
 
@@ -73,12 +73,34 @@ async function getFileGroups(filesToCheck) {
 }
 
 /**
+ * Checks for the existence of a local wasm / js validator binary and returns
+ * its location. Defaults to the wasm binary on the CDN.
+ * @return {Promise<string>}
+ */
+async function getValidatorJs() {
+  const localWasmValidatorPath =
+    'validator/bazel-bin/cpp/engine/wasm/validator_js_bin.js';
+  const localJsValidatorPath = 'validator/dist/validator_minified.js';
+  if (await pathExists(localWasmValidatorPath)) {
+    log('Using the', cyan('locally built wasm validator') + '...');
+    return localWasmValidatorPath;
+  }
+  if (await pathExists(localJsValidatorPath)) {
+    log('Using the', cyan('locally built js validator') + '...');
+    return localJsValidatorPath;
+  }
+  log('Using the', cyan('wasm validator from the CDN') + '...');
+  return 'https://cdn.ampproject.org/v0/validator_wasm.js'; // eslint-disable-line local/no-forbidden-terms
+}
+
+/**
  * Runs amphtml-validator on the given list of files and prints results.
  *
  * @param {Array<string>} filesToCheck
  * @return {Promise<void>}
  */
 async function runCheck(filesToCheck) {
+  const validatorJs = await getValidatorJs();
   const fileGroups = await getFileGroups(filesToCheck);
   const formats = Object.keys(fileGroups);
   let foundValidationErrors = false;
@@ -88,7 +110,10 @@ async function runCheck(filesToCheck) {
     }
     const files = fileGroups[format].sort().join(' ');
     logLocalDev(green('Validating'), cyan(format), green('fixtures...'));
-    const validateFixturesCmd = `FORCE_COLOR=1 npx amphtml-validator --html_format ${format} ${files}`;
+    const validatorCmd = 'FORCE_COLOR=1 npx amphtml-validator';
+    const validatorJsArg = `--validator_js ${validatorJs}`;
+    const htmlFormatArg = `--html_format ${format}`;
+    const validateFixturesCmd = `${validatorCmd} ${validatorJsArg} ${htmlFormatArg} ${files}`;
     const result = getOutput(validateFixturesCmd);
     logWithoutTimestampLocalDev(result.stdout);
     if (result.stderr) {

--- a/build-system/tasks/validate-html-fixtures.js
+++ b/build-system/tasks/validate-html-fixtures.js
@@ -90,6 +90,11 @@ async function getValidatorJs() {
     return localJsValidatorPath;
   }
   log('Using the', cyan('wasm validator from the CDN') + '...');
+  logLocalDev(
+    '⤷ To use a locally built wasm or js validator,',
+    'run the build command from',
+    cyan('validator/README.md') + '.'
+  );
   return 'https://cdn.ampproject.org/v0/validator_wasm.js'; // eslint-disable-line local/no-forbidden-terms
 }
 

--- a/build-system/test-configs/config.js
+++ b/build-system/test-configs/config.js
@@ -276,6 +276,7 @@ const htmlFixtureGlobs = [
   '!examples/amp-subscriptions-google/amp-subscriptions.amp.html',
   '!examples/amp-subscriptions-rtp.amp.html',
   '!examples/amp-tiktok.amp.html',
+  '!examples/amp-toggle-theme.html',
   '!examples/ampcontext-creative-json.html',
   '!examples/ampcontext-creative.html',
   '!examples/amphtml-ads/adchoices-1.a4a.html',


### PR DESCRIPTION
Adding new validation rules while also adding new AMP code could result in a mismatch with the existing rules in the `amphtml-validator` npm pacakge, and lead to developer friction similar to https://github.com/ampproject/amphtml/pull/37414#discussion_r791078244.

This PR updates the `amp validate-html-fixtures` task to attempt to use the locally built wasm / js validator, failing which it will default to the wasm validator from the CDN.

Right now, this will result in CI checks using the locally built js validator. When the wasm validator is added to our CI workflow in future, the task will start using it.

Fixes #37467
