### PR TITLE
🏗 Remove unnecessary `mkdir`

### DIFF
--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -12,7 +12,6 @@ const {
 const {bentoBundles, verifyBentoBundles} = require('../compile/bundles.config');
 const {endBuildStep, watchDebounceDelay} = require('./helpers');
 const {log} = require('../common/logging');
-const {mkdirSync} = require('fs');
 const {red} = require('kleur/colors');
 const {watch} = require('chokidar');
 
@@ -139,7 +138,6 @@ async function buildBentoComponent(name, version, hasCss, options = {}) {
   /** @type {Promise<void>[]} */
   const promises = [];
   if (hasCss) {
-    mkdirSync('build/css', {recursive: true});
     promises.push(buildExtensionCss(componentsDir, name, version, options));
     if (options.compileOnlyCss) {
       return Promise.all(promises);

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -436,8 +436,6 @@ async function buildExtension(name, version, hasCss, options) {
   }
 
   if (hasCss) {
-    mkdirSync('build');
-    mkdirSync('build/css');
     await buildExtensionCss(extDir, name, version, options);
     if (options.compileOnlyCss) {
       return;


### PR DESCRIPTION
It's not necessary to explicitly create the output directory, since we use `outputFile`, which ensures that the directory exists.