### PR TITLE
handle remapping to a node module that is bundled

### DIFF
--- a/build-system/tasks/extension-helpers.js
+++ b/build-system/tasks/extension-helpers.js
@@ -674,7 +674,9 @@ async function buildNpmBinaries(extDir, name, options) {
         ...(npm[mode].remap || {}),
         ...bentoRemaps,
       };
-      npm[mode].external = [...(npm[mode].external || []), ...bentoExternals];
+      npm[mode].external = [
+        ...new Set([...(npm[mode].external || []), ...bentoExternals]),
+      ];
     }
   }
   const binaries = Object.values(npm);

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -23,6 +23,7 @@ const {watch} = require('chokidar');
 const {debug} = require('../compile/debug-compilation-lifecycle');
 const babel = require('@babel/core');
 const {
+  ampResolve,
   remapDependenciesPlugin,
 } = require('./remap-dependencies-plugin/remap-dependencies');
 
@@ -333,7 +334,9 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
   if (options.remapDependencies) {
     const {externalDependencies: externals, remapDependencies: remaps} =
       options;
-    plugins.unshift(remapDependenciesPlugin({externals, remaps}));
+    plugins.unshift(
+      remapDependenciesPlugin({externals, remaps, resolve: ampResolve})
+    );
   }
 
   let result = null;


### PR DESCRIPTION
needed because resolvePath() only handles local modules

We would run into this anytime we would try to remap to non-external node module. But we don't actually run into this bug yet because whenever we remap to a node module (`react`), we're also setting it as an external, so it never calls resolvePath(). 

The tests already assume this, so they don't need to change

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
