### PR TITLE
🏗 Simplify bundle resolution under `src/bento/components`

### DIFF
--- a/build-system/compile/bundles.config.bento.json
+++ b/build-system/compile/bundles.config.bento.json
@@ -2,16 +2,11 @@
   {
     "name": "bento-accordion",
     "version": "1.0",
-    "options": {
-      "hasCss": true,
-      "npm": true
-    }
+    "npm": true
   },
   {
     "name": "bento-jwplayer",
     "version": "1.0",
-    "options": {
-      "hasCss": true
-    }
+    "npm": true
   }
 ]

--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -2,95 +2,71 @@ const argv = require('minimist')(process.argv.slice(2));
 const debounce = require('../common/debounce');
 const {
   buildBentoExtensionJs,
-  buildBinaries,
   buildExtensionCss,
   buildNpmBinaries,
   buildNpmCss,
-  declareExtension,
-  getExtensionsFromArg,
 } = require('./extension-helpers');
-const {bentoBundles, verifyBentoBundles} = require('../compile/bundles.config');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {log} = require('../common/logging');
-const {mkdirSync} = require('fs');
 const {red} = require('kleur/colors');
 const {watch} = require('chokidar');
+const {once} = require('../common/once');
+const {bentoBundles, verifyBentoBundles} = require('../compile/bundles.config');
 
-// All declared components.
-const COMPONENTS = {};
+const bentoComponentsDir = 'src/bento/components';
+
+const getComponentDir = (name, version) =>
+  `${bentoComponentsDir}/${name}/${version}`;
 
 /**
- * Initializes all components from build-system/compile/bundles.config.bento.json
- * if not already done and populates the given components object.
- * @param {Object} componentsObject
+ * @type {{
+ *   name: string,
+ *   version: string,
+ *   npm: ?boolean,
+ * }}
  */
-function maybeInitializeBentoComponents(componentsObject) {
-  if (Object.keys(componentsObject).length > 0) {
-    return;
-  }
+let BentoBundleDef;
+
+/** @return {BentoBundleDef[]} */
+const getBentoComponentsToBuild = once(() => {
   verifyBentoBundles();
-  bentoBundles.forEach((c) => {
-    declareExtension(c.name, c.version, c.options, componentsObject);
-  });
-}
-
-/**
- * Process the command line arguments --noextensions, --components, and
- * --extensions_from and return a list of the referenced components.
- *
- * @param {boolean} preBuild Used for lazy building of components.
- * @return {!Array<string>}
- */
-function getBentoComponentsToBuild(preBuild = false) {
-  const componentsToBuild = new Set();
-  if (argv.extensions) {
-    if (typeof argv.extensions !== 'string') {
-      log(red('ERROR:'), 'Missing list of components.');
+  if (argv.noextensions) {
+    return [];
+  }
+  // TODO(alanorozco): preBuild
+  const {extensions} = argv;
+  if (extensions) {
+    if (typeof extensions !== 'string') {
+      log(red('ERROR:'), '--extensions must be a comma-separated list');
       process.exit(1);
     }
-    const explicitComponents = argv.extensions.replace(/\s/g, '').split(',');
-    explicitComponents.forEach((component) => componentsToBuild.add(component));
-  }
-  if (argv.extensions_from) {
-    const componentsFrom = getExtensionsFromArg(argv.extensions_from);
-    componentsFrom.forEach((component) => componentsToBuild.add(component));
+    const names = new Set(extensions.split(','));
+    return bentoBundles.filter(({name}) => names.has(name));
   }
   if (
-    !preBuild &&
-    !argv.noextensions &&
-    !argv.extensions &&
-    !argv.extensions_from &&
-    !argv.core_runtime_only
+    argv.extensions_from ||
+    argv.bento_runtime_only ||
+    argv.core_runtime_only
   ) {
-    const allComponents = Object.values(COMPONENTS).map((c) => c.name);
-    allComponents.forEach((component) => componentsToBuild.add(component));
+    return [];
   }
-  return Array.from(componentsToBuild);
-}
+  return bentoBundles;
+});
 
 /**
  * Watches for non-JS changes within an components directory to trigger
  * recompilation.
  *
- * @param {string} componentsDir
- * @param {string} name
- * @param {string} version
- * @param {boolean} hasCss
- * @param {?Object} options
+ * @param {BentoBundleDef} component
+ * @param {Object} options
  * @return {Promise<void>}
  */
-async function watchBentoComponent(
-  componentsDir,
-  name,
-  version,
-  hasCss,
-  options
-) {
+async function watchBentoComponent(component, options) {
   /**
    * Steps to run when a watched file is modified.
    */
   function watchFunc() {
-    buildBentoComponent(name, version, hasCss, {
+    buildBentoComponent(component, {
       ...options,
       continueOnError: true,
       isRebuild: true,
@@ -98,7 +74,8 @@ async function watchBentoComponent(
     });
   }
 
-  const cssDeps = `${componentsDir}/**/*.css`;
+  const dir = getComponentDir(component.name, component.version);
+  const cssDeps = `${dir}/**/*.css`;
   const ignored = /dist/; //should not watch npm dist folders.
   watch([cssDeps], {ignored}).on(
     'change',
@@ -116,46 +93,29 @@ async function watchBentoComponent(
  * a generated JS file that can be required from the components as
  * `import {CSS} from '../../../build/$name-0.1.css';`
  *
- * @param {string} name Name of the extension. Must be the sub directory in
- *     the components directory and the name of the JS and optional CSS file.
- * @param {string} version Version of the extension. Must be identical to
- *     the sub directory inside the extension directory
- * @param {boolean} hasCss Whether there is a CSS file for this extension.
- * @param {?Object} options
- * @return {!Promise<void|void[]>}
+ * @param {BentoBundleDef} bundle
+ * @param {?Object=} options
+ * @return {!Promise<void>}
  */
-async function buildBentoComponent(name, version, hasCss, options = {}) {
-  options.npm = true;
-  options.bento = true;
-
-  if (options.compileOnlyCss && !hasCss) {
-    return;
-  }
-  const componentsDir = `src/bento/components/${name}/${version}`;
+async function buildBentoComponent(bundle, options = {}) {
+  const {name, npm, version} = bundle;
   if (options.watch) {
-    await watchBentoComponent(componentsDir, name, version, hasCss, options);
+    await watchBentoComponent(bundle, options);
   }
-
-  /** @type {Promise<void>[]} */
+  const dir = `${bentoComponentsDir}/${name}/${version}`;
   const promises = [];
-  if (hasCss) {
-    mkdirSync('build/css', {recursive: true});
-    promises.push(buildExtensionCss(componentsDir, name, version, options));
-    if (options.compileOnlyCss) {
-      return Promise.all(promises);
+  promises.push(buildExtensionCss(dir, name, version, options));
+  if (!options.compileOnlyCss) {
+    if (npm) {
+      // TODO(alanorozco): Change buildNpmBinaries to not require options.npm
+      promises.push(buildNpmBinaries(dir, name, {...options, npm}));
+      promises.push(buildNpmCss(dir, options));
+    }
+    if (!options.isRebuild) {
+      promises.push(buildBentoExtensionJs(dir, name, options));
     }
   }
-  promises.push(buildNpmBinaries(componentsDir, name, options));
-  promises.push(buildNpmCss(componentsDir, options));
-  if (options.binaries) {
-    promises.push(buildBinaries(componentsDir, options.binaries, options));
-  }
-  if (options.isRebuild) {
-    return Promise.all(promises);
-  }
-
-  promises.push(buildBentoExtensionJs(componentsDir, name, options));
-  return Promise.all(promises);
+  await Promise.all(promises);
 }
 
 /**
@@ -166,20 +126,10 @@ async function buildBentoComponent(name, version, hasCss, options = {}) {
  */
 async function buildBentoComponents(options) {
   const startTime = Date.now();
-  maybeInitializeBentoComponents(COMPONENTS);
-  const toBuild = getBentoComponentsToBuild();
-  const results = Object.values(COMPONENTS)
-    .filter(
-      (component) => options.compileOnlyCss || toBuild.includes(component.name)
-    )
-    .map((component) =>
-      buildBentoComponent(component.name, component.version, component.hasCss, {
-        ...options,
-        ...component,
-      })
-    );
-
-  await Promise.all(results);
+  const bundles = getBentoComponentsToBuild();
+  const results = await Promise.all(
+    bundles.map((bundle) => buildBentoComponent(bundle, options))
+  );
   if (!options.compileOnlyCss && results.length > 0) {
     endBuildStep(
       options.minify ? 'Minified all' : 'Compiled all',
@@ -191,7 +141,6 @@ async function buildBentoComponents(options) {
 
 module.exports = {
   buildBentoComponents,
-  buildComponent: buildBentoComponent,
+  buildBentoComponent,
   getBentoComponentsToBuild,
-  maybeInitializeBentoComponents,
 };

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -574,6 +574,9 @@ async function buildExtensionCss(extDir, name, version, options) {
       const css = await jsifyCssAsync(filename);
       await writeCssBinaries(name, versions, css);
 
+      // TODO(wg-infra): This option is only required on components not yet
+      // moved from extensions/. Once all are moved into src/bento/components,
+      // this can be removed.
       if (options.bento) {
         await buildBentoCss(name, versions, css);
       }


### PR DESCRIPTION
- Derives bundle list from file structure. This allows us to remove `bundles.config.bento.json`. If the directory exists, it's a component bundle. Release can be configured in each component directory's own `npm.json`.

- Simplifies bundle resolution logic. Removes options and bundle structures that are AMP-only.