### PR TITLE
🐛 Fix viewer banner/top sticky ads conflicts

### DIFF
--- a/extensions/amp-ad/0.1/amp-ad-ui.js
+++ b/extensions/amp-ad/0.1/amp-ad-ui.js
@@ -14,8 +14,7 @@ const TAG = 'amp-ad-ui';
 const STICKY_AD_MAX_SIZE_LIMIT = 0.2;
 const STICKY_AD_MAX_HEIGHT_LIMIT = 0.5;
 
-const TOP_STICKY_AD_CLOSE_THRESHOLD = 50;
-const TOP_STICKY_AD_TRIGGER_THRESHOLD = 200;
+const TOP_STICKY_AD_OFFSET_THRESHOLD = 50;
 
 /**
  * Permissible sticky ad options.
@@ -83,13 +82,6 @@ export class AmpAdUIHandler {
      * @private {!Function}
      */
     this.topStickyAdScrollListener_ = undefined;
-
-    /**
-     * For top sticky ads, we waited until scrolling down before activating
-     * the closing ads listener.
-     * @private {boolean}
-     */
-    this.topStickyAdCloserAcitve_ = false;
 
     /**
      * Unlisteners to be unsubscribed after destroying.
@@ -233,35 +225,30 @@ export class AmpAdUIHandler {
    */
   maybeInitStickyAd() {
     if (this.isStickyAd()) {
+      const doc = this.element_.getAmpDoc();
       setStyle(this.element_, 'visibility', 'visible');
 
       if (this.stickyAdPosition_ == StickyAdPositions.TOP) {
-        const doc = this.element_.getAmpDoc();
-
-        // Let the top sticky ad be below the viewer top.
-        const paddingTop = Services.viewportForDoc(doc).getPaddingTop();
-        setStyle(this.element_, 'top', `${paddingTop}px`);
-
         this.topStickyAdScrollListener_ = Services.viewportForDoc(doc).onScroll(
           () => {
-            const scrollPos = doc.win./*OK*/ scrollY;
-            if (scrollPos > TOP_STICKY_AD_TRIGGER_THRESHOLD) {
-              this.topStickyAdCloserAcitve_ = true;
-            }
-
-            // When the scroll position is close to the top, we close the
+            // When the scroll position is close to the top, we hide the
             // top sticky ad in order not to have the ads overlap the
             // content.
-            if (
-              this.topStickyAdCloserAcitve_ &&
-              scrollPos < TOP_STICKY_AD_CLOSE_THRESHOLD
-            ) {
-              this.closeStickyAd_();
-            }
+            const scrollPos = doc.win./*OK*/ scrollY;
+            setStyle(
+              this.element_,
+              'visibility',
+              scrollPos > TOP_STICKY_AD_OFFSET_THRESHOLD ? 'visible' : 'hidden'
+            );
           }
         );
         this.unlisteners_.push(this.topStickyAdScrollListener_);
       }
+
+      Services.viewportForDoc(doc).addToFixedLayer(
+        this.element_,
+        /* forceTransfer */ true
+      );
 
       this.adjustPadding();
       if (!this.closeButtonRendered_) {

--- a/extensions/amp-ad/0.1/amp-ad.css
+++ b/extensions/amp-ad/0.1/amp-ad.css
@@ -64,7 +64,6 @@ amp-ad[data-a4a-upgrade-type='amp-ad-network-doubleclick-impl'][height='fluid'] 
 
 amp-ad .amp-ad-close-button {
   position: absolute;
-  visibility: visible;
   width: 28px;
   height: 28px;
   right: 0;
@@ -132,6 +131,7 @@ amp-ad[sticky='top'] {
   max-height: 20% !important;
   background: #fff;
   padding-bottom: 5px;
+  top: 0;
 }
 
 amp-ad[sticky='bottom'] {


### PR DESCRIPTION
The viewer debug tool actually behaves differently than a real viewer in that the fixed layer automatically adjusts by viewer's paddingTop. This PR:

1. Set `top` css to 0 and attaches the sticky ad to the fixed layer so that its top automatically gets adjusted.
2. Hide the top sticky ads when scrolled to top and show it upon scrolling down again.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
