### PR TITLE
dependencies: bump bento-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ampproject/animations": "0.2.2",
-        "@ampproject/bento-compiler": "0.0.12",
+        "@ampproject/bento-compiler": "0.0.13",
         "@ampproject/toolbox-cache-url": "2.8.0",
         "@ampproject/viewer-messaging": "1.1.2",
         "@ampproject/worker-dom": "0.32.1",
@@ -186,9 +186,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ampproject/bento-compiler": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.12.tgz",
-      "integrity": "sha512-9cMESvUspEIMn+Vc9ZZaeoEUgh+m3TlfdWH2AZlk5G9iVZjbXj+JBrhX1IXVe2I45sdq6J7P1XkdQhZMWv6Hgg==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.13.tgz",
+      "integrity": "sha512-XVPQxyEYJwHaZw+apNt+iIMkbwfDlkLfgR0f8pg0Uu7i6l+KRa/8Sr1K7JMo6rT33v3sru2beag2XWg0yF1rtQ==",
       "dependencies": {
         "@ampproject/worker-dom": "0.32.1"
       }
@@ -23076,9 +23076,9 @@
       "version": "0.2.2"
     },
     "@ampproject/bento-compiler": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.12.tgz",
-      "integrity": "sha512-9cMESvUspEIMn+Vc9ZZaeoEUgh+m3TlfdWH2AZlk5G9iVZjbXj+JBrhX1IXVe2I45sdq6J7P1XkdQhZMWv6Hgg==",
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/@ampproject/bento-compiler/-/bento-compiler-0.0.13.tgz",
+      "integrity": "sha512-XVPQxyEYJwHaZw+apNt+iIMkbwfDlkLfgR0f8pg0Uu7i6l+KRa/8Sr1K7JMo6rT33v3sru2beag2XWg0yF1rtQ==",
       "requires": {
         "@ampproject/worker-dom": "0.32.1"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@ampproject/animations": "0.2.2",
-    "@ampproject/bento-compiler": "0.0.12",
+    "@ampproject/bento-compiler": "0.0.13",
     "@ampproject/toolbox-cache-url": "2.8.0",
     "@ampproject/viewer-messaging": "1.1.2",
     "@ampproject/worker-dom": "0.32.1",

--- a/test/unit/compiler/test-compile.js
+++ b/test/unit/compiler/test-compile.js
@@ -28,8 +28,8 @@ describes.sandboxed('compile', {}, () => {
 
   it('should return compiled nodes', () => {
     const nodes = [
-      {tagid: 1, value: 'a', children: [], attributes: []},
-      {tagid: 7, value: 'b', children: [], attributes: []},
+      {tagid: 1, value: 'a'},
+      {tagid: 7, value: 'b'},
     ];
 
     // eslint-disable-next-line local/camelcase


### PR DESCRIPTION
Incorporates important fixes for boolean attributes: https://github.com/ampproject/bento-compiler/pull/40

/to @rcebulko 

Unsure why renovate didn't jump on this.
CP Incoming right afterwards.