### PR TITLE
🏗 Allow `bento-mustache` build

### DIFF
--- a/build-system/common/fs.js
+++ b/build-system/common/fs.js
@@ -1,0 +1,18 @@
+const glob = require('globby');
+
+/**
+ * @param {string} nameWithoutExtension
+ * @param {?string|void} cwd
+ * @return {Promise<string|undefined>}
+ */
+async function findJsSourceFilename(nameWithoutExtension, cwd) {
+  const [filename] = await glob(
+    `${nameWithoutExtension}.{js,ts,tsx}`,
+    cwd ? {cwd} : undefined
+  );
+  return filename;
+}
+
+module.exports = {
+  findJsSourceFilename,
+};

--- a/build-system/compile/bundles.config.bento.json
+++ b/build-system/compile/bundles.config.bento.json
@@ -12,7 +12,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -20,7 +21,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -28,7 +30,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -36,7 +39,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -44,7 +48,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -52,7 +57,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -64,20 +70,12 @@
     }
   },
   {
-    "name": "bento-mustache",
-    "version": "1.0",
-    "options": {
-      "// 1": "This is a dependency for CDN builds, not to be published in NPM.",
-      "// 2": "(NPM builds depend on the third-party `mustache` directly.)",
-      "npm": false
-    }
-  },
-  {
     "name": "bento-lightbox",
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -85,7 +83,17 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
+    }
+  },
+  {
+    "name": "bento-mustache",
+    "version": "1.0",
+    "options": {
+      "// 1": "This is a dependency for CDN builds, not to be published on NPM.",
+      "// 2": "(NPM builds depend on the third-party `mustache` directly.)",
+      "npm": false
     }
   },
   {
@@ -93,7 +101,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -101,7 +110,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -109,7 +119,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -117,7 +128,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -125,7 +137,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -133,7 +146,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -141,7 +155,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   },
   {
@@ -149,7 +164,8 @@
     "version": "1.0",
     "latestVersion": "0.1",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
     }
   }
 ]

--- a/build-system/compile/bundles.config.bento.json
+++ b/build-system/compile/bundles.config.bento.json
@@ -59,7 +59,17 @@
     "name": "bento-jwplayer",
     "version": "1.0",
     "options": {
-      "hasCss": true
+      "hasCss": true,
+      "npm": true
+    }
+  },
+  {
+    "name": "bento-mustache",
+    "version": "1.0",
+    "options": {
+      "// 1": "This is a dependency for CDN builds, not to be published in NPM.",
+      "// 2": "(NPM builds depend on the third-party `mustache` directly.)",
+      "npm": false
     }
   },
   {

--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -12,7 +12,6 @@ const {
 const {bentoBundles, verifyBentoBundles} = require('../compile/bundles.config');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {log} = require('../common/logging');
-const {mkdir} = require('fs-extra');
 const {red} = require('kleur/colors');
 const {watch} = require('chokidar');
 
@@ -139,10 +138,6 @@ async function buildBentoComponent(name, version, hasCss, options = {}) {
   /** @type {Promise<void>[]} */
   const promises = [];
   if (hasCss) {
-<<<<<<< HEAD
-    await mkdir('build/css', {recursive: true});
-=======
->>>>>>> 1f6a4e7913 (fix css)
     promises.push(buildExtensionCss(componentsDir, name, version, options));
     if (options.compileOnlyCss) {
       return Promise.all(promises);

--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -125,7 +125,6 @@ async function watchBentoComponent(
  * @return {!Promise<void|void[]>}
  */
 async function buildBentoComponent(name, version, hasCss, options = {}) {
-  options.npm = true;
   options.bento = true;
 
   if (options.compileOnlyCss && !hasCss) {
@@ -146,8 +145,10 @@ async function buildBentoComponent(name, version, hasCss, options = {}) {
       return Promise.all(promises);
     }
   }
-  promises.push(buildNpmBinaries(componentsDir, name, options));
-  promises.push(buildNpmCss(componentsDir, options));
+  if (options.npm) {
+    promises.push(buildNpmBinaries(componentsDir, name, options));
+    promises.push(buildNpmCss(componentsDir, options));
+  }
   if (options.binaries) {
     promises.push(buildBinaries(componentsDir, options.binaries, options));
   }

--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -139,7 +139,10 @@ async function buildBentoComponent(name, version, hasCss, options = {}) {
   /** @type {Promise<void>[]} */
   const promises = [];
   if (hasCss) {
+<<<<<<< HEAD
     await mkdir('build/css', {recursive: true});
+=======
+>>>>>>> 1f6a4e7913 (fix css)
     promises.push(buildExtensionCss(componentsDir, name, version, options));
     if (options.compileOnlyCss) {
       return Promise.all(promises);

--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -12,6 +12,7 @@ const {
 const {bentoBundles, verifyBentoBundles} = require('../compile/bundles.config');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {log} = require('../common/logging');
+const {mkdir} = require('fs').promises;
 const {red} = require('kleur/colors');
 const {watch} = require('chokidar');
 

--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -12,7 +12,7 @@ const {
 const {bentoBundles, verifyBentoBundles} = require('../compile/bundles.config');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {log} = require('../common/logging');
-const {mkdir} = require('fs').promises;
+const {mkdir} = require('fs-extra');
 const {red} = require('kleur/colors');
 const {watch} = require('chokidar');
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -726,51 +726,20 @@ function buildBinaries(extDir, binaries, options) {
 }
 
 /**
- * @param {string} nameWithoutExtension
- * @param {?string|void} cwd
- * @return {Promise<string|undefined>}
- */
-async function findJsSourceFilename(nameWithoutExtension, cwd) {
-  const [filename] = await fastGlob(
-    `${nameWithoutExtension}.{js,ts,tsx}`,
-    cwd ? {cwd} : undefined
-  );
-  return filename;
-}
-
-/**
  * @param {string} dir
  * @param {string} name
  * @param {!Object} options
  * @return {!Promise}
  */
 async function buildBentoExtensionJs(dir, name, options) {
-<<<<<<< HEAD
-<<<<<<< HEAD
-  const entryPoint = await findJsSourceFilename(path.join(dir, name));
-  const remapDependencies = getRemapBentoDependencies(
-    entryPoint,
-    options.minify
-  );
-=======
-  const remapDependencies = getRemapBentoDependencies(options.minify);
-
-  // Delete entry point from dependency mapping
-=======
->>>>>>> 86a9d60956 (structure)
   const entryPoint = await findJsSourceFilename(path.join(dir, name));
   if (!entryPoint) {
     throw new Error(`No source file matching ${dir}/${name} was found`);
   }
-<<<<<<< HEAD
-
->>>>>>> 6bef82d552 (🏗 Allow `bento-mustache` build)
-=======
   const remapDependencies = getRemapBentoDependencies(
     entryPoint,
     options.minify
   );
->>>>>>> 86a9d60956 (structure)
   await buildExtensionJs(dir, name, {
     ...options,
     externalDependencies: [...new Set(Object.values(remapDependencies))],

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -728,7 +728,6 @@ async function buildBentoExtensionJs(dir, name, options) {
     entryPoint,
     options.minify
   );
-  console.log({remapDependencies});
   await buildExtensionJs(dir, name, {
     ...options,
     externalDependencies: [...new Set(Object.values(remapDependencies))],

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -622,6 +622,19 @@ async function buildBentoCss(name, versions, minifiedAmpCss) {
 }
 
 /**
+ * @param {string} nameWithoutExtension
+ * @param {?string|void} cwd
+ * @return {Promise<string|undefined>}
+ */
+async function findJsSourceFilename(nameWithoutExtension, cwd) {
+  const [filename] = await fastGlob(
+    `${nameWithoutExtension}.{js,ts,tsx}`,
+    cwd ? {cwd} : undefined
+  );
+  return filename;
+}
+
+/**
  * @param {string} extDir
  * @param {string} name
  * @param {!Object} options
@@ -732,11 +745,22 @@ async function findJsSourceFilename(nameWithoutExtension, cwd) {
  * @return {!Promise}
  */
 async function buildBentoExtensionJs(dir, name, options) {
+<<<<<<< HEAD
   const entryPoint = await findJsSourceFilename(path.join(dir, name));
   const remapDependencies = getRemapBentoDependencies(
     entryPoint,
     options.minify
   );
+=======
+  const remapDependencies = getRemapBentoDependencies(options.minify);
+
+  // Delete entry point from dependency mapping
+  const entryPoint = await findJsSourceFilename(path.join(dir, name));
+  if (entryPoint) {
+    delete remapDependencies[`./${entryPoint}`];
+  }
+
+>>>>>>> 6bef82d552 (🏗 Allow `bento-mustache` build)
   await buildExtensionJs(dir, name, {
     ...options,
     externalDependencies: [...new Set(Object.values(remapDependencies))],
@@ -825,7 +849,11 @@ function generateBentoEntryPointSource(name, toExport, outputFilename) {
  */
 async function buildExtensionJs(dir, name, options) {
   const isLatest = legacyLatestVersions[options.name] === options.version;
-  const {version, filename = `${name}.js`, wrapper = 'extension'} = options;
+  const {
+    filename = await findJsSourceFilename(name, dir),
+    version,
+    wrapper = 'extension',
+  } = options;
 
   const wrapperOrFn = wrappers[wrapper];
   if (!wrapperOrFn) {

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -728,6 +728,7 @@ async function buildBentoExtensionJs(dir, name, options) {
     entryPoint,
     options.minify
   );
+  console.log({remapDependencies});
   await buildExtensionJs(dir, name, {
     ...options,
     externalDependencies: [...new Set(Object.values(remapDependencies))],

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -721,9 +721,6 @@ function buildBinaries(extDir, binaries, options) {
  */
 async function buildBentoExtensionJs(dir, name, options) {
   const entryPoint = await findJsSourceFilename(path.join(dir, name));
-  if (!entryPoint) {
-    throw new Error(`No source file matching ${dir}/${name} was found`);
-  }
   const remapDependencies = getRemapBentoDependencies(
     entryPoint,
     options.minify

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -641,6 +641,7 @@ async function findJsSourceFilename(nameWithoutExtension, cwd) {
  * @return {!Promise}
  */
 async function buildNpmBinaries(extDir, name, options) {
+<<<<<<< HEAD
   let {npm} = options;
   if (npm === true) {
     npm = {
@@ -650,6 +651,29 @@ async function buildNpmBinaries(extDir, name, options) {
         external: ['preact', 'preact/dom', 'preact/compat', 'preact/hooks'],
         remap: {'preact/dom': 'preact'},
         wrapper: '',
+=======
+  // Some component bundles may not have a React implementation, like
+  // bento-mustache
+  const preactEntryPoint = await findJsSourceFilename('component', extDir);
+  const npm = {
+    preact: preactEntryPoint && {
+      entryPoint: preactEntryPoint,
+      outfile: 'component-preact.js',
+      external: ['preact', 'preact/dom', 'preact/compat', 'preact/hooks'],
+      remap: {'preact/dom': 'preact'},
+      wrapper: '',
+    },
+    react: preactEntryPoint && {
+      babelCaller: options.minify ? 'react-minified' : 'react-unminified',
+      entryPoint: preactEntryPoint,
+      outfile: 'component-react.js',
+      external: ['react', 'react-dom'],
+      remap: {
+        'preact': 'react',
+        '.*/preact/compat': 'react',
+        'preact/hooks': 'react',
+        'preact/dom': 'react-dom',
+>>>>>>> ce594ff3dc (oops)
       },
       react: {
         babelCaller: options.minify ? 'react-minified' : 'react-unminified',

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -41,6 +41,7 @@ const {
   getRemapBentoDependencies,
   getRemapBentoNpmDependencies,
 } = require('../compile/bento-remap');
+const {findJsSourceFilename} = require('../common/fs');
 
 const legacyLatestVersions = json5.parse(
   fs.readFileSync(
@@ -619,19 +620,6 @@ async function buildBentoCss(name, versions, minifiedAmpCss) {
   const bentoName = getBentoName(name);
   const renamedCss = await renameSelectorsToBentoTagNames(minifiedAmpCss);
   await writeCssBinaries(bentoName, versions, renamedCss);
-}
-
-/**
- * @param {string} nameWithoutExtension
- * @param {?string|void} cwd
- * @return {Promise<string|undefined>}
- */
-async function findJsSourceFilename(nameWithoutExtension, cwd) {
-  const [filename] = await fastGlob(
-    `${nameWithoutExtension}.{js,ts,tsx}`,
-    cwd ? {cwd} : undefined
-  );
-  return filename;
 }
 
 /**

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -641,7 +641,6 @@ async function findJsSourceFilename(nameWithoutExtension, cwd) {
  * @return {!Promise}
  */
 async function buildNpmBinaries(extDir, name, options) {
-<<<<<<< HEAD
   let {npm} = options;
   if (npm === true) {
     npm = {
@@ -651,29 +650,6 @@ async function buildNpmBinaries(extDir, name, options) {
         external: ['preact', 'preact/dom', 'preact/compat', 'preact/hooks'],
         remap: {'preact/dom': 'preact'},
         wrapper: '',
-=======
-  // Some component bundles may not have a React implementation, like
-  // bento-mustache
-  const preactEntryPoint = await findJsSourceFilename('component', extDir);
-  const npm = {
-    preact: preactEntryPoint && {
-      entryPoint: preactEntryPoint,
-      outfile: 'component-preact.js',
-      external: ['preact', 'preact/dom', 'preact/compat', 'preact/hooks'],
-      remap: {'preact/dom': 'preact'},
-      wrapper: '',
-    },
-    react: preactEntryPoint && {
-      babelCaller: options.minify ? 'react-minified' : 'react-unminified',
-      entryPoint: preactEntryPoint,
-      outfile: 'component-react.js',
-      external: ['react', 'react-dom'],
-      remap: {
-        'preact': 'react',
-        '.*/preact/compat': 'react',
-        'preact/hooks': 'react',
-        'preact/dom': 'react-dom',
->>>>>>> ce594ff3dc (oops)
       },
       react: {
         babelCaller: options.minify ? 'react-minified' : 'react-unminified',

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -746,6 +746,7 @@ async function findJsSourceFilename(nameWithoutExtension, cwd) {
  */
 async function buildBentoExtensionJs(dir, name, options) {
 <<<<<<< HEAD
+<<<<<<< HEAD
   const entryPoint = await findJsSourceFilename(path.join(dir, name));
   const remapDependencies = getRemapBentoDependencies(
     entryPoint,
@@ -755,12 +756,21 @@ async function buildBentoExtensionJs(dir, name, options) {
   const remapDependencies = getRemapBentoDependencies(options.minify);
 
   // Delete entry point from dependency mapping
+=======
+>>>>>>> 86a9d60956 (structure)
   const entryPoint = await findJsSourceFilename(path.join(dir, name));
-  if (entryPoint) {
-    delete remapDependencies[`./${entryPoint}`];
+  if (!entryPoint) {
+    throw new Error(`No source file matching ${dir}/${name} was found`);
   }
+<<<<<<< HEAD
 
 >>>>>>> 6bef82d552 (🏗 Allow `bento-mustache` build)
+=======
+  const remapDependencies = getRemapBentoDependencies(
+    entryPoint,
+    options.minify
+  );
+>>>>>>> 86a9d60956 (structure)
   await buildExtensionJs(dir, name, {
     ...options,
     externalDependencies: [...new Set(Object.values(remapDependencies))],

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -435,7 +435,6 @@ async function buildExtension(name, version, hasCss, options) {
   }
 
   if (hasCss) {
-    await fs.mkdir('build/css', {recursive: true});
     await buildExtensionCss(extDir, name, version, options);
     if (options.compileOnlyCss) {
       return;
@@ -515,6 +514,7 @@ async function buildNpmBentoWebComponentCss(extDir, options) {
     await buildExtensionCss(extDir, options.name, options.version, options);
   }
   const destFilepath = path.resolve(`${extDir}/dist/web-component.css`);
+  await fs.ensureDir(path.dirname(destFilepath));
   await fs.copyFile(srcFilepath, destFilepath);
 }
 


### PR DESCRIPTION
Generic:
- Pass `npm` through from `bundles.config.bento.json`
- Remove self from dependency remapping.

Special:
- NPM builds should remap its dependency to `mustache` instead of `@bentoproject/mustache`.