### PR TITLE
🏗 🐛 Release-tagger should respect the bundles.config.bento.json file

### DIFF
--- a/build-system/npm-publish/get-extensions.js
+++ b/build-system/npm-publish/get-extensions.js
@@ -3,6 +3,6 @@
  * Logs Bento components to publish.
  */
 
-const {getExtensions} = require('./utils');
+const {getExtensionsAndComponents} = require('./utils');
 console /*OK*/
-  .log(JSON.stringify(getExtensions()));
+  .log(JSON.stringify(getExtensionsAndComponents()));

--- a/build-system/npm-publish/utils.js
+++ b/build-system/npm-publish/utils.js
@@ -19,11 +19,11 @@ function getExtensions() {
  */
 function getComponents() {
   const bundles = require('../compile/bundles.config.bento.json');
-  const extensions = bundles.map((bundle) => ({
+  const components = bundles.map((bundle) => ({
     'extension': bundle.name,
     'version': bundle.version,
   }));
-  return extensions;
+  return components;
 }
 
 /**

--- a/build-system/npm-publish/utils.js
+++ b/build-system/npm-publish/utils.js
@@ -14,6 +14,27 @@ function getExtensions() {
 }
 
 /**
+ * Get bento components to be published on npm
+ * @return {Array<any>}
+ */
+function getComponents() {
+  const bundles = require('../compile/bundles.config.bento.json');
+  const extensions = bundles.map((bundle) => ({
+    'extension': bundle.name,
+    'version': bundle.version,
+  }));
+  return extensions;
+}
+
+/**
+ * Get bento components and extensions to be published on npm
+ * @return {Array<any>}
+ */
+function getExtensionsAndComponents() {
+  return [...getExtensions(), ...getComponents()];
+}
+
+/**
  * Get semver from extension version and amp version
  * See build-system/compile/internal-version.js for versioning description
  * @param {string} extensionVersion
@@ -28,6 +49,8 @@ function getSemver(extensionVersion, ampVersion) {
 }
 
 module.exports = {
+  getComponents,
   getExtensions,
+  getExtensionsAndComponents,
   getSemver,
 };

--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -3,6 +3,7 @@
  * Creates npm package files for a given component and AMP version.
  */
 
+const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
 const fastGlob = require('fast-glob');
 const marked = require('marked');
 const path = require('path');
@@ -14,7 +15,6 @@ const {log} = require('../common/logging');
 const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
 
-const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
 const packageName = getNameWithoutComponentPrefix(extension);
 
 /**
@@ -22,11 +22,16 @@ const packageName = getNameWithoutComponentPrefix(extension);
  * @return {string}
  */
 function getDir() {
-  if (extension.startsWith('bento')) {
-    return `src/bento/components/${extension}/${extensionVersion}`;
-  }
-  return `extensions/${extension}/${extensionVersion}`;
+  return extension.startsWith('bento')
+    ? `src/bento/components/${extension}/${extensionVersion}`
+    : `extensions/${extension}/${extensionVersion}`;
 }
+
+/**
+ * The directory of the component or extension.
+ * @type {string}
+ */
+const dir = getDir();
 
 /**
  * Determines whether to skip
@@ -34,7 +39,7 @@ function getDir() {
  */
 async function shouldSkip() {
   try {
-    await stat(getDir());
+    await stat(dir);
     return false;
   } catch {
     log(`${extension} ${extensionVersion} : skipping, does not exist`);
@@ -48,7 +53,7 @@ async function shouldSkip() {
  * @return {Promise<string[]>}
  */
 async function getStylesheets() {
-  const extDir = `${getDir()}/dist`.split('/').join(path.sep);
+  const extDir = `${dir}/dist`.split('/').join(path.sep);
   const files = await fastGlob(path.join(extDir, '**', '*.css'));
   return files.map((file) => path.relative(extDir, file));
 }
@@ -106,7 +111,7 @@ async function getFirstParagraphOrSentence(markdown, maxLengthChars) {
 async function getDescription() {
   let description;
   try {
-    const markdown = await readFile(`${getDir()}/README.md`, 'utf8');
+    const markdown = await readFile(`${dir}/README.md`, 'utf8');
     description = await getFirstParagraphOrSentence(markdown, 200);
   } catch {}
   return description || `Bento ${packageName} Component`;
@@ -181,7 +186,7 @@ async function writePackageJson({useBentoCore}) {
   }
 
   try {
-    await writeFile(`${getDir()}/package.json`, JSON.stringify(json, null, 2));
+    await writeFile(`${dir}/package.json`, JSON.stringify(json, null, 2));
     log(
       json.name,
       extensionVersion,
@@ -202,7 +207,7 @@ async function writePackageJson({useBentoCore}) {
 async function writeReactJs() {
   const content = "module.exports = require('./dist/component-react');";
   try {
-    await writeFile(`${getDir()}/react.js`, content);
+    await writeFile(`${dir}/react.js`, content);
     log(packageName, extensionVersion, ': created react.js');
   } catch (e) {
     log(e);

--- a/build-system/npm-publish/write-package-files.js
+++ b/build-system/npm-publish/write-package-files.js
@@ -3,7 +3,6 @@
  * Creates npm package files for a given component and AMP version.
  */
 
-const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
 const fastGlob = require('fast-glob');
 const marked = require('marked');
 const path = require('path');
@@ -15,8 +14,19 @@ const {log} = require('../common/logging');
 const {stat, writeFile} = require('fs/promises');
 const {valid} = require('semver');
 
+const [extension, ampVersion, extensionVersion] = process.argv.slice(2);
 const packageName = getNameWithoutComponentPrefix(extension);
-const dir = `extensions/${extension}/${extensionVersion}`;
+
+/**
+ * Gets the directory of the component or extension.
+ * @return {string}
+ */
+function getDir() {
+  if (extension.startsWith('bento')) {
+    return `src/bento/components/${extension}/${extensionVersion}`;
+  }
+  return `extensions/${extension}/${extensionVersion}`;
+}
 
 /**
  * Determines whether to skip
@@ -24,7 +34,7 @@ const dir = `extensions/${extension}/${extensionVersion}`;
  */
 async function shouldSkip() {
   try {
-    await stat(dir);
+    await stat(getDir());
     return false;
   } catch {
     log(`${extension} ${extensionVersion} : skipping, does not exist`);
@@ -38,7 +48,7 @@ async function shouldSkip() {
  * @return {Promise<string[]>}
  */
 async function getStylesheets() {
-  const extDir = `${dir}/dist`.split('/').join(path.sep);
+  const extDir = `${getDir()}/dist`.split('/').join(path.sep);
   const files = await fastGlob(path.join(extDir, '**', '*.css'));
   return files.map((file) => path.relative(extDir, file));
 }
@@ -96,7 +106,7 @@ async function getFirstParagraphOrSentence(markdown, maxLengthChars) {
 async function getDescription() {
   let description;
   try {
-    const markdown = await readFile(`${dir}/README.md`, 'utf8');
+    const markdown = await readFile(`${getDir()}/README.md`, 'utf8');
     description = await getFirstParagraphOrSentence(markdown, 200);
   } catch {}
   return description || `Bento ${packageName} Component`;
@@ -171,7 +181,7 @@ async function writePackageJson({useBentoCore}) {
   }
 
   try {
-    await writeFile(`${dir}/package.json`, JSON.stringify(json, null, 2));
+    await writeFile(`${getDir()}/package.json`, JSON.stringify(json, null, 2));
     log(
       json.name,
       extensionVersion,
@@ -192,7 +202,7 @@ async function writePackageJson({useBentoCore}) {
 async function writeReactJs() {
   const content = "module.exports = require('./dist/component-react');";
   try {
-    await writeFile(`${dir}/react.js`, content);
+    await writeFile(`${getDir()}/react.js`, content);
     log(packageName, extensionVersion, ': created react.js');
   } catch (e) {
     log(e);

--- a/build-system/release-tagger/make-release.js
+++ b/build-system/release-tagger/make-release.js
@@ -10,7 +10,7 @@ const {
   getPullRequestsBetweenCommits,
   getRef,
 } = require('./utils');
-const {getExtensions, getSemver} = require('../npm-publish/utils');
+const {getExtensionsAndComponents, getSemver} = require('../npm-publish/utils');
 const {GraphQlQueryResponseData} = require('@octokit/graphql'); // eslint-disable-line @typescript-eslint/no-unused-vars
 
 const prereleaseConfig = {
@@ -48,7 +48,7 @@ function _formatPullRequestLine(pr) {
  * @return {PackageMetadata}
  */
 function _createPackageSections(prs) {
-  const bundles = getExtensions();
+  const bundles = getExtensionsAndComponents();
   const majors = [...new Set(bundles.map((b) => b.version))];
   /** @type PackageMetadata */
   const metadata = {};

--- a/build-system/release-tagger/test/make-release.test.js
+++ b/build-system/release-tagger/test/make-release.test.js
@@ -1,6 +1,6 @@
 const nock = require('nock');
 const test = require('ava');
-const {getExtensions} = require('../../npm-publish/utils');
+const {getExtensionsAndComponents} = require('../../npm-publish/utils');
 const {makeRelease} = require('../make-release');
 
 test.before(() => nock.disableNetConnect());
@@ -20,7 +20,7 @@ test('create', async (t) => {
     '<a href="https://github.com/ampproject/amphtml/commit/3abcdef">' +
     '<code>3abc</code></a> - Update packages';
 
-  const packages = getExtensions().map((e) => e.extension);
+  const packages = getExtensionsAndComponents().map((e) => e.extension);
 
   const rest = nock('https://api.github.com')
     // https://docs.github.com/en/rest/reference/git#get-a-reference
@@ -186,7 +186,7 @@ test('cherry-pick', async (t) => {
     '<a href="https://github.com/ampproject/amphtml/commit/2abcdef">' +
     '<code>2abc</code></a> - Cherry pick fix';
 
-  const packages = getExtensions().map((e) => e.extension);
+  const packages = getExtensionsAndComponents().map((e) => e.extension);
 
   const rest = nock('https://api.github.com')
     // https://docs.github.com/en/rest/reference/git#get-a-reference

--- a/build-system/tasks/build-bento.js
+++ b/build-system/tasks/build-bento.js
@@ -132,6 +132,7 @@ async function buildBentoComponent(name, version, hasCss, options = {}) {
     return;
   }
   const componentsDir = `src/bento/components/${name}/${version}`;
+  mkdirSync(`${componentsDir}/dist`, {recursive: true});
   if (options.watch) {
     await watchBentoComponent(componentsDir, name, version, hasCss, options);
   }


### PR DESCRIPTION
Components in the `src/bento/components` directory have not been getting picked up by the `publish-npm-packages` workflow. My fix is to ensure the workflow reads the `bundles.config.bento.json` file as well as the `bundles.config.extensions.json` file and adds the adds knowledge of the new `src/bento/components` directory to the build flow.

#37737
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
