### PR TITLE
🐛 [amp story shopping tag] Call To Initialize listeners

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -117,8 +117,10 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
       true /** callToInitialize */
     );
 
-    this.storeService_.subscribe(StateProperty.CURRENT_PAGE_ID, (id) =>
-      this.toggleShoppingTagActive_(id)
+    this.storeService_.subscribe(
+      StateProperty.CURRENT_PAGE_ID,
+      (id) => this.toggleShoppingTagActive_(id),
+      true /** callToInitialize */
     );
   }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -107,8 +107,10 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
       true /** callToInitialize */
     );
 
-    this.storeService_.subscribe(StateProperty.RTL_STATE, (rtlState) =>
-      this.onRtlStateUpdate_(rtlState)
+    this.storeService_.subscribe(
+      StateProperty.RTL_STATE,
+      (rtlState) => this.onRtlStateUpdate_(rtlState),
+      true /** callToInitialize */
     );
 
     this.storeService_.subscribe(


### PR DESCRIPTION
There is a race condition where the tag will sometimes not get the `active` attribute.
This happens when the layoutCallback runs after the `CURRENT_PAGE_ID` state is set on load.
callToInitialize is also added to RTL state in this PR since this may also happen in that case.