### PR TITLE
🏗  🐛 build-bento should respect no extensions

### DIFF
--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -37,8 +37,8 @@ function maybeInitializeBentoComponents(componentsObject) {
 }
 
 /**
- * Process the command line arguments --nocomponents, --components, and
- * --components_from and return a list of the referenced components.
+ * Process the command line arguments --noextensions, --components, and
+ * --extensions_from and return a list of the referenced components.
  *
  * @param {boolean} preBuild Used for lazy building of components.
  * @return {!Array<string>}
@@ -59,7 +59,7 @@ function getBentoComponentsToBuild(preBuild = false) {
   }
   if (
     !preBuild &&
-    !argv.nocomponents &&
+    !argv.noextensions &&
     !argv.extensions &&
     !argv.extensions_from &&
     !argv.core_runtime_only


### PR DESCRIPTION
When writing the build-bento script I had originally planned to support a separate set of flags for building components. Upon reviewing the completed system I thought it was too complicated and removed what I thought to be all references. It seems like I missed this one.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
