### PR TITLE
✨ [amp story shopping attachment] Add details module to PDP template

### DIFF
--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -62,7 +62,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -76,7 +77,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci. Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -91,7 +93,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",

--- a/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
@@ -63,7 +63,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -77,7 +78,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -92,7 +94,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",

--- a/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
@@ -61,7 +61,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -75,7 +76,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -90,7 +92,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",

--- a/examples/visual-tests/amp-story/amp-story-shopping.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping.html
@@ -61,7 +61,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -90,7 +91,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {
                     "productUrl": "https://www.google.com",
@@ -105,7 +107,8 @@
                       "ratingValue": "4.4",
                       "reviewCount": "89",
                       "reviewUrl": "https://www.google.com"
-                    }
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    }
                 ]
               }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -3,8 +3,8 @@ amp-story-shopping-attachment {
   width: 100% !important;
   font-family: 'Poppins', sans-serif !important;
   font-size: calc(var(--story-page-vmin) * 3) !important; /* override with ems for pixel perfect layout */
-  --i-amphtml-shopping-attachment-horizontal-padding: 1.5em !important;
-  --i-amphtml-shopping-attachment-vertical-padding: 1.2em !important;
+  --i-amphtml-shopping-attachment-horizontal-spacing: 1.5em !important;
+  --i-amphtml-shopping-attachment-vertical-spacing: 1.2em !important;
   --i-amphtml-shopping-three-percent-overlay: rgba(0, 0, 0,  .03) !important;
 }
 
@@ -16,6 +16,7 @@ amp-story-shopping-attachment a {
   text-decoration: none !important;
 }
 
+/* Button reset. */
 amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header { 
   background: none !important;
   border: none !important;
@@ -36,13 +37,13 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 .i-amphtml-amp-story-shopping-sub-section-header {
   font-weight: 600 !important;
   font-size: 1.5em !important;
-  padding: var(--i-amphtml-shopping-attachment-vertical-padding) 0 !important;
+  padding: var(--i-amphtml-shopping-attachment-vertical-spacing) 0 !important;
 }
 
 /* PLP (Product Listing Page). */
 
 .i-amphtml-amp-story-shopping-plp {
-  padding: 0 var(--i-amphtml-shopping-attachment-horizontal-padding) !important;
+  padding: 0 var(--i-amphtml-shopping-attachment-horizontal-spacing) !important;
 }
 
 .i-amphtml-amp-story-shopping-plp-cards {
@@ -52,7 +53,7 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 }
 
 .i-amphtml-amp-story-shopping-plp-card {
-  width: calc(50% - var(--i-amphtml-shopping-attachment-horizontal-padding) / 2) !important;
+  width: calc(50% - var(--i-amphtml-shopping-attachment-horizontal-spacing) / 2) !important;
   margin-bottom: 3em !important;
   cursor: pointer !important;
 }
@@ -104,7 +105,7 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 }
 
 .i-amphtml-amp-story-shopping-pdp-header {
-  margin: 1.5em var(--i-amphtml-shopping-attachment-horizontal-padding) 2em !important;
+  margin: 1.5em var(--i-amphtml-shopping-attachment-horizontal-spacing) 2em !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-header-brand {
@@ -205,7 +206,7 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 
 /* Only adds bottom margin if carousel is last child. */
 .i-amphtml-amp-story-shopping-pdp-carousel:last-child {
-  margin-bottom: var(--i-amphtml-shopping-attachment-vertical-padding) !important;
+  margin-bottom: var(--i-amphtml-shopping-attachment-vertical-spacing) !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel::-webkit-scrollbar {
@@ -213,7 +214,7 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel-card {
-  margin-inline-start: calc(var(--i-amphtml-shopping-attachment-horizontal-padding) / 2) !important;
+  margin-inline-start: calc(var(--i-amphtml-shopping-attachment-horizontal-spacing) / 2) !important;
   scroll-snap-align: center !important;
   flex-shrink: 0 !important;
   background-color: var(--i-amphtml-shopping-three-percent-overlay) !important;
@@ -226,18 +227,18 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel-card:first-child {
-  margin-inline-start: var(--i-amphtml-shopping-attachment-horizontal-padding) !important;
+  margin-inline-start: var(--i-amphtml-shopping-attachment-horizontal-spacing) !important;
   border-radius: 1.1em 0 0 1.1em !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel-card:last-child {
-  margin-inline-end: var(--i-amphtml-shopping-attachment-horizontal-padding) !important;
+  margin-inline-end: var(--i-amphtml-shopping-attachment-horizontal-spacing) !important;
   border-radius: 0 1.1em 1.1em 0 !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel-card:only-child {
-  width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-padding) * 2) !important;
-  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-padding) * 2)!important;
+  width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
+  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
   border-radius: 1.1em !important;
   cursor: auto !important;
 }
@@ -250,11 +251,10 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
   border-radius: 1.1em 0 0 1.1em !important;
 }
 
-
 /* PDP deatils */
 
 .i-amphtml-amp-story-shopping-pdp-details {
-  padding: 0 var(--i-amphtml-shopping-attachment-horizontal-padding) !important;
+  padding: 0 var(--i-amphtml-shopping-attachment-horizontal-spacing) !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-details-header {
@@ -297,5 +297,5 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 .i-amphtml-amp-story-shopping-pdp-details-text:after {
   content: '' !important;
   display: block !important;
-  padding-bottom: var(--i-amphtml-shopping-attachment-vertical-padding) !important;
+  padding-bottom: var(--i-amphtml-shopping-attachment-vertical-spacing) !important;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -16,7 +16,7 @@ amp-story-shopping-attachment a {
   text-decoration: none !important;
 }
 
-amp-story-shopping-attachment button { 
+amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header { 
   background: none !important;
   border: none !important;
   padding: 0 !important;
@@ -36,7 +36,7 @@ amp-story-shopping-attachment button {
 .i-amphtml-amp-story-shopping-sub-section-header {
   font-weight: 600 !important;
   font-size: 1.5em !important;
-  margin: var(--i-amphtml-shopping-attachment-vertical-padding) 0 !important;
+  padding: var(--i-amphtml-shopping-attachment-vertical-padding) 0 !important;
 }
 
 /* PLP (Product Listing Page). */
@@ -160,9 +160,6 @@ amp-story-shopping-attachment button {
   filter: invert(1) !important;
 }
 
-.i-amphtml-amp-story-shopping-sub-section-header {
-
-}
 /* PDP reviews */
 
 .i-amphtml-amp-story-shopping-pdp-reviews {
@@ -262,16 +259,12 @@ amp-story-shopping-attachment button {
 
 .i-amphtml-amp-story-shopping-pdp-details-header {
   cursor: pointer !important;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  display: flex !important;
+  justify-content: space-between !important;
+  align-items: center !important;
 }
 
-.i-amphtml-amp-story-shopping-pdp-details-header-text {
-  pointer-events: none;
-}
-
-.i-amphtml-amp-story-shopping-pdp-details-header-caret {
+.i-amphtml-amp-story-shopping-pdp-details-header-arrow {
   padding: 0 0.5em;
   height: 0.6em;
   fill: none;
@@ -279,12 +272,12 @@ amp-story-shopping-attachment button {
   pointer-events: none;
 }
 
-.i-amphtml-amp-story-shopping-pdp-details .i-amphtml-amp-story-shopping-pdp-details-header-caret path {
+.i-amphtml-amp-story-shopping-pdp-details .i-amphtml-amp-story-shopping-pdp-details-header-arrow path {
   d: path("M.5,.5 L5,5.2 L9.5,.5");
   transition: d 0.3s;
 }
 
-.i-amphtml-amp-story-shopping-pdp-details[active] .i-amphtml-amp-story-shopping-pdp-details-header-caret path {
+.i-amphtml-amp-story-shopping-pdp-details[active] .i-amphtml-amp-story-shopping-pdp-details-header-arrow path {
   d: path("M.5,5.2 L5,.8 L9.5,5.2");
 }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -24,6 +24,7 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
   margin: 0 !important;
   width: 100% !important;
   font-family: inherit !important;
+  font-size: inherit !important;
 }
 
 .i-amphtml-amp-story-shopping {

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -17,7 +17,7 @@ amp-story-shopping-attachment a {
 }
 
 /* Button reset. */
-amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header { 
+amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
   background: none !important;
   border: none !important;
   padding: 0 !important;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -265,33 +265,33 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 }
 
 .i-amphtml-amp-story-shopping-pdp-details-header-arrow {
-  padding: 0 0.5em;
-  height: 0.6em;
-  fill: none;
+  padding: 0 0.5em !important;
+  height: 0.6em !important;
+  fill: none !important;
   stroke: var(--i-amphtml-draggable-drawer-text-color) !important;
-  pointer-events: none;
+  pointer-events: none !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-details .i-amphtml-amp-story-shopping-pdp-details-header-arrow path {
-  d: path("M.5,.5 L5,5.2 L9.5,.5");
-  transition: d 0.3s;
+  d: path("M.5,.5 L5,5.2 L9.5,.5") !important;
+  transition: d 0.3s !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-details[active] .i-amphtml-amp-story-shopping-pdp-details-header-arrow path {
-  d: path("M.5,5.2 L5,.8 L9.5,5.2");
+  d: path("M.5,5.2 L5,.8 L9.5,5.2") !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-details .i-amphtml-amp-story-shopping-pdp-details-text {
   display: block !important;
   overflow: hidden !important;
   height: 0 !important;
-  opacity: 0;
-  transition: opacity .3s;
+  opacity: 0 !important;
+  transition: opacity .3s !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-details[active] .i-amphtml-amp-story-shopping-pdp-details-text {
   height: auto !important;
-  opacity: 1;
+  opacity: 1 !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-details-text:after {

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -16,6 +16,15 @@ amp-story-shopping-attachment a {
   text-decoration: none !important;
 }
 
+amp-story-shopping-attachment button { 
+  background: none !important;
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  font-family: inherit !important;
+}
+
 .i-amphtml-amp-story-shopping {
   display: none !important;
 }
@@ -24,16 +33,16 @@ amp-story-shopping-attachment a {
   display: block !important;
 }
 
+.i-amphtml-amp-story-shopping-sub-section-header {
+  font-weight: 600 !important;
+  font-size: 1.5em !important;
+  margin: var(--i-amphtml-shopping-attachment-vertical-padding) 0 !important;
+}
+
 /* PLP (Product Listing Page). */
 
 .i-amphtml-amp-story-shopping-plp {
   padding: 0 var(--i-amphtml-shopping-attachment-horizontal-padding) !important;
-}
-
-.i-amphtml-amp-story-shopping-plp-header {
-  font-weight: 600 !important;
-  font-size: 1.5em !important;
-  margin: var(--i-amphtml-shopping-attachment-vertical-padding) 0 !important;
 }
 
 .i-amphtml-amp-story-shopping-plp-cards {
@@ -151,6 +160,11 @@ amp-story-shopping-attachment a {
   filter: invert(1) !important;
 }
 
+.i-amphtml-amp-story-shopping-sub-section-header {
+
+}
+/* PDP reviews */
+
 .i-amphtml-amp-story-shopping-pdp-reviews {
   display: flex !important;
   align-items: center !important;
@@ -181,14 +195,20 @@ amp-story-shopping-attachment a {
   text-decoration: underline !important;
 }
 
+/* PDP carousel */
+
 .i-amphtml-amp-story-shopping-pdp-carousel {
   display: flex !important;
   overflow-x: auto !important;
   scroll-snap-type: x mandatory !important;
-  margin-bottom: var(--i-amphtml-shopping-attachment-vertical-padding) !important;
   --carousel-height: calc(var(--story-page-vh) * 80 - var(--story-page-vw) * 60) !important;
   height: var(--carousel-height) !important;
   max-height: 100vw !important;
+}
+
+/* Only adds bottom margin if carousel is last child. */
+.i-amphtml-amp-story-shopping-pdp-carousel:last-child {
+  margin-bottom: var(--i-amphtml-shopping-attachment-vertical-padding) !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel::-webkit-scrollbar {
@@ -231,4 +251,58 @@ amp-story-shopping-attachment a {
 
 [dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:last-child {
   border-radius: 1.1em 0 0 1.1em !important;
+}
+
+
+/* PDP deatils */
+
+.i-amphtml-amp-story-shopping-pdp-details {
+  padding: 0 var(--i-amphtml-shopping-attachment-horizontal-padding) !important;
+}
+
+.i-amphtml-amp-story-shopping-pdp-details-header {
+  cursor: pointer !important;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.i-amphtml-amp-story-shopping-pdp-details-header-text {
+  pointer-events: none;
+}
+
+.i-amphtml-amp-story-shopping-pdp-details-header-caret {
+  padding: 0 0.5em;
+  height: 0.6em;
+  fill: none;
+  stroke: var(--i-amphtml-draggable-drawer-text-color) !important;
+  pointer-events: none;
+}
+
+.i-amphtml-amp-story-shopping-pdp-details .i-amphtml-amp-story-shopping-pdp-details-header-caret path {
+  d: path("M.5,.5 L5,5.2 L9.5,.5");
+  transition: d 0.3s;
+}
+
+.i-amphtml-amp-story-shopping-pdp-details[active] .i-amphtml-amp-story-shopping-pdp-details-header-caret path {
+  d: path("M.5,5.2 L5,.8 L9.5,5.2");
+}
+
+.i-amphtml-amp-story-shopping-pdp-details .i-amphtml-amp-story-shopping-pdp-details-text {
+  display: block !important;
+  overflow: hidden !important;
+  height: 0 !important;
+  opacity: 0;
+  transition: opacity .3s;
+}
+
+.i-amphtml-amp-story-shopping-pdp-details[active] .i-amphtml-amp-story-shopping-pdp-details-text {
+  height: auto !important;
+  opacity: 1;
+}
+
+.i-amphtml-amp-story-shopping-pdp-details-text:after {
+  content: '' !important;
+  display: block !important;
+  padding-bottom: var(--i-amphtml-shopping-attachment-vertical-padding) !important;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -274,7 +274,6 @@ amp-story-shopping-attachment .i-amphtml-amp-story-shopping-pdp-details-header {
 }
 
 .i-amphtml-amp-story-shopping-pdp-details .i-amphtml-amp-story-shopping-pdp-details-header-arrow path {
-  d: path("M.5,.5 L5,5.2 L9.5,.5") !important;
   transition: d 0.3s !important;
 }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -277,8 +277,10 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
       '.i-amphtml-amp-story-shopping-pdp-details-text'
     );
     const toggleActive = !detailsContainer.hasAttribute('active');
-    toggleAttribute(detailsContainer, 'active', toggleActive);
-    detailsText.setAttribute('aria-hidden', !toggleActive);
+    this.mutateElement(() => {
+      toggleAttribute(detailsContainer, 'active', toggleActive);
+      detailsText.setAttribute('aria-hidden', !toggleActive);
+    });
   }
 
   /**

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -286,7 +286,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
    * @private
    */
   renderPdpTemplate_(activeProductData) {
-    console.log(activeProductData.productDetails);
     return (
       <div class="i-amphtml-amp-story-shopping-pdp">
         <div class="i-amphtml-amp-story-shopping-pdp-header">
@@ -343,7 +342,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
             ></div>
           ))}
         </div>
-
         {activeProductData.productDetails && (
           <div class="i-amphtml-amp-story-shopping-pdp-details">
             <button
@@ -363,7 +361,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
                 <path />
               </svg>
             </button>
-
             <span class="i-amphtml-amp-story-shopping-pdp-details-text">
               {activeProductData.productDetails}
             </span>

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -286,6 +286,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
    * @private
    */
   renderPdpTemplate_(activeProductData) {
+    console.log(activeProductData.productDetails);
     return (
       <div class="i-amphtml-amp-story-shopping-pdp">
         <div class="i-amphtml-amp-story-shopping-pdp-header">
@@ -349,7 +350,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
               class="i-amphtml-amp-story-shopping-pdp-details-header"
               onClick={(e) => this.onDetailsHeaderClick_(e.target)}
             >
-              <span class="i-amphtml-amp-story-shopping-pdp-details-header-text i-amphtml-amp-story-shopping-sub-section-header">
+              <span class="i-amphtml-amp-story-shopping-sub-section-header">
                 {this.localizationService_.getLocalizedString(
                   LocalizedStringId_Enum.AMP_STORY_SHOPPING_ATTACHMENT_DETAILS,
                   this.element
@@ -357,7 +358,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
               </span>
               <svg
                 viewBox="0 0 10 6"
-                class="i-amphtml-amp-story-shopping-pdp-details-header-caret"
+                class="i-amphtml-amp-story-shopping-pdp-details-header-arrow"
               >
                 <path />
               </svg>

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -1,3 +1,4 @@
+import {toggleAttribute} from '#core/dom';
 import * as Preact from '#core/dom/jsx';
 import {Layout_Enum} from '#core/dom/layout';
 
@@ -264,6 +265,22 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
   }
 
   /**
+   * Expands or collabses the content of the details section.
+   * @param {!Element} detailsHeader
+   * @private
+   */
+  onDetailsHeaderClick_(detailsHeader) {
+    const detailsContainer = detailsHeader.closest(
+      '.i-amphtml-amp-story-shopping-pdp-details'
+    );
+    toggleAttribute(
+      detailsContainer,
+      'active',
+      !detailsContainer.hasAttribute('active')
+    );
+  }
+
+  /**
    * @param {!ShoppingConfigDataDef} activeProductData
    * @return {Element}
    * @private
@@ -325,6 +342,32 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
             ></div>
           ))}
         </div>
+
+        {activeProductData.productDetails && (
+          <div class="i-amphtml-amp-story-shopping-pdp-details">
+            <button
+              class="i-amphtml-amp-story-shopping-pdp-details-header"
+              onClick={(e) => this.onDetailsHeaderClick_(e.target)}
+            >
+              <span class="i-amphtml-amp-story-shopping-pdp-details-header-text i-amphtml-amp-story-shopping-sub-section-header">
+                {this.localizationService_.getLocalizedString(
+                  LocalizedStringId_Enum.AMP_STORY_SHOPPING_ATTACHMENT_DETAILS,
+                  this.element
+                )}
+              </span>
+              <svg
+                viewBox="0 0 10 6"
+                class="i-amphtml-amp-story-shopping-pdp-details-header-caret"
+              >
+                <path />
+              </svg>
+            </button>
+
+            <span class="i-amphtml-amp-story-shopping-pdp-details-text">
+              {activeProductData.productDetails}
+            </span>
+          </div>
+        )}
       </div>
     );
   }
@@ -337,7 +380,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
   renderPlpTemplate_(shoppingDataForPage) {
     return (
       <div class="i-amphtml-amp-story-shopping-plp">
-        <div class="i-amphtml-amp-story-shopping-plp-header">
+        <div class="i-amphtml-amp-story-shopping-sub-section-header">
           {this.localizationService_.getLocalizedString(
             LocalizedStringId_Enum.AMP_STORY_SHOPPING_PLP_HEADER,
             this.element

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -273,11 +273,12 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     const detailsContainer = detailsHeader.closest(
       '.i-amphtml-amp-story-shopping-pdp-details'
     );
-    toggleAttribute(
-      detailsContainer,
-      'active',
-      !detailsContainer.hasAttribute('active')
+    const detailsText = detailsContainer.querySelector(
+      '.i-amphtml-amp-story-shopping-pdp-details-text'
     );
+    const toggleActive = !detailsContainer.hasAttribute('active');
+    toggleAttribute(detailsContainer, 'active', toggleActive);
+    detailsText.setAttribute('aria-hidden', !toggleActive);
   }
 
   /**
@@ -358,10 +359,13 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
                 viewBox="0 0 10 6"
                 class="i-amphtml-amp-story-shopping-pdp-details-header-arrow"
               >
-                <path />
+                <path d="M.5,.5 L5,5.2 L9.5,.5" />
               </svg>
             </button>
-            <span class="i-amphtml-amp-story-shopping-pdp-details-text">
+            <span
+              class="i-amphtml-amp-story-shopping-pdp-details-text"
+              aria-hidden="true"
+            >
               {activeProductData.productDetails}
             </span>
           </div>

--- a/extensions/amp-story/1.0/_locales/en.json
+++ b/extensions/amp-story/1.0/_locales/en.json
@@ -230,5 +230,9 @@
   "104": {
     "string": "reviews",
     "description": "Button label prompting users to read about peoples assessments of an item."
+  },
+  "105": {
+    "string": "Details",
+    "description": "Button label prompting users to read about details of a product."
   }
 }

--- a/src/service/localization/strings.js
+++ b/src/service/localization/strings.js
@@ -9,7 +9,7 @@ import {parseJson} from '#core/types/object/json';
  *   - NOT be reused; to deprecate an ID, comment it out and prefix its key with
  *     the string "DEPRECATED_"
  *
- * Next ID: 105
+ * Next ID: 106
  *
  * @const @enum {string}
  */
@@ -102,6 +102,7 @@ export const LocalizedStringId_Enum = {
   AMP_STORY_SHOPPING_PLP_HEADER: '102',
   AMP_STORY_SHOPPING_ATTACHMENT_CTA_LABEL: '103',
   AMP_STORY_SHOPPING_ATTACHMENT_REVIEWS_LABEL: '104',
+  AMP_STORY_SHOPPING_ATTACHMENT_DETAILS: '105',
 
   // DEPRECATED_AMP_STORY_EXPERIMENT_ENABLE_BUTTON_LABEL: '0',
   // DEPRECATED_AMP_STORY_EXPERIMENT_ENABLED_TEXT: '1',


### PR DESCRIPTION
Adds a plaintext expandable/collapsable details section to the PDP template.
Adds i18n string.

[Demo](https://philipbell-shopping.web.app/examples/amp-story/amp-story-shopping.html)

Fixes #36740

<img width="387" alt="Screen Shot 2022-02-14 at 3 24 59 PM" src="https://user-images.githubusercontent.com/3860311/153948925-295f32b1-1440-4148-9584-420a73c39f77.png">
