### PR TITLE
Avoid sourcesContent when remapping esbuild output

### DIFF
--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -1,6 +1,7 @@
 const babel = require('@babel/core');
 const path = require('path');
 const {debug} = require('../compile/debug-compilation-lifecycle');
+const {includeSourcesContent} = require('./sourcemaps');
 const {TransformCache, batchedRead, md5} = require('./transform-cache');
 const Remapping = require('@ampproject/remapping');
 
@@ -58,12 +59,10 @@ function getEsbuildBabelPlugin(
       }
     }
 
-    debug('pre-babel', filename, contents);
     const promise = babel
       .transformAsync(contents, babelOptions)
       .then((result) => {
         const {code, map} = /** @type {!babel.BabelFileResult} */ (result);
-        debug('post-babel', filename, code, map);
         return {filename, code: code || '', map};
       });
 
@@ -107,16 +106,18 @@ function getEsbuildBabelPlugin(
             })
           );
 
-          const transformed = await transformContents(
+          debug('pre-babel', filename, contents);
+          const {code, map} = await transformContents(
             filename,
             contents,
             rehash,
             getFileBabelOptions(babelOptions, filename)
           );
 
-          babelMaps.set(filename, transformed.map);
+          debug('post-babel', filename, code, map);
+          babelMaps.set(filename, map);
           postLoad?.();
-          return {contents: transformed.code};
+          return {contents: code};
         }
       );
 
@@ -126,32 +127,39 @@ function getEsbuildBabelPlugin(
         const map = outputFiles.find(({path}) => path.endsWith('.map'));
 
         if (!map) {
+          debug('post-esbuild', code.path, code.text);
           return;
         }
 
         const root = path.dirname(map.path);
         const nodeMods = path.normalize('/node_modules/');
-        const remapped = remapping(map.text, (f, ctx) => {
-          // The Babel tranformed file and the original file have the same
-          // path, which makes it difficult to distinguish during remapping's
-          // load phase. To prevent an infinite recursion, we check if the
-          // importer is ourselves (which is nonsensical) and early exit.
-          if (f === ctx.importer) {
-            return null;
-          }
-
-          const file = path.join(root, f);
-          const map = babelMaps.get(file);
-          if (!map) {
-            if (file.includes(nodeMods)) {
-              // Excuse node_modules since they may have been marked external
-              // (and so not processed by babel).
+        const remapped = remapping(
+          map.text,
+          (f, ctx) => {
+            // The Babel tranformed file and the original file have the same
+            // path, which makes it difficult to distinguish during remapping's
+            // load phase. To prevent an infinite recursion, we check if the
+            // importer is ourselves (which is nonsensical) and early exit.
+            if (f === ctx.importer) {
               return null;
             }
-            throw new Error(`failed to find sourcemap for babel file "${f}"`);
-          }
-          return map;
-        });
+
+            const file = path.join(root, f);
+            const map = babelMaps.get(file);
+            if (!map) {
+              if (file.includes(nodeMods)) {
+                // Excuse node_modules since they may have been marked external
+                // (and so not processed by babel).
+                return null;
+              }
+              throw new Error(`failed to find sourcemap for babel file "${f}"`);
+            }
+            return map;
+          },
+          !includeSourcesContent()
+        );
+
+        debug('post-esbuild', code.path, code.text, remapped);
 
         const sourcemapJson = remapped.toString();
         replaceOutputFile(outputFiles, map, sourcemapJson);

--- a/build-system/compile/debug-compilation-lifecycle.js
+++ b/build-system/compile/debug-compilation-lifecycle.js
@@ -13,12 +13,6 @@ const pad = (value, length) =>
     length
   );
 
-const LIFECYCLES = {
-  'pre-babel': 'pre-babel',
-  'post-babel': 'post-babel',
-  'complete': 'complete',
-};
-
 /**
  * Output debugging information when developing changes in this functionality.
  *
@@ -28,7 +22,7 @@ const LIFECYCLES = {
  * @param {Object=} sourcemap
  */
 function debug(lifecycle, fullpath, content, sourcemap) {
-  if (argv.debug && Object.keys(LIFECYCLES).includes(lifecycle)) {
+  if (argv.debug) {
     if (!content) {
       content = fs.readFileSync(fullpath, 'utf-8');
     }
@@ -62,5 +56,4 @@ function displayLifecycleDebugging() {
 module.exports = {
   displayLifecycleDebugging,
   debug,
-  CompilationLifecycles: LIFECYCLES,
 };

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -21,6 +21,7 @@ const {log, logLocalDev} = require('../common/logging');
 const {thirdPartyFrames} = require('../test-configs/config');
 const {watch} = require('chokidar');
 const {resolvePath} = require('../babel-config/import-resolver');
+const {debug} = require('../compile/debug-compilation-lifecycle');
 const babel = require('@babel/core');
 
 /**
@@ -396,6 +397,12 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
       });
       code = result.code;
       mapChain.unshift(result.map);
+      debug(
+        'post-terser',
+        path.join(process.cwd(), destFile),
+        code,
+        result.map
+      );
     }
 
     await Promise.all([


### PR DESCRIPTION
It also adds more lifecycle debugs, so that we can inspect the transformation process.

I mistakenly thought that the original Babel maps wouldn't include `sourcesContent` and so not including a `!includeSourcesContent()` wouldn't affect anything (remapping just makes an empty `sourcesContent` if the originals didn't have it). But the original maps _do_ have it, and we can speed up building by excluding them.

Re: https://github.com/ampproject/amphtml/pull/37720#discussion_r809129763