### PR TITLE
🏗♻️🚮 Disable `@storybook/addon-knobs`

### DIFF
--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -50,7 +50,7 @@ module.exports = {
       }
 
       const [nextComment] = context.getCommentsAfter(node);
-      const [nextCommentStart] = nextComment.range;
+      const [nextCommentStart] = nextComment?.range ?? [];
       if (
         nextComment &&
         text.substr(end, nextCommentStart - end).indexOf('\n') < 0

--- a/build-system/eslint-rules/forbidden-terms-config.js
+++ b/build-system/eslint-rules/forbidden-terms-config.js
@@ -50,7 +50,7 @@ module.exports = {
       }
 
       const [nextComment] = context.getCommentsAfter(node);
-      const [nextCommentStart] = nextComment?.range ?? [];
+      const [nextCommentStart] = nextComment.range;
       if (
         nextComment &&
         text.substr(end, nextCommentStart - end).indexOf('\n') < 0

--- a/build-system/tasks/storybook/env/amp/main.js
+++ b/build-system/tasks/storybook/env/amp/main.js
@@ -1,11 +1,13 @@
+const {globExcludeDisabledStorybookFiles} = require('../disabled-stories');
+
 const rootDir = '../../../../..';
 
 module.exports = {
   staticDirs: [rootDir],
-  stories: [
+  stories: globExcludeDisabledStorybookFiles([
     `${rootDir}/src/builtins/storybook/*.amp.js`,
     `${rootDir}/extensions/**/*.*/storybook/*.amp.js`,
-  ],
+  ]),
   addons: [
     // TODO(alanorozco): AMP previews are loaded inside an iframe, so the a11y
     // addon is not able to inspect the tree inside it. Its results are incorrect,
@@ -14,9 +16,6 @@ module.exports = {
     // '@storybook/addon-a11y',
     '@storybook/addon-viewport/register',
     '@storybook/addon-controls/register',
-    // TODO(#35923): Remove addon-knobs once all stories are migrated to
-    // addon-controls (args/argTypes).
-    '@storybook/addon-knobs',
     '@ampproject/storybook-addon',
   ],
   webpackFinal: (config) => {

--- a/build-system/tasks/storybook/env/amp/register.js
+++ b/build-system/tasks/storybook/env/amp/register.js
@@ -1,3 +1,0 @@
-/**
- */
-export function register() {}

--- a/build-system/tasks/storybook/env/amp/register.js
+++ b/build-system/tasks/storybook/env/amp/register.js
@@ -1,8 +1,3 @@
-import {addons} from '@storybook/addons';
-
 /**
- * Register the AMP Storybook decorator addon
  */
-export function register() {
-  addons.register('amp/storybook', () => {});
-}
+export function register() {}

--- a/build-system/tasks/storybook/env/disabled-stories.js
+++ b/build-system/tasks/storybook/env/disabled-stories.js
@@ -1,0 +1,31 @@
+const globby = require('globby');
+const {forbiddenTermsGlobal} = require('../../../test-configs/forbidden-terms');
+
+/**
+ * Remove disabled Storybook files from an evaluated glob pattern.
+ * This is required since the disabled Stories use the Knobs addon, which is now
+ * obsolete and prevents us from upgrading the Storybook version.
+ * @param {string[]} inclusionPattern
+ * @return {string[]}
+ */
+function globExcludeDisabledStorybookFiles(inclusionPattern) {
+  const forbiddenTerm = `@storybook/${''}addon-knobs`;
+  const forbiddenTermsEntry = forbiddenTermsGlobal[forbiddenTerm];
+  if (!forbiddenTermsEntry?.allowlist?.length) {
+    throw new Error(
+      `Forbidden terms entry for "${forbiddenTerm}" not found, or it lacks an allowlist.` +
+        '\nThis likely means that globExcludeDisabledStorybookFiles() should be removed.' +
+        '\nIts callsites can be replaced with its argument, like the diff at:' +
+        '\nhttps://gist.github.com/alanorozco/6e8a64a38cb0d6967c193784624d1011'
+    );
+  }
+  const excluded = new Set(forbiddenTermsEntry.allowlist);
+  return globby.sync(inclusionPattern).filter((filename) => {
+    const relativeToRoot = filename.replace(/^([.]{1,2}\/)+/, '');
+    return !excluded.has(relativeToRoot);
+  });
+}
+
+module.exports = {
+  globExcludeDisabledStorybookFiles,
+};

--- a/build-system/tasks/storybook/env/preact/main.js
+++ b/build-system/tasks/storybook/env/preact/main.js
@@ -1,18 +1,17 @@
+const {globExcludeDisabledStorybookFiles} = require('../disabled-stories');
+
 const rootDir = '../../../../..';
 
 module.exports = {
   staticDirs: [rootDir],
-  stories: [
+  stories: globExcludeDisabledStorybookFiles([
     `${rootDir}/src/**/storybook/!(*.amp).js`,
     `${rootDir}/extensions/**/*.*/storybook/!(*.amp).js`,
-  ],
+  ]),
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-viewport/register',
     '@storybook/addon-controls/register',
-    // TODO(#35923): Remove addon-knobs once all stories are migrated to
-    // addon-controls (args/argTypes).
-    '@storybook/addon-knobs',
   ],
   webpackFinal: async (config) => {
     // Disable entry point size warnings.

--- a/build-system/tasks/storybook/env/react/main.js
+++ b/build-system/tasks/storybook/env/react/main.js
@@ -1,3 +1,5 @@
+const {globExcludeDisabledStorybookFiles} = require('../disabled-stories');
+
 const rootDir = '../../../../..';
 
 module.exports = {
@@ -5,17 +7,14 @@ module.exports = {
   // Unlike the `amp` and `preact` environments, we search Storybook files only
   // under component paths. This is because only components have React build
   // output, but directories in src/ outside src/bento/components/ do not.
-  stories: [
+  stories: globExcludeDisabledStorybookFiles([
     `${rootDir}/extensions/**/*.*/storybook/!(*.amp).js`,
     `${rootDir}/src/bento/components/**/*.*/storybook/*.js`,
-  ],
+  ]),
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-viewport/register',
     '@storybook/addon-controls/register',
-    // TODO(#35923): Remove addon-knobs once all stories are migrated to
-    // addon-controls (args/argTypes).
-    '@storybook/addon-knobs',
   ],
   webpackFinal: (config) => {
     // Disable entry point size warnings.

--- a/build-system/tasks/storybook/package-lock.json
+++ b/build-system/tasks/storybook/package-lock.json
@@ -13,7 +13,6 @@
         "@babel/runtime-corejs3": "7.15.4",
         "@storybook/addon-a11y": "6.3.12",
         "@storybook/addon-controls": "6.3.12",
-        "@storybook/addon-knobs": "6.3.1",
         "@storybook/addon-viewport": "6.3.12",
         "@storybook/client-api": "6.3.12",
         "babel-loader": "8.2.3",
@@ -919,43 +918,6 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/@storybook/addon-knobs": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-6.3.1.tgz",
-      "integrity": "sha512-2GGGnQSPXXUhHHYv4IW6pkyQlCPYXKYiyGzfhV7Zhs95M2Ban08OA6KLmliMptWCt7U9tqTO8dB5u0C2cWmCTw==",
-      "deprecated": "deprecating @storybook/addon-knobs in favor of @storybook/addon-controls",
-      "dev": true,
-      "dependencies": {
-        "copy-to-clipboard": "^3.3.1",
-        "core-js": "^3.8.2",
-        "escape-html": "^1.0.3",
-        "fast-deep-equal": "^3.1.3",
-        "global": "^4.4.0",
-        "lodash": "^4.17.20",
-        "prop-types": "^15.7.2",
-        "qs": "^6.10.0",
-        "react-colorful": "^5.1.2",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-select": "^3.2.0"
-      },
-      "peerDependencies": {
-        "@storybook/addons": "^6.3.0",
-        "@storybook/api": "^6.3.0",
-        "@storybook/components": "^6.3.0",
-        "@storybook/core-events": "^6.3.0",
-        "@storybook/theming": "^6.3.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@storybook/addon-viewport": {
       "version": "6.3.12",
       "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.3.12.tgz",
@@ -1093,128 +1055,6 @@
         "lodash": "^4.17.20",
         "memoizerific": "^1.11.3",
         "qs": "^6.10.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@storybook/addons": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.4.14.tgz",
-      "integrity": "sha512-Snu42ejLyBAh6PWdlrdI72HKN1oKY7q0R9qEID2wk953WrqgGu4URakp14YLxghJCyKTSfGPs6LNZRRI6H5xgA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@storybook/api": "6.4.14",
-        "@storybook/channels": "6.4.14",
-        "@storybook/client-logger": "6.4.14",
-        "@storybook/core-events": "6.4.14",
-        "@storybook/csf": "0.0.2--canary.87bc651.0",
-        "@storybook/router": "6.4.14",
-        "@storybook/theming": "6.4.14",
-        "@types/webpack-env": "^1.16.0",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "regenerator-runtime": "^0.13.7"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@storybook/addons/node_modules/@storybook/api": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.4.14.tgz",
-      "integrity": "sha512-GGGwB5+EquoausTXYx4dnLBBk2sOiS1Z58mDj0swBXCZdjfyUfLyxjxvvb/hl65ltufWP3IdmlKKaLiuARXNtw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@storybook/channels": "6.4.14",
-        "@storybook/client-logger": "6.4.14",
-        "@storybook/core-events": "6.4.14",
-        "@storybook/csf": "0.0.2--canary.87bc651.0",
-        "@storybook/router": "6.4.14",
-        "@storybook/semver": "^7.3.2",
-        "@storybook/theming": "6.4.14",
-        "core-js": "^3.8.2",
-        "fast-deep-equal": "^3.1.3",
-        "global": "^4.4.0",
-        "lodash": "^4.17.21",
-        "memoizerific": "^1.11.3",
-        "regenerator-runtime": "^0.13.7",
-        "store2": "^2.12.0",
-        "telejson": "^5.3.2",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@storybook/addons/node_modules/@storybook/channels": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.4.14.tgz",
-      "integrity": "sha512-3QOVxFG6ZAxDXCta1ie4SUPQ3s50yHeuZzVg6uPp+DcC1FrXeDFYBcU9t0j/jrSgbeKcnFHWxmRHNy1BRyWv/A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-js": "^3.8.2",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addons/node_modules/@storybook/client-logger": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.14.tgz",
-      "integrity": "sha512-4VmFWZxhpeiG5fDhfqAyQbCfXZSBKS4fNKf35ABWiHStZRDndxml8K5WFtmOmMvVzjrGQx8HesenYMawK6xo/Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-js": "^3.8.2",
-        "global": "^4.4.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/addons/node_modules/@storybook/theming": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.4.14.tgz",
-      "integrity": "sha512-kqmXNnIoOSAS4cgr9PitMgVrOps725O99eTsJNxB6J1Ide0CsA5v2tV6AmQn/scnpCQNr8uSjZerNlEcl/ensg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^0.8.6",
-        "@emotion/styled": "^10.0.27",
-        "@storybook/client-logger": "6.4.14",
-        "core-js": "^3.8.2",
-        "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.27",
-        "global": "^4.4.0",
-        "memoizerific": "^1.11.3",
-        "polished": "^4.0.5",
-        "resolve-from": "^5.0.0",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -1478,115 +1318,6 @@
         "url": "https://opencollective.com/storybook"
       }
     },
-    "node_modules/@storybook/components": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.4.14.tgz",
-      "integrity": "sha512-M7unerbOnvg+UN7qPxBCBWzK/boVdSSQxRiPAr1OL3M4OyEU8+TNPdQeAG0aF4zqtU0BrsDf4E85EznoMXUiFQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@popperjs/core": "^2.6.0",
-        "@storybook/client-logger": "6.4.14",
-        "@storybook/csf": "0.0.2--canary.87bc651.0",
-        "@storybook/theming": "6.4.14",
-        "@types/color-convert": "^2.0.0",
-        "@types/overlayscrollbars": "^1.12.0",
-        "@types/react-syntax-highlighter": "11.0.5",
-        "color-convert": "^2.0.1",
-        "core-js": "^3.8.2",
-        "fast-deep-equal": "^3.1.3",
-        "global": "^4.4.0",
-        "lodash": "^4.17.21",
-        "markdown-to-jsx": "^7.1.3",
-        "memoizerific": "^1.11.3",
-        "overlayscrollbars": "^1.13.1",
-        "polished": "^4.0.5",
-        "prop-types": "^15.7.2",
-        "react-colorful": "^5.1.2",
-        "react-popper-tooltip": "^3.1.1",
-        "react-syntax-highlighter": "^13.5.3",
-        "react-textarea-autosize": "^8.3.0",
-        "regenerator-runtime": "^0.13.7",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@storybook/components/node_modules/@storybook/client-logger": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.14.tgz",
-      "integrity": "sha512-4VmFWZxhpeiG5fDhfqAyQbCfXZSBKS4fNKf35ABWiHStZRDndxml8K5WFtmOmMvVzjrGQx8HesenYMawK6xo/Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-js": "^3.8.2",
-        "global": "^4.4.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/components/node_modules/@storybook/theming": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.4.14.tgz",
-      "integrity": "sha512-kqmXNnIoOSAS4cgr9PitMgVrOps725O99eTsJNxB6J1Ide0CsA5v2tV6AmQn/scnpCQNr8uSjZerNlEcl/ensg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@emotion/core": "^10.1.1",
-        "@emotion/is-prop-valid": "^0.8.6",
-        "@emotion/styled": "^10.0.27",
-        "@storybook/client-logger": "6.4.14",
-        "core-js": "^3.8.2",
-        "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.27",
-        "global": "^4.4.0",
-        "memoizerific": "^1.11.3",
-        "polished": "^4.0.5",
-        "resolve-from": "^5.0.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@storybook/core-events": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.4.14.tgz",
-      "integrity": "sha512-9QFltg2mxTDjMBfmVtFHtrAEPY/i0oVp2kVdTWo6g05cPffYKAjNUnUVjUl7yiqcQmdEcdqUUQ0ut3xgmcYi/A==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-js": "^3.8.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      }
-    },
-    "node_modules/@storybook/csf": {
-      "version": "0.0.2--canary.87bc651.0",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.87bc651.0.tgz",
-      "integrity": "sha512-ajk1Uxa+rBpFQHKrCcTmJyQBXZ5slfwHVEaKlkuFaW77it8RgbPJp/ccna3sgoi8oZ7FkkOyvv1Ve4SmwFqRqw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/@storybook/node-logger": {
       "version": "6.3.12",
       "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.3.12.tgz",
@@ -1654,49 +1385,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@storybook/router": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.4.14.tgz",
-      "integrity": "sha512-5+tePyINtwPYm4izgOBZ2sX2ViWtfmmO2vwOAPlWWEGzsRosVQsGMdZv1R8rk4Jl/TotMjlTmd8I1/BufEeIeQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@storybook/client-logger": "6.4.14",
-        "core-js": "^3.8.2",
-        "fast-deep-equal": "^3.1.3",
-        "global": "^4.4.0",
-        "history": "5.0.0",
-        "lodash": "^4.17.21",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0",
-        "react-router": "^6.0.0",
-        "react-router-dom": "^6.0.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/@storybook/router/node_modules/@storybook/client-logger": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.14.tgz",
-      "integrity": "sha512-4VmFWZxhpeiG5fDhfqAyQbCfXZSBKS4fNKf35ABWiHStZRDndxml8K5WFtmOmMvVzjrGQx8HesenYMawK6xo/Q==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-js": "^3.8.2",
-        "global": "^4.4.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
       }
     },
     "node_modules/@storybook/semver": {
@@ -3284,15 +2972,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
-      "dev": true,
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "node_modules/core-js": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.0.tgz",
@@ -3501,22 +3180,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/dom-helpers/node_modules/csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-      "dev": true
-    },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
@@ -3684,12 +3347,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -4612,16 +4269,6 @@
         "node": "*"
       }
     },
-    "node_modules/history": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
-      "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -5209,12 +4856,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "node_modules/memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "dev": true
     },
     "node_modules/memoizerific": {
       "version": "1.11.3",
@@ -6121,18 +5762,6 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
       "dev": true
     },
-    "node_modules/react-input-autosize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-      "dev": true,
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0"
-      }
-    },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -6166,74 +5795,6 @@
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0",
         "react-dom": "^16.6.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-router": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
-      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "history": "^5.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
-      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "history": "^5.2.0",
-        "react-router": "6.2.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/history": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
-      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
-    "node_modules/react-router/node_modules/history": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
-      "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
-    "node_modules/react-select": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz",
-      "integrity": "sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/cache": "^10.0.9",
-        "@emotion/core": "^10.0.9",
-        "@emotion/css": "^10.0.9",
-        "memoize-one": "^5.0.0",
-        "prop-types": "^15.6.0",
-        "react-input-autosize": "^3.0.0",
-        "react-transition-group": "^4.3.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/react-sizeme": {
@@ -6279,22 +5840,6 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/readable-stream": {
@@ -7476,12 +7021,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
-      "dev": true
     },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
@@ -9164,25 +8703,6 @@
         }
       }
     },
-    "@storybook/addon-knobs": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-6.3.1.tgz",
-      "integrity": "sha512-2GGGnQSPXXUhHHYv4IW6pkyQlCPYXKYiyGzfhV7Zhs95M2Ban08OA6KLmliMptWCt7U9tqTO8dB5u0C2cWmCTw==",
-      "dev": true,
-      "requires": {
-        "copy-to-clipboard": "^3.3.1",
-        "core-js": "^3.8.2",
-        "escape-html": "^1.0.3",
-        "fast-deep-equal": "^3.1.3",
-        "global": "^4.4.0",
-        "lodash": "^4.17.20",
-        "prop-types": "^15.7.2",
-        "qs": "^6.10.0",
-        "react-colorful": "^5.1.2",
-        "react-lifecycles-compat": "^3.0.4",
-        "react-select": "^3.2.0"
-      }
-    },
     "@storybook/addon-viewport": {
       "version": "6.3.12",
       "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-6.3.12.tgz",
@@ -9284,98 +8804,6 @@
             "lodash": "^4.17.20",
             "memoizerific": "^1.11.3",
             "qs": "^6.10.0",
-            "ts-dedent": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@storybook/addons": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-6.4.14.tgz",
-      "integrity": "sha512-Snu42ejLyBAh6PWdlrdI72HKN1oKY7q0R9qEID2wk953WrqgGu4URakp14YLxghJCyKTSfGPs6LNZRRI6H5xgA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@storybook/api": "6.4.14",
-        "@storybook/channels": "6.4.14",
-        "@storybook/client-logger": "6.4.14",
-        "@storybook/core-events": "6.4.14",
-        "@storybook/csf": "0.0.2--canary.87bc651.0",
-        "@storybook/router": "6.4.14",
-        "@storybook/theming": "6.4.14",
-        "@types/webpack-env": "^1.16.0",
-        "core-js": "^3.8.2",
-        "global": "^4.4.0",
-        "regenerator-runtime": "^0.13.7"
-      },
-      "dependencies": {
-        "@storybook/api": {
-          "version": "6.4.14",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-6.4.14.tgz",
-          "integrity": "sha512-GGGwB5+EquoausTXYx4dnLBBk2sOiS1Z58mDj0swBXCZdjfyUfLyxjxvvb/hl65ltufWP3IdmlKKaLiuARXNtw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@storybook/channels": "6.4.14",
-            "@storybook/client-logger": "6.4.14",
-            "@storybook/core-events": "6.4.14",
-            "@storybook/csf": "0.0.2--canary.87bc651.0",
-            "@storybook/router": "6.4.14",
-            "@storybook/semver": "^7.3.2",
-            "@storybook/theming": "6.4.14",
-            "core-js": "^3.8.2",
-            "fast-deep-equal": "^3.1.3",
-            "global": "^4.4.0",
-            "lodash": "^4.17.21",
-            "memoizerific": "^1.11.3",
-            "regenerator-runtime": "^0.13.7",
-            "store2": "^2.12.0",
-            "telejson": "^5.3.2",
-            "ts-dedent": "^2.0.0",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/channels": {
-          "version": "6.4.14",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-6.4.14.tgz",
-          "integrity": "sha512-3QOVxFG6ZAxDXCta1ie4SUPQ3s50yHeuZzVg6uPp+DcC1FrXeDFYBcU9t0j/jrSgbeKcnFHWxmRHNy1BRyWv/A==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-js": "^3.8.2",
-            "ts-dedent": "^2.0.0",
-            "util-deprecate": "^1.0.2"
-          }
-        },
-        "@storybook/client-logger": {
-          "version": "6.4.14",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.14.tgz",
-          "integrity": "sha512-4VmFWZxhpeiG5fDhfqAyQbCfXZSBKS4fNKf35ABWiHStZRDndxml8K5WFtmOmMvVzjrGQx8HesenYMawK6xo/Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-js": "^3.8.2",
-            "global": "^4.4.0"
-          }
-        },
-        "@storybook/theming": {
-          "version": "6.4.14",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.4.14.tgz",
-          "integrity": "sha512-kqmXNnIoOSAS4cgr9PitMgVrOps725O99eTsJNxB6J1Ide0CsA5v2tV6AmQn/scnpCQNr8uSjZerNlEcl/ensg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@emotion/core": "^10.1.1",
-            "@emotion/is-prop-valid": "^0.8.6",
-            "@emotion/styled": "^10.0.27",
-            "@storybook/client-logger": "6.4.14",
-            "core-js": "^3.8.2",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.27",
-            "global": "^4.4.0",
-            "memoizerific": "^1.11.3",
-            "polished": "^4.0.5",
-            "resolve-from": "^5.0.0",
             "ts-dedent": "^2.0.0"
           }
         }
@@ -9575,93 +9003,6 @@
         "global": "^4.4.0"
       }
     },
-    "@storybook/components": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-6.4.14.tgz",
-      "integrity": "sha512-M7unerbOnvg+UN7qPxBCBWzK/boVdSSQxRiPAr1OL3M4OyEU8+TNPdQeAG0aF4zqtU0BrsDf4E85EznoMXUiFQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@popperjs/core": "^2.6.0",
-        "@storybook/client-logger": "6.4.14",
-        "@storybook/csf": "0.0.2--canary.87bc651.0",
-        "@storybook/theming": "6.4.14",
-        "@types/color-convert": "^2.0.0",
-        "@types/overlayscrollbars": "^1.12.0",
-        "@types/react-syntax-highlighter": "11.0.5",
-        "color-convert": "^2.0.1",
-        "core-js": "^3.8.2",
-        "fast-deep-equal": "^3.1.3",
-        "global": "^4.4.0",
-        "lodash": "^4.17.21",
-        "markdown-to-jsx": "^7.1.3",
-        "memoizerific": "^1.11.3",
-        "overlayscrollbars": "^1.13.1",
-        "polished": "^4.0.5",
-        "prop-types": "^15.7.2",
-        "react-colorful": "^5.1.2",
-        "react-popper-tooltip": "^3.1.1",
-        "react-syntax-highlighter": "^13.5.3",
-        "react-textarea-autosize": "^8.3.0",
-        "regenerator-runtime": "^0.13.7",
-        "ts-dedent": "^2.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "dependencies": {
-        "@storybook/client-logger": {
-          "version": "6.4.14",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.14.tgz",
-          "integrity": "sha512-4VmFWZxhpeiG5fDhfqAyQbCfXZSBKS4fNKf35ABWiHStZRDndxml8K5WFtmOmMvVzjrGQx8HesenYMawK6xo/Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-js": "^3.8.2",
-            "global": "^4.4.0"
-          }
-        },
-        "@storybook/theming": {
-          "version": "6.4.14",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.4.14.tgz",
-          "integrity": "sha512-kqmXNnIoOSAS4cgr9PitMgVrOps725O99eTsJNxB6J1Ide0CsA5v2tV6AmQn/scnpCQNr8uSjZerNlEcl/ensg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@emotion/core": "^10.1.1",
-            "@emotion/is-prop-valid": "^0.8.6",
-            "@emotion/styled": "^10.0.27",
-            "@storybook/client-logger": "6.4.14",
-            "core-js": "^3.8.2",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.27",
-            "global": "^4.4.0",
-            "memoizerific": "^1.11.3",
-            "polished": "^4.0.5",
-            "resolve-from": "^5.0.0",
-            "ts-dedent": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@storybook/core-events": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-6.4.14.tgz",
-      "integrity": "sha512-9QFltg2mxTDjMBfmVtFHtrAEPY/i0oVp2kVdTWo6g05cPffYKAjNUnUVjUl7yiqcQmdEcdqUUQ0ut3xgmcYi/A==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "core-js": "^3.8.2"
-      }
-    },
-    "@storybook/csf": {
-      "version": "0.0.2--canary.87bc651.0",
-      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.87bc651.0.tgz",
-      "integrity": "sha512-ajk1Uxa+rBpFQHKrCcTmJyQBXZ5slfwHVEaKlkuFaW77it8RgbPJp/ccna3sgoi8oZ7FkkOyvv1Ve4SmwFqRqw==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "lodash": "^4.17.15"
-      }
-    },
     "@storybook/node-logger": {
       "version": "6.3.12",
       "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-6.3.12.tgz",
@@ -9707,39 +9048,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "@storybook/router": {
-      "version": "6.4.14",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-6.4.14.tgz",
-      "integrity": "sha512-5+tePyINtwPYm4izgOBZ2sX2ViWtfmmO2vwOAPlWWEGzsRosVQsGMdZv1R8rk4Jl/TotMjlTmd8I1/BufEeIeQ==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@storybook/client-logger": "6.4.14",
-        "core-js": "^3.8.2",
-        "fast-deep-equal": "^3.1.3",
-        "global": "^4.4.0",
-        "history": "5.0.0",
-        "lodash": "^4.17.21",
-        "memoizerific": "^1.11.3",
-        "qs": "^6.10.0",
-        "react-router": "^6.0.0",
-        "react-router-dom": "^6.0.0",
-        "ts-dedent": "^2.0.0"
-      },
-      "dependencies": {
-        "@storybook/client-logger": {
-          "version": "6.4.14",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-6.4.14.tgz",
-          "integrity": "sha512-4VmFWZxhpeiG5fDhfqAyQbCfXZSBKS4fNKf35ABWiHStZRDndxml8K5WFtmOmMvVzjrGQx8HesenYMawK6xo/Q==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-js": "^3.8.2",
-            "global": "^4.4.0"
           }
         }
       }
@@ -11096,15 +10404,6 @@
       "dev": true,
       "peer": true
     },
-    "copy-to-clipboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
-      "dev": true,
-      "requires": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "core-js": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.0.tgz",
@@ -11286,24 +10585,6 @@
         }
       }
     },
-    "dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      },
-      "dependencies": {
-        "csstype": {
-          "version": "3.0.10",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-          "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-          "dev": true
-        }
-      }
-    },
     "dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
@@ -11451,12 +10732,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
@@ -12199,16 +11474,6 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "dev": true
     },
-    "history": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.0.0.tgz",
-      "integrity": "sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -12663,12 +11928,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "memoize-one": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
-      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
-      "dev": true
     },
     "memoizerific": {
       "version": "1.11.3",
@@ -13447,15 +12706,6 @@
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
       "dev": true
     },
-    "react-input-autosize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
-      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
@@ -13481,67 +12731,6 @@
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.5.4",
         "react-popper": "^2.2.4"
-      }
-    },
-    "react-router": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.1.tgz",
-      "integrity": "sha512-2fG0udBtxou9lXtK97eJeET2ki5//UWfQSl1rlJ7quwe6jrktK9FCCc8dQb5QY6jAv3jua8bBQRhhDOM/kVRsg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "history": "^5.2.0"
-      },
-      "dependencies": {
-        "history": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
-          "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.7.6"
-          }
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.1.tgz",
-      "integrity": "sha512-I6Zax+/TH/cZMDpj3/4Fl2eaNdcvoxxHoH1tYOREsQ22OKDYofGebrNm6CTPUcvLvZm63NL/vzCYdjf9CUhqmA==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "history": "^5.2.0",
-        "react-router": "6.2.1"
-      },
-      "dependencies": {
-        "history": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/history/-/history-5.2.0.tgz",
-          "integrity": "sha512-uPSF6lAJb3nSePJ43hN3eKj1dTWpN9gMod0ZssbFTIsen+WehTmEadgL+kg78xLJFdRfrrC//SavDzmRVdE+Ig==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.7.6"
-          }
-        }
-      }
-    },
-    "react-select": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz",
-      "integrity": "sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/cache": "^10.0.9",
-        "@emotion/core": "^10.0.9",
-        "@emotion/css": "^10.0.9",
-        "memoize-one": "^5.0.0",
-        "prop-types": "^15.6.0",
-        "react-input-autosize": "^3.0.0",
-        "react-transition-group": "^4.3.0"
       }
     },
     "react-sizeme": {
@@ -13578,18 +12767,6 @@
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.0.0",
         "use-latest": "^1.0.0"
-      }
-    },
-    "react-transition-group": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
-      "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
       }
     },
     "readable-stream": {
@@ -14579,12 +13756,6 @@
       "requires": {
         "is-number": "^7.0.0"
       }
-    },
-    "toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI=",
-      "dev": true
     },
     "ts-dedent": {
       "version": "2.2.0",

--- a/build-system/tasks/storybook/package.json
+++ b/build-system/tasks/storybook/package.json
@@ -8,7 +8,6 @@
     "@babel/runtime-corejs3": "7.15.4",
     "@storybook/addon-a11y": "6.3.12",
     "@storybook/addon-controls": "6.3.12",
-    "@storybook/addon-knobs": "6.3.1",
     "@storybook/addon-viewport": "6.3.12",
     "@storybook/client-api": "6.3.12",
     "babel-loader": "8.2.3",

--- a/build-system/test-configs/forbidden-terms.js
+++ b/build-system/test-configs/forbidden-terms.js
@@ -722,10 +722,6 @@ const forbiddenTermsGlobal = {
       'The @storybook/addon-knobs package has been deprecated. Use Controls instead (`args` and `argTypes`). https://storybook.js.org/docs/react/essentials/controls',
     allowlist: [
       // TODO(#35923): Update existing files to use Controls instead.
-      'build-system/tasks/storybook/env/amp/main.js',
-      'build-system/tasks/storybook/env/preact/main.js',
-      'build-system/tasks/storybook/env/react/main.js',
-      'extensions/amp-animation/0.1/storybook/template.js',
       'extensions/amp-date-display/1.0/storybook/Basic.amp.js',
       'extensions/amp-date-display/1.0/storybook/Basic.js',
       'extensions/amp-iframe/0.1/storybook/Basic.amp.js',

--- a/extensions/amp-animation/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-animation/0.1/storybook/Basic.amp.js
@@ -2,7 +2,11 @@ import {withAmp} from '@ampproject/storybook-addon';
 
 import * as Preact from '#preact';
 
-import {AnimationTemplate} from './template';
+import {
+  AnimationTemplate,
+  animationDirectionArgType,
+  animationFillArgType,
+} from './template';
 
 const KEYFRAMES_OPTIONS = {
   'rotate': {
@@ -43,20 +47,35 @@ export default {
     extensions: [{name: 'amp-animation', version: 0.1}],
   },
   argTypes: {
+    fill: animationFillArgType,
+    direction: animationDirectionArgType,
     keyframesName: {
       control: {type: 'select'},
       options: keyframesOptions,
     },
   },
   args: {
+    duration: '1s',
+    iterations: 2,
     keyframesName: keyframesOptions[0],
     easing: 'cubic-bezier(0,0,.21,1)',
   },
 };
 
-export const Default = ({easing, keyframesName}) => {
+export const Default = ({
+  direction,
+  duration,
+  easing,
+  fill,
+  iterations,
+  keyframesName,
+}) => {
   const keyframes = KEYFRAMES_OPTIONS[keyframesName];
   const spec = {
+    direction,
+    duration,
+    fill,
+    iterations,
     animations: {
       selector: '#block',
       easing,

--- a/extensions/amp-animation/0.1/storybook/Basic.amp.js
+++ b/extensions/amp-animation/0.1/storybook/Basic.amp.js
@@ -50,6 +50,7 @@ export default {
     fill: animationFillArgType,
     direction: animationDirectionArgType,
     keyframesName: {
+      name: 'keyframesName',
       control: {type: 'select'},
       options: keyframesOptions,
     },

--- a/extensions/amp-animation/0.1/storybook/Random.amp.js
+++ b/extensions/amp-animation/0.1/storybook/Random.amp.js
@@ -2,7 +2,7 @@ import {withAmp} from '@ampproject/storybook-addon';
 
 import * as Preact from '#preact';
 
-import {AnimationTemplate} from './template';
+import {AnimationTemplate, animationFillArgType} from './template';
 
 const CONTAINER_STYLE = {
   position: 'absolute',
@@ -31,10 +31,20 @@ export default {
   parameters: {
     extensions: [{name: 'amp-animation', version: 0.1}],
   },
+  argTypes: {
+    fill: animationFillArgType,
+  },
+  args: {
+    duration: '1s',
+    iterations: 2,
+  },
 };
 
-export const Random = () => {
+export const Random = ({duration, fill, iterations}) => {
   const spec = {
+    duration,
+    fill,
+    iterations,
     selector: '.drop',
     '--delay': 'rand(0.1s, 5s)',
     delay: 'var(--delay)',
@@ -68,5 +78,3 @@ export const Random = () => {
     </AnimationTemplate>
   );
 };
-
-Random.storyName = 'random';

--- a/extensions/amp-animation/0.1/storybook/template.js
+++ b/extensions/amp-animation/0.1/storybook/template.js
@@ -65,7 +65,7 @@ export function AnimationTemplate(props) {
         <button on="tap:anim1.cancel">Cancel</button>
       </div>
       <div style={CONTAINER_STYLE}>
-        <pre style={INFO_STYLE}>{JSON.stringify(speec, null, 2)}</pre>
+        <pre style={INFO_STYLE}>{JSON.stringify(spec, null, 2)}</pre>
 
         {children}
       </div>

--- a/extensions/amp-animation/0.1/storybook/template.js
+++ b/extensions/amp-animation/0.1/storybook/template.js
@@ -1,15 +1,13 @@
-import {number, select, text} from '@storybook/addon-knobs';
-
 import * as Preact from '#preact';
 
-const FILL_OPTIONS = {
+export const FILL_OPTIONS = {
   none: 'none',
   forwards: 'forwards',
   backwards: 'backwards',
   both: 'both',
 };
 
-const DIRECTION_OPTIONS = {
+export const DIRECTION_OPTIONS = {
   normal: 'normal',
   reverse: 'reverse',
   alternate: 'alternate',
@@ -38,29 +36,22 @@ const INFO_STYLE = {
   overflow: 'auto',
 };
 
+export const animationFillArgType = {options: FILL_OPTIONS};
+
+export const animationDirectionArgType = {options: DIRECTION_OPTIONS};
+
 /**
  * @param {!Object} props
  * @return {!Object}
  */
 export function AnimationTemplate(props) {
   const {children, spec} = props;
-  const duration = text('Duration', '1s');
-  const iterations = number('Iterations', 2);
-  const fill = select('Fill', FILL_OPTIONS, 'both');
-  const direction = select('Direction', DIRECTION_OPTIONS, 'alternate');
-  const fullSpec = {
-    duration,
-    iterations,
-    fill,
-    direction,
-    ...spec,
-  };
   return (
     <main>
       <amp-animation id="anim1" layout="nodisplay">
         <script
           type="application/json"
-          dangerouslySetInnerHTML={{__html: JSON.stringify(fullSpec)}}
+          dangerouslySetInnerHTML={{__html: JSON.stringify(spec)}}
         />
       </amp-animation>
 
@@ -74,7 +65,7 @@ export function AnimationTemplate(props) {
         <button on="tap:anim1.cancel">Cancel</button>
       </div>
       <div style={CONTAINER_STYLE}>
-        <pre style={INFO_STYLE}>{JSON.stringify(fullSpec, null, 2)}</pre>
+        <pre style={INFO_STYLE}>{JSON.stringify(speec, null, 2)}</pre>
 
         {children}
       </div>

--- a/extensions/amp-animation/0.1/storybook/template.js
+++ b/extensions/amp-animation/0.1/storybook/template.js
@@ -36,9 +36,19 @@ const INFO_STYLE = {
   overflow: 'auto',
 };
 
-export const animationFillArgType = {options: FILL_OPTIONS};
+export const animationFillArgType = {
+  name: 'fill',
+  options: FILL_OPTIONS,
+  control: {type: 'select'},
+  defaultValue: 'both',
+};
 
-export const animationDirectionArgType = {options: DIRECTION_OPTIONS};
+export const animationDirectionArgType = {
+  name: 'duration',
+  options: DIRECTION_OPTIONS,
+  control: {type: 'select'},
+  defaultValue: 'alternate',
+};
 
 /**
  * @param {!Object} props


### PR DESCRIPTION
Related to #35923

`@storybook/addon-knobs` has been deprecated, and it's officially obsolete. This prevents us from upgrading the Storybook version due to a peer dependency conflict. 

This change:

- Removes `@storybook/addon-knobs`
- Disables Storybook files that require Knobs. We use the forbidden term allowlist to find disabled files. 
- Since `amp-animation` tests do not match the allowlist schema for disabling, we migrate those to Controls instead.