### PR TITLE
🖍️ [amp story page attachment] Box shadow on header

### DIFF
--- a/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer-header.css
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer-header.css
@@ -15,7 +15,7 @@
   z-index: 1 !important;
   --i-amphtml-draggable-drawer-background-color: #fff !important;
   --i-amphtml-draggable-drawer-text-color: #202125 !important;
-  --i-amphtml-draggable-drawer-handle-color: rgba(0, 0, 0, .2) !important;
+  --i-amphtml-draggable-drawer-header-twenty-percent-gray: rgba(0, 0, 0, .2) !important;
   --i-amphtml-draggable-drawer-header-font-family: 'Roboto', sans-serif !important;
   --i-amphtml-draggable-drawer-header-font-size: 18px !important;
   --i-amphtml-draggable-drawer-header-title-height: 44px !important;
@@ -34,14 +34,14 @@
   top: 8px !important;
   width: 40px !important;
   height: 3px !important;
-  background-color: var(--i-amphtml-draggable-drawer-handle-color) !important;
+  background-color: var(--i-amphtml-draggable-drawer-header-twenty-percent-gray) !important;
   border-radius: 3px !important;
 }
 
 [theme="dark"].i-amphtml-story-draggable-drawer-header {
   --i-amphtml-draggable-drawer-background-color: #202125 !important;
   --i-amphtml-draggable-drawer-text-color: #fff !important;
-  --i-amphtml-draggable-drawer-handle-color: rgba(255, 255, 255, .2) !important;
+  --i-amphtml-draggable-drawer-header-twenty-percent-gray: rgba(255, 255, 255, .2) !important;
 }
 
 :not([desktop]).i-amphtml-story-draggable-drawer-header {
@@ -93,6 +93,7 @@
   justify-content: center !important;
   background: var(--i-amphtml-draggable-drawer-background-color) !important;
   border-radius: inherit !important;
+  box-shadow: 0px 0px 1px var(--i-amphtml-draggable-drawer-header-twenty-percent-gray) !important;
 }
 
 :not([desktop]).i-amphtml-story-draggable-drawer-header .i-amphtml-story-draggable-drawer-header-title-and-close {


### PR DESCRIPTION
A thin drop shadow was intended to be added to the header as part of the header UI updates.
It was just noticed in the shopping UI design files and confirmed to be in the original UI update design file.

This PR 
- Adds the drop shadow.
- Renames the color variable so it makes sense used in additional places.

<img width="647" alt="Screen Shot 2022-02-04 at 9 55 58 AM" src="https://user-images.githubusercontent.com/3860311/152560471-409eb9bf-883d-4111-9f56-f07e3bb89a7c.png">
 