### PR TITLE
🌐 🖍 [Amp story shopping] Border radius on single image in RTL

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -240,8 +240,8 @@ amp-story-shopping-attachment a {
   border-radius: 1.1em 0 0 1.1em !important;
 }
 
-.i-amphtml-amp-story-shopping-pdp-carousel-card:only-child,
-[dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:only-child {
+/* Override when it's the first and last child. */
+.i-amphtml-amp-story-shopping-pdp-carousel-card:first-child:last-child {
   width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
   max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
   border-radius: 1.1em !important;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -243,7 +243,7 @@ amp-story-shopping-attachment a {
 /* Override when it's the only child. First and last selectors are used for specificity. */
 .i-amphtml-amp-story-shopping-pdp-carousel-card:first-child:last-child {
   width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
-  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
+  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
   border-radius: 1.1em !important;
   cursor: auto !important;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -232,7 +232,7 @@ amp-story-shopping-attachment a {
   border-radius: 0 1.1em 1.1em 0 !important;
 }
 
-.i-amphtml-amp-story-shopping-pdp-carousel-card:only-child, 
+.i-amphtml-amp-story-shopping-pdp-carousel-card:only-child,
 [dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:only-child {
   width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
   max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -243,7 +243,7 @@ amp-story-shopping-attachment a {
 /* Override when it's the first and last child. */
 .i-amphtml-amp-story-shopping-pdp-carousel-card:first-child:last-child {
   width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
-  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
+  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
   border-radius: 1.1em !important;
   cursor: auto !important;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -232,20 +232,20 @@ amp-story-shopping-attachment a {
   border-radius: 0 1.1em 1.1em 0 !important;
 }
 
-.i-amphtml-amp-story-shopping-pdp-carousel-card:only-child,
-[dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:only-child {
-  width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
-  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
-  border-radius: 1.1em !important;
-  cursor: auto !important;
-}
-
 [dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:first-child {
   border-radius: 0 1.1em 1.1em 0 !important;
 }
 
 [dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:last-child {
   border-radius: 1.1em 0 0 1.1em !important;
+}
+
+.i-amphtml-amp-story-shopping-pdp-carousel-card:only-child,
+[dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:only-child {
+  width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
+  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
+  border-radius: 1.1em !important;
+  cursor: auto !important;
 }
 
 /* PDP deatils */

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -240,10 +240,10 @@ amp-story-shopping-attachment a {
   border-radius: 1.1em 0 0 1.1em !important;
 }
 
-/* Override when it's the first and last child. */
+/* Override when it's the only child. First and last selectors are used for specificity. */
 .i-amphtml-amp-story-shopping-pdp-carousel-card:first-child:last-child {
   width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
-  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
+  max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
   border-radius: 1.1em !important;
   cursor: auto !important;
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.css
@@ -232,7 +232,8 @@ amp-story-shopping-attachment a {
   border-radius: 0 1.1em 1.1em 0 !important;
 }
 
-.i-amphtml-amp-story-shopping-pdp-carousel-card:only-child {
+.i-amphtml-amp-story-shopping-pdp-carousel-card:only-child, 
+[dir=rtl] .i-amphtml-amp-story-shopping-pdp-carousel-card:only-child {
   width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2) !important;
   max-width: calc(100% - var(--i-amphtml-shopping-attachment-horizontal-spacing) * 2)!important;
   border-radius: 1.1em !important;


### PR DESCRIPTION
This PR adds CSS targeting for border radius around a single image in RTL.

Before:
<img width="200" alt="Screen Shot 2022-03-01 at 10 31 32 AM" src="https://user-images.githubusercontent.com/3860311/156210741-139b513c-e905-41c8-9bfa-667f2c95dd4f.png">

After:
<img width="200" alt="Screen Shot 2022-03-01 at 10 31 18 AM" src="https://user-images.githubusercontent.com/3860311/156210776-734b79b2-d53b-4ef0-b914-936d825646ce.png">

