### PR TITLE
🚀 [amp story shopping] [amp story interactive] Load fonts in layoutCallback

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
@@ -259,7 +259,6 @@ export class AmpStoryInteractive extends AMP.BaseElement {
 
   /** @override */
   buildCallback(concreteCSS = '') {
-    this.loadFonts_();
     this.options_ = this.parseOptions_();
     this.element.classList.add('i-amphtml-story-interactive-component');
     this.adjustGridLayer_();
@@ -397,6 +396,7 @@ export class AmpStoryInteractive extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    this.loadFonts_();
     this.initializeListeners_();
     return (this.backendDataPromise_ = this.element.hasAttribute('endpoint')
       ? this.retrieveInteractiveData_()

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -65,7 +65,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     this.shoppingTags_ = Array.from(
       this.pageEl_.querySelectorAll('amp-story-shopping-tag')
     );
-    loadFonts(this.win, FONTS_TO_LOAD);
 
     const pageElement = this.element.parentElement;
     getShoppingConfig(pageElement).then((config) =>
@@ -81,7 +80,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     if (this.shoppingTags_.length === 0) {
       return;
     }
-    loadFonts(this.win, FONTS_TO_LOAD);
 
     return Promise.all([
       Services.storyStoreServiceForOrNull(this.win),
@@ -109,7 +107,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     if (this.shoppingTags_.length === 0) {
       return;
     }
-
+    loadFonts(this.win, FONTS_TO_LOAD);
     // Update template on attachment state update or shopping data update.
     this.storeService_.subscribe(
       StateProperty.PAGE_ATTACHMENT_STATE,

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -48,7 +48,6 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    loadFonts(this.win, FONTS_TO_LOAD);
     this.element.setAttribute('role', 'button');
 
     return Promise.all([
@@ -62,6 +61,7 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
+    loadFonts(this.win, FONTS_TO_LOAD);
     this.storeService_.subscribe(
       StateProperty.SHOPPING_DATA,
       (shoppingData) => this.createAndAppendInnerShoppingTagEl_(shoppingData),


### PR DESCRIPTION
Lazy load fonts by moving them to layoutCallback.
Removes a duplicate font load.

Note: this causes CLS if component is on the first page of a story.

Fixes #37684