### PR TITLE
🚀♻️ Use sync services in `amp-story-shopping` and `amp-story-share-menu`

### DIFF
--- a/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
+++ b/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
@@ -91,37 +91,27 @@ export class AmpStoryShareMenu extends AMP.BaseElement {
     /** @const @private {!../../../src/service/vsync-impl.Vsync} */
     this.vsync_ = Services.vsyncFor(this.win);
 
-    /** @private {?../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = null;
+    /** @private @const {!../../../src/service/localization.LocalizationService} */
+    this.localizationService_ = Services.localizationForDoc(this.element);
 
-    /** @private {?../../../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = null;
+    /** @private @const {!../../../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = Services.storyStoreService(this.win);
   }
 
   /**
    * Builds and appends the component in the story. Could build either the
    * amp-social-share button to display the native system sharing, or a fallback
    * UI.
-   * @return {!Promise}
    */
   buildCallback() {
     if (this.rootEl_) {
       return;
     }
 
-    return Promise.all([
-      Services.storyStoreServiceForOrNull(this.win).then(
-        (service) => (this.storeService_ = service)
-      ),
-      Services.localizationServiceForOrNull(this.element).then(
-        (service) => (this.localizationService_ = service)
-      ),
-    ]).then(() => {
-      const providersList = this.buildProvidersList_();
-      this.rootEl_ = this.buildDialog_(providersList);
-      createShadowRootWithStyle(this.element, this.rootEl_, CSS);
-      this.initializeListeners_();
-    });
+    const providersList = this.buildProvidersList_();
+    this.rootEl_ = this.buildDialog_(providersList);
+    createShadowRootWithStyle(this.element, this.rootEl_, CSS);
+    this.initializeListeners_();
   }
 
   /**

--- a/extensions/amp-story-share-menu/0.1/test/test-amp-story-share-menu.js
+++ b/extensions/amp-story-share-menu/0.1/test/test-amp-story-share-menu.js
@@ -43,8 +43,8 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
 
     const localizationService = new LocalizationService(win.document.body);
     env.sandbox
-      .stub(Services, 'localizationServiceForOrNull')
-      .returns(Promise.resolve(localizationService));
+      .stub(Services, 'localizationForDoc')
+      .returns(localizationService);
 
     hostEl = win.document.createElement('div');
     ampStory = win.document.createElement('amp-story');

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -48,11 +48,11 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     /** @private @const {!Element} */
     this.templateContainer_ = <div></div>;
 
-    /** @private {?../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = null;
+    /** @private @const {!../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = Services.storyStoreService(this.win);
 
-    /** @private {?../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = null;
+    /** @private @const {!../../../src/service/localization.LocalizationService} */
+    this.localizationService_ = Services.localizationForDoc(this.element);
 
     /** @private {!Map<string, Element>} */
     this.builtTemplates_ = {};
@@ -73,26 +73,18 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
       return;
     }
 
-    return Promise.all([
-      Services.storyStoreServiceForOrNull(this.win),
-      Services.localizationServiceForOrNull(this.element),
-    ]).then(([storeService, localizationService]) => {
-      this.storeService_ = storeService;
-      this.localizationService_ = localizationService;
-
-      this.attachmentEl_ = (
-        <amp-story-page-attachment
-          layout="nodisplay"
-          theme={this.element.getAttribute('theme')}
-          cta-text={this.localizationService_.getLocalizedString(
-            LocalizedStringId_Enum.AMP_STORY_SHOPPING_CTA_LABEL
-          )}
-        >
-          {this.templateContainer_}
-        </amp-story-page-attachment>
-      );
-      this.element.appendChild(this.attachmentEl_);
-    });
+    this.attachmentEl_ = (
+      <amp-story-page-attachment
+        layout="nodisplay"
+        theme={this.element.getAttribute('theme')}
+        cta-text={this.localizationService_.getLocalizedString(
+          LocalizedStringId_Enum.AMP_STORY_SHOPPING_CTA_LABEL
+        )}
+      >
+        {this.templateContainer_}
+      </amp-story-page-attachment>
+    );
+    this.element.appendChild(this.attachmentEl_);
   }
 
   /** @override */

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-config.js
@@ -45,13 +45,12 @@ function keyByProductTagId(config) {
 /**
  * @param {!Element} pageElement
  * @param {!KeyedShoppingConfigDef} config
- * @return {!Promise<!ShoppingConfigResponseDef>}
+ * @return {!ShoppingConfigResponseDef}
  */
 export function storeShoppingConfig(pageElement, config) {
   const win = pageElement.ownerDocument.defaultView;
-  return Services.storyStoreServiceForOrNull(win).then((storeService) => {
-    const pageIdToConfig = {[pageElement.id]: config};
-    storeService?.dispatch(Action.ADD_SHOPPING_DATA, pageIdToConfig);
-    return config;
-  });
+  const storeService = Services.storyStoreService(win);
+  const pageIdToConfig = {[pageElement.id]: config};
+  storeService?.dispatch(Action.ADD_SHOPPING_DATA, pageIdToConfig);
+  return config;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -9,8 +9,6 @@ import {computedStyle} from '#core/dom/style';
 
 import {Services} from '#service';
 
-import {devAssert} from '#utils/log';
-
 import {formatI18nNumber, loadFonts} from './amp-story-shopping';
 
 import {CSS as shoppingSharedCSS} from '../../../build/amp-story-shopping-shared-0.1.css';
@@ -41,11 +39,12 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
   /** @param {!AmpElement} element */
   constructor(element) {
     super(element);
-    /** @private @const {?../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
-    this.storeService_ = null;
 
-    /** @private {?../../../src/service/localization.LocalizationService} */
-    this.localizationService_ = null;
+    /** @private @const {!../../amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
+    this.storeService_ = Services.storyStoreService(this.win);
+
+    /** @private @const {!../../../src/service/localization.LocalizationService} */
+    this.localizationService_ = Services.localizationForDoc(this.element);
 
     /** @private {boolean} element */
     this.hasAppendedInnerShoppingTagEl_ = false;
@@ -64,14 +63,14 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
 
   /** @override */
   buildCallback() {
-    /* This is used to prevent the shopping tag component from building if there is no shopping attachment. */
-    const pageElement = closestAncestorElementBySelector(
+    this.pageEl_ = closestAncestorElementBySelector(
       this.element,
       'amp-story-page'
     );
 
+    /* This is used to prevent the shopping tag component from building if there is no shopping attachment. */
     this.shoppingAttachment_ = childElementByTag(
-      pageElement,
+      this.pageEl_,
       'amp-story-shopping-attachment'
     );
 
@@ -80,18 +79,6 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
     }
 
     this.element.setAttribute('role', 'button');
-
-    this.pageEl_ = devAssert(
-      closestAncestorElementBySelector(this.element, 'amp-story-page')
-    );
-
-    return Promise.all([
-      Services.storyStoreServiceForOrNull(this.win),
-      Services.localizationServiceForOrNull(this.element),
-    ]).then(([storeService, localizationService]) => {
-      this.storeService_ = storeService;
-      this.localizationService_ = localizationService;
-    });
   }
 
   /** @override */

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping.js
@@ -41,7 +41,7 @@ export const loadFonts = (win, fontFaces) => {
 AMP.extension('amp-story-shopping', '0.1', (AMP) => {
   AMP.registerElement(
     'amp-story-shopping-tag',
-    AmpStoryShoppingTag,
+    dependsOnStoryServices(AmpStoryShoppingTag),
     shoppingCSS
   );
   AMP.registerElement(

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
@@ -210,15 +210,13 @@ describes.realWin(
 
       beforeEach(async () => {
         storeService = {dispatch: env.sandbox.spy()};
-        env.sandbox
-          .stub(Services, 'storyStoreServiceForOrNull')
-          .resolves(storeService);
+        env.sandbox.stub(Services, 'storyStoreService').resolves(storeService);
       });
 
       it('dispatches ADD_SHOPPING_DATA', async () => {
         const dummyConfig = {foo: {bar: true}};
 
-        await storeShoppingConfig(pageElement, dummyConfig);
+        storeShoppingConfig(pageElement, dummyConfig);
 
         const pageIdToConfig = {[pageElement.id]: dummyConfig};
         expect(

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-config.js
@@ -210,7 +210,7 @@ describes.realWin(
 
       beforeEach(async () => {
         storeService = {dispatch: env.sandbox.spy()};
-        env.sandbox.stub(Services, 'storyStoreService').resolves(storeService);
+        env.sandbox.stub(Services, 'storyStoreService').returns(storeService);
       });
 
       it('dispatches ADD_SHOPPING_DATA', async () => {

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
@@ -91,7 +91,11 @@ describes.realWin(
       expect(shoppingTag.shoppingTagEl_).to.be.null;
     });
 
-    it('should process config data and set text container content if data not null', async () => {
+    // TODO(wg-stories): Re-enable. This wasn't executing previously due to the
+    // callsFake() codepath not being hit. It can't pass since
+    // `amp-story-shopping-tag` does not currently use `productTitle`, which
+    // this compares against.
+    it.skip('should process config data and set text container content if data not null', async () => {
       shoppingTag.element.setAttribute('data-product-id', 'sunglasses');
       await setUpShoppingData();
       env.sandbox.stub(shoppingTag, 'measureMutateElement').callsFake(() => {

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
@@ -1,4 +1,4 @@
-import {createElementWithAttributes} from '#core/dom';
+import * as Preact from '#core/dom/jsx';
 import {Layout_Enum} from '#core/dom/layout';
 
 import '../amp-story-shopping';
@@ -26,8 +26,6 @@ describes.realWin(
     let shoppingTag;
     let storeService;
     let localizationService;
-    let attachmentElement;
-    let pageEl;
 
     beforeEach(async () => {
       win = env.win;
@@ -40,29 +38,22 @@ describes.realWin(
 
       localizationService = new LocalizationService(win.document.body);
       env.sandbox
-        .stub(Services, 'localizationServiceForOrNull')
-        .returns(Promise.resolve(localizationService));
+        .stub(Services, 'localizationForDoc')
+        .returns(localizationService);
 
       await setUpStoryWithShoppingTag();
     });
 
     async function setUpStoryWithShoppingTag() {
-      pageEl = win.document.createElement('amp-story-page');
-      pageEl.id = 'page1';
-      tagEl = createElementWithAttributes(
-        win.document,
-        'amp-story-shopping-tag',
-        {'layout': 'container'}
+      tagEl = (
+        <amp-story-shopping-tag layout="container"></amp-story-shopping-tag>
       );
-      pageEl.appendChild(tagEl);
-
-      attachmentElement = win.document.createElement(
-        'amp-story-shopping-attachment'
+      env.win.document.body.appendChild(
+        <amp-story-page id="page1">
+          {tagEl}
+          <amp-story-shopping-attachment></amp-story-shopping-attachment>
+        </amp-story-page>
       );
-      const story = win.document.createElement('amp-story');
-      win.document.body.appendChild(story);
-      story.appendChild(pageEl);
-      pageEl.appendChild(attachmentElement);
       shoppingTag = await tagEl.getImpl();
     }
 
@@ -86,16 +77,12 @@ describes.realWin(
     });
 
     it('should not build shopping tag if page attachment is missing', async () => {
-      pageEl.removeChild(attachmentElement);
+      env.win.document.querySelector('amp-story-shopping-attachment').remove();
       await setupShoppingTagAndData();
       expect(shoppingTag.shoppingTagEl_).to.be.null;
     });
 
-    // TODO(wg-stories): Re-enable. This wasn't executing previously due to the
-    // callsFake() codepath not being hit. It can't pass since
-    // `amp-story-shopping-tag` does not currently use `productTitle`, which
-    // this compares against.
-    it.skip('should process config data and set text container content if data not null', async () => {
+    it('should process config data and set text container content if data not null', async () => {
       shoppingTag.element.setAttribute('data-product-id', 'sunglasses');
       await setUpShoppingData();
       env.sandbox.stub(shoppingTag, 'measureMutateElement').callsFake(() => {

--- a/extensions/amp-story/1.0/test/test-utils.js
+++ b/extensions/amp-story/1.0/test/test-utils.js
@@ -1,4 +1,7 @@
-import {UPGRADE_TO_CUSTOMELEMENT_RESOLVER} from '#core/dom/amp-element-helpers';
+import {
+  UPGRADE_TO_CUSTOMELEMENT_PROMISE,
+  UPGRADE_TO_CUSTOMELEMENT_RESOLVER,
+} from '#core/dom/amp-element-helpers';
 import * as Preact from '#core/dom/jsx';
 
 import {StateProperty} from '../amp-story-store-service';
@@ -184,6 +187,7 @@ describes.fakeWin('amp-story utils', {}, (env) => {
       story.getImpl = () => Promise.resolve();
       story[UPGRADE_TO_CUSTOMELEMENT_RESOLVER](story);
       delete story[UPGRADE_TO_CUSTOMELEMENT_RESOLVER];
+      delete story[UPGRADE_TO_CUSTOMELEMENT_PROMISE];
 
       const upgraded = await upgradedPromise;
 

--- a/extensions/amp-story/1.0/test/test-utils.js
+++ b/extensions/amp-story/1.0/test/test-utils.js
@@ -1,5 +1,9 @@
+import {UPGRADE_TO_CUSTOMELEMENT_RESOLVER} from '#core/dom/amp-element-helpers';
+import * as Preact from '#core/dom/jsx';
+
 import {StateProperty} from '../amp-story-store-service';
 import {
+  dependsOnStoryServices,
   getRGBFromCssColorValue,
   getTextColorForRGB,
   shouldShowStoryUrlInfo,
@@ -149,6 +153,42 @@ describes.fakeWin('amp-story utils', {}, (env) => {
       expect(getStub).to.be.calledOnceWithExactly(
         StateProperty.CAN_SHOW_STORY_URL_INFO
       );
+    });
+  });
+
+  describe('dependsOnStoryServices', () => {
+    class Upgraded extends AMP.BaseElement {}
+
+    const Preupgrade = dependsOnStoryServices(Upgraded);
+
+    it('should upgrade immediately when not inside amp-story', () => {
+      const element = <div></div>;
+
+      const instance = new Preupgrade(element);
+      const upgraded = instance.upgradeCallback();
+
+      expect(upgraded instanceof Upgraded).to.be.true;
+      expect(upgraded.element).to.equal(element);
+    });
+
+    it('should upgrade after ancestor amp-story', async () => {
+      const element = <div></div>;
+      const story = <amp-story>{element}</amp-story>;
+
+      const instance = new Preupgrade(element);
+      const upgradedSpy = env.sandbox.spy((impl) => impl);
+      const upgradedPromise = instance.upgradeCallback().then(upgradedSpy);
+
+      expect(upgradedSpy).to.not.have.been.called;
+
+      story.getImpl = () => Promise.resolve();
+      story[UPGRADE_TO_CUSTOMELEMENT_RESOLVER](story);
+      delete story[UPGRADE_TO_CUSTOMELEMENT_RESOLVER];
+
+      const upgraded = await upgradedPromise;
+
+      expect(upgraded instanceof Upgraded).to.be.true;
+      expect(upgraded.element).to.equal(element);
     });
   });
 });

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -356,12 +356,6 @@ export function isTransformed(ampdoc) {
  * @return {AMP.BaseElement.constructor}
  */
 export function dependsOnStoryServices(klass) {
-  if (getMode().test) {
-    // Unit tests mock or install the services internally, so returning the
-    // class directly allows us to instantiate elements without placing them
-    // inside an <amp-story>.
-    return klass;
-  }
   return class extends AMP.BaseElement {
     /**
      * @override
@@ -372,6 +366,14 @@ export function dependsOnStoryServices(klass) {
         this.element,
         'amp-story'
       );
+      if (!storyEl) {
+        // Unit tests may mock or install the services internally, so returning
+        // the instance immediately allows us to instantiate elements when
+        // they're not placed inside an <amp-story>.
+        // In reality, doing this would fail. This is okay since elements whose
+        // implementations we wrap should be inside an <amp-story> in any case.
+        return new klass(this.element);
+      }
       return whenUpgradedToCustomElement(storyEl)
         .then(() => storyEl.getImpl())
         .then(() => new klass(this.element));

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -366,7 +366,7 @@ export function dependsOnStoryServices(klass) {
         this.element,
         'amp-story'
       );
-      if (!storyEl) {
+      if (getMode(this.win).test && !storyEl) {
         // Unit tests may mock or install the services internally, so returning
         // the instance immediately allows us to instantiate elements when
         // they're not placed inside an <amp-story>.

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -366,10 +366,12 @@ export function dependsOnStoryServices(klass) {
         this.element,
         'amp-story'
       );
-      if (getMode().test && !storyEl) {
+      if (!storyEl) {
         // Unit tests may mock or install the services internally, so
         // instantiating immediately allows us to test implementations without
         // placing the element inside an <amp-story>.
+        // In reality, this would cause failures. This is okay since upgradable
+        // elements are required to descend from an <amp-story>.
         return new klass(this.element);
       }
       return whenUpgradedToCustomElement(storyEl)

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -366,7 +366,7 @@ export function dependsOnStoryServices(klass) {
         this.element,
         'amp-story'
       );
-      if (getMode(this.win).test && !storyEl) {
+      if (getMode().test && !storyEl) {
         // Unit tests may mock or install the services internally, so returning
         // the instance immediately allows us to instantiate elements when
         // they're not placed inside an <amp-story>.

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -367,11 +367,9 @@ export function dependsOnStoryServices(klass) {
         'amp-story'
       );
       if (getMode().test && !storyEl) {
-        // Unit tests may mock or install the services internally, so returning
-        // the instance immediately allows us to instantiate elements when
-        // they're not placed inside an <amp-story>.
-        // In reality, doing this would fail. This is okay since elements whose
-        // implementations we wrap should be inside an <amp-story> in any case.
+        // Unit tests may mock or install the services internally, so
+        // instantiating immediately allows us to test implementations without
+        // placing the element inside an <amp-story>.
         return new klass(this.element);
       }
       return whenUpgradedToCustomElement(storyEl)

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -359,7 +359,7 @@ export function dependsOnStoryServices(klass) {
   return class extends AMP.BaseElement {
     /**
      * @override
-     * @return {!Promise}
+     * @return {AMP.BaseElement|Promise<AMP.BaseElement>}
      */
     upgradeCallback() {
       const storyEl = closestAncestorElementBySelector(

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -356,6 +356,12 @@ export function isTransformed(ampdoc) {
  * @return {AMP.BaseElement.constructor}
  */
 export function dependsOnStoryServices(klass) {
+  if (getMode().test) {
+    // Unit tests mock or install the services internally, so returning the
+    // class directly allows us to instantiate elements without placing them
+    // inside an <amp-story>.
+    return klass;
+  }
   return class extends AMP.BaseElement {
     /**
      * @override


### PR DESCRIPTION
Element implementations are able to use the synchronous Story service getters by wrapping their class in `dependsOnStoryServices`. This simplifies the initialization flow.

This reduces the compressed size of each extension by ~0.5 kb, by stripping out the base definition of asynchronous getters entirely.