### PR TITLE
Pre-compress release files in Brotli before uploading

### DIFF
--- a/build-system/release-workflows/upload-release.js
+++ b/build-system/release-workflows/upload-release.js
@@ -9,6 +9,7 @@ const {log} = require('../common/logging');
 const {runReleaseJob} = require('./release-job');
 const {Storage} = require('@google-cloud/storage');
 const {timedExecOrDie} = require('../pr-check/utils');
+const zlib = require('zlib');
 
 /**
  * @fileoverview Script that uploads a release build.
@@ -75,20 +76,20 @@ function mergeFilesTxt_(flavor) {
 let printProgressReady = true;
 
 /**
- * Logs file upload progress every 1 second.
+ * Logs file processing progress every 1 second.
  *
  * @param {number} totalFiles
- * @param {number} uploadedFiles
+ * @param {number} processedFiles
  */
-function logProgress_(totalFiles, uploadedFiles) {
-  const percentage = Math.round((uploadedFiles / totalFiles) * PROGRESS_WIDTH);
-  if (printProgressReady || uploadedFiles === totalFiles) {
+function logProgress_(totalFiles, processedFiles) {
+  const percentage = Math.round((processedFiles / totalFiles) * PROGRESS_WIDTH);
+  if (printProgressReady || processedFiles === totalFiles) {
     log(
       '[' +
         bgWhite(' '.repeat(percentage)) +
         '.'.repeat(PROGRESS_WIDTH - percentage) +
         ']',
-      cyan(uploadedFiles),
+      cyan(processedFiles),
       '/',
       cyan(totalFiles)
     );
@@ -98,6 +99,50 @@ function logProgress_(totalFiles, uploadedFiles) {
       printProgressReady = true;
     }, 1000);
   }
+}
+
+/**
+ * Compresses a single file with Brotli and writes it to ${path}.br.
+ * @param {string} path
+ * @return {Promise<void>}
+ */
+async function brotliCompressFile_(path) {
+  const fileBuffer = fs.readFileSync(path);
+  const compressedBuffer = zlib.brotliCompressSync(fileBuffer, {
+    params: {[zlib.constants.BROTLI_PARAM_QUALITY]: 11},
+  });
+  return fs.writeFileSync(`${path}.br`, compressedBuffer);
+}
+
+/**
+ * Compresses all files with Brotli.
+ * @return {Promise<void>}
+ */
+async function brotliCompressAll_() {
+  let totalFiles = 0;
+  for await (const {stats} of klaw(DEST_DIR)) {
+    if (stats.isFile()) {
+      totalFiles++;
+    }
+  }
+
+  log('Brotli compression of', cyan(totalFiles), 'files:');
+  const compressPromises = [];
+  let compressedFiles = 0;
+  for await (const {path, stats} of klaw(DEST_DIR)) {
+    if (!stats.isFile()) {
+      continue;
+    }
+
+    compressPromises.push(
+      brotliCompressFile_(path).then(() => {
+        logProgress_(totalFiles, ++compressedFiles);
+      })
+    );
+  }
+
+  await Promise.all(compressPromises);
+  log('Finished Brotli compression of all files.');
 }
 
 /**
@@ -137,14 +182,16 @@ async function uploadFiles_() {
   const uploadsPromises = [];
   let uploadedFiles = 0;
   for await (const {path, stats} of klaw(DEST_DIR)) {
-    if (stats.isFile()) {
-      const destination = path.slice(DEST_DIR.length + 1);
-      uploadsPromises.push(
-        bucket.upload(path, {destination, resumable: false}).then(() => {
-          logProgress_(totalFiles, ++uploadedFiles);
-        })
-      );
+    if (!stats.isFile()) {
+      continue;
     }
+
+    const destination = path.slice(DEST_DIR.length + 1);
+    uploadsPromises.push(
+      bucket.upload(path, {destination, resumable: false}).then(() => {
+        logProgress_(totalFiles, ++uploadedFiles);
+      })
+    );
   }
 
   await Promise.all(uploadsPromises);
@@ -159,6 +206,7 @@ runReleaseJob(jobName, async () => {
     mergeFilesTxt_(flavor);
   }
 
+  await brotliCompressAll_();
   await uploadFiles_();
 
   log('Archiving releases to', cyan(ARTIFACT_FILE_NAME));

--- a/build-system/release-workflows/upload-release.js
+++ b/build-system/release-workflows/upload-release.js
@@ -104,12 +104,16 @@ function logProgress_(totalFiles, processedFiles) {
 /**
  * Compresses a single file with Brotli and writes it to ${path}.br.
  * @param {string} path
+ * @param {number} sizeHint
  * @return {Promise<void>}
  */
-async function brotliCompressFile_(path) {
+async function brotliCompressFile_(path, sizeHint) {
   const fileBuffer = fs.readFileSync(path);
   const compressedBuffer = zlib.brotliCompressSync(fileBuffer, {
-    params: {[zlib.constants.BROTLI_PARAM_QUALITY]: 11},
+    params: {
+      [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+      [zlib.constants.BROTLI_PARAM_SIZE_HINT]: sizeHint,
+    },
   });
   return fs.writeFileSync(`${path}.br`, compressedBuffer);
 }
@@ -135,7 +139,7 @@ async function brotliCompressAll_() {
     }
 
     compressPromises.push(
-      brotliCompressFile_(path).then(() => {
+      brotliCompressFile_(path, stats.size).then(() => {
         logProgress_(totalFiles, ++compressedFiles);
       })
     );


### PR DESCRIPTION
Partial for https://github.com/ampproject/cdn-worker/pull/91

Tested running this script on my machine and the compression phase pass. I don't have a gcloud upload key locally (nor should I) so the script failed when attempting to actually upload the files, but it looks like the compression part is complete and the upload part hasn't changed