### PR TITLE
🐛 [story] fix spacing when pause button is hidden

### DIFF
--- a/extensions/amp-story/1.0/amp-story-system-layer.css
+++ b/extensions/amp-story/1.0/amp-story-system-layer.css
@@ -241,6 +241,8 @@
 .i-amphtml-story-system-layer:not([desktop]):not(.i-amphtml-story-desktop-one-panel):not(.amp-mode-keyboard-active)
   .i-amphtml-paused-display
   button:not(:focus) {
+  margin: 0 !important;
+  padding: 0 !important;
   width: 0px !important;
   opacity: 0 !important;
   pointer-events: none !important;


### PR DESCRIPTION
Regression introduced in #37582 When adding our "visible to screen reader only logic" I failed to notice new padding that was introduced when videos are playing in a story page.

Bad:
![image](https://user-images.githubusercontent.com/16087874/155805068-10251b48-dd10-4362-a090-10551f6c262d.png)

Good:
![image](https://user-images.githubusercontent.com/16087874/155804996-5ce6a9c0-2292-401a-9333-65b4922f49ce.png)

TODO: see if we can write a visual test that would have caught this regression.

