### PR TITLE
🐛added optional extention matching for dependency remap when bundling

### DIFF
--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -415,7 +415,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
    */
   function remapDependenciesPlugin() {
     const remaps = Object.entries(options.remapDependencies).map(
-      ([path, value]) => ({regex: new RegExp(`^${path}(\.[jt]s)?$`), value})
+      ([path, value]) => ({regex: new RegExp(`^${path}(\.[jt]sx?)?$`), value})
     );
     const external = options.externalDependencies;
     return {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -415,7 +415,10 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
    */
   function remapDependenciesPlugin() {
     const remaps = Object.entries(options.remapDependencies).map(
-      ([path, value]) => ({regex: new RegExp(`^${path}(\.[jt]sx?)?$`), value})
+      ([path, value]) => ({
+        regex: new RegExp(`^${path}(\.js|\.jsx|\.ts|\.tsx)?$`),
+        value,
+      })
     );
     const external = options.externalDependencies;
     return {

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -415,7 +415,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
    */
   function remapDependenciesPlugin() {
     const remaps = Object.entries(options.remapDependencies).map(
-      ([path, value]) => ({regex: new RegExp(`^${path}$`), value})
+      ([path, value]) => ({regex: new RegExp(`^${path}(\.[jt]s)?$`), value})
     );
     const external = options.externalDependencies;
     return {


### PR DESCRIPTION
Fix a bug when bundling not being able to find, very specifically `src/preact/compat.js` when remapping dependencies for react.

But this fix should also cover any remap key that is missing the js or ts extension.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
