### PR TITLE
R1: schedule amp-bind targets

### DIFF
--- a/src/custom-element.js
+++ b/src/custom-element.js
@@ -1800,6 +1800,11 @@ function createBaseCustomElementClass(win, elementConnectedCallback) {
     mutatedAttributesCallback(mutations) {
       if (this.impl_) {
         this.impl_.mutatedAttributesCallback(mutations);
+      } else if (this.R1()) {
+        // If amp-bind is trying to mutate an uninitialized BaseElement, it is probably about time
+        // to initialize it.
+        const scheduler = getSchedulerForDoc(this);
+        scheduler.scheduleAsap(this);
       }
     }
 

--- a/test/unit/test-custom-element-v1.js
+++ b/test/unit/test-custom-element-v1.js
@@ -625,6 +625,14 @@ describes.realWin('CustomElement V1', {amp: true}, (env) => {
       await element.buildInternal();
       await promise;
     });
+
+    it('should build if amp-bind mutation', async () => {
+      const element = new ElementClass();
+      builderMock.expects('scheduleAsap').withExactArgs(element).once();
+
+      doc.body.appendChild(element);
+      element.mutatedAttributesCallback({});
+    });
   });
 
   describe('mount/unmount', () => {


### PR DESCRIPTION
**summary**
Schedules an element to be laid out if it is the target of an amp-bind mutation.

Fixes https://github.com/ampproject/amphtml/issues/37400
