### PR TITLE
🐛 Add missing latestVersion strings

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -175,6 +175,7 @@
   {
     "name": "amp-app-banner",
     "version": "1.0",
+    "latestVersion": "0.1",
     "options": {
       "hasCss": true,
       "npm": true,
@@ -479,6 +480,7 @@
   {
     "name": "amp-gist",
     "version": "1.0",
+    "latestVersion": "0.1",
     "options": {
       "hasCss": true,
       "bento": true,
@@ -492,7 +494,8 @@
   },
   {
     "name": "amp-google-read-aloud-player",
-    "version": "0.1"
+    "version": "0.1",
+    "latestVersion": "0.1"
   },
   {
     "name": "amp-gwd-animation",
@@ -681,6 +684,7 @@
   {
     "name": "amp-list",
     "version": "1.0",
+    "latestVersion": "0.1",
     "options": {
       "hasCss": false,
       "npm": true,
@@ -1063,6 +1067,7 @@
   {
     "name": "amp-story-page-attachment",
     "version": "0.1",
+    "latestVersion": "0.1",
     "options": {
       "hasCss": true
     }
@@ -1102,6 +1107,7 @@
   {
     "name": "amp-story-subscriptions",
     "version": "0.1",
+    "latestVersion": "0.1",
     "options": {
       "hasCss": true
     }


### PR DESCRIPTION
The PR https://github.com/ampproject/amphtml/pull/37355 reverted the removal of the `latestVersion` strings in the extension meta information, because outside code relies on it.

However, the new components that have been added are missing the `latestVersion` information still.

This PR adds the missing entries to make the presence of the `latestVersion` entry consistent across the entire `bundles.config.extensions.json` file.