### PR TITLE
🚀 🚀 🚀  amp-carousel ssr: allow render without JS 🚀 🚀 🚀 

### DIFF
--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -1,3 +1,5 @@
+
+
 /**
  * @fileoverview CSS specifically for non-AMP4ADS formats.
  */
@@ -74,6 +76,7 @@ html.i-amphtml-fie:not(.i-amphtml-inabox) > body {
   position: relative !important;
 }
 
+
 /**
  * iOS-Embed mode (iOS <= 8). The `body` itself is scrollable.
  */
@@ -147,6 +150,7 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   visibility: visible;
 }
 
+
 .i-amphtml-scroll-disabled {
   overflow-x: hidden !important;
   overflow-y: hidden !important;
@@ -200,6 +204,7 @@ body:not(.i-amphtml-subs-ready) [subscriptions-action],
   display: none !important;
 }
 
+
 /**
  * Hide the update reference point of amp-live-list by default. This is
  * reset by the `amp-live-list > .amp-active[update]` selector.
@@ -230,29 +235,29 @@ amp-list[resizable-children] > .i-amphtml-loading-container.amp-hidden {
 amp-list[load-more] [load-more-loading],
 amp-list[load-more] [load-more-failed],
 amp-list[load-more] [load-more-button],
-amp-list[load-more] [load-more-end] {
+amp-list[load-more] [load-more-end]
+{
   display: none;
 }
 
 /**
  * amp-list error messaging container should be hidden at first.
  */
-amp-list [fetch-error] {
+ amp-list [fetch-error] {
   display: none;
 }
 
 /**
  * amp-list initial content should be displayed (similar to placeholder).
  */
-amp-list[diffable] div[role='list'] {
+amp-list[diffable] div[role="list"] {
   display: block;
 }
 
 /**
  * amp-story
  */
-amp-story[standalone],
-amp-story-page {
+amp-story[standalone], amp-story-page {
   /* Ensures amp-story and amp-story-page have a height and are prerendered. */
   min-height: 1px !important;
   display: block !important;
@@ -319,15 +324,14 @@ amp-autocomplete > textarea,
  * loaded. This cause the element to jump. This is a fix for that, which
  * doesn't push the preset's defaults into v0.js making it larger.
  */
-[amp-fx^='fly-in'] {
+[amp-fx^="fly-in"] {
   visibility: hidden;
 }
 
 /**
  * amp-script[nodom] is an element with no UI, similar to amp-analytics.
  */
-amp-script[nodom],
-amp-script[sandboxed] {
+amp-script[nodom], amp-script[sandboxed] {
   /* Fixed to make position independent of page other elements. */
   position: fixed !important;
   top: 0 !important;
@@ -335,11 +339,4 @@ amp-script[sandboxed] {
   height: 1px !important;
   overflow: hidden !important;
   visibility: hidden;
-}
-
-/**
- * Belongs in amp-carousel-0.1.css. Placed here temporarily to aid in SSR.
- */
-.i-amphtml-slide-item-show {
-  display: flex !important;
 }

--- a/css/ampdoc.css
+++ b/css/ampdoc.css
@@ -1,5 +1,3 @@
-
-
 /**
  * @fileoverview CSS specifically for non-AMP4ADS formats.
  */
@@ -76,7 +74,6 @@ html.i-amphtml-fie:not(.i-amphtml-inabox) > body {
   position: relative !important;
 }
 
-
 /**
  * iOS-Embed mode (iOS <= 8). The `body` itself is scrollable.
  */
@@ -150,7 +147,6 @@ html.i-amphtml-ios-embed.i-amphtml-ios-overscroll > #i-amphtml-wrapper {
   visibility: visible;
 }
 
-
 .i-amphtml-scroll-disabled {
   overflow-x: hidden !important;
   overflow-y: hidden !important;
@@ -204,7 +200,6 @@ body:not(.i-amphtml-subs-ready) [subscriptions-action],
   display: none !important;
 }
 
-
 /**
  * Hide the update reference point of amp-live-list by default. This is
  * reset by the `amp-live-list > .amp-active[update]` selector.
@@ -235,29 +230,29 @@ amp-list[resizable-children] > .i-amphtml-loading-container.amp-hidden {
 amp-list[load-more] [load-more-loading],
 amp-list[load-more] [load-more-failed],
 amp-list[load-more] [load-more-button],
-amp-list[load-more] [load-more-end]
-{
+amp-list[load-more] [load-more-end] {
   display: none;
 }
 
 /**
  * amp-list error messaging container should be hidden at first.
  */
- amp-list [fetch-error] {
+amp-list [fetch-error] {
   display: none;
 }
 
 /**
  * amp-list initial content should be displayed (similar to placeholder).
  */
-amp-list[diffable] div[role="list"] {
+amp-list[diffable] div[role='list'] {
   display: block;
 }
 
 /**
  * amp-story
  */
-amp-story[standalone], amp-story-page {
+amp-story[standalone],
+amp-story-page {
   /* Ensures amp-story and amp-story-page have a height and are prerendered. */
   min-height: 1px !important;
   display: block !important;
@@ -324,14 +319,15 @@ amp-autocomplete > textarea,
  * loaded. This cause the element to jump. This is a fix for that, which
  * doesn't push the preset's defaults into v0.js making it larger.
  */
-[amp-fx^="fly-in"] {
+[amp-fx^='fly-in'] {
   visibility: hidden;
 }
 
 /**
  * amp-script[nodom] is an element with no UI, similar to amp-analytics.
  */
-amp-script[nodom], amp-script[sandboxed] {
+amp-script[nodom],
+amp-script[sandboxed] {
   /* Fixed to make position independent of page other elements. */
   position: fixed !important;
   top: 0 !important;
@@ -339,4 +335,11 @@ amp-script[nodom], amp-script[sandboxed] {
   height: 1px !important;
   overflow: hidden !important;
   visibility: hidden;
+}
+
+/**
+ * Belongs in amp-carousel-0.1.css. Placed here temporarily to aid in SSR.
+ */
+.i-amphtml-slide-item-show {
+  display: flex !important;
 }

--- a/examples/compiler-hydration.html
+++ b/examples/compiler-hydration.html
@@ -32,12 +32,20 @@
         Unlike most AMPHTML pages, this file's components should all be rendered.
     -->
 
-    <h1><code>amp-layout</code> with a 4:1 responsive ratio </h1>
-    <amp-layout layout="responsive" width="4" height="1" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive" i-amphtml-ssr="">
+    <h1><code>client render: amp-layout</code> with a 4:1 responsive ratio </h1>
+    <amp-layout layout="responsive" width="4" height="1">
+        <svg viewBox="0 0 100 25">
+            <circle cx="50%" cy="50%" r="15%" stroke="black" stroke-width="3"></circle>
+            Sorry, your browser does not support inline SVG.
+        </svg>
+    </amp-layout>
+
+    <h1><code>server render: amp-layout</code> with a 4:1 responsive ratio </h1>
+    <amp-layout class="i-amphtml-layout-responsive i-amphtml-layout-size-defined i-amphtml-element" height=1 i-amphtml-layout=responsive i-amphtml-ssr layout=responsive width=4>
         <i-amphtml-sizer slot="i-amphtml-svc" style="padding-top: 25%;"></i-amphtml-sizer>
         <div class="i-amphtml-fill-content">
             <svg viewBox="0 0 100 25">
-                <circle cx="50%" cy="50%" r="15%" stroke="black" stroke-width="3"></circle>
+                <circle cx="50%" cy="50%" r="15%" stroke=black stroke-width=3></circle>
                 Sorry, your browser does not support inline SVG.
             </svg>
         </div>

--- a/examples/compiler-hydration.html
+++ b/examples/compiler-hydration.html
@@ -5,6 +5,9 @@
   <title>Hydration Test</title>
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   <script async custom-element="amp-fit-text" src="https://cdn.ampproject.org/v0/amp-fit-text-0.1.js"></script>
+  <!-- TODO: make lazy server work with .css files. -->
+  <link rel="stylesheet" href="/extensions/amp-carousel/0.1/amp-carousel.css" />
+  <link rel="stylesheet" href="/dist/v0.css" />
   <script async custom-element="amp-carousel" src="https://cdn.ampproject.org/v0/amp-carousel-0.1.js"></script>
   <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
@@ -58,48 +61,51 @@
 
     <h1><code>client render: carousel-0.1 type=slides</code></h1>
     <amp-carousel type="slides" width="400" height="300" controls loop>
-        <amp-img src="https://picsum.photos/400/300?img=1" width="400" height="300"></amp-img>
-        <amp-img src="https://picsum.photos/400/200?img=2" width="400" height="300"></amp-img>
-        <amp-img src="https://picsum.photos/400/200?img=3" width="400" height="300"></amp-img>
-        <amp-img src="https://picsum.photos/400/200?img=4" width="400" height="300"></amp-img>
-        <amp-img src="https://picsum.photos/400/200?img=5" width="400" height="300"></amp-img>
+        <img src="https://picsum.photos/400/300?img=1" width="400" height="300"></img>
+        <img src="https://picsum.photos/400/200?img=2" width="400" height="300"></img>
+        <img src="https://picsum.photos/400/200?img=3" width="400" height="300"></img>
+        <img src="https://picsum.photos/400/200?img=4" width="400" height="300"></img>
+        <img src="https://picsum.photos/400/200?img=5" width="400" height="300"></img>
     </amp-carousel>
 
     <h1><code>server render: carousel-0.1 type=slides</code></h1>
-    <amp-carousel class="i-amphtml-layout-fixed i-amphtml-layout-size-defined i-amphtml-slidescroll i-amphtml-carousel-has-controls" controls height=300 i-amphtml-layout=fixed i-amphtml-ssr loop style="width: 400px; height: 300px;" type=slides width=400>
-        <div aria-live=polite class="i-amphtml-slides-container i-amphtml-slidescroll-no-snap" tabindex="-1">
-            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/300?img=1" width=400></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=2" width=400></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=3" width=400></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=4" width=400></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=5" width=400></amp-img></div>
+    <amp-carousel class="i-amphtml-layout-fixed i-amphtml-layout-size-defined i-amphtml-slidescroll i-amphtml-carousel-has-controls i-amphtml-element" controls height="300" i-amphtml-layout="fixed" i-amphtml-ssr loop style="width: 400px; height: 300px" type="slides" width="400">
+        <div aria-live="polite" class="i-amphtml-slides-container i-amphtml-slidescroll-no-snap" tabindex="-1">
+            <div class="i-amphtml-slide-item i-amphtml-slide-item-show">
+                <img class="amp-carousel-slide" height="300" src="https://picsum.photos/400/300?img=1" width="400" />
+            </div>
+            <div class="i-amphtml-slide-item"><img class="amp-carousel-slide" height="300" src="https://picsum.photos/400/200?img=2" width="400"></div>
+            <div class="i-amphtml-slide-item"><img class="amp-carousel-slide" height="300" src="https://picsum.photos/400/200?img=3" width="400"></div>
+            <div class="i-amphtml-slide-item"><img class="amp-carousel-slide" height="300" src="https://picsum.photos/400/200?img=4" width="400"></div>
+            <div class="i-amphtml-slide-item"><img class="amp-carousel-slide" height="300" src="https://picsum.photos/400/200?img=5" width="400"></div>
         </div>
-        <div aria-disabled=false class="amp-carousel-button amp-carousel-button-prev" role=button tabindex=0 title="Previous item in carousel (5 of 5)"></div>
-        <div aria-disabled=false class="amp-carousel-button amp-carousel-button-next" role=button tabindex=0 title="Next item in carousel (2 of 5)"></div>
+        <div aria-disabled="false" class="amp-carousel-button amp-carousel-button-prev" role="button" tabindex="0" title="Previous item in carousel (5 of 5)"></div>
+        <div aria-disabled="false" class="amp-carousel-button amp-carousel-button-next" role="button" tabindex="0" title="Next item in carousel (2 of 5)"></div>
     </amp-carousel>
 
     <h1><code>client render: carousel-0.1 type=scrollable</code></h1>
     <amp-carousel width="300" height="100">
-        <amp-img src="https://picsum.photos/300/400?img=1" width="120" height="100"></amp-img>
-        <amp-img src="https://picsum.photos/300/400?img=2" width="120" height="100"></amp-img>
-        <amp-img src="https://picsum.photos/300/400?img=3" width="120" height="100"></amp-img>
-        <amp-img src="https://picsum.photos/300/400?img=4" width="120" height="100"></amp-img>
-        <amp-img src="https://picsum.photos/300/400?img=5" width="120" height="100"></amp-img>
-        <amp-img src="https://picsum.photos/300/400?img=6" width="120" height="100"></amp-img>
-        <amp-img src="https://picsum.photos/300/400?img=7" width="120" height="100"></amp-img>
+        <img src="https://picsum.photos/300/400?img=1" width="120" height="100">
+        <img src="https://picsum.photos/300/400?img=2" width="120" height="100">
+        <img src="https://picsum.photos/300/400?img=3" width="120" height="100">
+        <img src="https://picsum.photos/300/400?img=4" width="120" height="100">
+        <img src="https://picsum.photos/300/400?img=5" width="120" height="100">
+        <img src="https://picsum.photos/300/400?img=6" width="120" height="100">
+        <img src="https://picsum.photos/300/400?img=7" width="120" height="100">
     </amp-carousel>
 
     <h1><code>server render: carousel-0.1 type=scrollable</code></h1>
-    <amp-carousel class="i-amphtml-layout-fixed i-amphtml-layout-size-defined" height=100 i-amphtml-layout=fixed i-amphtml-ssr style="width: 300px; height: 100px;" width=300>
+    <amp-carousel class="i-amphtml-layout-fixed i-amphtml-layout-size-defined i-amphtml-element" height="100" i-amphtml-layout="fixed" i-amphtml-ssr style="width: 300px; height: 100px" width="300">
         <div class="i-amphtml-scrollable-carousel-container" tabindex="-1">
-            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=1" width=120></amp-img>
-            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=2" width=120></amp-img>
-            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=3" width=120></amp-img>
-            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=4" width=120></amp-img>
-            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=5" width=120></amp-img>
-            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=6" width=120></amp-img><amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=7" width=120></amp-img>
+          <img class="amp-carousel-slide amp-scrollable-carousel-slide" height="100" src="https://picsum.photos/300/400?img=1" width="120" />
+          <img class="amp-carousel-slide amp-scrollable-carousel-slide" height="100" src="https://picsum.photos/300/400?img=2" width="120" />
+          <img class="amp-carousel-slide amp-scrollable-carousel-slide" height="100" src="https://picsum.photos/300/400?img=3" width="120" />
+          <img class="amp-carousel-slide amp-scrollable-carousel-slide" height="100" src="https://picsum.photos/300/400?img=4" width="120" />
+          <img class="amp-carousel-slide amp-scrollable-carousel-slide" height="100" src="https://picsum.photos/300/400?img=5" width="120" />
+          <img class="amp-carousel-slide amp-scrollable-carousel-slide" height="100" src="https://picsum.photos/300/400?img=6" width="120" />
+          <img class="amp-carousel-slide amp-scrollable-carousel-slide" height="100" src="https://picsum.photos/300/400?img=7" width="120" />
         </div>
-        <div aria-disabled=true class="amp-carousel-button amp-carousel-button-prev amp-disabled" role=presentation tabindex="-1" title="Previous item in carousel"></div>
-        <div aria-disabled=false class="amp-carousel-button amp-carousel-button-next" role=presentation tabindex=0 title="Next item in carousel"></div>
+        <div aria-disabled="true" class="amp-carousel-button amp-carousel-button-prev amp-disabled" role="presentation" tabindex="-1" title="Previous item in carousel"></div>
+        <div aria-disabled="false" class="amp-carousel-button amp-carousel-button-next" role="presentation" tabindex="0" title="Next item in carousel"></div>
     </amp-carousel>
 </html>

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -8,6 +8,7 @@ import {
   CONSENT_STRING_TYPE,
 } from '#core/constants/consent-state';
 import {addAttributesToElement, createElementWithAttributes} from '#core/dom';
+import {camelCaseToHyphenCase} from '#core/dom/style';
 import {utf8Decode, utf8Encode} from '#core/types/string/bytes';
 import {toWin} from '#core/window';
 
@@ -1536,7 +1537,12 @@ describes.realWin(
         };
         impl.iframe = {
           contentWindow: window,
-          style: {'visibility': 'hidden'},
+          style: {
+            'visibility': 'hidden',
+            setProperty: (name, value) => {
+              impl.iframe.style[camelCaseToHyphenCase(name)] = value;
+            },
+          },
         };
         win.postMessage('fill_sticky', '*');
         return renderPromise.then(() => {

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -16,12 +16,14 @@ export const ClassNames = {
 
   // Generic
   SLIDE: 'amp-carousel-slide',
+  SHOW_SLIDE: 'amp-carousel-slide',
 
   // SlideScroll Carousel
   SLIDESCROLL_CAROUSEL: 'i-amphtml-slidescroll',
   SLIDE_WRAPPER: 'i-amphtml-slide-item',
   SLIDES_CONTAINER: 'i-amphtml-slides-container',
   SLIDES_CONTAINER_NOSNAP: 'i-amphtml-slidescroll-no-snap',
+  SLIDES_ITEM_SHOW: 'i-amphtml-slide-item-show',
 
   // Scrollable Carousel
   SCROLLABLE_CONTAINER: 'i-amphtml-scrollable-carousel-container',
@@ -220,7 +222,7 @@ function buildSlideScrollCarousel(element) {
 
   /** @type {HTMLDivElement[]} */
   const slideWrappers = [];
-  slides.forEach((slide) => {
+  slides.forEach((slide, i) => {
     slide.classList.add(ClassNames.SLIDE);
 
     const slideWrapper = doc.createElement('div');
@@ -229,6 +231,8 @@ function buildSlideScrollCarousel(element) {
     slidesContainer.appendChild(slideWrapper);
     slideWrappers.push(slideWrapper);
   });
+  // Initialize the first slide to be shown.
+  slides[0]?.classList.add(ClassNames.SLIDES_ITEM_SHOW);
 
   return {slidesContainer, slides, slideWrappers};
 }

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -222,7 +222,7 @@ function buildSlideScrollCarousel(element) {
 
   /** @type {HTMLDivElement[]} */
   const slideWrappers = [];
-  slides.forEach((slide, i) => {
+  slides.forEach((slide) => {
     slide.classList.add(ClassNames.SLIDE);
 
     const slideWrapper = doc.createElement('div');

--- a/extensions/amp-carousel/0.1/build-dom.js
+++ b/extensions/amp-carousel/0.1/build-dom.js
@@ -232,7 +232,7 @@ function buildSlideScrollCarousel(element) {
     slideWrappers.push(slideWrapper);
   });
   // Initialize the first slide to be shown.
-  slides[0]?.classList.add(ClassNames.SLIDES_ITEM_SHOW);
+  slideWrappers[0]?.classList.add(ClassNames.SLIDES_ITEM_SHOW);
 
   return {slidesContainer, slides, slideWrappers};
 }

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -31,7 +31,6 @@ import {
 import {CarouselControls} from './carousel-controls';
 
 /** @const {string} */
-const SHOWN_CSS_CLASS = 'i-amphtml-slide-item-show';
 
 /** @const {number} */
 const NATIVE_SNAP_TIMEOUT = 200;
@@ -842,7 +841,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
       if (this.shouldLoop_) {
         setStyle(this.slideWrappers_[showIndex], 'order', loopIndex + 1);
       }
-      this.slideWrappers_[showIndex].classList.add(SHOWN_CSS_CLASS);
+      this.slideWrappers_[showIndex].classList.add(ClassNames.SLIDES_ITEM_SHOW);
       const owners = Services.ownersForDoc(this.element);
       if (showIndex == newIndex) {
         owners.scheduleLayout(this.element, this.slides_[showIndex]);
@@ -929,7 +928,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
   hideRestOfTheSlides_(indexArr) {
     const {noOfSlides_} = this;
     for (let i = 0; i < noOfSlides_; i++) {
-      if (!this.slideWrappers_[i].classList.contains(SHOWN_CSS_CLASS)) {
+      if (!this.slideWrappers_[i].classList.contains(ClassNames.SLIDES_ITEM_SHOW)) {
         continue;
       }
       // Hide if not shown anymore
@@ -939,7 +938,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
         }
         dev()
           .assertElement(this.slideWrappers_[i])
-          .classList.remove(SHOWN_CSS_CLASS);
+          .classList.remove(ClassNames.SLIDES_ITEM_SHOW);
         this.slides_[i].removeAttribute('aria-hidden');
       }
       // Pause if not the current slide

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -928,7 +928,9 @@ export class AmpSlideScroll extends AMP.BaseElement {
   hideRestOfTheSlides_(indexArr) {
     const {noOfSlides_} = this;
     for (let i = 0; i < noOfSlides_; i++) {
-      if (!this.slideWrappers_[i].classList.contains(ClassNames.SLIDES_ITEM_SHOW)) {
+      if (
+        !this.slideWrappers_[i].classList.contains(ClassNames.SLIDES_ITEM_SHOW)
+      ) {
         continue;
       }
       // Hide if not shown anymore

--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -938,9 +938,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
         if (this.shouldLoop_) {
           setStyle(this.slideWrappers_[i], 'order', '');
         }
-        dev()
-          .assertElement(this.slideWrappers_[i])
-          .classList.remove(ClassNames.SLIDES_ITEM_SHOW);
+        this.slideWrappers_[i].classList.remove(ClassNames.SLIDES_ITEM_SHOW);
         this.slides_[i].removeAttribute('aria-hidden');
       }
       // Pause if not the current slide

--- a/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
@@ -2,7 +2,10 @@ import {createDocument as createWorkerDomDoc} from '@ampproject/worker-dom/dist/
 
 import {createElementWithAttributes} from '#core/dom';
 
-import {getDeterministicOuterHTML} from '#testing/helpers';
+import {
+  getDeterministicOuterHTML,
+  hypenCaseToCamelCase,
+} from '#testing/helpers';
 
 import {AmpFitText, calculateFontSize_, updateOverflow_} from '../amp-fit-text';
 import {buildDom} from '../build-dom';
@@ -244,7 +247,11 @@ describes.realWin('amp-fit-text updateOverflow', {}, (env) => {
     doc = win.document;
     classToggles = {};
     content = {
-      style: {},
+      style: {
+        setProperty(name, value) {
+          content.style[hypenCaseToCamelCase(name)] = value;
+        },
+      },
       classList: {
         toggle: (className, on) => {
           classToggles[className] = on;

--- a/src/compiler/builders.ts
+++ b/src/compiler/builders.ts
@@ -26,6 +26,7 @@ function wrap(buildDom: BuildDom): BuildDom {
     applyStaticLayout(element as AmpElement);
     buildDom(element);
     element.setAttribute('i-amphtml-ssr', '');
+    element.classList.add('i-amphtml-element');
   };
 }
 

--- a/src/core/dom/style.js
+++ b/src/core/dom/style.js
@@ -28,6 +28,14 @@ export function camelCaseToTitleCase(camelCase) {
 }
 
 /**
+ * @param {string} camelCase camel cased string
+ * @return {string} hyphen-cased string
+ */
+export function camelCaseToHyphenCase(camelCase) {
+  return camelCase.replace(/[A-Z]/g, (match) => '-' + match.toLowerCase());
+}
+
+/**
   Checks the style if a prefixed version of a property exists and returns
  * it or returns an empty string.
  * @private
@@ -44,15 +52,6 @@ function getVendorJsPropertyName_(style, titleCase) {
   }
   return '';
 }
-
-/**
- * A small set of curated properties that are valid with setProperty.
- * Within worker-dom, only `.setProperty` properly reflects into the attribute.
- * If we solve that, or decide to always use setProperty, this kludge can be removed.
- *
- * TODO(https://github.com/ampproject/worker-dom/issues/1134)
- */
-const SHOULD_USE_SET_PROPERTY = new Set(['width', 'height', 'order', 'hidden']);
 
 /**
  * Returns the possibly prefixed JavaScript property name of a style property
@@ -126,11 +125,7 @@ export function setStyle(element, property, value, opt_units, opt_bypassCache) {
     return;
   }
   const styleValue = opt_units ? value + opt_units : value;
-  if (isVar(propertyName) || SHOULD_USE_SET_PROPERTY.has(propertyName)) {
-    element.style.setProperty(propertyName, styleValue);
-  } else {
-    /** @type {*} */ (element.style)[propertyName] = styleValue;
-  }
+  element.style.setProperty(camelCaseToHyphenCase(propertyName), styleValue);
 }
 
 /**

--- a/src/core/dom/style.js
+++ b/src/core/dom/style.js
@@ -32,7 +32,16 @@ export function camelCaseToTitleCase(camelCase) {
  * @return {string} hyphen-cased string
  */
 export function camelCaseToHyphenCase(camelCase) {
-  return camelCase.replace(/[A-Z]/g, (match) => '-' + match.toLowerCase());
+  const hyphenated = camelCase.replace(
+    /[A-Z]/g,
+    (match) => '-' + match.toLowerCase()
+  );
+
+  // For o-foo or ms-foo, we need to convert to -o-foo and ms-foo
+  if (vendorPrefixes.some((prefix) => hyphenated.startsWith(prefix + '-'))) {
+    return `-${hyphenated}`;
+  }
+  return hyphenated;
 }
 
 /**
@@ -100,7 +109,7 @@ export function setImportantStyles(element, styles) {
   const {style} = element;
   for (const k in styles) {
     style.setProperty(
-      getVendorJsPropertyName(style, k),
+      camelCaseToHyphenCase(getVendorJsPropertyName(style, k)),
       String(styles[k]),
       'important'
     );

--- a/test/unit/core/dom/test-style.js
+++ b/test/unit/core/dom/test-style.js
@@ -75,7 +75,7 @@ describes.sandboxed('DOM - style helpers', {}, (env) => {
       transitionDurationImportant: '1s',
     });
     expect(spy).to.have.been.calledWith(
-      'WebkitTransitionDurationImportant',
+      '-webkit-transition-duration-important',
       '1s',
       'important'
     );
@@ -108,6 +108,10 @@ describes.sandboxed('DOM - style helpers', {}, (env) => {
     expect(st.camelCaseToHyphenCase('WebkitTransition')).to.equal(
       '-webkit-transition'
     );
+    expect(st.camelCaseToHyphenCase('webkitTransition')).to.equal(
+      '-webkit-transition'
+    );
+    expect(st.camelCaseToHyphenCase('oTransition')).to.equal('-o-transition');
   });
 
   it('removeAlphaFromColor', () => {

--- a/test/unit/core/dom/test-style.js
+++ b/test/unit/core/dom/test-style.js
@@ -104,8 +104,10 @@ describes.sandboxed('DOM - style helpers', {}, (env) => {
   });
 
   it('camelCaseToHyphenCase', () => {
-    const str = 'paddingTop';
-    expect(st.camelCaseToHyphenCase(str)).to.equal('padding-top');
+    expect(st.camelCaseToHyphenCase('paddingTop')).to.equal('padding-top');
+    expect(st.camelCaseToHyphenCase('WebkitTransition')).to.equal(
+      '-webkit-transition'
+    );
   });
 
   it('removeAlphaFromColor', () => {

--- a/test/unit/core/dom/test-style.js
+++ b/test/unit/core/dom/test-style.js
@@ -24,9 +24,17 @@ describes.sandboxed('DOM - style helpers', {}, (env) => {
   });
 
   it('setStyle with vendor prefix', () => {
-    const element = {style: {WebkitTransitionDuration: ''}};
+    const element = {
+      style: {
+        WebkitTransitionDuration: '',
+        setProperty: (name, value) => {
+          element.style[name] = value;
+        },
+      },
+    };
+
     st.setStyle(element, 'transitionDuration', '1s', undefined, true);
-    expect(element.style.WebkitTransitionDuration).to.equal('1s');
+    expect(element.style['-webkit-transition-duration']).to.equal('1s');
   });
 
   it('setStyle with custom var', () => {
@@ -97,7 +105,7 @@ describes.sandboxed('DOM - style helpers', {}, (env) => {
 
   it('camelCaseToHyphenCase', () => {
     const str = 'paddingTop';
-    expect(st.camelCaseToTitleCase(str)).to.equal('padding-top');
+    expect(st.camelCaseToHyphenCase(str)).to.equal('padding-top');
   });
 
   it('removeAlphaFromColor', () => {

--- a/test/unit/core/dom/test-style.js
+++ b/test/unit/core/dom/test-style.js
@@ -95,6 +95,11 @@ describes.sandboxed('DOM - style helpers', {}, (env) => {
     expect(st.camelCaseToTitleCase(str)).to.equal('TheQuickBrownFox');
   });
 
+  it('camelCaseToHyphenCase', () => {
+    const str = 'paddingTop';
+    expect(st.camelCaseToTitleCase(str)).to.equal('padding-top');
+  });
+
   it('removeAlphaFromColor', () => {
     expect(st.removeAlphaFromColor('rgba(1, 1, 1, 0)')).to.equal(
       'rgba(1, 1, 1, 1)'

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -17,6 +17,7 @@ import {
   FakePerformance,
   FakeWindow,
 } from '#testing/fake-dom';
+import {hypenCaseToCamelCase} from '#testing/helpers';
 
 describes.sandboxed('FixedLayer', {}, (env) => {
   let parentApi;
@@ -223,70 +224,32 @@ describes.sandboxed('FixedLayer', {}, (env) => {
         return id;
       },
       style: {
-        _top: '15px',
-        _bottom: '',
-        _position: '',
-        _opacity: '0.9',
-        _visibility: 'visible',
-        _transition: '',
+        top: '15px',
+        bottom: '',
+        position: '',
+        opacity: '0.9',
+        visibility: 'visible',
+        transition: '',
 
-        get top() {
-          return this._top;
-        },
-        set top(v) {
-          elem.style.setProperty('top', v);
-        },
-        get bottom() {
-          return this._bottom;
-        },
-        set bottom(v) {
-          elem.style.setProperty('bottom', v);
-        },
-        get position() {
-          return this._position;
-        },
-        set position(v) {
-          elem.style.setProperty('position', v);
-        },
-        get opacity() {
-          return this._opacity;
-        },
-        set opacity(v) {
-          elem.style.setProperty('opacity', v);
-        },
-        get visibility() {
-          return this._visibility;
-        },
-        set visibility(v) {
-          elem.style.setProperty('visibility', v);
-        },
-        get transition() {
-          return this._transition;
-        },
-        set transition(v) {
-          elem.style.setProperty('transition', v);
-        },
         setProperty(prop, value, priority) {
-          const privProp = '_' + prop;
-
           // Override if important
           if (priority === 'important') {
-            elem.style[privProp] = `${value} !${priority}`;
+            elem.style[prop] = `${value} !${priority}`;
           } else if (
-            elem.style[privProp] ||
+            elem.style[prop] ||
             !elem.computedStyle[prop]?.endsWith('!important')
           ) {
             if (
               prop === 'transition' &&
               !value &&
-              endsWith(elem.style[privProp] || '', '!important')
+              endsWith(elem.style[prop] || '', '!important')
             ) {
               // Emulate a stupid Safari bug.
               // noop.
             } else {
               // If element style is already set, we can override
               // Or, if computed style is not important priority
-              elem.style[privProp] = value;
+              elem.style[hypenCaseToCamelCase(prop)] = value;
             }
           }
         },
@@ -1466,11 +1429,11 @@ describes.sandboxed('FixedLayer', {}, (env) => {
 
       expect(fixedLayer.transferLayer_).to.exist;
       const layer = fixedLayer.transferLayer_.layer_;
-      expect(layer.style['pointerEvents']).to.equal('none');
+      expect(layer.style.pointerEvents).to.equal('none');
 
       expect(fe.element.parentElement).to.equal(layer);
-      expect(fe.element.style['pointer-events']).to.equal('initial');
-      expect(fe.element.style['zIndex']).to.equal('calc(10001 + 11)');
+      expect(fe.element.style.pointerEvents).to.equal('initial');
+      expect(fe.element.style.zIndex).to.equal('calc(10001 + 11)');
     });
 
     it('should ignore transfer when non-transferrable', () => {

--- a/test/unit/test-friendly-iframe-embed.js
+++ b/test/unit/test-friendly-iframe-embed.js
@@ -973,7 +973,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
         tagName: 'IFRAME',
         nodeType: 1,
         ownerDocument: {defaultView: win},
-        style: {},
+        style: {setProperty: () => {}},
         setAttribute: () => {},
         addEventListener: (eventType, listener) => {
           if (eventType == 'load') {
@@ -985,7 +985,7 @@ describes.realWin('friendly-iframe-embed', {amp: true}, (env) => {
       contentWindow = new FakeWindow();
       contentDocument = contentWindow.document;
       contentWindow.frameElement = iframe;
-      contentBody = {nodeType: 1, style: {}};
+      contentBody = {nodeType: 1, style: {setProperty: () => {}}};
       container = {
         appendChild: () => {},
       };

--- a/testing/helpers/index.js
+++ b/testing/helpers/index.js
@@ -117,3 +117,11 @@ export function getDeterministicOuterHTML(node) {
   }
   return start + contents + `</${tag}>`;
 }
+
+/**
+ * @param {string} hyphenCase camel cased string
+ * @return {string} camelCased string
+ */
+export function hypenCaseToCamelCase(hyphenCase) {
+  return hyphenCase.replace(/-./g, (match) => match.slice(1).toUpperCase());
+}


### PR DESCRIPTION
**summary**
Server-rendering AMP Components should allow us to have UI visible without blocking on JS executaion.
Via disabling JS locally, I was surprised to see that this wasn't the case yet.

We still have two issues stopping `<amp-carousel>` from rendering without JS:
1. Loading extension CSS is still bundled with JS execution. We need to add a `<style>` link to the CSS to the `<head>`.
2. The application of class names which unhide the amp-carousel take place in `layoutCallback` instead of `buildDom`.  In this case it is the addition of `i-amphtml-element` and `i-amphtml-slide-item-show`.

I solve (2) in this PR, and am working on (1) separately.

🚀 🚀 🚀  **results** 🚀 🚀 🚀 
For webpages with their LCP Element in the amp-carouse, we can expect a ~40% improvement to LCP. [source](https://webpagetest.org/video/compare.php?tests=220211_AiDc37_DBC,220211_BiDcYW_BQN)

![lcp-improvement](https://user-images.githubusercontent.com/4656974/153900248-d458c808-ab64-47ac-b05c-af2d651ba5fb.png)