### PR TITLE
🐛 amp-story-shopping Get examples and visual diff tests ready for dev preview

### DIFF
--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -121,14 +121,6 @@
           </script>
         </amp-story-shopping-attachment>
       </amp-story-page>
-      <amp-story-page id="remote-dark-theme">
-        <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="vertical">
-          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
-        </amp-story-grid-layer>
-      </amp-story-page>
       <amp-story-page id="inline-dark-theme">
         <!--
           Dark theme example of Inline config. Multiple product tags with icon defined.
@@ -250,6 +242,18 @@
           }
         </script>
       </amp-story-shopping-attachment>
+      </amp-story-page>
+       <!--
+          Example of:
+          CTA Button not rendering due to no page attachment.
+        -->
+      <amp-story-page id="remote-dark-theme">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
       </amp-story-page>
     </amp-story>
   </body>

--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -36,7 +36,7 @@
         poster-portrait-src="example.com/poster.jpg">
       <amp-story-page id="inline-light-theme">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -59,12 +59,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -79,7 +79,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -94,7 +94,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -109,7 +109,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -126,7 +126,7 @@
           Dark theme example of Inline config. Multiple product tags with icon defined.
         -->
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -146,12 +146,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -166,7 +166,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -181,7 +181,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -196,7 +196,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -210,7 +210,7 @@
       </amp-story-page>
       <amp-story-page id="remote-with-product">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
@@ -229,7 +229,7 @@
       </amp-story-page>
       <amp-story-page id="inline-no-product">
       <amp-story-grid-layer template="fill">
-        <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+        <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
       </amp-story-grid-layer>
         <!--
           Example of:
@@ -245,11 +245,11 @@
       </amp-story-page>
        <!--
           Example of:
-          CTA Button not rendering due to no page attachment.
+          CTA Button not rendering due to no shopping attachment.
         -->
       <amp-story-page id="remote-dark-theme">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>

--- a/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
@@ -36,7 +36,7 @@
         poster-portrait-src="example.com/poster.jpg">
       <amp-story-page id="inline-light-theme">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -59,12 +59,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -79,7 +79,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -94,7 +94,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -109,7 +109,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -121,20 +121,12 @@
           </script>
         </amp-story-shopping-attachment>
       </amp-story-page>
-      <amp-story-page id="remote-dark-theme">
-        <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="vertical">
-          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
-        </amp-story-grid-layer>
-      </amp-story-page>
       <amp-story-page id="inline-dark-theme">
         <!--
           Dark theme example of Inline config. Multiple product tags with icon defined.
         -->
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -154,12 +146,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -174,7 +166,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -189,7 +181,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -204,7 +196,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -218,7 +210,7 @@
       </amp-story-page>
       <amp-story-page id="remote-with-product">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
@@ -237,7 +229,7 @@
       </amp-story-page>
       <amp-story-page id="inline-no-product">
       <amp-story-grid-layer template="fill">
-        <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+        <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
       </amp-story-grid-layer>
         <!--
           Example of:
@@ -250,6 +242,18 @@
           }
         </script>
       </amp-story-shopping-attachment>
+      </amp-story-page>
+       <!--
+          Example of:
+          CTA Button not rendering due to no page attachment.
+        -->
+      <amp-story-page id="remote-dark-theme">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
       </amp-story-page>
     </amp-story>
   </body>

--- a/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
@@ -245,7 +245,7 @@
       </amp-story-page>
        <!--
           Example of:
-          CTA Button not rendering due to no page attachment.
+          CTA Button not rendering due to no shopping attachment.
         -->
       <amp-story-page id="remote-dark-theme">
         <amp-story-grid-layer template="fill">

--- a/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
@@ -36,7 +36,7 @@
         poster-portrait-src="example.com/poster.jpg">
       <amp-story-page id="inline-light-theme">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -59,12 +59,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -79,7 +79,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -94,7 +94,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -109,7 +109,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -121,20 +121,12 @@
           </script>
         </amp-story-shopping-attachment>
       </amp-story-page>
-      <amp-story-page id="remote-dark-theme">
-        <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="vertical">
-          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
-        </amp-story-grid-layer>
-      </amp-story-page>
       <amp-story-page id="inline-dark-theme">
         <!--
           Dark theme example of Inline config. Multiple product tags with icon defined.
         -->
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -154,12 +146,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -174,7 +166,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -189,7 +181,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -204,7 +196,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -218,7 +210,7 @@
       </amp-story-page>
       <amp-story-page id="remote-with-product">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
@@ -237,7 +229,7 @@
       </amp-story-page>
       <amp-story-page id="inline-no-product">
       <amp-story-grid-layer template="fill">
-        <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+        <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
       </amp-story-grid-layer>
         <!--
           Example of:
@@ -250,6 +242,18 @@
           }
         </script>
       </amp-story-shopping-attachment>
+      </amp-story-page>
+       <!--
+          Example of:
+          CTA Button not rendering due to no page attachment.
+        -->
+      <amp-story-page id="remote-dark-theme">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
       </amp-story-page>
     </amp-story>
   </body>

--- a/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
@@ -245,7 +245,7 @@
       </amp-story-page>
        <!--
           Example of:
-          CTA Button not rendering due to no page attachment.
+          CTA Button not rendering due to no shopping attachment.
         -->
       <amp-story-page id="remote-dark-theme">
         <amp-story-grid-layer template="fill">

--- a/examples/visual-tests/amp-story/amp-story-shopping.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping.html
@@ -36,7 +36,7 @@
         poster-portrait-src="example.com/poster.jpg">
       <amp-story-page id="inline-light-theme">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -59,12 +59,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -79,7 +79,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -94,7 +94,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -109,7 +109,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -121,20 +121,12 @@
           </script>
         </amp-story-shopping-attachment>
       </amp-story-page>
-      <amp-story-page id="remote-dark-theme">
-        <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
-        </amp-story-grid-layer>
-        <amp-story-grid-layer template="vertical">
-          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
-        </amp-story-grid-layer>
-      </amp-story-page>
       <amp-story-page id="inline-dark-theme">
         <!--
           Dark theme example of Inline config. Multiple product tags with icon defined.
         -->
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -154,12 +146,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
-                       {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
-                       {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
-                       {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
-                       {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
-                       {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -174,7 +166,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -189,7 +181,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -204,7 +196,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -218,7 +210,7 @@
       </amp-story-page>
       <amp-story-page id="remote-with-product">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
@@ -237,7 +229,7 @@
       </amp-story-page>
       <amp-story-page id="inline-no-product">
       <amp-story-grid-layer template="fill">
-        <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
+        <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
       </amp-story-grid-layer>
         <!--
           Example of:
@@ -250,6 +242,18 @@
           }
         </script>
       </amp-story-shopping-attachment>
+      </amp-story-page>
+       <!--
+          Example of:
+          CTA Button not rendering due to no page attachment.
+        -->
+      <amp-story-page id="remote-dark-theme">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
       </amp-story-page>
     </amp-story>
   </body>

--- a/examples/visual-tests/amp-story/amp-story-shopping.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping.html
@@ -245,7 +245,7 @@
       </amp-story-page>
        <!--
           Example of:
-          CTA Button not rendering due to no page attachment.
+          CTA Button not rendering due to no shopping attachment.
         -->
       <amp-story-page id="remote-dark-theme">
         <amp-story-grid-layer template="fill">


### PR DESCRIPTION
Rearranges examples and images for the amp-story-shopping component.
Static images are added in the visual tests to avoid test flakiness. 