### PR TITLE
✨ Allow `alt` attribute on `input[type=image]` and allow in any `form` (not just with `method=post`)

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -2946,6 +2946,7 @@ tags: {
   html_format: AMP
   tag_name: "INPUT"
   spec_name: "INPUT [type=image]"
+  attrs: { name: "alt" }
   attrs: {
     name: "type"
     value_casei: "image"
@@ -2968,7 +2969,7 @@ tags: {
   }
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  mandatory_ancestor: "FORM [method=POST]"
+  mandatory_ancestor: "FORM"
   spec_url: "https://amp.dev/documentation/components/amp-form/"
 }
 # 4.10.6 The button element


### PR DESCRIPTION
This is a follow-up on #37651.

For a11y, `input[type=image]` elements [support](https://html.spec.whatwg.org/multipage/input.html#:~:text=The%20alt%20attribute%20provides%20the%20textual%20label%20for%20the%20button%20for%20users%20and%20user%20agents%20who%20cannot%20use%20the%20image.) `alt` attributes the same as `img` does. This is currently missing.

Also, these elements are essentially just submit buttons, so they should be allowed in `GET` forms as well as `POST` forms. 