### PR TITLE
🐛  compiler.js buildDoms: ensure behavior matches browser

### DIFF
--- a/examples/compiler-hydration.html
+++ b/examples/compiler-hydration.html
@@ -66,16 +66,16 @@
     </amp-carousel>
 
     <h1><code>server render: carousel-0.1 type=slides</code></h1>
-    <amp-carousel type="slides" width="400" height="300" controls="" loop="" i-amphtml-ssr style="position: relative;" class="i-amphtml-slidescroll i-amphtml-carousel-has-controls">
-        <div tabindex="-1" class="i-amphtml-slides-container i-amphtml-slidescroll-no-snap" aria-live="polite">
-            <div class="i-amphtml-slide-item"><amp-img src="https://picsum.photos/400/300?img=1" width="400" height="300" data-slide-id="slide-id" style="display: inline;" class="amp-carousel-slide"></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img src="https://picsum.photos/400/300?img=2" width="400" height="300" style="display: inline;" class="amp-carousel-slide"></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img src="https://picsum.photos/400/300?img=3" width="400" height="300" style="display: inline;" class="amp-carousel-slide"></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img src="https://picsum.photos/400/300?img=4" width="400" height="300" style="display: inline;" class="amp-carousel-slide"></amp-img></div>
-            <div class="i-amphtml-slide-item"><amp-img src="https://picsum.photos/400/300?img=5" width="400" height="300" style="display: inline;" class="amp-carousel-slide"></amp-img></div>
+    <amp-carousel class="i-amphtml-layout-fixed i-amphtml-layout-size-defined i-amphtml-slidescroll i-amphtml-carousel-has-controls" controls height=300 i-amphtml-layout=fixed i-amphtml-ssr loop style="width: 400px; height: 300px;" type=slides width=400>
+        <div aria-live=polite class="i-amphtml-slides-container i-amphtml-slidescroll-no-snap" tabindex="-1">
+            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/300?img=1" width=400></amp-img></div>
+            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=2" width=400></amp-img></div>
+            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=3" width=400></amp-img></div>
+            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=4" width=400></amp-img></div>
+            <div class="i-amphtml-slide-item"><amp-img class="amp-carousel-slide" height=300 src="https://picsum.photos/400/200?img=5" width=400></amp-img></div>
         </div>
-        <div tabindex="0" class="amp-carousel-button amp-carousel-button-prev" role="button" title="Previous item in carousel (5 of 5)" aria-disabled="false"></div>
-        <div tabindex="0" class="amp-carousel-button amp-carousel-button-next" role="button" title="Next item in carousel (2 of 5)" aria-disabled="false"></div>
+        <div aria-disabled=false class="amp-carousel-button amp-carousel-button-prev" role=button tabindex=0 title="Previous item in carousel (5 of 5)"></div>
+        <div aria-disabled=false class="amp-carousel-button amp-carousel-button-next" role=button tabindex=0 title="Next item in carousel (2 of 5)"></div>
     </amp-carousel>
 
     <h1><code>client render: carousel-0.1 type=scrollable</code></h1>
@@ -90,17 +90,16 @@
     </amp-carousel>
 
     <h1><code>server render: carousel-0.1 type=scrollable</code></h1>
-    <amp-carousel width="300" height="100" i-amphtml-ssr>
+    <amp-carousel class="i-amphtml-layout-fixed i-amphtml-layout-size-defined" height=100 i-amphtml-layout=fixed i-amphtml-ssr style="width: 300px; height: 100px;" width=300>
         <div class="i-amphtml-scrollable-carousel-container" tabindex="-1">
-            <amp-img src="https://picsum.photos/300/400?img=1" width="120" height="100" id="img-0" style="width: 120px; height: 100px;" class="amp-carousel-slide amp-scrollable-carousel-slide"></amp-img>
-            <amp-img src="https://picsum.photos/300/400?img=2" width="120" height="100" id="img-1" style="width: 120px; height: 100px;" class="amp-carousel-slide amp-scrollable-carousel-slide"></amp-img>
-            <amp-img src="https://picsum.photos/300/400?img=3" width="120" height="100" id="img-2" style="width: 120px; height: 100px;" class="amp-carousel-slide amp-scrollable-carousel-slide"></amp-img>
-            <amp-img src="https://picsum.photos/300/400?img=4" width="120" height="100" id="img-3" style="width: 120px; height: 100px;" class="amp-carousel-slide amp-scrollable-carousel-slide"></amp-img>
-            <amp-img src="https://picsum.photos/300/400?img=5" width="120" height="100" id="img-4" style="width: 120px; height: 100px;" class="amp-carousel-slide amp-scrollable-carousel-slide"></amp-img>
-            <amp-img src="https://picsum.photos/300/400?img=6" width="120" height="100" id="img-5" style="width: 120px; height: 100px;" class="amp-carousel-slide amp-scrollable-carousel-slide"></amp-img>
-            <amp-img src="https://picsum.photos/300/400?img=7" width="120" height="100" id="img-6" style="width: 120px; height: 100px;" class="amp-carousel-slide amp-scrollable-carousel-slide"></amp-img>
+            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=1" width=120></amp-img>
+            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=2" width=120></amp-img>
+            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=3" width=120></amp-img>
+            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=4" width=120></amp-img>
+            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=5" width=120></amp-img>
+            <amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=6" width=120></amp-img><amp-img class="amp-carousel-slide amp-scrollable-carousel-slide" height=100 src="https://picsum.photos/300/400?img=7" width=120></amp-img>
         </div>
-        <div tabindex="-1" class="amp-carousel-button amp-carousel-button-prev amp-disabled" role="presentation" title="Previous item in carousel" aria-disabled="true"></div>
-        <div tabindex="0" class="amp-carousel-button amp-carousel-button-next" role="presentation" title="Next item in carousel" aria-disabled="false"></div>
+        <div aria-disabled=true class="amp-carousel-button amp-carousel-button-prev amp-disabled" role=presentation tabindex="-1" title="Previous item in carousel"></div>
+        <div aria-disabled=false class="amp-carousel-button amp-carousel-button-next" role=presentation tabindex=0 title="Next item in carousel"></div>
     </amp-carousel>
 </html>

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -458,7 +458,7 @@ describes.realWin(
         impl.iframe = {
           contentWindow: window,
           nodeType: 1,
-          style: {},
+          style: {setProperty: () => {}},
         };
         impl.element.setAttribute('data-ad-client', 'ca-adsense');
 

--- a/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
+++ b/extensions/amp-fit-text/0.1/test/test-amp-fit-text.js
@@ -1,4 +1,8 @@
+import {createDocument as createWorkerDomDoc} from '@ampproject/worker-dom/dist/server-lib.mjs';
+
 import {createElementWithAttributes} from '#core/dom';
+
+import {getDeterministicOuterHTML} from '#testing/helpers';
 
 import {AmpFitText, calculateFontSize_, updateOverflow_} from '../amp-fit-text';
 import {buildDom} from '../build-dom';
@@ -51,6 +55,28 @@ describes.realWin(
       buildDom(fitText2);
 
       expect(fitText1.outerHTML).to.equal(fitText2.outerHTML);
+    });
+
+    it('buildDom should behave same in browser and in WorkerDOM', async () => {
+      const browserFitText = createElementWithAttributes(doc, 'amp-fit-text', {
+        width: '111px',
+        height: '222px',
+      });
+      const workerFitText = createElementWithAttributes(
+        createWorkerDomDoc(),
+        'amp-fit-text',
+        {
+          width: '111px',
+          height: '222px',
+        }
+      );
+
+      buildDom(browserFitText);
+      buildDom(workerFitText);
+
+      const browserHtml = getDeterministicOuterHTML(browserFitText);
+      const workerHtml = getDeterministicOuterHTML(workerFitText);
+      expect(workerHtml).to.equal(browserHtml);
     });
 
     it('buildCallback should assign ivars even when server rendered', async () => {

--- a/src/core/dom/style.js
+++ b/src/core/dom/style.js
@@ -46,6 +46,11 @@ function getVendorJsPropertyName_(style, titleCase) {
 }
 
 /**
+ * A small set of curated properties that are valid with setProp
+ */
+const SHOULD_USE_SET_PROPERTY = new Set(['width', 'height', 'order', 'hidden']);
+
+/**
  * Returns the possibly prefixed JavaScript property name of a style property
  * (ex. WebkitTransitionDuration) given a camelCase'd version of the property
  * (ex. transitionDuration).
@@ -60,6 +65,7 @@ export function getVendorJsPropertyName(style, camelCase, opt_bypassCache) {
     // CSS vars are returned as is.
     return camelCase;
   }
+
   if (!propertyNameCache) {
     propertyNameCache = map();
   }
@@ -116,7 +122,7 @@ export function setStyle(element, property, value, opt_units, opt_bypassCache) {
     return;
   }
   const styleValue = opt_units ? value + opt_units : value;
-  if (isVar(propertyName)) {
+  if (isVar(propertyName) || SHOULD_USE_SET_PROPERTY.has(propertyName)) {
     element.style.setProperty(propertyName, styleValue);
   } else {
     /** @type {*} */ (element.style)[propertyName] = styleValue;

--- a/src/core/dom/style.js
+++ b/src/core/dom/style.js
@@ -46,7 +46,11 @@ function getVendorJsPropertyName_(style, titleCase) {
 }
 
 /**
- * A small set of curated properties that are valid with setProp
+ * A small set of curated properties that are valid with setProperty.
+ * Within worker-dom, only `.setProperty` properly reflects into the attribute.
+ * If we solve that, or decide to always use setProperty, this kludge can be removed.
+ *
+ * TODO(https://github.com/ampproject/worker-dom/issues/1134)
  */
 const SHOULD_USE_SET_PROPERTY = new Set(['width', 'height', 'order', 'hidden']);
 

--- a/test/integration/test-video-manager.js
+++ b/test/integration/test-video-manager.js
@@ -356,6 +356,9 @@ describes.sandboxed
           width: null,
           height: null,
           opacity: null,
+          setProperty(name, value) {
+            video.style[name] = value;
+          },
         },
         muted: null,
         playsinline: null,

--- a/test/unit/builtins/test-amp-layout.js
+++ b/test/unit/builtins/test-amp-layout.js
@@ -1,8 +1,12 @@
+import {createDocument as createWorkerDomDoc} from '@ampproject/worker-dom/dist/server-lib.mjs';
+
 import {AmpLayout} from '#builtins/amp-layout/amp-layout';
 import {buildDom} from '#builtins/amp-layout/build-dom';
 
 import {createElementWithAttributes} from '#core/dom';
 import {Layout_Enum} from '#core/dom/layout';
+
+import {getDeterministicOuterHTML as getOuterHtml} from '#testing/helpers';
 
 describes.realWin('amp-layout', {amp: true}, (env) => {
   async function getAmpLayout(attrs, innerHTML) {
@@ -58,6 +62,32 @@ describes.realWin('amp-layout', {amp: true}, (env) => {
     buildDom(layout2);
 
     expect(layout1.outerHTML).to.equal(layout2.outerHTML);
+  });
+
+  it('buildDom should result in the same outerHTML in WorkerDOM and Browser', () => {
+    const browserAmpLayout = createElementWithAttributes(
+      env.win.document,
+      'amp-layout',
+      {
+        width: 100,
+        height: 100,
+      }
+    );
+    const workerDomAmpLayout = createElementWithAttributes(
+      createWorkerDomDoc(),
+      'amp-layout',
+      {
+        width: 100,
+        height: 100,
+      }
+    );
+
+    buildDom(browserAmpLayout);
+    buildDom(workerDomAmpLayout);
+
+    const browserHtml = getOuterHtml(browserAmpLayout);
+    const workerDomHtml = getOuterHtml(workerDomAmpLayout);
+    expect(browserHtml).to.equal(workerDomHtml);
   });
 
   it('buildDom does not modify server rendered elements', () => {

--- a/test/unit/builtins/test-amp-layout.js
+++ b/test/unit/builtins/test-amp-layout.js
@@ -6,7 +6,7 @@ import {buildDom} from '#builtins/amp-layout/build-dom';
 import {createElementWithAttributes} from '#core/dom';
 import {Layout_Enum} from '#core/dom/layout';
 
-import {getDeterministicOuterHTML as getOuterHtml} from '#testing/helpers';
+import {getDeterministicOuterHTML} from '#testing/helpers';
 
 describes.realWin('amp-layout', {amp: true}, (env) => {
   async function getAmpLayout(attrs, innerHTML) {
@@ -85,8 +85,8 @@ describes.realWin('amp-layout', {amp: true}, (env) => {
     buildDom(browserAmpLayout);
     buildDom(workerDomAmpLayout);
 
-    const browserHtml = getOuterHtml(browserAmpLayout);
-    const workerDomHtml = getOuterHtml(workerDomAmpLayout);
+    const browserHtml = getDeterministicOuterHTML(browserAmpLayout);
+    const workerDomHtml = getDeterministicOuterHTML(workerDomAmpLayout);
     expect(browserHtml).to.equal(workerDomHtml);
   });
 

--- a/test/unit/compiler/test-builders.js
+++ b/test/unit/compiler/test-builders.js
@@ -1,6 +1,10 @@
+import {createDocument as createWorkerDomDoc} from '@ampproject/worker-dom/dist/server-lib.mjs';
+
 import {getBuilders} from '#compiler/builders';
 
 import {createElementWithAttributes} from '#core/dom';
+
+import {getDeterministicOuterHTML} from '#testing/helpers';
 
 describes.fakeWin('getBuilders', {}, (env) => {
   let doc;
@@ -51,6 +55,28 @@ describes.fakeWin('getBuilders', {}, (env) => {
       });
       builders.noop(elem);
       expect(elem.getAttribute('i-amphtml-layout')).equal('fixed');
+    });
+
+    it('wrapper should behave same in browser as in WorkerDOM', () => {
+      const browserDiv = createElementWithAttributes(doc, 'div', {
+        height: 100,
+        width: 100,
+      });
+      const workerDomDiv = createElementWithAttributes(
+        createWorkerDomDoc(),
+        'div',
+        {
+          height: 100,
+          width: 100,
+        }
+      );
+
+      builders.noop(browserDiv);
+      builders.noop(workerDomDiv);
+
+      const browserHtml = getDeterministicOuterHTML(browserDiv);
+      const workerHtml = getDeterministicOuterHTML(workerDomDiv);
+      expect(workerHtml).equal(browserHtml);
     });
   });
 });

--- a/test/unit/test-fixed-layer.js
+++ b/test/unit/test-fixed-layer.js
@@ -274,7 +274,7 @@ describes.sandboxed('FixedLayer', {}, (env) => {
             elem.style[privProp] = `${value} !${priority}`;
           } else if (
             elem.style[privProp] ||
-            !endsWith(elem.computedStyle[prop], '!important')
+            !elem.computedStyle[prop]?.endsWith('!important')
           ) {
             if (
               prop === 'transition' &&

--- a/testing/helpers/index.js
+++ b/testing/helpers/index.js
@@ -62,3 +62,54 @@ export async function awaitFrameAfter(ms) {
   await sleep(ms);
   await afterRenderPromise();
 }
+
+const VOID_ELEMENTS = new Set([
+  'AREA',
+  'BASE',
+  'BR',
+  'COL',
+  'EMBED',
+  'HR',
+  'IMG',
+  'INPUT',
+  'LINK',
+  'META',
+  'PARAM',
+  'SOURCE',
+  'TRACK',
+  'WBR',
+]);
+
+/**
+ * Returns true of node is a void element.
+ * @param {Node} node
+ * @return {boolean}
+ */
+function isVoidElement(node) {
+  return node.nodeType === Node.ELEMENT_NODE && VOID_ELEMENTS.has(node);
+}
+
+/**
+ * Returns the outerHTML for an element, but with lexicographically sorted attributes.
+ * @param {Node} node
+ * @return {string}
+ */
+export function getDeterministicOuterHTML(node) {
+  const tag = node.localName || node.tagName;
+  const attributes = Array.from(node.attributes)
+    .map(({name, value}) => `${name}="${value}"`)
+    .sort()
+    .join(' ');
+  const start = `<${tag} ${attributes}>`;
+  const contents = Array.from(node.childNodes).map((childNode) => {
+    if (childNode.nodeType === Node.ELEMENT_NODE) {
+      return getDeterministicOuterHTML(childNode);
+    }
+    return childNode.innerHTML || childNode.textContent;
+  });
+
+  if (!contents && isVoidElement(node)) {
+    return start;
+  }
+  return start + contents + `</${tag}>`;
+}

--- a/testing/helpers/index.js
+++ b/testing/helpers/index.js
@@ -82,11 +82,15 @@ const VOID_ELEMENTS = new Set([
 
 /**
  * Returns true of node is a void element.
+ * @see https://developer.mozilla.org/en-US/docs/Glossary/Empty_element
+ *
  * @param {Node} node
  * @return {boolean}
  */
 function isVoidElement(node) {
-  return node.nodeType === Node.ELEMENT_NODE && VOID_ELEMENTS.has(node);
+  return (
+    node.nodeType === Node.ELEMENT_NODE && VOID_ELEMENTS.has(node.nodeName)
+  );
 }
 
 /**


### PR DESCRIPTION
**summary**
While testing server-side transforms, I noticed [a bug in `worker-dom`](https://github.com/ampproject/worker-dom/issues/1134). Specifically, setting keys of the `style` prop on a node does not reflect in attributes properly. Instead [style.setProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty) has to be used to trigger the  "PropertyBackedAttribute" flow.

Separately, if we actually need JS in `setStyles` to dynamically figure out vendor-specific prop names, that of course won't work either.

This PR does a few things:
1. Swaps applications of a few known style props (`width`, `height`, `order`) to be set with `setProperty`. I scanned the relevant components we plan on server-rendering and I believe this covers it.
2. Creates a new test helper, `getDeterministicOuterHTML` that behaves similarly to `el.outerHTML` except sorts the attributes. Note that this doesn't deterministically print tokens within `style=` attr, but that hasn't been an issue yet and can be added later.
3. Adds a new test to each of `amp-carousel`, `amp-fit-text`, and `amp-layout` to ensure WorkerDOM behavior matches browser. Also adds a similar test to the builder wrapper, which for now mostly means checking `applyStaticLayout`.
4. Updates `compiler-hydration.html` with the results of actually running the "client render" HTML through `compiler.js`.