### PR TITLE
🏗 Make visual tests depend on module build

### DIFF
--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -26,16 +26,19 @@ function pushBuildWorkflow() {
  * Steps to run during PR builds.
  */
 function prBuildWorkflow() {
-  // TODO(#31102): This list must eventually match the same buildTargets check
-  // found in pr-check/nomodule-build.js as we turn on the systems that
-  // run against the module build. (ex. visual diffs, e2e, etc.)
-  if (buildTargetsInclude(Targets.RUNTIME, Targets.INTEGRATION_TEST)) {
+  if (
+    buildTargetsInclude(
+      Targets.RUNTIME,
+      Targets.INTEGRATION_TEST,
+      Targets.VISUAL_DIFF
+    )
+  ) {
     timedExecOrDie('amp dist --esm --fortesting');
     storeModuleBuildToWorkspace();
   } else {
     skipDependentJobs(
       jobName,
-      'this PR does not affect the runtime or integration tests'
+      'this PR does not affect the runtime, integration tests, or visual diff tests'
     );
   }
 }


### PR DESCRIPTION
#37115 made the visual tests use the module build, but did not express a dependency so that the build is performed when a visual test is modified.

https://github.com/ampproject/amphtml/blob/49445839c2a35af58984299c0a77a924e23e45fd/build-system/pr-check/module-build.js#L28-L41

 This PR adds the dependency.