### PR TITLE
🐛 Insert empty newline as first line of minified outputs

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -77,7 +77,7 @@ function getMinifiedConfig() {
   return {
     compact: false,
     plugins,
-    sourceMaps: 'both',
+    sourceMaps: true,
     presets: [presetTypescript, presetEnv],
     retainLines: true,
     assumptions: {

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -55,7 +55,7 @@ function getUnminifiedConfig() {
     compact: false,
     plugins: unminifiedPlugins,
     presets: unminifiedPresets,
-    sourceMaps: 'both',
+    sourceMaps: true,
     assumptions: {
       constantSuper: true,
       noClassCalls: true,

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -77,8 +77,16 @@ function getEsbuildBabelPlugin(
         {filter: /\.(cjs|mjs|js|jsx|ts|tsx)$/, namespace: ''},
         async (file) => {
           const filename = file.path;
-          const babelOptions =
-            babel.loadOptions({caller: {name: callerName}, filename}) || {};
+          const babelOptions = /** @type {*} */ (
+            babel.loadOptions({caller: {name: callerName}, filename}) || {}
+          );
+
+          if ('sourceMap' in babelOptions) {
+            throw new Error('use sourceMaps option instead of sourceMap');
+          }
+          if (babelOptions.sourceMaps === true) {
+            babelOptions.sourceMaps = 'both';
+          }
 
           const {contents, hash} = await batchedRead(filename);
           const rehash = md5(

--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -2,11 +2,18 @@ const babel = require('@babel/core');
 const path = require('path');
 const {debug} = require('../compile/debug-compilation-lifecycle');
 const {TransformCache, batchedRead, md5} = require('./transform-cache');
+const Remapping = require('@ampproject/remapping');
+
+/** @type {Remapping.default} */
+const remapping = /** @type {*} */ (Remapping);
+
+const argv = require('minimist')(process.argv.slice(2));
 
 /**
  * @typedef {{
  *   filename: string,
  *   code: string,
+ *   map: Object,
  * }}
  */
 let CacheMessageDef;
@@ -33,6 +40,8 @@ function getEsbuildBabelPlugin(
   enableCache,
   {preSetup = () => {}, postLoad = () => {}} = {}
 ) {
+  const babelMaps = new Map();
+
   /**
    * @param {string} filename
    * @param {string} contents
@@ -57,14 +66,14 @@ function getEsbuildBabelPlugin(
       .then((result) => {
         const {code, map} = /** @type {!babel.BabelFileResult} */ (result);
         debug('post-babel', filename, code, map);
-        return {filename, code: code || ''};
+        return {filename, code: code || '', map};
       });
 
     if (enableCache) {
       transformCache.set(hash, promise);
     }
 
-    return promise.finally(postLoad);
+    return promise;
   }
 
   return {
@@ -73,6 +82,13 @@ function getEsbuildBabelPlugin(
     async setup(build) {
       preSetup();
 
+      const {initialOptions} = build;
+      const {sourcemap} = initialOptions;
+      const inlineSourcemap = sourcemap === 'inline' || sourcemap === 'both';
+      if (inlineSourcemap) {
+        initialOptions.sorucemap = true;
+      }
+
       build.onLoad(
         {filter: /\.(cjs|mjs|js|jsx|ts|tsx)$/, namespace: ''},
         async (file) => {
@@ -80,13 +96,7 @@ function getEsbuildBabelPlugin(
           const babelOptions = /** @type {*} */ (
             babel.loadOptions({caller: {name: callerName}, filename}) || {}
           );
-
-          if ('sourceMap' in babelOptions) {
-            throw new Error('use sourceMaps option instead of sourceMap');
-          }
-          if (babelOptions.sourceMaps === true) {
-            babelOptions.sourceMaps = 'both';
-          }
+          babelOptions.sourceMaps = true;
 
           const {contents, hash} = await batchedRead(filename);
           const rehash = md5(
@@ -105,11 +115,89 @@ function getEsbuildBabelPlugin(
             rehash,
             getFileBabelOptions(babelOptions, filename)
           );
+
+          babelMaps.set(filename, transformed.map);
+          postLoad?.();
           return {contents: transformed.code};
         }
       );
+
+      build.onEnd(async (result) => {
+        const {outputFiles} = result;
+        const code = outputFiles.find(({path}) => !path.endsWith('.map'));
+        const map = outputFiles.find(({path}) => path.endsWith('.map'));
+
+        if (!map) {
+          return;
+        }
+
+        const root = path.dirname(map.path);
+        const remapped = remapping(
+          map.text,
+          (f, ctx) => {
+            // The Babel tranformed file and the original file have the same
+            // path, which makes it difficult to distinguish during remapping's
+            // load phase. To prevent an infinite recursion, we check if the
+            // importer is ourselves (which is nonsensical) and early exit.
+            if (f === ctx.importer) {
+              return null;
+            }
+
+            const file = path.join(root, f);
+            const map = babelMaps.get(file);
+            if (!map) {
+              if (file.includes('/node_modules/')) {
+                // Excuse node_modules since they may have been marked external
+                // (and so not processed by babel).
+                return null;
+              }
+              throw new Error(`failed to find sourcemap for babel file "${f}"`);
+            }
+            return map;
+          },
+          !argv.full_sourcemaps
+        );
+
+        const sourcemapJson = remapped.toString();
+        replaceOutputFile(outputFiles, map, sourcemapJson);
+        if (inlineSourcemap) {
+          const base64 = Buffer.from(sourcemapJson).toString('base64');
+          replaceOutputFile(
+            outputFiles,
+            code,
+            code.text.replace(
+              /sourceMappingURL=.*/,
+              `sourceMappingURL=data:application/json;charset=utf-8;base64,${base64}`
+            )
+          );
+        }
+      });
     },
   };
+}
+
+/**
+ * @param {Array<import('esbuild').OutputFile>} outputFiles
+ * @param {import('esbuild').OutputFile} original
+ * @param {string} text
+ */
+function replaceOutputFile(outputFiles, original, text) {
+  const index = outputFiles.indexOf(original);
+  if (index === -1) {
+    throw new Error(`couldn't find outputFile ${original.path}`);
+  }
+
+  let contents;
+  const file = {
+    path: original.path,
+    text,
+    get contents() {
+      // eslint-disable-next-line local/no-forbidden-terms
+      const te = new TextEncoder();
+      return (contents ||= te.encode(text));
+    },
+  };
+  outputFiles[index] = file;
 }
 
 const CJS_TRANSFORMS = new Set([

--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -113,7 +113,7 @@ function checkSourcemapMappings(sourcemapJson, map) {
   }
 
   // See https://www.npmjs.com/package/sourcemap-codec#usage.
-  const firstLineMapping = decode(sourcemapJson.mappings)[0][0];
+  const firstLineMapping = decode(sourcemapJson.mappings)[1][0];
   const [, sourceIndex = 0, sourceCodeLine = 0, sourceCodeColumn] =
     firstLineMapping;
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -398,9 +398,11 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
       mapChain.unshift(result.map);
     }
 
-    const sourceMapComment = `\n//# sourceMappingURL=${destFilename}.map`;
     await Promise.all([
-      fs.outputFile(destFile, `${code}\n${sourceMapComment}`),
+      fs.outputFile(
+        destFile,
+        `${code}\n//# sourceMappingURL=${destFilename}.map`
+      ),
       fs.outputJson(`${destFile}.map`, massageSourcemaps(mapChain, options)),
     ]);
 
@@ -528,6 +530,11 @@ async function minify(code, options = {}) {
     output: {
       beautify: !!argv.pretty_print,
       keep_quoted_props: true,
+      // We naively prepend content on the first line of during dists and
+      // serving (for AMP_CONFIG and AMP_EXP). In order for these to not affect
+      // the sourcemap, we must ensure there is no other content on the first
+      // line. If you remove this you will annoy Justin. Don't do it.
+      preamble: ';',
     },
     sourceMap: true,
     toplevel: true,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -343,7 +343,6 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
         entryPoints: [entryPoint],
         bundle: true,
         sourcemap: 'external',
-        sourceRoot: path.dirname(destFile),
         sourcesContent: !!argv.full_sourcemaps,
         outfile: destFile,
         define: experimentDefines,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -530,8 +530,8 @@ async function minify(code, options = {}) {
     output: {
       beautify: !!argv.pretty_print,
       keep_quoted_props: true,
-      // We naively prepend content on the first line of during dists and
-      // serving (for AMP_CONFIG and AMP_EXP). In order for these to not affect
+      // The AMP Cache will prepend content on the first line during serving
+      // (for AMP_CONFIG and AMP_EXP). In order for these to not affect
       // the sourcemap, we must ensure there is no other content on the first
       // line. If you remove this you will annoy Justin. Don't do it.
       preamble: ';',

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -236,12 +236,7 @@ function maybeToNpmEsmName(name) {
  * @param {string} destFilename
  */
 function handleBundleError(err, continueOnError, destFilename) {
-  throw err;
-  let message = err.toString();
-  if (err.stack) {
-    // Drop the node_modules call stack, which begins with '    at'.
-    message = err.stack.replace(/    at[^]*/, '').trim();
-  }
+  const message = err.stack || err.toString();
   log(red('ERROR:'), message, '\n');
   const reasonMessage = `Could not compile ${cyan(destFilename)}`;
   if (continueOnError) {

--- a/build-system/tasks/sourcemaps.js
+++ b/build-system/tasks/sourcemaps.js
@@ -19,6 +19,13 @@ function massageSourcemaps(mapChain, options) {
   if (map.file) {
     map.file = path.basename(map.file);
   }
+  map.sources = map.sources.map((s) => {
+    if (s?.startsWith('../')) {
+      return s.slice('../'.length);
+    }
+    return s;
+  });
+
   return map;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       },
       "devDependencies": {
         "@ampproject/filesize": "4.3.0",
-        "@ampproject/remapping": "1.0.1",
+        "@ampproject/remapping": "2.1.0",
         "@babel/core": "7.15.0",
         "@babel/helper-module-imports": "7.14.5",
         "@babel/helper-plugin-test-runner": "7.14.5",
@@ -145,6 +145,7 @@
         "kleur": "4.1.4",
         "list-imports-exports": "0.1.2",
         "lodash.debounce": "4.0.8",
+        "magic-string": "0.25.7",
         "markdown-link-check": "3.8.7",
         "markdown-toc": "1.2.0",
         "marked": "3.0.8",
@@ -228,12 +229,12 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "1.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
+      "integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@jridgewell/resolve-uri": "1.0.0",
-        "sourcemap-codec": "1.4.8"
+        "@jridgewell/trace-mapping": "^0.3.0"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -3689,11 +3690,28 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "1.0.0",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
+      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
+      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@kristoferbaxter/async": {
@@ -16522,6 +16540,15 @@
         "node": "*"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -23110,11 +23137,12 @@
       }
     },
     "@ampproject/remapping": {
-      "version": "1.0.1",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
+      "integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
       "dev": true,
       "requires": {
-        "@jridgewell/resolve-uri": "1.0.0",
-        "sourcemap-codec": "1.4.8"
+        "@jridgewell/trace-mapping": "^0.3.0"
       }
     },
     "@ampproject/toolbox-cache-url": {
@@ -25539,8 +25567,26 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "1.0.0",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
+      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
       "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.10.tgz",
+      "integrity": "sha512-Ht8wIW5v165atIX1p+JvKR5ONzUyF4Ac8DZIQ5kZs9zrb6M8SJNXpx1zn04rn65VjBMygRoMXcyYwNK0fT7bEg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@kristoferbaxter/async": {
       "version": "1.0.0",
@@ -34588,6 +34634,15 @@
     "luxon": {
       "version": "1.26.0",
       "optional": true
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,6 @@
         "kleur": "4.1.4",
         "list-imports-exports": "0.1.2",
         "lodash.debounce": "4.0.8",
-        "magic-string": "0.25.7",
         "markdown-link-check": "3.8.7",
         "markdown-toc": "1.2.0",
         "marked": "3.0.8",
@@ -16538,15 +16537,6 @@
       "optional": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "dependencies": {
-        "sourcemap-codec": "^1.4.4"
       }
     },
     "node_modules/make-dir": {
@@ -34634,15 +34624,6 @@
     "luxon": {
       "version": "1.26.0",
       "optional": true
-    },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3690,9 +3690,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -25567,9 +25567,9 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz",
-      "integrity": "sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@ampproject/filesize": "4.3.0",
-    "@ampproject/remapping": "1.0.1",
+    "@ampproject/remapping": "2.1.0",
     "@babel/core": "7.15.0",
     "@babel/helper-module-imports": "7.14.5",
     "@babel/helper-plugin-test-runner": "7.14.5",
@@ -150,6 +150,7 @@
     "kleur": "4.1.4",
     "list-imports-exports": "0.1.2",
     "lodash.debounce": "4.0.8",
+    "magic-string": "0.25.7",
     "markdown-link-check": "3.8.7",
     "markdown-toc": "1.2.0",
     "marked": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "kleur": "4.1.4",
     "list-imports-exports": "0.1.2",
     "lodash.debounce": "4.0.8",
-    "magic-string": "0.25.7",
     "markdown-link-check": "3.8.7",
     "markdown-toc": "1.2.0",
     "marked": "3.0.8",


### PR DESCRIPTION
Our sourcemaps got borked again by prepending code **without** updating the sourcemaps. To make this easy for both `AMP_CONFIG` and `AMP_EXP`, we're putting the `;\n` back at the beginning of every file. Basically a revert of https://github.com/ampproject/amphtml/pull/36008. revert revert revert revert…