### PR TITLE
✨ 🖍 [amp story shopping] Display in desktop supports-landscape

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-shopping-landscape.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-landscape.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<html amp lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Shopping</title>
+    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+    <script async src="https://cdn.ampproject.org/v0.js"></script>
+    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-story-shopping" src="https://cdn.ampproject.org/v0/amp-story-shopping-0.1.js"></script>
+    <style amp-custom>
+      [data-product-id="lamp"] {
+        top: 31%;
+        left: 1%;
+      }
+      [data-product-id="art"] {
+        top: 15%;
+        left: 40%;
+      }
+      [data-product-id="chair"] {
+        top: 53%;
+        left: 30%;
+      }
+      [data-product-id="flowers"] {
+        top: 46%;
+        left: 83%;
+      }
+    </style>
+  </head>
+  <body>
+    <amp-story
+        standalone
+        title="Story Shopping Component"
+        publisher="AMP Story Shopping"
+        publisher-logo-src="example.com/logo.png"
+        poster-portrait-src="example.com/poster.jpg"
+        supports-landscape>
+      <amp-story-page id="inline-light-theme">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-product-id="chair" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-product-id="flowers" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+        <!--
+          Example of Inline config. Multiple product tags with icon defined.
+        -->
+        <amp-story-shopping-attachment>
+          <script type="application/json">
+            {
+                "items" : [
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "lamp",
+                    "productTitle": "Brass Lamp",
+                    "productBrand": "Lamp Co",
+                    "productPrice": 799.00,
+                    "productPriceCurrency": "USD",
+                    "productImages": [
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
+                    ],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
+                   },
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "art",
+                    "productTitle": "Abstract Art",
+                    "productBrand": "V. Artsy",
+                    "productPrice": 1200.00,
+                    "productPriceCurrency": "INR",
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    }
+                   },
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "chair",
+                    "productTitle": "Yellow chair",
+                    "productBrand": "Chair Co.",
+                    "productPrice": 1000.00,
+                    "productPriceCurrency": "BRL",
+                    "productTagText": "The perfectly imperfect yellow chair",
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
+                   },
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "flowers",
+                    "productTitle": "Flowers",
+                    "productBrand": "Very Long Flower Company Name",
+                    "productPrice": 10.00,
+                    "productPriceCurrency": "USD",
+                    "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    },
+                    "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
+                   }
+                ]
+              }
+          </script>
+        </amp-story-shopping-attachment>
+      </amp-story-page>
+      <amp-story-page id="inline-dark-theme">
+        <!--
+          Dark theme example of Inline config. Multiple product tags with icon defined.
+        -->
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="lamp" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-product-id="chair" ></amp-story-shopping-tag>
+          <amp-story-shopping-tag data-product-id="flowers" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+        <amp-story-shopping-attachment theme="dark">
+          <script type="application/json">
+            {
+                "items" : [
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "lamp",
+                    "productTitle": "Brass Lamp",
+                    "productBrand": "Lamp Co",
+                    "productPrice": 799.00,
+                    "productPriceCurrency": "USD",
+                    "productImages": [
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 1"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 2"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 3"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 4"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 5"},
+                       {"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "lamp 6"}
+                    ],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    }
+                   },
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "art",
+                    "productTitle": "Abstract Art",
+                    "productBrand": "V. Artsy",
+                    "productPrice": 1200.00,
+                    "productPriceCurrency": "INR",
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "art"}],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    }
+                   },
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "chair",
+                    "productTitle": "Yellow chair",
+                    "productBrand": "Chair Co.",
+                    "productPrice": 1000.00,
+                    "productPriceCurrency": "BRL",
+                    "productTagText": "The perfectly imperfect yellow chair",
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "chair"}],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    }
+                   },
+                   {
+                    "productUrl": "https://www.google.com",
+                    "productId": "flowers",
+                    "productTitle": "Flowers",
+                    "productBrand": "Very Long Flower Company Name",
+                    "productPrice": 10.00,
+                    "productPriceCurrency": "USD",
+                    "productIcon": "/examples/visual-tests/amp-story/img/shopping/icon.png",
+                    "productImages": [{"url": "/examples/visual-tests/amp-story/img/cat1.jpg", "alt": "flowers"}],
+                    "aggregateRating": {
+                      "ratingValue": "4.4",
+                      "reviewCount": "89",
+                      "reviewUrl": "https://www.google.com"
+                    }
+                   }
+                ]
+              }
+          </script>
+        </amp-story-shopping-attachment>
+      </amp-story-page>
+      <amp-story-page id="remote-with-product">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+        <!--
+          Example of:
+          CTA Button rendering due to remote product tag existing, but no inline.
+        -->
+        <amp-story-shopping-attachment theme="dark" src="/examples/amp-story/shopping/remote.json">
+          <script type="application/json">
+            {
+              "items" : []
+            }
+          </script>
+        </amp-story-shopping-attachment>
+      </amp-story-page>
+      <amp-story-page id="inline-no-product">
+      <amp-story-grid-layer template="fill">
+        <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+      </amp-story-grid-layer>
+        <!--
+          Example of:
+          CTA Button not rendering due to no product tags.
+        -->
+      <amp-story-shopping-attachment>
+        <script type="application/json">
+          {
+            "items" : []
+          }
+        </script>
+      </amp-story-shopping-attachment>
+      </amp-story-page>
+       <!--
+          Example of:
+          CTA Button not rendering due to no shopping attachment.
+        -->
+      <amp-story-page id="remote-dark-theme">
+        <amp-story-grid-layer template="fill">
+          <amp-img layout="fill" src="/examples/visual-tests/amp-story/img/cat1.jpg"></amp-img>
+        </amp-story-grid-layer>
+        <amp-story-grid-layer template="vertical">
+          <amp-story-shopping-tag data-product-id="art" ></amp-story-shopping-tag>
+        </amp-story-grid-layer>
+      </amp-story-page>
+    </amp-story>
+  </body>
+</html>

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -11,7 +11,7 @@ amp-story-shopping-attachment {
 
 amp-story[desktop][supports-landscape] amp-story-shopping-attachment {
   /* Sets static values in desktop supports landscape mode. */
-  font-size: calc(18px) !important; 
+  font-size: calc(18px) !important;
   --i-amphtml-shopping-pdp-carousel-height: 32em !important;
 }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -2,11 +2,18 @@ amp-story-shopping-attachment {
   height: 100% !important;
   width: 100% !important;
   font-family: 'Poppins', sans-serif !important;
-  font-size: calc(var(--story-page-vmin) * 3) !important; /* override with ems for pixel perfect layout */
+  font-size: calc(var(--story-page-vmin) * 3) !important; /* Override with ems for pixel perfect layout. */
   --i-amphtml-shopping-attachment-horizontal-spacing: 1.5em !important;
   --i-amphtml-shopping-attachment-vertical-spacing: 1.2em !important;
   --i-amphtml-shopping-three-percent-overlay: rgba(0, 0, 0,  .03) !important;
+  --i-amphtml-amp-story-shopping-pdp-carousel-height: calc(var(--story-page-vh) * 80 - var(--story-page-vw) * 60) !important;
 }
+
+[desktop][supports-landscape] amp-story-shopping-attachment {
+  font-size: calc(18px) !important; /* Text should not be responsive in desktop supports landscape mode. */
+  --i-amphtml-amp-story-shopping-pdp-carousel-height: 32em !important;
+}
+
 
 amp-story-shopping-attachment[theme="dark"] {
   --i-amphtml-shopping-three-percent-overlay: rgba(255, 255, 255, .03) !important;
@@ -189,8 +196,7 @@ amp-story-shopping-attachment a {
   display: flex !important;
   overflow-x: auto !important;
   scroll-snap-type: x mandatory !important;
-  --carousel-height: calc(var(--story-page-vh) * 80 - var(--story-page-vw) * 60) !important;
-  height: var(--carousel-height) !important;
+  height: var(--i-amphtml-amp-story-shopping-pdp-carousel-height) !important;
   max-height: 100vw !important;
 }
 
@@ -213,7 +219,7 @@ amp-story-shopping-attachment a {
   background-repeat: no-repeat !important;
   cursor: pointer !important;
   width: calc(var(--story-page-vw) * 100 - 7.5em) !important;
-  max-width: calc(var(--carousel-height) * 1.25) !important;
+  max-width: calc(var(--i-amphtml-amp-story-shopping-pdp-carousel-height) * 1.25) !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel-card:first-child {

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -14,7 +14,6 @@ amp-story-shopping-attachment {
   --i-amphtml-amp-story-shopping-pdp-carousel-height: 32em !important;
 }
 
-
 amp-story-shopping-attachment[theme="dark"] {
   --i-amphtml-shopping-three-percent-overlay: rgba(255, 255, 255, .03) !important;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -9,7 +9,7 @@ amp-story-shopping-attachment {
   --i-amphtml-amp-story-shopping-pdp-carousel-height: calc(var(--story-page-vh) * 80 - var(--story-page-vw) * 60) !important;
 }
 
-[desktop][supports-landscape] amp-story-shopping-attachment {
+amp-story[desktop][supports-landscape] amp-story-shopping-attachment {
   font-size: calc(18px) !important; /* Text should not be responsive in desktop supports landscape mode. */
   --i-amphtml-amp-story-shopping-pdp-carousel-height: 32em !important;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -10,7 +10,8 @@ amp-story-shopping-attachment {
 }
 
 amp-story[desktop][supports-landscape] amp-story-shopping-attachment {
-  font-size: calc(18px) !important; /* Text should not be responsive in desktop supports landscape mode. */
+  /* Sets static values in desktop supports landscape mode. */
+  font-size: calc(18px) !important; 
   --i-amphtml-amp-story-shopping-pdp-carousel-height: 32em !important;
 }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -6,13 +6,13 @@ amp-story-shopping-attachment {
   --i-amphtml-shopping-attachment-horizontal-spacing: 1.5em !important;
   --i-amphtml-shopping-attachment-vertical-spacing: 1.2em !important;
   --i-amphtml-shopping-three-percent-overlay: rgba(0, 0, 0,  .03) !important;
-  --i-amphtml-amp-story-shopping-pdp-carousel-height: calc(var(--story-page-vh) * 80 - var(--story-page-vw) * 60) !important;
+  --i-amphtml-shopping-pdp-carousel-height: calc(var(--story-page-vh) * 80 - var(--story-page-vw) * 60) !important;
 }
 
 amp-story[desktop][supports-landscape] amp-story-shopping-attachment {
   /* Sets static values in desktop supports landscape mode. */
   font-size: calc(18px) !important; 
-  --i-amphtml-amp-story-shopping-pdp-carousel-height: 32em !important;
+  --i-amphtml-shopping-pdp-carousel-height: 32em !important;
 }
 
 amp-story-shopping-attachment[theme="dark"] {
@@ -196,7 +196,7 @@ amp-story-shopping-attachment a {
   display: flex !important;
   overflow-x: auto !important;
   scroll-snap-type: x mandatory !important;
-  height: var(--i-amphtml-amp-story-shopping-pdp-carousel-height) !important;
+  height: var(--i-amphtml-shopping-pdp-carousel-height) !important;
   max-height: 100vw !important;
 }
 
@@ -219,7 +219,7 @@ amp-story-shopping-attachment a {
   background-repeat: no-repeat !important;
   cursor: pointer !important;
   width: calc(var(--story-page-vw) * 100 - 7.5em) !important;
-  max-width: calc(var(--i-amphtml-amp-story-shopping-pdp-carousel-height) * 1.25) !important;
+  max-width: calc(var(--i-amphtml-shopping-pdp-carousel-height) * 1.25) !important;
 }
 
 .i-amphtml-amp-story-shopping-pdp-carousel-card:first-child {

--- a/test/visual-diff/visual-tests.jsonc
+++ b/test/visual-diff/visual-tests.jsonc
@@ -827,6 +827,15 @@
       "name": "amp-story-shopping UI number format based on language",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [".i-amphtml-story-loaded"]
+    },
+    {
+      // TODO(wg-stories): Re-enable as part of https://go.amp.dev/pr/37600
+      "flaky": true,
+      "url": "examples/visual-tests/amp-story/amp-story-shopping-landscape.html",
+      "name": "amp-story-shopping UI in desktop supports landscape mode",
+      "viewport": {"width": 1500, "height": 1000},
+      "loading_complete_selectors": [".i-amphtml-story-loaded"],
+      "interactive_tests": "examples/visual-tests/amp-story/amp-story-shopping.js"
     }
   ]
 }

--- a/test/visual-diff/visual-tests.jsonc
+++ b/test/visual-diff/visual-tests.jsonc
@@ -803,8 +803,6 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment.js"
     },
     {
-      // TODO(wg-stories): Re-enable as part of https://go.amp.dev/pr/37600
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/amp-story-shopping.html",
       "name": "amp-story-shopping UI",
       "viewport": {"width": 320, "height": 900},
@@ -812,8 +810,6 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-shopping.js"
     },
     {
-      // TODO(wg-stories): Re-enable as part of https://go.amp.dev/pr/37600
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/amp-story-shopping-rtl.html",
       "name": "amp-story-shopping UI RTL",
       "viewport": {"width": 320, "height": 900},
@@ -821,16 +817,12 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-shopping.js"
     },
     {
-      // TODO(wg-stories): Re-enable as part of https://go.amp.dev/pr/37600
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/amp-story-shopping-lang-de.html",
       "name": "amp-story-shopping UI number format based on language",
       "viewport": {"width": 320, "height": 480},
       "loading_complete_selectors": [".i-amphtml-story-loaded"]
     },
     {
-      // TODO(wg-stories): Re-enable as part of https://go.amp.dev/pr/37600
-      "flaky": true,
       "url": "examples/visual-tests/amp-story/amp-story-shopping-landscape.html",
       "name": "amp-story-shopping UI in desktop supports landscape mode",
       "viewport": {"width": 1500, "height": 1000},


### PR DESCRIPTION
The responsive UI for the shopping experience breaks in desktop full-bleed since it's displayed in a modal with a static width.

This PR sets a static size for the UI in desktop supports-landscape.

[Demo](https://discovery-ec239.web.app/examples/amp-story/amp-story-shopping.html)

Before:
<img width="500" alt="Screen Shot 2022-02-22 at 3 38 37 PM" src="https://user-images.githubusercontent.com/3860311/155224902-7b0e87a8-3774-469e-9561-ee40168df665.png">

After:
<img width="500" alt="Screen Shot 2022-02-22 at 3 37 59 PM" src="https://user-images.githubusercontent.com/3860311/155224935-1ed5c10e-e932-4b83-82c1-637c8a584d12.png">

We may want to re-visit the full-bleed attachment experience to be more consistent with mobile but this will allow the shopping experience to be functional in desktop full-bleed for the time being.