### PR TITLE
🏗 🐛 Fix bento peer dependency remapping on Windows

### DIFF
--- a/build-system/common/esbuild-babel.js
+++ b/build-system/common/esbuild-babel.js
@@ -127,7 +127,7 @@ function getEsbuildBabelPlugin(
         const map = outputFiles.find(({path}) => path.endsWith('.map'));
 
         if (!map) {
-          debug('post-esbuild', code.path, code.text);
+          debug('post-esbuild', code?.path, code?.text);
           return;
         }
 

--- a/build-system/compile/bento-remap.js
+++ b/build-system/compile/bento-remap.js
@@ -6,6 +6,7 @@ const {once} = require('../common/once');
 const {bentoBundles} = require('./bundles.config');
 const glob = require('globby');
 const {getNameWithoutComponentPrefix} = require('../tasks/bento-helpers');
+const {posix} = require('path');
 
 /**
  * @param {string} path
@@ -69,8 +70,16 @@ const getAllRemappings = once(() => {
   const componentRemappings = bentoBundles.map(({name, version}) => {
     const nameWithoutPrefix = getNameWithoutComponentPrefix(name);
     return {
-      source: `./src/bento/components/${name}/${version}/${name}`,
-      cdn: `./${name}-${version}.mjs`,
+      source: posix.join(
+        '.',
+        'src',
+        'bento',
+        'components',
+        name,
+        version,
+        name
+      ),
+      cdn: posix.join('.', `${name}-${version}.mjs`),
       npm:
         // Special: NPM builds depend on `mustache` directly
         nameWithoutPrefix === 'mustache'


### PR DESCRIPTION
When attempting to fix Bento component peer remapping, I introduced a bug where the remapped paths do not work on Windows.

#37797
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
