### PR TITLE
🏗🐛 Add `src/bento/components` to Storybook React paths

### DIFF
--- a/build-system/tasks/storybook/env/react/main.js
+++ b/build-system/tasks/storybook/env/react/main.js
@@ -3,8 +3,12 @@ const rootDir = '../../../../..';
 module.exports = {
   staticDirs: [rootDir],
   // Unlike the `amp` and `preact` environments, we search Storybook files only
-  // under extensions/. This is because only extensions have React build output.
-  stories: [`${rootDir}/extensions/**/*.*/storybook/!(*.amp).js`],
+  // under component paths. This is because only components have React build
+  // output, but directories in src/ outside src/bento do not.
+  stories: [
+    `${rootDir}/extensions/**/*.*/storybook/!(*.amp).js`,
+    `${rootDir}/src/bento/components/**/*.*/storybook/*.js`,
+  ],
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-viewport/register',

--- a/build-system/tasks/storybook/env/react/main.js
+++ b/build-system/tasks/storybook/env/react/main.js
@@ -4,7 +4,7 @@ module.exports = {
   staticDirs: [rootDir],
   // Unlike the `amp` and `preact` environments, we search Storybook files only
   // under component paths. This is because only components have React build
-  // output, but directories in src/ outside src/bento do not.
+  // output, but directories in src/ outside src/bento/components/ do not.
   stories: [
     `${rootDir}/extensions/**/*.*/storybook/!(*.amp).js`,
     `${rootDir}/src/bento/components/**/*.*/storybook/*.js`,


### PR DESCRIPTION
React Storybook references `extensions/` only. It should have an equivalent glob pattern under `src/bento/components`