### PR TITLE
🐛 Teads Ads: remove prefetch domain from preconnect

### DIFF
--- a/ads/_config.js
+++ b/ads/_config.js
@@ -1276,7 +1276,6 @@ const adConfig = jsonConfiguration({
     prefetch: 'https://a.teads.tv/media/format/v3/teads-format.min.js',
     preconnect: [
       'https://cdn2.teads.tv',
-      'https://a.teads.tv',
       'https://t.teads.tv',
       'https://r.teads.tv',
     ],


### PR DESCRIPTION
No need to preconnect to a domain that is being prefetched. Fixes https://app.circleci.com/pipelines/github/ampproject/amphtml/22850/workflows/27e01357-051d-45b4-a77d-2d57da0cf6ed/jobs/455841

Follow up to #37672

@github-vincent-mathon Let me know if you have any concern.