### PR TITLE
🐛 Fix amp-twitter component resizing issue

### DIFF
--- a/extensions/amp-twitter/1.0/component.js
+++ b/extensions/amp-twitter/1.0/component.js
@@ -1,7 +1,8 @@
 import {MessageType_Enum, deserializeMessage} from '#core/3p-frame-messaging';
+import {setStyles} from '#core/dom/style';
 
 import * as Preact from '#preact';
-import {useCallback, useMemo, useState} from '#preact';
+import {useCallback, useEffect, useMemo, useRef, useState} from '#preact';
 import {forwardRef} from '#preact/compat';
 import {useValueRef} from '#preact/component';
 import {ProxyIframeEmbed} from '#preact/component/3p-frame';
@@ -40,6 +41,7 @@ function BentoTwitterWithRef(
   const [height, setHeight] = useState(null);
   const onLoadRef = useValueRef(onLoad);
   const onErrorRef = useValueRef(onError);
+  const iframeRef = useRef(ref);
 
   const messageHandler = useCallback(
     (event) => {
@@ -48,6 +50,17 @@ function BentoTwitterWithRef(
         const height = data['height'];
         if (requestResize) {
           requestResize(height);
+
+          // Remove the position style from embed after the resize is complete.
+          setStyles(iframeRef.current.node.getRootNode().host, {
+            position: '',
+            opacity: '',
+            top: '',
+            bottom: '',
+            left: '',
+            right: '',
+            pointerEvents: '',
+          });
           setHeight(FULL_HEIGHT);
         } else {
           setHeight(height);
@@ -87,10 +100,25 @@ function BentoTwitterWithRef(
     ]
   );
 
+  useEffect(() => {
+    // This style is added as part of a workaround to fix the component resizing issue because
+    // the resizing happens only when the embed comes into viewport and most of the time the
+    // attemptChangeHeight request is gets rejected.
+    setStyles(iframeRef.current.node.getRootNode().host, {
+      position: 'fixed',
+      opacity: '0',
+      top: '0',
+      bottom: '0',
+      left: '0',
+      right: '0',
+      pointerEvents: 'none',
+    });
+  }, [iframeRef]);
+
   return (
     <ProxyIframeEmbed
       allowfullscreen
-      ref={ref}
+      ref={iframeRef}
       title={title}
       {...rest}
       // non-overridable props


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/37117

This PR fixes the Twitter embed resizing issue using the workaround mentioned by @alanorozco in https://github.com/ampproject/amphtml/issues/37117#issuecomment-1043194503. As the resizing of the Twitter embed happens only when it comes into viewport in most cases the embed gets loaded in the unexpanded state this PR uses a workaround to resize the embed when the component gets built.
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
