### PR TITLE
Add a custom-config.json to the automated releases that uses ampjs.org as the default runtime CDN

### DIFF
--- a/build-system/release-workflows/build-release.js
+++ b/build-system/release-workflows/build-release.js
@@ -12,6 +12,13 @@ const jobName = 'build-release.js';
 
 runReleaseJob(jobName, async () => {
   const {ESM, FLAVOR} = process.env;
+
+  // TODO(danielrozenberg): remove temporary custom-config when ampjs.org
+  // becomes the default runtime CDN.
+  fs.writeJsonSync('build-system/global-configs/custom-config.json', {
+    'cdnUrl': 'https://ampjs.org',
+  });
+
   timedExecOrThrow(`amp release --flavor=${FLAVOR} --${ESM} --dedup_v0`);
   fs.ensureDirSync(`/tmp/workspace/releases/${FLAVOR}/${ESM}`);
   fs.copySync('release/', `/tmp/workspace/releases/${FLAVOR}/${ESM}`);


### PR DESCRIPTION
See example release build: https://app.circleci.com/pipelines/github/ampproject/amphtml/23608/workflows/387e9047-ccf0-41ec-acaa-73c2d98a7528/jobs/476041/artifacts