### PR TITLE
Adsense to disable anchor ads if detected non-amp adsbygoogle tag

### DIFF
--- a/extensions/amp-auto-ads/0.1/ad-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ad-network-config.js
@@ -37,6 +37,14 @@ export class AdNetworkConfigDef {
   getConfigUrl() {}
 
   /**
+   * After fetching the config, this method is called to allow rewriting the
+   * config on the client side.
+   * @param {!JsonObject} unusedConfig
+   * @return {!JsonObject}
+   */
+  filterConfig(unusedConfig) {}
+
+  /**
    * Any attributes derived from either the page or the auto-amp-ads tag that
    * should be applied to any ads inserted.
    * @return {!JsonObject<string, string>}

--- a/extensions/amp-auto-ads/0.1/adsense-network-config.js
+++ b/extensions/amp-auto-ads/0.1/adsense-network-config.js
@@ -4,6 +4,8 @@ import {getWin} from '#core/window';
 
 import {Services} from '#service';
 
+import {Attributes} from './attributes';
+
 import {parseUrlDeprecated} from '../../../src/url';
 
 /**
@@ -46,6 +48,19 @@ export class AdSenseNetworkConfig {
       },
       4096
     );
+  }
+
+  /** @override */
+  filterConfig(config) {
+    // Force no fill on anchor ads if adsbygoogle tag (non-AMP Adsense) is already loaded.
+    // We do this to prevent multiple anchor ads from being loaded.
+    if (
+      getWin(this.autoAmpAdsElement_).adsbygoogle &&
+      config[Attributes.STICKY_AD_ATTRIBUTES]
+    ) {
+      config[Attributes.STICKY_AD_ATTRIBUTES]['data-no-fill'] = 'true';
+    }
+    return config;
   }
 
   /** @override */

--- a/extensions/amp-auto-ads/0.1/alright-network-config.js
+++ b/extensions/amp-auto-ads/0.1/alright-network-config.js
@@ -52,6 +52,11 @@ export class AlrightNetworkConfig {
   }
 
   /** @override */
+  filterConfig(config) {
+    return config;
+  }
+
+  /** @override */
   getAttributes() {
     const attributes = {
       'width': 300,

--- a/extensions/amp-auto-ads/0.1/amp-auto-ads.js
+++ b/extensions/amp-auto-ads/0.1/amp-auto-ads.js
@@ -45,7 +45,9 @@ export class AmpAutoAds extends AMP.BaseElement {
     this.configPromise_ = this.getAmpDoc()
       .whenFirstVisible()
       .then(() => {
-        return this.getConfig_(this.adNetwork_.getConfigUrl());
+        return this.adNetwork_.filterConfig(
+          this.getConfig_(this.adNetwork_.getConfigUrl())
+        );
       });
 
     if (!this.isAutoAdsLayoutCallbackExperimentOn_()) {

--- a/extensions/amp-auto-ads/0.1/denakop-network-config.js
+++ b/extensions/amp-auto-ads/0.1/denakop-network-config.js
@@ -59,6 +59,11 @@ export class DenakopNetworkConfig {
   }
 
   /** @override */
+  filterConfig(config) {
+    return config;
+  }
+
+  /** @override */
   getAttributes() {
     const attributes = {
       'data-multi-size-validation': 'false',

--- a/extensions/amp-auto-ads/0.1/doubleclick-network-config.js
+++ b/extensions/amp-auto-ads/0.1/doubleclick-network-config.js
@@ -48,6 +48,11 @@ export class DoubleclickNetworkConfig {
   }
 
   /** @override */
+  filterConfig(config) {
+    return config;
+  }
+
+  /** @override */
   getAttributes() {
     const attributes = {
       'type': 'doubleclick',

--- a/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
+++ b/extensions/amp-auto-ads/0.1/firstimpression.io-network-config.js
@@ -102,6 +102,11 @@ export class FirstImpressionIoConfig {
   }
 
   /** @override */
+  filterConfig(config) {
+    return config;
+  }
+
+  /** @override */
   getAttributes() {
     const attributes = {
       'type': 'firstimpression',

--- a/extensions/amp-auto-ads/0.1/ping-network-config.js
+++ b/extensions/amp-auto-ads/0.1/ping-network-config.js
@@ -38,6 +38,11 @@ export class PingNetworkConfig {
   }
 
   /** @override */
+  filterConfig(config) {
+    return config;
+  }
+
+  /** @override */
   getAttributes() {
     return {
       'type': '_ping_',

--- a/extensions/amp-auto-ads/0.1/premiumads-network-config.js
+++ b/extensions/amp-auto-ads/0.1/premiumads-network-config.js
@@ -35,6 +35,11 @@ export class PremiumadsNetworkConfig {
   }
 
   /** @override */
+  filterConfig(config) {
+    return config;
+  }
+
+  /** @override */
   getAttributes() {
     const data = this.autoAmpAdsElement_.dataset;
     return {

--- a/extensions/amp-auto-ads/0.1/test/test-adsense-network-config.js
+++ b/extensions/amp-auto-ads/0.1/test/test-adsense-network-config.js
@@ -1,6 +1,7 @@
 import {Services} from '#service';
 
 import {getAdNetworkConfig} from '../ad-network-config';
+import {Attributes} from '../attributes';
 
 describes.realWin(
   'adsense-network-config',
@@ -47,6 +48,23 @@ describes.realWin(
       it('should report responsive-enabled', () => {
         const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
         expect(adNetwork.isResponsiveEnabled()).to.equal(true);
+      });
+
+      it('should force no-fill if adsbygoogle is set', () => {
+        const adNetwork = getAdNetworkConfig('adsense', ampAutoAdsElem);
+        env.win.adsbygoogle = {};
+        expect(
+          adNetwork.filterConfig({
+            [Attributes.STICKY_AD_ATTRIBUTES]: {
+              'data-google-id': '123',
+            },
+          })
+        ).to.deep.equal({
+          [Attributes.STICKY_AD_ATTRIBUTES]: {
+            'data-google-id': '123',
+            'data-no-fill': 'true',
+          },
+        });
       });
 
       // TODO(bradfrizzell, #12476): Make this test work with sinon 4.0.

--- a/extensions/amp-auto-ads/0.1/wunderkind-network-config.js
+++ b/extensions/amp-auto-ads/0.1/wunderkind-network-config.js
@@ -46,6 +46,11 @@ export class WunderkindNetworkConfig {
   }
 
   /** @override */
+  filterConfig(config) {
+    return config;
+  }
+
+  /** @override */
   getAttributes() {
     const attributes = {
       'type': 'wunderkind',


### PR DESCRIPTION
We have found that in some pages, where both amp-auto-ads and adsbygoogle tags are present, both could load anchor ads and conflict with each other. This PR aims at fixing that.