### PR TITLE
Add react remapping to import resolver plugin

### DIFF
--- a/build-system/babel-config/import-resolver.js
+++ b/build-system/babel-config/import-resolver.js
@@ -41,22 +41,32 @@ function readJsconfigPaths() {
   return tsConfigPaths;
 }
 
-// Necessary for external modules that rely on React.
-const moduleAliases = {
-  'react': './src/react',
-  'react-dom': './src/react/dom',
-};
+/**
+ * Remap external modules that rely on React if building for Preact.
+ * @param {'preact' | 'react'} buildFor
+ * @return {Object}
+ */
+function moduleAliases(buildFor) {
+  if (buildFor === 'react') {
+    return {};
+  }
+  return {
+    'react': './src/react',
+    'react-dom': './src/react/dom',
+  };
+}
 
 /**
  * Import map configuration.
+ * @param {'preact' | 'react'} buildFor
  * @return {Object}
  */
-function getImportResolver() {
+function getImportResolver(buildFor = 'preact') {
   return {
     root: ['.'],
     alias: {
       ...readJsconfigPaths(),
-      ...moduleAliases,
+      ...moduleAliases(buildFor),
     },
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     stripExtensions: [],
@@ -71,23 +81,24 @@ function getImportResolver() {
 /**
  * Produces an alias map with paths relative to the provided root.
  * @param {string} rootDir
+ * @param {'preact' | 'react'} buildFor
  * @return {!Object<string, string>}
  */
-function getRelativeAliasMap(rootDir) {
+function getRelativeAliasMap(rootDir, buildFor = 'preact') {
   return Object.fromEntries(
-    Object.entries(getImportResolver().alias).map(([alias, destPath]) => [
-      alias,
-      path.join(rootDir, destPath),
-    ])
+    Object.entries(getImportResolver(buildFor).alias).map(
+      ([alias, destPath]) => [alias, path.join(rootDir, destPath)]
+    )
   );
 }
 
 /**
  * Import resolver Babel plugin configuration.
+ * @param {'preact' | 'react'} buildFor
  * @return {!Array}
  */
-function getImportResolverPlugin() {
-  return ['module-resolver', getImportResolver()];
+function getImportResolverPlugin(buildFor = 'preact') {
+  return ['module-resolver', getImportResolver(buildFor)];
 }
 
 /**

--- a/build-system/babel-config/import-resolver.js
+++ b/build-system/babel-config/import-resolver.js
@@ -41,6 +41,11 @@ function readJsconfigPaths() {
   return tsConfigPaths;
 }
 
+const moduleAliases = {
+  'react': './src/react',
+  'react-dom': './src/react/dom',
+};
+
 /**
  * Import map configuration.
  * @return {Object}
@@ -48,7 +53,10 @@ function readJsconfigPaths() {
 function getImportResolver() {
   return {
     root: ['.'],
-    alias: readJsconfigPaths(),
+    alias: {
+      ...readJsconfigPaths(),
+      ...moduleAliases,
+    },
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     stripExtensions: [],
     babelOptions: {

--- a/build-system/babel-config/import-resolver.js
+++ b/build-system/babel-config/import-resolver.js
@@ -41,6 +41,7 @@ function readJsconfigPaths() {
   return tsConfigPaths;
 }
 
+// Necessary for external modules that rely on React.
 const moduleAliases = {
   'react': './src/react',
   'react-dom': './src/react/dom',

--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -8,9 +8,10 @@ const {getReplacePlugin} = require('./helpers');
 /**
  * Gets the config for minified babel transforms run, used by 3p vendors.
  *
+ * @param {'preact' | 'react'} buildFor
  * @return {!Object}
  */
-function getMinifiedConfig() {
+function getMinifiedConfig(buildFor = 'preact') {
   const isProd = argv._.includes('dist') && !argv.fortesting;
 
   const reactJsxPlugin = [
@@ -27,7 +28,7 @@ function getMinifiedConfig() {
     'optimize-objstr',
     './build-system/babel-plugins/babel-plugin-mangle-object-values',
     './build-system/babel-plugins/babel-plugin-jsx-style-object',
-    getImportResolverPlugin(),
+    getImportResolverPlugin(buildFor),
     argv.coverage ? 'babel-plugin-istanbul' : null,
     './build-system/babel-plugins/babel-plugin-imported-helpers',
     './build-system/babel-plugins/babel-plugin-transform-inline-isenumvalue',

--- a/build-system/babel-config/react-config.js
+++ b/build-system/babel-config/react-config.js
@@ -26,14 +26,14 @@ function mergeReactBabelConfig(config) {
  * @return {!Object}
  */
 function getReactUnminifiedConfig() {
-  return mergeReactBabelConfig(getUnminifiedConfig());
+  return mergeReactBabelConfig(getUnminifiedConfig('react'));
 }
 
 /**
  * @return {!Object}
  */
 function getReactMinifiedConfig() {
-  return mergeReactBabelConfig(getMinifiedConfig());
+  return mergeReactBabelConfig(getMinifiedConfig('react'));
 }
 
 module.exports = {

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -7,9 +7,10 @@ const {getReplacePlugin} = require('./helpers');
 /**
  * Gets the config for babel transforms run during `amp build`.
  *
+ * @param {'preact' | 'react'} buildFor
  * @return {!Object}
  */
-function getUnminifiedConfig() {
+function getUnminifiedConfig(buildFor = 'preact') {
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',
     {
@@ -38,7 +39,7 @@ function getUnminifiedConfig() {
   const replacePlugin = getReplacePlugin();
   const unminifiedPlugins = [
     './build-system/babel-plugins/babel-plugin-jsx-style-object',
-    getImportResolverPlugin(),
+    getImportResolverPlugin(buildFor),
     argv.coverage ? 'babel-plugin-istanbul' : null,
     replacePlugin,
     './build-system/babel-plugins/babel-plugin-transform-json-import',

--- a/build-system/tasks/storybook/env/preact/webpack.config.js
+++ b/build-system/tasks/storybook/env/preact/webpack.config.js
@@ -21,9 +21,9 @@ module.exports = ({config}) => {
     modules,
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
     alias: {
+      ...getRelativeAliasMap(rootDir),
       'react': 'preact/compat',
       'react-dom': 'preact/compat',
-      ...getRelativeAliasMap(rootDir),
     },
   };
   config.module = {

--- a/build-system/tasks/storybook/env/react/webpack.config.js
+++ b/build-system/tasks/storybook/env/react/webpack.config.js
@@ -72,7 +72,7 @@ module.exports = ({config}) => {
     plugins: [new ReactBuildImportResolver()],
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
     alias: {
-      ...getRelativeAliasMap(rootDir),
+      ...getRelativeAliasMap(rootDir, 'react'),
       // Alias preact to react
       'preact/dom': 'react-dom',
       'preact/hooks': 'react',

--- a/src/react/dom.js
+++ b/src/react/dom.js
@@ -1,0 +1,5 @@
+import {hydrate, render} from '#preact';
+
+export {hydrate, render};
+
+export default {hydrate, render};

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -7,4 +7,5 @@ export * from '#preact/compat';
 // This file allows us to remap react imports from external libraries to
 // our internal preact exports. This file uses a default export in order to
 // be compatible with libraries that use react default import syntax.
+
 export default {...Preact, ...PreactCompat};

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,0 +1,45 @@
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from '#preact';
+import {forwardRef} from '#preact/compat';
+
+// This file allows us to remap react imports from external libraries to
+// our internal preact exports. This file uses a default export in order to
+// be compatible with libraries that use react default import syntax.
+
+export {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  forwardRef,
+  createElement,
+};
+
+export default {
+  useState,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useContext,
+  useCallback,
+  createContext,
+  useImperativeHandle,
+  useMemo,
+  forwardRef,
+  createElement,
+};

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,45 +1,10 @@
-import {
-  createContext,
-  createElement,
-  useCallback,
-  useContext,
-  useEffect,
-  useImperativeHandle,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from '#preact';
-import {forwardRef} from '#preact/compat';
+import * as Preact from '#preact';
+import * as PreactCompat from '#preact/compat';
+
+export * from '#preact';
+export * from '#preact/compat';
 
 // This file allows us to remap react imports from external libraries to
 // our internal preact exports. This file uses a default export in order to
 // be compatible with libraries that use react default import syntax.
-
-export {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useImperativeHandle,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-  forwardRef,
-  createElement,
-};
-
-export default {
-  useState,
-  useRef,
-  useEffect,
-  useLayoutEffect,
-  useContext,
-  useCallback,
-  createContext,
-  useImperativeHandle,
-  useMemo,
-  forwardRef,
-  createElement,
-};
+export default {...Preact, ...PreactCompat};


### PR DESCRIPTION
This work is also incorporated in #37385, but this is just the module replacement that allows Bento components to use external libraries that rely on React. 

The original problem: `react-day-picker` (the library that is used for the date picker under the hood) relies on React. Without any module replacement, rendering the day picker component in Bento mode doesn't render the calendar and fails silently. Aliasing `react` to `preact/compat` also results in some weird compatibility issues between `preact/compat` and `src/preact`. 

While the compiled bento code `bento.js` or `bento.max.js` also exports all the necessary React functions from `src/preact`, it is incompatible with synthetic default import syntax (`import React from 'react'`) used by many libraries.

Doing this module replacement in the babel config makes the most sense for now, and works with both test files and bento components.