### PR TITLE
✨ [amp story shopping] Optionally render rating

### DIFF
--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -81,11 +81,6 @@
                     "productPrice": 1200.00,
                     "productPriceCurrency": "INR",
                     "productImages": [{"url": "https://source.unsplash.com/BdVQU-NDtA8/500x500", "alt": "art"}],
-                    "aggregateRating": {
-                      "ratingValue": 4.4,
-                      "reviewCount": 89,
-                      "reviewUrl": "https://www.google.com"
-                    },
                     "productDetails": "Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci. Lorem ipsum dolor sit amet consectetur adipisicing elit. Facere error deserunt dignissimos in laborum ea molestias veritatis sint laudantium iusto expedita atque provident doloremque, ad voluptatem culpa adipisci."
                    },
                    {

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -314,21 +314,23 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
               )}
             </span>
           </div>
-          <span class="i-amphtml-amp-story-shopping-pdp-reviews">
-            {activeProductData.aggregateRating.ratingValue} (
-            <a
-              class="i-amphtml-amp-story-shopping-pdp-reviews-link"
-              href={activeProductData.aggregateRating.reviewUrl}
-              target="_top"
-            >
-              {activeProductData.aggregateRating.reviewCount + ' '}
-              {this.localizationService_.getLocalizedString(
-                LocalizedStringId_Enum.AMP_STORY_SHOPPING_ATTACHMENT_REVIEWS_LABEL,
-                this.element
-              )}
-            </a>
-            )
-          </span>
+          {activeProductData.aggregateRating && (
+            <span class="i-amphtml-amp-story-shopping-pdp-reviews">
+              {activeProductData.aggregateRating.ratingValue} (
+              <a
+                class="i-amphtml-amp-story-shopping-pdp-reviews-link"
+                href={activeProductData.aggregateRating.reviewUrl}
+                target="_top"
+              >
+                {activeProductData.aggregateRating.reviewCount + ' '}
+                {this.localizationService_.getLocalizedString(
+                  LocalizedStringId_Enum.AMP_STORY_SHOPPING_ATTACHMENT_REVIEWS_LABEL,
+                  this.element
+                )}
+              </a>
+              )
+            </span>
+          )}
           <a
             class="i-amphtml-amp-story-shopping-pdp-cta"
             href={activeProductData.productUrl}


### PR DESCRIPTION
Allow the template to render if `aggregateRating` is not defined. 
Ensure spacing is maintained between "title" and "buy now".
<img width="250" alt="Screen Shot 2022-03-01 at 11 23 55 AM" src="https://user-images.githubusercontent.com/3860311/156218038-682b2471-8030-4fea-9c3e-34f1384260c5.png">
