### PR TITLE
Fixes amp-story-shopping shopping tag not showing up on refresh when using remote data

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -120,9 +120,11 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
    */
   toggleShoppingTagActive_(currentPageId) {
     const isActive = currentPageId === this.pageEl_.id;
-    this.mutateElement(() =>
-      toggleAttribute(this.shoppingTagEl_, 'active', isActive)
-    );
+    if (this.shoppingTagEl_) {
+      this.mutateElement(() =>
+        toggleAttribute(this.shoppingTagEl_, 'active', isActive)
+      );
+    }
   }
 
   /**
@@ -147,12 +149,12 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
         shouldFlip = offsetLeft + offsetWidth > storyPageWidth;
       },
       () => {
-        this.shoppingTagEl_.classList.toggle(
+        this.shoppingTagEl_?.classList.toggle(
           'i-amphtml-amp-story-shopping-tag-inner-flipped',
           shouldFlip
         );
 
-        this.shoppingTagEl_.classList.toggle(
+        this.shoppingTagEl_?.classList.toggle(
           'i-amphtml-amp-story-shopping-tag-visible',
           true
         );
@@ -168,8 +170,8 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
   onRtlStateUpdate_(rtlState) {
     this.mutateElement(() => {
       rtlState
-        ? this.shoppingTagEl_.setAttribute('dir', 'rtl')
-        : this.shoppingTagEl_.removeAttribute('dir');
+        ? this.shoppingTagEl_?.setAttribute('dir', 'rtl')
+        : this.shoppingTagEl_?.removeAttribute('dir');
     });
   }
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -277,18 +277,15 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
       this.element,
       'amp-story-page'
     );
-
     this.tagData_ =
+      shoppingData[pageElement.id] &&
       shoppingData[pageElement.id][
         this.element.getAttribute('data-product-id')
       ];
     if (this.hasAppendedInnerShoppingTagEl_ || !this.tagData_) {
       return;
     }
-
-    this.onRtlStateUpdate_(this.storeService_.get(StateProperty.RTL_STATE));
     this.shoppingTagEl_ = this.renderShoppingTagTemplate_();
-
     createShadowRootWithStyle(
       this.element,
       this.shoppingTagEl_,
@@ -296,5 +293,8 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
     );
     this.hasAppendedInnerShoppingTagEl_ = true;
     this.styleTagText_();
+    this.onRtlStateUpdate_(this.storeService_.get(StateProperty.RTL_STATE));
+    this.flipTagIfOffscreen_(this.storeService_.get(StateProperty.PAGE_SIZE));
+    this.toggleShoppingTagActive_(pageElement.id);
   }
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -90,7 +90,7 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
     this.storeService_.subscribe(
       StateProperty.SHOPPING_DATA,
       (shoppingData) =>
-        this.tryToCreateAndAppendInnerShoppingTagEl_(shoppingData),
+        this.maybeCreateAndAppendInnerShoppingTagEl_(shoppingData),
       true /** callToInitialize */
     );
   }
@@ -251,7 +251,7 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
   }
 
   /**
-   * Initialize listeners (data,orinetation,visibility) for the shopping tag on creation.
+   * Initialize listeners (data, orientation, visibility) for the shopping tag on creation.
    * @private
    */
   initializeTagStateListeners_() {
@@ -278,7 +278,7 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
    * @param {!ShoppingDataDef} shoppingData
    * @private
    */
-  tryToCreateAndAppendInnerShoppingTagEl_(shoppingData) {
+  maybeCreateAndAppendInnerShoppingTagEl_(shoppingData) {
     const pageElement = closestAncestorElementBySelector(
       this.element,
       'amp-story-page'


### PR DESCRIPTION
Closes #37749

There is an issue with the shopping data: the shopping tags subscribe to changes to the shopping data in the store service. However, it may not always be the case that the correct data will be loaded for the tag as sometimes the promises are unresolved, such as the case with remote data.

To fix this problem,  we have added an additional conditional check for making sure that the data is loaded first before rendering. We have also refactored it so it only adds the shopping tag listeners after a valid shopping tag is created, not in the layout callback.