### PR TITLE
🏗️  Fix the `sources` of extension sourcemaps

### DIFF
--- a/build-system/tasks/check-sourcemaps.js
+++ b/build-system/tasks/check-sourcemaps.js
@@ -8,11 +8,10 @@ const {execOrDie} = require('../common/exec');
 const {log} = require('../common/logging');
 
 // Compile related constants
-const distWithSourcemapsCmd = 'amp dist --core_runtime_only --full_sourcemaps';
-const v0JsMap = 'dist/v0.js.map';
+const distWithSourcemapsCmd =
+  'amp dist --core_runtime_only --extensions=amp-audio --full_sourcemaps';
 const distEsmWithSourcemapsCmd =
-  'amp dist --core_runtime_only --full_sourcemaps --esm';
-const v0MjsMap = 'dist/v0.mjs.map';
+  'amp dist --core_runtime_only --extensions=amp-audio --full_sourcemaps --esm';
 
 // Sourcemap URL related constants
 const sourcemapUrlMatcher =
@@ -24,9 +23,9 @@ const sourcemapUrlMatcher =
 function maybeBuild() {
   if (!argv.nobuild) {
     log('Compiling', cyan('v0.js'), 'with full sourcemaps...');
-    execOrDie(distWithSourcemapsCmd, {'stdio': 'ignore'});
+    execOrDie(distWithSourcemapsCmd);
     log('Compiling', cyan('v0.mjs'), 'with full sourcemaps...');
-    execOrDie(distEsmWithSourcemapsCmd, {'stdio': 'ignore'});
+    execOrDie(distEsmWithSourcemapsCmd);
   }
 }
 
@@ -154,12 +153,15 @@ function checkSourcemapMappings(sourcemapJson, map) {
 
 /**
  * @param {string} map The map filepath to check
+ * @param {boolean} checkMappings Whether to test a mapping points to a correct source.
  */
-function checkSourceMap(map) {
+function checkSourceMap(map, checkMappings) {
   const sourcemapJson = getSourcemapJson(map);
   checkSourcemapUrl(sourcemapJson, map);
   checkSourcemapSources(sourcemapJson, map);
-  checkSourcemapMappings(sourcemapJson, map);
+  if (checkMappings) {
+    checkSourcemapMappings(sourcemapJson, map);
+  }
 }
 
 /**
@@ -169,8 +171,12 @@ function checkSourceMap(map) {
  */
 async function checkSourcemaps() {
   maybeBuild();
-  checkSourceMap(v0JsMap);
-  checkSourceMap(v0MjsMap);
+  checkSourceMap('dist/v0.js.map', true);
+  checkSourceMap('dist/v0.mjs.map', true);
+
+  checkSourceMap('dist/v0/amp-audio-0.1.js.map', false);
+  checkSourceMap('dist/v0/amp-audio-0.1.mjs.map', false);
+
   log(green('SUCCESS:'), 'All sourcemaps checks passed.');
 }
 

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -410,7 +410,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
         destFile,
         `${code}\n//# sourceMappingURL=${destFilename}.map`
       ),
-      fs.outputJson(`${destFile}.map`, massageSourcemaps(mapChain, options)),
+      fs.outputJson(`${destFile}.map`, massageSourcemaps(mapChain, destFile, options)),
     ]);
 
     await finishBundle(destDir, destFilename, options, startTime);

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "@google-cloud/storage": "5.15.3",
         "@jest/core": "27.3.1",
         "@jridgewell/doctrine": "3.0.2",
+        "@jridgewell/resolve-uri": "3.0.5",
         "@octokit/graphql": "4.8.0",
         "@octokit/rest": "18.12.0",
         "@sinonjs/fake-timers": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@google-cloud/storage": "5.15.3",
     "@jest/core": "27.3.1",
     "@jridgewell/doctrine": "3.0.2",
+    "@jridgewell/resolve-uri": "3.0.5",
     "@octokit/graphql": "4.8.0",
     "@octokit/rest": "18.12.0",
     "@sinonjs/fake-timers": "7.1.2",


### PR DESCRIPTION
We're still getting incorrect RTVs in our sourcemaps, which I thought I had fixed. The issue before was that the `sources` paths contained a `../src/...`, where `..` is relative to the map file. We fixed this by chopping off the `../`.

But this only worked for `v0.js` and other entrypoint files. For extension maps, the map file is written to `dist/v0/FOO.js.map`, and the `sources` paths start with `../../src/...`. This fixes all maps by resolving the relative path into a `cwd` relative source, which can then be joined with the `sourceRoot` without issue.