### PR TITLE
♻️ `amp-story-shopping-attachment`: Remove duplicate `-page-attachment`

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -71,12 +71,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
       storeShoppingConfig(pageElement, config)
     );
 
-    this.attachmentEl_ = (
-      <amp-story-page-attachment
-        layout="nodisplay"
-        theme={this.element.getAttribute('theme')}
-      ></amp-story-page-attachment>
-    );
     if (this.shoppingTags_.length === 0) {
       return;
     }
@@ -95,10 +89,11 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
           cta-text={this.localizationService_.getLocalizedString(
             LocalizedStringId_Enum.AMP_STORY_SHOPPING_CTA_LABEL
           )}
-        ></amp-story-page-attachment>
+        >
+          {this.templateContainer_}
+        </amp-story-page-attachment>
       );
       this.element.appendChild(this.attachmentEl_);
-      this.attachmentEl_.appendChild(this.templateContainer_);
     });
   }
 


### PR DESCRIPTION
Original `attachmentEl_` is discarded in the same element callback. Don't create it.