### PR TITLE
🐛[bento-facebook] Invert error conditions to make sure both errors are thrown appropriately. 

### DIFF
--- a/extensions/amp-facebook/0.1/amp-facebook.js
+++ b/extensions/amp-facebook/0.1/amp-facebook.js
@@ -76,7 +76,7 @@ class AmpFacebook extends AMP.BaseElement {
     const embedAs = this.element.getAttribute('data-embed-as');
     if (embedAs === 'comment') {
       this.user().warn(
-        'BENTO-LIGTHBOX',
+        'AMP-FACEBOOK',
         'Embedded Comments have been deprecated: https://developers.facebook.com/docs/plugins/embedded-comments'
       );
       return;

--- a/extensions/amp-facebook/1.0/base-element.js
+++ b/extensions/amp-facebook/1.0/base-element.js
@@ -68,15 +68,15 @@ BaseElement['props'] = {
 function parseEmbed(element) {
   const embedAs = element.getAttribute('data-embed-as');
   userAssert(
+    embedAs !== 'comment',
+    'Embedded Comments have been deprecated: https://developers.facebook.com/docs/plugins/embedded-comments'
+  );
+  userAssert(
     !embedAs ||
       ['post', 'video', 'comments', 'like', 'page'].indexOf(embedAs) !== -1,
     'Attribute data-embed-as for <amp-facebook> value is wrong, should be' +
       ' "post", "video", "comments", "like", or "page", but was: %s',
     embedAs
-  );
-  userAssert(
-    embedAs !== 'comment',
-    'Embedded Comments have been deprecated: https://developers.facebook.com/docs/plugins/embedded-comments'
   );
   return embedAs;
 }

--- a/extensions/amp-facebook/1.0/base-element.js
+++ b/extensions/amp-facebook/1.0/base-element.js
@@ -68,10 +68,6 @@ BaseElement['props'] = {
 function parseEmbed(element) {
   const embedAs = element.getAttribute('data-embed-as');
   userAssert(
-    embedAs !== 'comment',
-    'Embedded Comments have been deprecated: https://developers.facebook.com/docs/plugins/embedded-comments'
-  );
-  userAssert(
     !embedAs ||
       ['post', 'video', 'comments', 'like', 'page'].indexOf(embedAs) !== -1,
     'Attribute data-embed-as for <amp-facebook> value is wrong, should be' +

--- a/extensions/amp-facebook/1.0/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/1.0/test/test-amp-facebook.js
@@ -44,33 +44,15 @@ describes.realWin(
       doNotLoadExternalResourcesInTest(window, env.sandbox);
     });
 
-    async function getAmpFacebook(href, opt_embedAs, opt_locale) {
+    it('renders', async () => {
       element = createElementWithAttributes(doc, 'amp-facebook', {
-        'data-href': href,
+        'data-href': fbPostHref,
         'height': 500,
         'width': 500,
         'layout': 'responsive',
       });
-      if (opt_embedAs) {
-        element.setAttribute('data-embed-as', opt_embedAs);
-      }
-      if (opt_locale) {
-        element.setAttribute('data-locale', opt_locale);
-      } else {
-        element.setAttribute('data-locale', 'en_US');
-      }
-
       doc.body.appendChild(element);
-      await element.buildInternal();
-      const loadPromise = element.layoutCallback();
-      const shadow = element.shadowRoot;
-      await waitFor(() => shadow.querySelector('iframe'), 'iframe mounted');
-      await loadPromise;
-      return element;
-    }
-
-    it('renders', async () => {
-      element = await getAmpFacebook(fbPostHref);
+      await waitForRender();
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.src).to.equal(
@@ -79,7 +61,15 @@ describes.realWin(
     });
 
     it('renders iframe in amp-facebook with video', async () => {
-      element = await getAmpFacebook(fbPostHref, 'video');
+      element = createElementWithAttributes(doc, 'amp-facebook', {
+        'data-href': fbPostHref,
+        'data-embed-as': 'video',
+        'height': 500,
+        'width': 500,
+        'layout': 'responsive',
+      });
+      doc.body.appendChild(element);
+      await waitForRender();
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.src).to.equal(
@@ -87,36 +77,44 @@ describes.realWin(
       );
     });
 
-    it('rejects other supported and unsupported data-embed-as types', async () => {
-      expectAsyncConsoleError(/.*/);
-      await expect(
-        getAmpFacebook(fbCommentsHref, 'comment')
-      ).to.be.rejectedWith(
-        /Embedded Comments have been deprecated: https:\/\/developers.facebook.com\/docs\/plugins\/embedded-comments/
-      );
-      await expect(
-        getAmpFacebook(fbVideoHref, 'unsupported')
-      ).to.be.rejectedWith(
-        /Attribute data-embed-as for <amp-facebook> value is wrong, should be "post", "video", "comments", "like", or "page", but was: unsupported/
-      );
-    });
-
     it('ensures iframe is not sandboxed in amp-facebook', async () => {
-      element = await getAmpFacebook(fbPostHref);
+      element = createElementWithAttributes(doc, 'amp-facebook', {
+        'data-href': fbPostHref,
+        'height': 500,
+        'width': 500,
+        'layout': 'responsive',
+      });
+      doc.body.appendChild(element);
+      await waitForRender();
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.hasAttribute('sandbox')).to.be.false;
     });
 
     it('renders amp-facebook with detected locale', async () => {
-      element = await getAmpFacebook(fbPostHref);
+      element = createElementWithAttributes(doc, 'amp-facebook', {
+        'data-href': fbPostHref,
+        'height': 500,
+        'width': 500,
+        'layout': 'responsive',
+      });
+      doc.body.appendChild(element);
+      await waitForRender();
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.getAttribute('name')).to.contain('"locale":"en_US"');
     });
 
     it('renders amp-facebook with specified locale', async () => {
-      element = await getAmpFacebook(fbPostHref, 'post', 'fr_FR');
+      element = createElementWithAttributes(doc, 'amp-facebook', {
+        'data-href': fbPostHref,
+        'data-locale': 'fr_FR',
+        'height': 500,
+        'width': 500,
+        'layout': 'responsive',
+      });
+      doc.body.appendChild(element);
+      await waitForRender();
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.getAttribute('name')).to.contain('"locale":"fr_FR"');
@@ -276,7 +274,14 @@ describes.realWin(
     });
 
     it('should set data-loading="auto" if no value is specified', async () => {
-      element = await getAmpFacebook(fbPostHref);
+      element = createElementWithAttributes(doc, 'amp-facebook', {
+        'data-href': fbPostHref,
+        'height': 500,
+        'width': 500,
+        'layout': 'responsive',
+      });
+      doc.body.appendChild(element);
+      await waitForRender();
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.getAttribute('loading')).to.equal('auto');

--- a/extensions/amp-facebook/1.0/test/test-amp-facebook.js
+++ b/extensions/amp-facebook/1.0/test/test-amp-facebook.js
@@ -44,15 +44,33 @@ describes.realWin(
       doNotLoadExternalResourcesInTest(window, env.sandbox);
     });
 
-    it('renders', async () => {
+    async function getAmpFacebook(href, opt_embedAs, opt_locale) {
       element = createElementWithAttributes(doc, 'amp-facebook', {
-        'data-href': fbPostHref,
+        'data-href': href,
         'height': 500,
         'width': 500,
         'layout': 'responsive',
       });
+      if (opt_embedAs) {
+        element.setAttribute('data-embed-as', opt_embedAs);
+      }
+      if (opt_locale) {
+        element.setAttribute('data-locale', opt_locale);
+      } else {
+        element.setAttribute('data-locale', 'en_US');
+      }
+
       doc.body.appendChild(element);
-      await waitForRender();
+      await element.buildInternal();
+      const loadPromise = element.layoutCallback();
+      const shadow = element.shadowRoot;
+      await waitFor(() => shadow.querySelector('iframe'), 'iframe mounted');
+      await loadPromise;
+      return element;
+    }
+
+    it('renders', async () => {
+      element = await getAmpFacebook(fbPostHref);
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.src).to.equal(
@@ -61,15 +79,7 @@ describes.realWin(
     });
 
     it('renders iframe in amp-facebook with video', async () => {
-      element = createElementWithAttributes(doc, 'amp-facebook', {
-        'data-href': fbPostHref,
-        'data-embed-as': 'video',
-        'height': 500,
-        'width': 500,
-        'layout': 'responsive',
-      });
-      doc.body.appendChild(element);
-      await waitForRender();
+      element = await getAmpFacebook(fbPostHref, 'video');
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.src).to.equal(
@@ -77,44 +87,36 @@ describes.realWin(
       );
     });
 
+    it('rejects other supported and unsupported data-embed-as types', async () => {
+      expectAsyncConsoleError(/.*/);
+      await expect(
+        getAmpFacebook(fbCommentsHref, 'comment')
+      ).to.be.rejectedWith(
+        /Embedded Comments have been deprecated: https:\/\/developers.facebook.com\/docs\/plugins\/embedded-comments/
+      );
+      await expect(
+        getAmpFacebook(fbVideoHref, 'unsupported')
+      ).to.be.rejectedWith(
+        /Attribute data-embed-as for <amp-facebook> value is wrong, should be "post", "video", "comments", "like", or "page", but was: unsupported/
+      );
+    });
+
     it('ensures iframe is not sandboxed in amp-facebook', async () => {
-      element = createElementWithAttributes(doc, 'amp-facebook', {
-        'data-href': fbPostHref,
-        'height': 500,
-        'width': 500,
-        'layout': 'responsive',
-      });
-      doc.body.appendChild(element);
-      await waitForRender();
+      element = await getAmpFacebook(fbPostHref);
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.hasAttribute('sandbox')).to.be.false;
     });
 
     it('renders amp-facebook with detected locale', async () => {
-      element = createElementWithAttributes(doc, 'amp-facebook', {
-        'data-href': fbPostHref,
-        'height': 500,
-        'width': 500,
-        'layout': 'responsive',
-      });
-      doc.body.appendChild(element);
-      await waitForRender();
+      element = await getAmpFacebook(fbPostHref);
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.getAttribute('name')).to.contain('"locale":"en_US"');
     });
 
     it('renders amp-facebook with specified locale', async () => {
-      element = createElementWithAttributes(doc, 'amp-facebook', {
-        'data-href': fbPostHref,
-        'data-locale': 'fr_FR',
-        'height': 500,
-        'width': 500,
-        'layout': 'responsive',
-      });
-      doc.body.appendChild(element);
-      await waitForRender();
+      element = await getAmpFacebook(fbPostHref, 'post', 'fr_FR');
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.getAttribute('name')).to.contain('"locale":"fr_FR"');
@@ -274,14 +276,7 @@ describes.realWin(
     });
 
     it('should set data-loading="auto" if no value is specified', async () => {
-      element = createElementWithAttributes(doc, 'amp-facebook', {
-        'data-href': fbPostHref,
-        'height': 500,
-        'width': 500,
-        'layout': 'responsive',
-      });
-      doc.body.appendChild(element);
-      await waitForRender();
+      element = await getAmpFacebook(fbPostHref);
 
       const iframe = element.shadowRoot.querySelector('iframe');
       expect(iframe.getAttribute('loading')).to.equal('auto');


### PR DESCRIPTION
Facebook recently deprecated its Embedded comments feature, and as such we added specific error/warn statements to alert authors to this change. However, `bento-facebook` never actually allowed `embedAs` to equal `comment` and this specific message is unnecessary. 

This PR also fixes the incorrect labeling of the `amp-facebook` warning as `bento-lightbox`. 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
