### PR TITLE
✨ [amp-story] Enables volume=0 and sets noaudio to be an alias for volume=0

### DIFF
--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -1331,7 +1331,9 @@ export class AmpStoryPage extends AMP.BaseElement {
     return waitForElementsWithUnresolvedAudio(this.element).then(() =>
       Array.prototype.some.call(
         ampVideoEls,
-        (video) => !video.hasAttribute('noaudio')
+        (video) =>
+          !video.hasAttribute('noaudio') &&
+          parseFloat(video.getAttribute('volume')) !== 0
       )
     );
   }

--- a/extensions/amp-story/1.0/test/validator-amp-story-video-error.html
+++ b/extensions/amp-story/1.0/test/validator-amp-story-video-error.html
@@ -34,13 +34,13 @@
     </amp-story-page>
     <amp-story-page id="2" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
-        <!-- This should fail because amp-video volume should be within [0.1, 1]. -->
+        <!-- This should fail because amp-video volume should be within [0, 1]. -->
         <amp-video width="480"
                    height="270"
                    poster="/foo.jpg"
                    src="/video/tokyo.mp4"
                    layout="responsive"
-                   volume="0">
+                   volume="-1">
              <div fallback>
                <p>Your browser doesn't support HTML5 video.</p>
              </div>
@@ -51,13 +51,47 @@
     </amp-story-page>
     <amp-story-page id="3" background-audio="path/to/my.mp3" auto-advance-after="any-value">
       <amp-story-grid-layer template="horizontal">
-        <!-- This should fail because amp-video volume should be within [0.1, 1]. -->
+        <!-- This should fail because amp-video volume should be within [0, 1]. -->
         <amp-video width="480"
                    height="270"
                    poster="/foo.jpg"
                    src="/video/tokyo.mp4"
                    layout="responsive"
                    volume="1.01">
+             <div fallback>
+               <p>Your browser doesn't support HTML5 video.</p>
+             </div>
+             <source type="video/mp4" src="/video/tokyo.mp4">
+             <source type="video/webm" src="/video/tokyo.webm">
+         </amp-video>
+      </amp-story-grid-layer>
+    </amp-story-page>
+    <amp-story-page id="4" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+      <amp-story-grid-layer template="horizontal">
+        <!-- This should not fail because amp-video volume is within [0, 1]. -->
+        <amp-video width="480"
+                   height="270"
+                   poster="/foo.jpg"
+                   src="/video/tokyo.mp4"
+                   layout="responsive"
+                   volume="0.42">
+             <div fallback>
+               <p>Your browser doesn't support HTML5 video.</p>
+             </div>
+             <source type="video/mp4" src="/video/tokyo.mp4">
+             <source type="video/webm" src="/video/tokyo.webm">
+         </amp-video>
+      </amp-story-grid-layer>
+    </amp-story-page>
+    <amp-story-page id="5" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+      <amp-story-grid-layer template="horizontal">
+        <!-- This should not fail because amp-video volume is within [0, 1]. -->
+        <amp-video width="480"
+                   height="270"
+                   poster="/foo.jpg"
+                   src="/video/tokyo.mp4"
+                   layout="responsive"
+                   volume="0">
              <div fallback>
                <p>Your browser doesn't support HTML5 video.</p>
              </div>

--- a/extensions/amp-story/1.0/test/validator-amp-story-video-error.out
+++ b/extensions/amp-story/1.0/test/validator-amp-story-video-error.out
@@ -39,15 +39,15 @@ amp-story/1.0/test/validator-amp-story-video-error.html:23:8 The mandatory attri
 |      </amp-story-page>
 |      <amp-story-page id="2" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
-|          <!-- This should fail because amp-video volume should be within [0.1, 1]. -->
+|          <!-- This should fail because amp-video volume should be within [0, 1]. -->
 |          <amp-video width="480"
 >>         ^~~~~~~~~
-amp-story/1.0/test/validator-amp-story-video-error.html:38:8 The attribute 'volume' in tag 'amp-video' is set to the invalid value '0'. (see https://amp.dev/documentation/components/amp-video/)
+amp-story/1.0/test/validator-amp-story-video-error.html:38:8 The attribute 'volume' in tag 'amp-video' is set to the invalid value '-1'. (see https://amp.dev/documentation/components/amp-video/)
 |                     height="270"
 |                     poster="/foo.jpg"
 |                     src="/video/tokyo.mp4"
 |                     layout="responsive"
-|                     volume="0">
+|                     volume="-1">
 |               <div fallback>
 |                 <p>Your browser doesn't support HTML5 video.</p>
 |               </div>
@@ -58,7 +58,7 @@ amp-story/1.0/test/validator-amp-story-video-error.html:38:8 The attribute 'volu
 |      </amp-story-page>
 |      <amp-story-page id="3" background-audio="path/to/my.mp3" auto-advance-after="any-value">
 |        <amp-story-grid-layer template="horizontal">
-|          <!-- This should fail because amp-video volume should be within [0.1, 1]. -->
+|          <!-- This should fail because amp-video volume should be within [0, 1]. -->
 |          <amp-video width="480"
 >>         ^~~~~~~~~
 amp-story/1.0/test/validator-amp-story-video-error.html:55:8 The attribute 'volume' in tag 'amp-video' is set to the invalid value '1.01'. (see https://amp.dev/documentation/components/amp-video/)
@@ -67,6 +67,44 @@ amp-story/1.0/test/validator-amp-story-video-error.html:55:8 The attribute 'volu
 |                     src="/video/tokyo.mp4"
 |                     layout="responsive"
 |                     volume="1.01">
+|               <div fallback>
+|                 <p>Your browser doesn't support HTML5 video.</p>
+|               </div>
+|               <source type="video/mp4" src="/video/tokyo.mp4">
+|               <source type="video/webm" src="/video/tokyo.webm">
+|           </amp-video>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|      <amp-story-page id="4" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+|        <amp-story-grid-layer template="horizontal">
+|          <!-- This should not fail because amp-video volume is within [0, 1]. -->
+|          <amp-video width="480"
+>>         ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-video-error.html:72:8 The mandatory attribute 'autoplay' is missing in tag 'amp-video'. (see https://amp.dev/documentation/components/amp-video/)
+|                     height="270"
+|                     poster="/foo.jpg"
+|                     src="/video/tokyo.mp4"
+|                     layout="responsive"
+|                     volume="0.42">
+|               <div fallback>
+|                 <p>Your browser doesn't support HTML5 video.</p>
+|               </div>
+|               <source type="video/mp4" src="/video/tokyo.mp4">
+|               <source type="video/webm" src="/video/tokyo.webm">
+|           </amp-video>
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|      <amp-story-page id="5" background-audio="path/to/my.mp3" auto-advance-after="any-value">
+|        <amp-story-grid-layer template="horizontal">
+|          <!-- This should not fail because amp-video volume is within [0, 1]. -->
+|          <amp-video width="480"
+>>         ^~~~~~~~~
+amp-story/1.0/test/validator-amp-story-video-error.html:89:8 The mandatory attribute 'autoplay' is missing in tag 'amp-video'. (see https://amp.dev/documentation/components/amp-video/)
+|                     height="270"
+|                     poster="/foo.jpg"
+|                     src="/video/tokyo.mp4"
+|                     layout="responsive"
+|                     volume="0">
 |               <div fallback>
 |                 <p>Your browser doesn't support HTML5 video.</p>
 |               </div>

--- a/extensions/amp-video/0.1/amp-video.md
+++ b/extensions/amp-video/0.1/amp-video.md
@@ -105,7 +105,7 @@ when the video has autoplay.
 
 ### volume
 
-Sets the current volume of the video, where the value must be in the range [0.1, 1]. The default value is 1.
+Sets the current volume of the video, where the value must be in the range [0, 1]. The default value is 1.
 [/filter]<!-- formats="stories" -->
 
 ### rotate-to-fullscreen

--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -185,9 +185,8 @@ tags: {  # <amp-video> in amp-story
   }
   attrs: {
     name: "volume"
-    # Disallow 0 to prevent shipping unnecessary audio track when the video is muted.
-    # Volume must be in the range [0.1, 1].
-    value_regex: "^((0?\\.[1-9]+)?|1(\\.0*)?)$"
+    # Volume must be in the range [0, 1].
+    value_regex: "^(0(\\.0*)?|(0?\\.[0-9]+)?|1(\\.0*)?)$"
   }
   attr_lists: "extended-amp-global"
   attr_lists: "amp-video-common"


### PR DESCRIPTION
This PR fixes #37372 and enables a few things:

- it allows the volume attribute on an amp-video in stories to be set to 0
- it removes the unmute button when the volume is set to 0
- it sets media with noaudio to a volume of 0