### PR TITLE
Remove @nocollapse annotation which was closure-specific.

### DIFF
--- a/extensions/amp-accordion/0.1/amp-accordion.js
+++ b/extensions/amp-accordion/0.1/amp-accordion.js
@@ -29,7 +29,7 @@ const EXPAND_CURVE_ = bezierCurve(0.47, 0, 0.745, 0.715);
 const COLLAPSE_CURVE_ = bezierCurve(0.39, 0.575, 0.565, 1);
 
 class AmpAccordion extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-base-carousel/0.1/amp-base-carousel.js
+++ b/extensions/amp-base-carousel/0.1/amp-base-carousel.js
@@ -45,7 +45,7 @@ function isSizer(el) {
 }
 
 export class AmpCarousel extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-brightcove/1.0/amp-brightcove.js
+++ b/extensions/amp-brightcove/1.0/amp-brightcove.js
@@ -20,7 +20,7 @@ import {AmpVideoBaseElement} from '../../amp-video/1.0/video-base-element';
 const TAG = 'amp-brightcove';
 
 class AmpBrightcove extends setSuperClass(BaseElement, AmpVideoBaseElement) {
-  /** @override @nocollapse */
+  /** @override  */
   static getPreconnects() {
     return ['https://players.brightcove.net'];
   }

--- a/extensions/amp-carousel/0.2/amp-carousel.js
+++ b/extensions/amp-carousel/0.2/amp-carousel.js
@@ -30,7 +30,7 @@ const CarouselType = {
 };
 
 class AmpCarousel extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-experiment/0.1/amp-experiment.js
+++ b/extensions/amp-experiment/0.1/amp-experiment.js
@@ -11,7 +11,7 @@ const TAG = 'amp-experiment';
 const ATTR_PREFIX = 'amp-x-';
 
 export class AmpExperiment extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     /*
      * Prerender is allowed because the client_id is only used to calculate

--- a/extensions/amp-experiment/1.0/amp-experiment.js
+++ b/extensions/amp-experiment/1.0/amp-experiment.js
@@ -19,7 +19,7 @@ import {getServicePromiseForDoc} from '../../../src/service-helpers';
 const TAG = 'amp-experiment';
 
 export class AmpExperiment extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     /*
      * Prerender is allowed because the client_id is only used to calculate

--- a/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
+++ b/extensions/amp-facebook-comments/0.1/amp-facebook-comments.js
@@ -15,7 +15,7 @@ import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 const TYPE = 'facebook';
 
 class AmpFacebookComments extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     return createLoaderLogo(element);
   }

--- a/extensions/amp-facebook-page/0.1/amp-facebook-page.js
+++ b/extensions/amp-facebook-page/0.1/amp-facebook-page.js
@@ -15,7 +15,7 @@ import {createLoaderLogo} from '../../amp-facebook/0.1/facebook-loader';
 const TYPE = 'facebook';
 
 class AmpFacebookPage extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     return createLoaderLogo(element);
   }

--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -18,7 +18,7 @@ import {getMode} from '../../../src/mode';
 const TYPE = 'facebook';
 
 class AmpFacebook extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     return createLoaderLogo(element);
   }

--- a/extensions/amp-facebook/1.0/amp-facebook.js
+++ b/extensions/amp-facebook/1.0/amp-facebook.js
@@ -24,12 +24,12 @@ const PAGE_TAG = 'amp-facebook-page';
 const TYPE = 'facebook';
 
 class AmpFacebookBase extends setSuperClass(BaseElement, AmpPreactBaseElement) {
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     return createLoaderLogo(element);
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static getPreconnects(element) {
     const ampdoc = element.getAmpDoc();
     const {win} = ampdoc;

--- a/extensions/amp-fit-text/0.1/amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/amp-fit-text.js
@@ -10,7 +10,7 @@ const TAG = 'amp-fit-text';
 const LINE_HEIGHT_EM_ = 1.15; // WARNING: when updating this ensure you also update the css values for line-height.
 const RESIZE_THROTTLE_MS = 100;
 export class AmpFitText extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-font/0.1/amp-font.js
+++ b/extensions/amp-font/0.1/amp-font.js
@@ -56,7 +56,7 @@ const DEFAULT_SIZE_ = 'medium';
 const CACHED_FONT_LOAD_TIME_ = 100;
 
 export class AmpFont extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-geo/0.1/amp-geo.js
+++ b/extensions/amp-geo/0.1/amp-geo.js
@@ -88,7 +88,7 @@ const mode = {
 export let GeoDef;
 
 export class AmpGeo extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.js
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery-pagination.js
@@ -30,7 +30,7 @@ export function exponentialFalloff(percentage, power) {
 }
 
 export class AmpInlineGalleryPagination extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery-thumbnails.js
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery-thumbnails.js
@@ -25,7 +25,7 @@ import {CarouselEvents} from '../../amp-base-carousel/0.1/carousel-events';
  * the next arrow works properly for that case.
  */
 export class AmpInlineGalleryThumbnails extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-inline-gallery/0.1/amp-inline-gallery.js
+++ b/extensions/amp-inline-gallery/0.1/amp-inline-gallery.js
@@ -37,7 +37,7 @@ const CAROUSEL_SELECTOR =
   '> amp-base-carousel, :not(amp-inline-gallery-thumbnails) > amp-base-carousel';
 
 class AmpInlineGallery extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-mathml/1.0/amp-mathml.js
+++ b/extensions/amp-mathml/1.0/amp-mathml.js
@@ -14,7 +14,7 @@ import {getBootstrapBaseUrl, getBootstrapUrl} from '../../../src/3p-frame';
 const TAG = 'amp-mathml';
 
 class AmpMathml extends setSuperClass(BaseElement, AmpPreactBaseElement) {
-  /** @override @nocollapse */
+  /** @override  */
   static getPreconnects(element) {
     const ampdoc = element.getAmpDoc();
     const {win} = ampdoc;

--- a/extensions/amp-mega-menu/0.1/amp-mega-menu.js
+++ b/extensions/amp-mega-menu/0.1/amp-mega-menu.js
@@ -30,7 +30,7 @@ const ARIA_LABEL_CLOSE = 'Close the menu';
  * template rendering via dynamically fetched data.
  */
 export class AmpMegaMenu extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-nested-menu/0.1/amp-nested-menu.js
+++ b/extensions/amp-nested-menu/0.1/amp-nested-menu.js
@@ -26,7 +26,7 @@ const Side = {
 const ANIMATION_TIMEOUT = 350;
 
 export class AmpNestedMenu extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-pinterest/0.1/amp-pinterest.js
+++ b/extensions/amp-pinterest/0.1/amp-pinterest.js
@@ -54,7 +54,7 @@ import {CSS} from '../../../build/amp-pinterest-0.1.css';
  *    - buttonFollow: User follow button
  */
 class AmpPinterest extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     const type = element.getAttribute('data-do');
     if (type != 'embedPin') {

--- a/extensions/amp-selector/0.1/amp-selector.js
+++ b/extensions/amp-selector/0.1/amp-selector.js
@@ -28,7 +28,7 @@ const KEYBOARD_SELECT_MODES = {
 };
 
 export class AmpSelector extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-sidebar/0.2/amp-sidebar.js
+++ b/extensions/amp-sidebar/0.2/amp-sidebar.js
@@ -65,7 +65,7 @@ const SidebarEvents = {
  * @extends {AMP.BaseElement}
  */
 export class AmpSidebar extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-social-share/0.1/amp-social-share.js
+++ b/extensions/amp-social-share/0.1/amp-social-share.js
@@ -16,7 +16,7 @@ import {addParamsToUrl} from '../../../src/url';
 const TAG = 'amp-social-share';
 
 class AmpSocialShare extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-debug.js
+++ b/extensions/amp-story-dev-tools/0.1/amp-story-dev-tools-tab-debug.js
@@ -68,7 +68,7 @@ const buildLogMessageTemplate = (element) => {
 };
 
 export class AmpStoryDevToolsTabDebug extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return false;
   }

--- a/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
@@ -60,7 +60,7 @@ const renderHeaderElement = () => {
  * @abstract
  */
 export class DraggableDrawer extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return false;
   }

--- a/extensions/amp-story-player/0.1/amp-story-player.js
+++ b/extensions/amp-story-player/0.1/amp-story-player.js
@@ -4,7 +4,7 @@ import {cssText} from '../../../build/amp-story-player.css';
 import {AmpStoryPlayer} from '../../../src/amp-story-player/amp-story-player-impl';
 
 class AmpStoryPlayerWrapper extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-story/1.0/amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/amp-story-grid-layer.js
@@ -59,7 +59,7 @@ export let PresetDetails;
  * Grid layer template templating system.
  */
 export class AmpStoryGridLayer extends AmpStoryBaseLayer {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed(element) {
     return isPrerenderActivePage(element.parentElement);
   }

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -155,7 +155,7 @@ export const NavigationDirection = {
  * an <amp-story>.
  */
 export class AmpStoryPage extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed(element) {
     return isPrerenderActivePage(element);
   }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -197,7 +197,7 @@ const DEFAULT_THEME_COLOR = '#202125';
  * @implements {./media-pool.MediaPoolRoot}
  */
 export class AmpStory extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-stream-gallery/0.1/amp-stream-gallery.js
+++ b/extensions/amp-stream-gallery/0.1/amp-stream-gallery.js
@@ -65,7 +65,7 @@ const TAG = 'amp-stream-gallery';
  * - Does not support autoplay
  */
 class AmpStreamGallery extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/extensions/amp-tiktok/0.1/amp-tiktok.js
+++ b/extensions/amp-tiktok/0.1/amp-tiktok.js
@@ -76,7 +76,7 @@ export class AmpTiktok extends AMP.BaseElement {
     );
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     const html = htmlFor(element);
     const placeholder = childElementByAttr(element, 'placeholder');

--- a/extensions/amp-twitter/0.1/amp-twitter.js
+++ b/extensions/amp-twitter/0.1/amp-twitter.js
@@ -11,7 +11,7 @@ import {listenFor} from '../../../src/iframe-helper';
 const TYPE = 'twitter';
 
 class AmpTwitter extends AMP.BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     const html = htmlFor(element);
     return {

--- a/extensions/amp-twitter/1.0/amp-twitter.js
+++ b/extensions/amp-twitter/1.0/amp-twitter.js
@@ -19,7 +19,7 @@ class AmpTwitter extends setSuperClass(BaseElement, AmpPreactBaseElement) {
     super(element);
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static createLoaderLogoCallback(element) {
     const html = htmlFor(element);
     return {
@@ -40,7 +40,7 @@ class AmpTwitter extends setSuperClass(BaseElement, AmpPreactBaseElement) {
     };
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static getPreconnects(element) {
     const ampdoc = element.getAmpDoc();
     const {win} = ampdoc;

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -119,7 +119,7 @@ export class AmpVideo extends AMP.BaseElement {
    * dependent on the value of `prerenderAllowed()`.
    *
    * @override
-   * @nocollapse
+   * 
    */
   static prerenderAllowed(element) {
     // Only allow prerender if video sources are cached on CDN or remote video

--- a/extensions/amp-video/0.1/amp-video.js
+++ b/extensions/amp-video/0.1/amp-video.js
@@ -119,7 +119,7 @@ export class AmpVideo extends AMP.BaseElement {
    * dependent on the value of `prerenderAllowed()`.
    *
    * @override
-   * 
+   *
    */
   static prerenderAllowed(element) {
     // Only allow prerender if video sources are cached on CDN or remote video

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -107,7 +107,7 @@ export class BaseElement {
    * independently handle each of these states internally.
    *
    * @return {boolean}
-   * 
+   *
    */
   static R1() {
     return false;
@@ -122,7 +122,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {boolean}
-   * 
+   *
    */
   static deferredMount(unusedElement) {
     return true;
@@ -138,7 +138,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {boolean}
-   * 
+   *
    */
   static prerenderAllowed(unusedElement) {
     return false;
@@ -152,7 +152,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {boolean}
-   * 
+   *
    */
   static usesLoading(unusedElement) {
     return false;
@@ -167,7 +167,7 @@ export class BaseElement {
    *  content: (!Element|undefined),
    *  color: (string|undefined),
    * }}
-   * 
+   *
    */
   static createLoaderLogoCallback(unusedElement) {
     return {};
@@ -182,7 +182,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {number}
-   * 
+   *
    */
   static getBuildPriority(unusedElement) {
     return LayoutPriority_Enum.CONTENT;
@@ -197,7 +197,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {?Array<string>}
-   * 
+   *
    */
   static getPreconnects(unusedElement) {
     return null;
@@ -209,7 +209,7 @@ export class BaseElement {
    * installed before upgrading and building this class.
    *
    * @return {boolean}
-   * 
+   *
    */
   static requiresShadowDom() {
     return false;

--- a/src/base-element.js
+++ b/src/base-element.js
@@ -107,7 +107,7 @@ export class BaseElement {
    * independently handle each of these states internally.
    *
    * @return {boolean}
-   * @nocollapse
+   * 
    */
   static R1() {
     return false;
@@ -122,7 +122,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {boolean}
-   * @nocollapse
+   * 
    */
   static deferredMount(unusedElement) {
     return true;
@@ -138,7 +138,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {boolean}
-   * @nocollapse
+   * 
    */
   static prerenderAllowed(unusedElement) {
     return false;
@@ -152,7 +152,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {boolean}
-   * @nocollapse
+   * 
    */
   static usesLoading(unusedElement) {
     return false;
@@ -167,7 +167,7 @@ export class BaseElement {
    *  content: (!Element|undefined),
    *  color: (string|undefined),
    * }}
-   * @nocollapse
+   * 
    */
   static createLoaderLogoCallback(unusedElement) {
     return {};
@@ -182,7 +182,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {number}
-   * @nocollapse
+   * 
    */
   static getBuildPriority(unusedElement) {
     return LayoutPriority_Enum.CONTENT;
@@ -197,7 +197,7 @@ export class BaseElement {
    *
    * @param {!AmpElement} unusedElement
    * @return {?Array<string>}
-   * @nocollapse
+   * 
    */
   static getPreconnects(unusedElement) {
     return null;
@@ -209,7 +209,7 @@ export class BaseElement {
    * installed before upgrading and building this class.
    *
    * @return {boolean}
-   * @nocollapse
+   * 
    */
   static requiresShadowDom() {
     return false;

--- a/src/builtins/amp-img/amp-img.js
+++ b/src/builtins/amp-img/amp-img.js
@@ -41,22 +41,22 @@ export const ATTRIBUTES_TO_PROPAGATE = [
 ];
 
 export class AmpImg extends BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static R1() {
     return R1_IMG_DEFERRED_BUILD;
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static usesLoading() {
     return true;
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static getPreconnects(element) {
     const src = element.getAttribute('src');
     if (src) {

--- a/src/builtins/amp-layout/amp-layout.js
+++ b/src/builtins/amp-layout/amp-layout.js
@@ -7,7 +7,7 @@ import {buildDom} from './build-dom';
 import {BaseElement} from '../../base-element';
 
 export class AmpLayout extends BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return true;
   }

--- a/src/preact/base-element.js
+++ b/src/preact/base-element.js
@@ -106,22 +106,22 @@ const HAS_PASSTHROUGH = (def) => !!(def.passthrough || def.passthroughNonEmpty);
  * }} API_TYPE
  */
 export class PreactBaseElement extends BaseElement {
-  /** @override @nocollapse */
+  /** @override  */
   static R1() {
     return true;
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static requiresShadowDom() {
     return this['usesShadowDom'];
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static usesLoading() {
     return this['loadable'];
   }
 
-  /** @override @nocollapse */
+  /** @override  */
   static prerenderAllowed() {
     return !this.usesLoading();
   }

--- a/third_party/subscriptions-project/swg-gaa.js
+++ b/third_party/subscriptions-project/swg-gaa.js
@@ -1301,7 +1301,7 @@ class GaaMeteringRegwall {
    *
    * This method opens a metering regwall dialog,
    * where users can sign in with Google.
-   * @nocollapse
+   * 
    * @param {{ iframeUrl: string, caslUrl: string }} params
    * @return {!Promise<!GaaUserDef|!GoogleIdentityV1|!Object>}
    */
@@ -1338,7 +1338,7 @@ class GaaMeteringRegwall {
 
   /**
    * Removes the Regwall.
-   * @nocollapse
+   * 
    */
   static remove() {
     const regwallContainer = self.document.getElementById(REGWALL_CONTAINER_ID);
@@ -1351,7 +1351,7 @@ class GaaMeteringRegwall {
    * Signs out of Google Sign-In.
    * This is useful for developers who are testing their
    * SwG integrations.
-   * @nocollapse
+   * 
    * @return {!Promise}
    */
   static signOut() {
@@ -1363,7 +1363,7 @@ class GaaMeteringRegwall {
   /**
    * Renders the Regwall.
    * @private
-   * @nocollapse
+   * 
    * @param {{ iframeUrl: string, caslUrl: string }} params
    */
   static render_({iframeUrl, caslUrl}) {
@@ -1468,7 +1468,7 @@ class GaaMeteringRegwall {
   /**
    * Gets publisher name from page config.
    * @private
-   * @nocollapse
+   * 
    * @return {string}
    */
   static getPublisherNameFromPageConfig_() {
@@ -1492,7 +1492,7 @@ class GaaMeteringRegwall {
   /**
    * Gets publisher name from JSON-LD page config.
    * @private
-   * @nocollapse
+   * 
    * @return {string|undefined}
    */
   static getPublisherNameFromJsonLdPageConfig_() {
@@ -1521,7 +1521,7 @@ class GaaMeteringRegwall {
   /**
    * Gets publisher name from Microdata page config.
    * @private
-   * @nocollapse
+   * 
    * @return {string|undefined}
    */
   static getPublisherNameFromMicrodataPageConfig_() {
@@ -1540,7 +1540,7 @@ class GaaMeteringRegwall {
   /**
    * Adds a click listener on the publisher sign-in button.
    * @private
-   * @nocollapse
+   * 
    */
   static addClickListenerOnPublisherSignInButton_() {
     self.document
@@ -1561,7 +1561,7 @@ class GaaMeteringRegwall {
   /**
    * Returns the GAA user, after the user signs in.
    * @private
-   * @nocollapse
+   * 
    * @return {!Promise<!GoogleUserDef>}
    */
   static getGaaUser_() {
@@ -1586,7 +1586,7 @@ class GaaMeteringRegwall {
   /**
    * Logs button click events.
    * @private
-   * @nocollapse
+   * 
    */
   static logButtonClickEvents_() {
     // Listen for button event messages.
@@ -1607,7 +1607,7 @@ class GaaMeteringRegwall {
   /**
    * Sends intro post message to Google Sign-In iframe.
    * @private
-   * @nocollapse
+   * 
    * @param {{ iframeUrl: string }} params
    */
   static sendIntroMessageToGsiIframe_({iframeUrl}) {
@@ -1632,7 +1632,7 @@ class GaaMeteringRegwall {
 class GaaGoogleSignInButton {
   /**
    * Renders the Google Sign-In button.
-   * @nocollapse
+   * 
    * @param {{ allowedOrigins: !Array<string> }} params
    */
   static show({allowedOrigins}) {
@@ -1849,7 +1849,7 @@ const GOOGLE_3P_SIGN_IN_BUTTON_HTML = `
 class GaaGoogle3pSignInButton {
   /**
    * Renders the third party Google Sign-In button for external authentication.
-   * @nocollapse
+   * 
    * @param {{ allowedOrigins: !Array<string>, authorizationUrl: string }} params
    */
   static show({allowedOrigins, authorizationUrl}) {

--- a/validator/js/engine/validator-deprecated.js
+++ b/validator/js/engine/validator-deprecated.js
@@ -64,7 +64,7 @@ exports.isSeverityWarning = isSeverityWarning;
  * DEPRECATED. This now always returns an error message stating this is
  * deprecated and to use validator_wasm.js instead.
  *
- * @nocollapse
+ * 
  * @param {string} inputDocContents ignored.
  * @param {string=} opt_htmlFormat the allowed format ignored.
  * @return {!Object} Validation Result (status and errors)

--- a/validator/js/engine/validator-deprecated.js
+++ b/validator/js/engine/validator-deprecated.js
@@ -64,7 +64,7 @@ exports.isSeverityWarning = isSeverityWarning;
  * DEPRECATED. This now always returns an error message stating this is
  * deprecated and to use validator_wasm.js instead.
  *
- * 
+ * @nocollapse
  * @param {string} inputDocContents ignored.
  * @param {string=} opt_htmlFormat the allowed format ignored.
  * @return {!Object} Validation Result (status and errors)


### PR DESCRIPTION
**summary**
The [@nocollapse](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#nocollapse) property allows for exporting mutable props, but is a Closure-specific annotation.

We no longer need this annotation now that we don't use Closure.