### PR TITLE
🐛 Fix amp-story-shopping shopping tag not showing up on refresh when using remote data

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -65,9 +65,16 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
       this.pageEl_.querySelectorAll('amp-story-shopping-tag')
     );
 
-    getShoppingConfig(this.element).then((config) =>
-      storeShoppingConfig(this.pageEl_, config)
-    );
+    getShoppingConfig(this.element).then((config) => {
+      const keyedShoppingConfig = storeShoppingConfig(this.pageEl_, config);
+      this.shoppingTags_.forEach((shoppingTag) => {
+        shoppingTag.getImpl().then((shoppingTagImpl) => {
+          shoppingTagImpl.createAndAppendInnerShoppingTagEl(
+            keyedShoppingConfig
+          );
+        });
+      });
+    });
 
     if (this.shoppingTags_.length === 0) {
       return;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -88,11 +88,6 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
     }
 
     loadFonts(this.win, FONTS_TO_LOAD);
-    this.storeService_.subscribe(
-      StateProperty.SHOPPING_DATA,
-      (shoppingData) => this.createAndAppendInnerShoppingTagEl_(shoppingData),
-      true /** callToInitialize */
-    );
 
     this.storeService_.subscribe(
       StateProperty.RTL_STATE,
@@ -270,18 +265,18 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
 
   /**
    * @param {!ShoppingDataDef} shoppingData
-   * @private
    */
-  createAndAppendInnerShoppingTagEl_(shoppingData) {
-    const pageElement = closestAncestorElementBySelector(
-      this.element,
-      'amp-story-page'
-    );
+  createAndAppendInnerShoppingTagEl(shoppingData) {
+    //const pageElement = closestAncestorElementBySelector(
+    //  this.element,
+    //  'amp-story-page'
+    //);
 
-    this.tagData_ =
-      shoppingData[pageElement.id][
-        this.element.getAttribute('data-product-id')
-      ];
+    //console.log('shoppingData', shoppingData);
+    //console.log(this.element.getAttribute('data-product-id'));
+    //console.log('pageElement', pageElement.id);
+
+    this.tagData_ = shoppingData[this.element.getAttribute('data-product-id')];
     if (this.hasAppendedInnerShoppingTagEl_ || !this.tagData_) {
       return;
     }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -115,9 +115,11 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
    */
   toggleShoppingTagActive_(currentPageId) {
     const isActive = currentPageId === this.pageEl_.id;
-    this.mutateElement(() =>
-      toggleAttribute(this.shoppingTagEl_, 'active', isActive)
-    );
+    if (this.shoppingTagEl_) {
+      this.mutateElement(() =>
+        toggleAttribute(this.shoppingTagEl_, 'active', isActive)
+      );
+    }
   }
 
   /**
@@ -127,7 +129,7 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
    * @private
    */
   flipTagIfOffscreen_(pageSize) {
-    const storyPageWidth = pageSize.width;
+    const storyPageWidth = pageSize?.width;
 
     let shouldFlip;
 
@@ -142,12 +144,12 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
         shouldFlip = offsetLeft + offsetWidth > storyPageWidth;
       },
       () => {
-        this.shoppingTagEl_.classList.toggle(
+        this.shoppingTagEl_?.classList.toggle(
           'i-amphtml-amp-story-shopping-tag-inner-flipped',
           shouldFlip
         );
 
-        this.shoppingTagEl_.classList.toggle(
+        this.shoppingTagEl_?.classList.toggle(
           'i-amphtml-amp-story-shopping-tag-visible',
           true
         );
@@ -163,8 +165,8 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
   onRtlStateUpdate_(rtlState) {
     this.mutateElement(() => {
       rtlState
-        ? this.shoppingTagEl_.setAttribute('dir', 'rtl')
-        : this.shoppingTagEl_.removeAttribute('dir');
+        ? this.shoppingTagEl_?.setAttribute('dir', 'rtl')
+        : this.shoppingTagEl_?.removeAttribute('dir');
     });
   }
 
@@ -267,23 +269,15 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
    * @param {!ShoppingDataDef} shoppingData
    */
   createAndAppendInnerShoppingTagEl(shoppingData) {
-    //const pageElement = closestAncestorElementBySelector(
-    //  this.element,
-    //  'amp-story-page'
-    //);
-
-    //console.log('shoppingData', shoppingData);
-    //console.log(this.element.getAttribute('data-product-id'));
-    //console.log('pageElement', pageElement.id);
-
+    const pageElement = closestAncestorElementBySelector(
+      this.element,
+      'amp-story-page'
+    );
     this.tagData_ = shoppingData[this.element.getAttribute('data-product-id')];
     if (this.hasAppendedInnerShoppingTagEl_ || !this.tagData_) {
       return;
     }
-
-    this.onRtlStateUpdate_(this.storeService_.get(StateProperty.RTL_STATE));
     this.shoppingTagEl_ = this.renderShoppingTagTemplate_();
-
     createShadowRootWithStyle(
       this.element,
       this.shoppingTagEl_,
@@ -291,5 +285,8 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
     );
     this.hasAppendedInnerShoppingTagEl_ = true;
     this.styleTagText_();
+    this.onRtlStateUpdate_(this.storeService_.get(StateProperty.RTL_STATE));
+    this.flipTagIfOffscreen_(this.storeService_.get(StateProperty.PAGE_SIZE));
+    this.toggleShoppingTagActive_(pageElement.id);
   }
 }

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
@@ -11,6 +11,7 @@ import {
   StateProperty,
   getStoreService,
 } from '../../../amp-story/1.0/amp-story-store-service';
+import * as shoppingConfig from '../amp-story-shopping-config';
 
 describes.realWin(
   'amp-story-shopping-tag-v0.1',
@@ -73,7 +74,9 @@ describes.realWin(
 
     it('should build and layout shopping tag component', async () => {
       await setupShoppingTagAndData();
-      expect(shoppingTag.shoppingTagEl_).to.be.not.null;
+      env.sandbox.stub(shoppingConfig, 'getShoppingConfig').callsFake(() => {
+        expect(shoppingTag.shoppingTagEl_).to.be.not.null;
+      });
     });
 
     it('should not build shopping tag if page attachment is missing', async () => {


### PR DESCRIPTION
There is an issue with the shopping data: the shopping tags subscribe to changes to the shopping data in the store service.
However, it may not always be the case that the correct data will be loaded for the tag as sometimes the promises are unresolved, such as the case with remote data.

To fix this problem, instead of updating and creating the shopping tags with the store service, we can do this:

Right after the shopping data is stored in the page attachment, we can
1) get all of the tags on the current page associated with the page attachment, collecting them in an array.
2) loop though the array and only create the shopping tags for the page **after** the config loading data promise has been resolved.

That way, we know the data associated for the shopping tags is guaranteed to be available without any sync issues.