### PR TITLE
🏗  🐛  Check build-system types when changes are made to testing

### DIFF
--- a/build-system/pr-check/build-targets.js
+++ b/build-system/pr-check/build-targets.js
@@ -142,6 +142,7 @@ const targetMatchers = {
     return (
       file == 'build-system/tasks/check-build-system.js' ||
       file == 'build-system/tsconfig.json' ||
+      file.startsWith('testing/') ||
       (file.startsWith('build-system') &&
         (file.endsWith('.js') ||
           file.endsWith('.ts') ||


### PR DESCRIPTION
#37671 highlighted how changes made to `testing` need to trigger `check-build-system` to run. This is because the build-system imports some files from the `testing` directory and thus type checking `build-system` requires type checking `testing`.
#37694
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
