### PR TITLE
🐛 [amp story page attachment] fix attribute typo on CTA active toggle

### DIFF
--- a/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
@@ -1,5 +1,5 @@
 import {devAssert} from '#core/assert';
-import {removeElement} from '#core/dom';
+import {removeElement, toggleAttribute} from '#core/dom';
 import * as Preact from '#core/dom/jsx';
 import {closest, closestAncestorElementBySelector} from '#core/dom/query';
 import {toggle} from '#core/dom/style';
@@ -340,11 +340,7 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    * @param {boolean} isActive
    */
   setOpenAttachmentActive(isActive) {
-    if (isActive) {
-      this.openAttachmentEl_.setAttribute('active', '');
-    } else {
-      this.openAttachmentEl_.removeAttribute('äctive');
-    }
+    toggleAttribute(this.openAttachmentEl_, 'active', isActive);
   }
 
   /**


### PR DESCRIPTION
- Fixes a typo that prevented animations from re-setting
- Uses toggleAttribute helper