### PR TITLE
🏗 Resolve extension entry points when TypeScript

### DIFF
--- a/build-system/common/fs.js
+++ b/build-system/common/fs.js
@@ -1,0 +1,18 @@
+const glob = require('globby');
+
+/**
+ * @param {string} nameWithoutExtension
+ * @param {?string|void} cwd
+ * @return {Promise<string|undefined>}
+ */
+async function findJsSourceFilename(nameWithoutExtension, cwd) {
+  const [filename] = await glob(
+    `${nameWithoutExtension}.{js,ts,tsx}`,
+    cwd ? {cwd} : undefined
+  );
+  return filename;
+}
+
+module.exports = {
+  findJsSourceFilename,
+};

--- a/build-system/common/fs.js
+++ b/build-system/common/fs.js
@@ -7,7 +7,7 @@ const glob = require('globby');
  */
 async function findJsSourceFilename(nameWithoutExtension, cwd) {
   const [filename] = await glob(
-    `${nameWithoutExtension}.{js,ts,tsx}`,
+    `${nameWithoutExtension}.{js,jsx,ts,tsx}`,
     cwd ? {cwd} : undefined
   );
   return filename;

--- a/build-system/compile/bento-remap.js
+++ b/build-system/compile/bento-remap.js
@@ -49,7 +49,7 @@ function getExportAll(filename) {
 /** @typedef {{source: string, cdn?: string, npm?: string}} */
 let MappingEntryDef;
 
-/** @return {MappingEntryDef[]}}} */
+/** @return {Promise<MappingEntryDef[]>}}} */
 const getAllRemappings = once(async () => {
   // IMPORTANT: cdn mappings must start with ./dist/
 
@@ -72,17 +72,23 @@ const getAllRemappings = once(async () => {
     (
       await Promise.all(
         [...coreBentoRemappings, ...componentRemappings].map(
-          async ({cdn, npm, source}) => {
-            const resolved = await resolveExactModuleFile(source);
-            if (resolved) {
-              return {source: resolved, cdn, npm};
-            }
-          }
+          resolveMappingEntry
         )
       )
     ).filter(Boolean)
   );
 });
+
+/**
+ * @param {MappingEntryDef} mapping
+ * @return {Promise<MappingEntryDef|undefined>}
+ */
+async function resolveMappingEntry({cdn, npm, source}) {
+  const resolved = await resolveExactModuleFile(source);
+  if (resolved) {
+    return {source: resolved, cdn, npm};
+  }
+}
 
 /**
  * @param {'npm'|'cdn'} type

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -672,7 +672,7 @@ async function buildNpmBinaries(extDir, name, options) {
       npm.bento.external = Object.values(npm.bento.remap);
     }
   }
-  const binaries = Object.values(npm);
+  const binaries = Object.values(npm).filter(Boolean);
   return buildBinaries(extDir, binaries, options);
 }
 

--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -659,8 +659,7 @@ async function buildNpmBinaries(extDir, name, options) {
         entryPoint: await getBentoBuildFilename(
           extDir,
           getBentoName(name),
-          'web-component',
-          options
+          'web-component'
         ),
         outfile: 'web-component.js',
         wrapper: '',
@@ -718,7 +717,7 @@ async function buildBentoExtensionJs(dir, name, options) {
     remapDependencies,
     wrapper: 'none',
     outputFormat: argv.esm ? 'esm' : 'nomodule-loader',
-    filename: await getBentoBuildFilename(dir, name, 'standalone', options),
+    filename: await getBentoBuildFilename(dir, name, 'standalone'),
   });
 }
 
@@ -728,11 +727,10 @@ async function buildBentoExtensionJs(dir, name, options) {
  * configuration.
  * @param {string} dir
  * @param {string} name
- * @param {string} mode
- * @param {Object} options
+ * @param {'standalone'|'web-component'} mode
  * @return {Promise<string>}
  */
-async function getBentoBuildFilename(dir, name, mode, options) {
+async function getBentoBuildFilename(dir, name, mode) {
   const modes = {
     'standalone': {
       basename: name,
@@ -744,12 +742,6 @@ async function getBentoBuildFilename(dir, name, mode, options) {
     },
   };
   const {basename, toExport} = modes[mode];
-  if (!basename) {
-    throw new Error(
-      `Unknown bento mode "${mode}" (${name}:${options.version})\n` +
-        `Expected one of: ${Object.keys(modes).join(', ')}`
-    );
-  }
   const existingFilename = await findJsSourceFilename(basename, dir);
   if (existingFilename) {
     return existingFilename;
@@ -767,7 +759,7 @@ async function getBentoBuildFilename(dir, name, mode, options) {
 
 /**
  * @param {string} name
- * @param {string} toExport
+ * @param {boolean} toExport
  * @param {string} outputFilename
  * @return {string}
  */


### PR DESCRIPTION
Even though we support writing TypeScript, our entry point resolution schema only looks for `.js` files.
This allows looking for any of `.js`, `.jsx`, `.ts` and `.tsx`.