### PR TITLE
🐛 [amp-jwplayer] Allow video docking during ad playback

### DIFF
--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -203,6 +203,18 @@ describes.realWin(
         expect(spy).to.be.calledWith('play', {reason: undefined});
       });
 
+      it('sets hasPlayed_ on play', () => {
+        expect(impl.hasPlayed_).to.equal(false);
+        mockMessage('play');
+        expect(impl.hasPlayed_).to.equal(true);
+      });
+
+      it('sets hasPlayed_ on adPlay', () => {
+        expect(impl.hasPlayed_).to.equal(false);
+        mockMessage('adPlay');
+        expect(impl.hasPlayed_).to.equal(true);
+      });
+
       it('autoplays', () => {
         const spy = env.sandbox.spy(impl, 'sendCommand_');
         impl.play(true);


### PR DESCRIPTION
This PR reverts amp-jwplayer to dispatching `VideoEvents_Enum.PLAYING` and `VideoEvents_Enum.PAUSE` on `adPlay` and `adPause` to allow for video docking during ad playback. In addition, element now triggers `VideoEvents_Enum.PLAY` on first playback of a playlist item to prevent redispatch of `VideoAnalyticsEvents_Enum.PLAY` on subsequent plays of a playlist item.