### PR TITLE
[amp story shopping] bring back images to example

### DIFF
--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -36,7 +36,7 @@
         poster-portrait-src="example.com/poster.jpg">
       <amp-story-page id="inline-light-theme">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -59,12 +59,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
+                      {"url": "https://source.unsplash.com/Ry9WBo3qmoc/500x500", "alt": "lamp 1"},
+                      {"url": "https://source.unsplash.com/KP7p0-DRGbg", "alt": "lamp 2"},
+                      {"url": "https://source.unsplash.com/mFnbFaCIu1I", "alt": "lamp 3"},
+                      {"url": "https://source.unsplash.com/py9sH2rThWs", "alt": "lamp 4"},
+                      {"url": "https://source.unsplash.com/VDPauwJ_sHo", "alt": "lamp 5"},
+                      {"url": "https://source.unsplash.com/3LTht2nxd34", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -80,7 +80,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
+                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -96,7 +96,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
+                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -112,7 +112,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
+                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -129,7 +129,7 @@
           Dark theme example of Inline config. Multiple product tags with icon defined.
         -->
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
@@ -149,12 +149,12 @@
                     "productPrice": 799.00,
                     "productPriceCurrency": "USD",
                     "productImages": [
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
-                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
+                      {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                      {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                      {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                      {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                      {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                      {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
                     ],
                     "aggregateRating": {
                       "ratingValue": "4.4",
@@ -169,7 +169,7 @@
                     "productBrand": "V. Artsy",
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
-                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
+                    "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -184,7 +184,7 @@
                     "productPrice": 1000.00,
                     "productPriceCurrency": "BRL",
                     "productTagText": "The perfectly imperfect yellow chair",
-                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
+                    "productImages": [{"url": "https://source.unsplash.com/DgQGKKLaVhY/500x500", "alt": "chair"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -199,7 +199,7 @@
                     "productPrice": 10.00,
                     "productPriceCurrency": "USD",
                     "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
-                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
+                    "productImages": [{"url": "https://source.unsplash.com/SavQfLRm4Do/500x500", "alt": "flowers"}],
                     "aggregateRating": {
                       "ratingValue": "4.4",
                       "reviewCount": "89",
@@ -213,7 +213,7 @@
       </amp-story-page>
       <amp-story-page id="remote-with-product">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
@@ -232,7 +232,7 @@
       </amp-story-page>
       <amp-story-page id="inline-no-product">
       <amp-story-grid-layer template="fill">
-        <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
       </amp-story-grid-layer>
         <!--
           Example of:
@@ -252,7 +252,7 @@
         -->
       <amp-story-page id="remote-dark-theme">
         <amp-story-grid-layer template="fill">
-          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+          <amp-img layout="fill" src="https://source.unsplash.com/_HqHX3LBN18/1000x2000"></amp-img>
         </amp-story-grid-layer>
         <amp-story-grid-layer template="vertical">
           <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>


### PR DESCRIPTION
Bringing back images to the example template that is not a visual diff test. Follow up to #37733