### PR TITLE
Add docs about updating output files by C++ validator

### DIFF
--- a/build-system/pr-check/validator-tests.js
+++ b/build-system/pr-check/validator-tests.js
@@ -15,8 +15,8 @@ const jobName = 'validator-tests.js';
  */
 function pushBuildWorkflow() {
   timedExecOrDie('amp validator-webui');
-  timedExecOrDie('amp validator');
   timedExecOrDie('amp validator-cpp');
+  timedExecOrDie('amp validator');
   timedExecOrDie('amp validate-html-fixtures');
 }
 
@@ -43,6 +43,10 @@ function prBuildWorkflow() {
     timedExecOrDie('amp validator-webui');
   }
 
+  if (buildTargetsInclude(Targets.VALIDATOR)) {
+    timedExecOrDie('amp validator-cpp');
+  }
+
   if (
     buildTargetsInclude(
       Targets.HTML_FIXTURES,
@@ -51,10 +55,6 @@ function prBuildWorkflow() {
     )
   ) {
     timedExecOrDie('amp validator');
-  }
-
-  if (buildTargetsInclude(Targets.VALIDATOR)) {
-    timedExecOrDie('amp validator-cpp');
   }
 
   if (buildTargetsInclude(Targets.HTML_FIXTURES)) {

--- a/docs/component-validator-rules.md
+++ b/docs/component-validator-rules.md
@@ -426,11 +426,23 @@ Optionally, you may add more than one valid variant and/or invalid examples.
 
 ## Test Output files
 
-After creating your validator html file, You need to create the corresponding `.out` file to act as your test results. These are used to verify if the validator is validating your extension correctly. To do this, navigate to the root of the project, `amphtml/` and run `amp validator --update_tests`. This should generate a matching `.out` file, and for this example, it would be:
+After creating your validator html file, You need to create the corresponding `.out` file to act as your test results. These are used to verify if the validator is validating your extension correctly.
+There are two alternative ways to do this.
 
-<pre>
-amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat.out</b>
-</pre>
+1. Option 1
+
+   Install [Bazel](https://docs.bazel.build/versions/main/install.html),
+   navigate to the validator folder `amphtml/validator`,
+   and run `bazel run cpp/engine:update-tests`.
+   This should generate a matching `.out` file, and for this example, it would be:
+   <pre>
+   amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat.out</b>
+   </pre>
+
+1. Option 2
+
+   Wait PR checks to fail.
+   The error message in CircleCI includes the expected content of the `.out` file.
 
 After generating the `.out` file, you should check it's contents that it gives the correct validation results/errors. If you only added valid examples, this file should contain a single line:
 

--- a/docs/component-validator-rules.md
+++ b/docs/component-validator-rules.md
@@ -441,8 +441,8 @@ There are two alternative ways to do this.
 
 1. Option 2
 
-    Wait PR checks to fail.
-    The error message in CircleCI includes the expected content of the `.out` file.
+    Wait for the PR checks on CircleCI to fail.
+    The error message in the logs will include the expected content of the `.out` file.
 
 After generating the `.out` file, you should check it's contents that it gives the correct validation results/errors. If you only added valid examples, this file should contain a single line:
 

--- a/docs/component-validator-rules.md
+++ b/docs/component-validator-rules.md
@@ -431,18 +431,18 @@ There are two alternative ways to do this.
 
 1. Option 1
 
-   Install [Bazel](https://docs.bazel.build/versions/main/install.html),
-   navigate to the validator folder `amphtml/validator`,
-   and run `bazel run cpp/engine:update-tests`.
-   This should generate a matching `.out` file, and for this example, it would be:
-   <pre>
-   amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat.out</b>
-   </pre>
+    Install [Bazel](https://docs.bazel.build/versions/main/install.html),
+    navigate to the validator folder `amphtml/validator`,
+    and run `bazel run cpp/engine:update-tests`.
+    This should generate a matching `.out` file, and for this example, it would be:
+    <pre>
+    amphtml/extensions/<b>amp-cat</b>/0.1/test/validator-<b>amp-cat.out</b>
+    </pre>
 
 1. Option 2
 
-   Wait PR checks to fail.
-   The error message in CircleCI includes the expected content of the `.out` file.
+    Wait PR checks to fail.
+    The error message in CircleCI includes the expected content of the `.out` file.
 
 After generating the `.out` file, you should check it's contents that it gives the correct validation results/errors. If you only added valid examples, this file should contain a single line:
 


### PR DESCRIPTION
* Remove docs about using the native JavaScript version Validator to update output files, because it has been deprecated since #36110. 
* Move C++ tests to run before JS tests in CircleCI, so that C++ error message will take precedence.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
