### PR TITLE
🏗️  Fix a bug with remapping when dist is run a second time

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -346,7 +346,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
       result = await esbuild.build({
         entryPoints: [entryPoint],
         bundle: true,
-        sourcemap: true,
+        sourcemap: 'external',
         sourceRoot: path.dirname(destFile),
         sourcesContent: !!argv.full_sourcemaps,
         outfile: destFile,


### PR DESCRIPTION
This is fun. When babel performs internal remapping (when there is an input sourcemap), it just fails to output a valid sourcemap if the output has multiple source files (I actually recently fixed this...). When esbuild generates a sourcemap, it'll link to the map file with a `sourceMappingUrl` comment. Babel will try see that comment, and interpret the sourcemap as an input. And we hit the bug if the output has multiple sources.

This works fine on the initial build, because the map file hasn't been written to disk yet. But on a re-dist, the map file will exist, and babel will read it. This will cause a bug in our `@ampproject/remapping`, because we see a transformation that outputs an invalid map (and we throw an error).
