### PR TITLE
🐛 amp-story-shopping removes support for different multi-line border radii

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -207,13 +207,13 @@ amp-story-shopping-tag {
     clip-path: var(--clip-path-inset-offset-supports-rtl);
   }
   100% {
-    clip-path: inset(0 0 0 0 round 10px);
+    clip-path: inset(0 0 0 0 round 30px);
   }
 }
 
 @keyframes i-amphtml-animate-out-sequence-pill {
   0% {
-    clip-path: inset(0 0 0 0 round 10px);
+    clip-path: inset(0 0 0 0 round 30px);
   }
   40% {
     animation-timing-function: cubic-bezier(.85, 0, .15, 1);

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -228,12 +228,6 @@ amp-story-shopping-tag {
   }
 }
 
-.i-amphtml-amp-story-shopping-tag-pill-multi-line {
-  border-radius: 10px !important;
-  margin-inline-start: 9px !important;
-  margin-inline-end: 4px !important;
-}
-
 .i-amphtml-amp-story-shopping-tag-pill-image {
   width: var(--i-amphtml-pill-icon-size) !important;
   height: var(--i-amphtml-pill-icon-size) !important;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css
@@ -156,7 +156,7 @@ amp-story-shopping-tag {
 .i-amphtml-amp-story-shopping-tag-pill {
   --i-amphtml-pill-icon-size: 24px !important;
   --i-amphtml-pill-padding-inline-start: 6px !important;
-  --i-amphtml-pill-transfrom-origin: calc(var(--i-amphtml-pill-padding-inline-start) + var(--i-amphtml-pill-icon-size) * .5) !important;
+  --i-amphtml-pill-transform-origin: calc(var(--i-amphtml-pill-padding-inline-start) + var(--i-amphtml-pill-icon-size) * .5) !important;
   display: flex !important;
   align-items: center !important;
   border-radius: 18px !important;
@@ -165,7 +165,7 @@ amp-story-shopping-tag {
   background-color: var(--i-amphtml-shopping-tag-bg-color) !important;
   padding-inline-start: var(--i-amphtml-pill-padding-inline-start) !important;
   padding-inline-end: 12px !important;
-  transform-origin: var(--i-amphtml-pill-transfrom-origin) !important;
+  transform-origin: var(--i-amphtml-pill-transform-origin) !important;
 }
 
 .i-amphtml-amp-story-shopping-tag-inner[active] .i-amphtml-amp-story-shopping-tag-pill {
@@ -184,7 +184,7 @@ amp-story-shopping-tag {
   --clip-path-inset-offset-supports-rtl: inset(0 0 0 calc(100% - 36px) round 30px) !important;
 
   /* Transform origin from center of icon (right side) in RTL. */
-  transform-origin: calc(100% - var(--i-amphtml-pill-transfrom-origin)) !important;
+  transform-origin: calc(100% - var(--i-amphtml-pill-transform-origin)) !important;
 }
 
 @keyframes i-amphtml-animate-in-sequence-pill {
@@ -207,13 +207,13 @@ amp-story-shopping-tag {
     clip-path: var(--clip-path-inset-offset-supports-rtl);
   }
   100% {
-    clip-path: inset(0 0 0 0 round 30px);
+    clip-path: inset(0 0 0 0 round 10px);
   }
 }
 
 @keyframes i-amphtml-animate-out-sequence-pill {
   0% {
-    clip-path: inset(0 0 0 0 round 30px);
+    clip-path: inset(0 0 0 0 round 10px);
   }
   40% {
     animation-timing-function: cubic-bezier(.85, 0, .15, 1);
@@ -228,7 +228,7 @@ amp-story-shopping-tag {
   }
 }
 
-.i-amphtml-story-shopping-tag-pill-multi-line {
+.i-amphtml-amp-story-shopping-tag-pill-multi-line {
   border-radius: 10px !important;
   margin-inline-start: 9px !important;
   margin-inline-end: 4px !important;

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -170,42 +170,6 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
   }
 
   /**
-   * This function counts the number of lines in the shopping tag
-   * and sets the styling properties dynamically based on the number of lines.
-   * @private
-   */
-  styleTagText_() {
-    const pillEl = this.element.shadowRoot.querySelector(
-      '.i-amphtml-amp-story-shopping-tag-pill'
-    );
-
-    const textEl = this.element.shadowRoot.querySelector(
-      '.i-amphtml-amp-story-shopping-tag-pill-text'
-    );
-
-    const fontSize = parseInt(
-      computedStyle(window, textEl).getPropertyValue('font-size'),
-      10
-    );
-    const ratioOfLineHeightToFontSize = 1.5;
-    const lineHeight = Math.floor(fontSize * ratioOfLineHeightToFontSize);
-
-    let numLines = 1;
-
-    this.measureElement(() => {
-      const height = textEl./*OK*/ clientHeight;
-      numLines = Math.ceil(height / lineHeight);
-    });
-
-    this.mutateElement(() => {
-      pillEl.classList.toggle(
-        'i-amphtml-amp-story-shopping-tag-pill-multi-line',
-        numLines > 1
-      );
-    });
-  }
-
-  /**
    * @return {!Element}
    * @private
    */
@@ -294,6 +258,5 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
     );
     this.hasAppendedInnerShoppingTagEl_ = true;
     this.initializeTagStateListeners_();
-    this.styleTagText_();
   }
 }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -5,7 +5,6 @@ import {
   childElementByTag,
   closestAncestorElementBySelector,
 } from '#core/dom/query';
-import {computedStyle} from '#core/dom/style';
 
 import {Services} from '#service';
 

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.js
@@ -175,17 +175,13 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
    * @private
    */
   styleTagText_() {
-    const pillEl = this.element.shadowRoot?.querySelector(
-      '.amp-story-shopping-tag-pill'
+    const pillEl = this.element.shadowRoot.querySelector(
+      '.i-amphtml-amp-story-shopping-tag-pill'
     );
 
-    const textEl = this.element.shadowRoot?.querySelector(
-      '.amp-story-shopping-tag-pill-text'
+    const textEl = this.element.shadowRoot.querySelector(
+      '.i-amphtml-amp-story-shopping-tag-pill-text'
     );
-
-    if (!pillEl || !textEl) {
-      return;
-    }
 
     const fontSize = parseInt(
       computedStyle(window, textEl).getPropertyValue('font-size'),
@@ -297,7 +293,7 @@ export class AmpStoryShoppingTag extends AMP.BaseElement {
       shoppingSharedCSS + shoppingTagCSS
     );
     this.hasAppendedInnerShoppingTagEl_ = true;
-    this.styleTagText_();
     this.initializeTagStateListeners_();
+    this.styleTagText_();
   }
 }

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
@@ -72,7 +72,6 @@ describes.realWin(
     }
 
     it('should build and layout shopping tag component', async () => {
-      env.sandbox.stub(shoppingTag, 'styleTagText_');
       await setupShoppingTagAndData();
       expect(shoppingTag.shoppingTagEl_).to.be.not.null;
     });

--- a/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
+++ b/extensions/amp-story-shopping/0.1/test/test-amp-story-shopping-tag.js
@@ -72,6 +72,7 @@ describes.realWin(
     }
 
     it('should build and layout shopping tag component', async () => {
+      env.sandbox.stub(shoppingTag, 'styleTagText_');
       await setupShoppingTagAndData();
       expect(shoppingTag.shoppingTagEl_).to.be.not.null;
     });


### PR DESCRIPTION
#closes https://github.com/ampproject/amphtml/issues/37808
Some animation CSS keyframes were not calculating the border-radius properly, this PR fixes them.