### PR TITLE
Paginate check runs in cut-nightly workflow

### DIFF
--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -33,12 +33,10 @@ async function getCommit(octokit) {
   );
 
   for (const {sha} of commits.data) {
-    const {'check_runs': checkRuns} = (
-      await octokit.rest.checks.listForRef({
-        ...params,
-        ref: sha,
-      })
-    ).data;
+    const checkRuns = await octokit.paginate(octokit.rest.checks.listForRef, {
+      ...params,
+      ref: sha,
+    });
     if (
       checkRuns
         .filter(({'external_id': id}) => id !== GITHUB_EXTERNAL_ID)


### PR DESCRIPTION
The API by default returns the first 30 results. Since now each Bento component has its own publish action, there are many more than 30 results, causing us to miss the self-check in the API (and worst, we could miss actual failures) - instead of setting a `per_page` value I prefer to use [`.paginate`](https://octokit.github.io/rest.js/v18#pagination) here to guarantee we get all results

// cc: @samouri 