### PR TITLE
🏗 Tree-shake included JSON Schema in compiled output

### DIFF
--- a/build-system/babel-plugins/babel-plugin-transform-json-import/index.js
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/index.js
@@ -51,8 +51,8 @@ module.exports = function (babel) {
       const schema = json5.parse(readFileSync(jsonPath, 'utf8'));
       const code = ajvCompile(schema);
 
-      const scope = Object.keys(path.scope.bindings);
-      const {name, result} = transformAjvCode(code, scope, {
+      const taken = new Set(Object.keys(path.scope.bindings));
+      const {name, result} = transformAjvCode(code, taken, {
         code: false,
         ast: true,
       });

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-complex/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-complex/output.mjs
@@ -3,170 +3,32 @@ import { isIso4217CurrencyCode } from '#core/json-schema';
 
 const _validate = validate0;
 const schema0 = {
-  "$id": "my-id",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["items"],
-  "properties": {
-    "recursive": {
-      "$ref": "#/"
-    },
-    "items": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
-        "properties": {
-          "recursive": {
-            "$ref": "#/properties/items"
-          },
-          "a": {
-            "oneOf": [{
-              "type": "string"
-            }, {
-              "type": "number"
-            }]
-          },
-          "b": {
-            "$ref": "#/properties/items/items/properties/a/oneOf/1"
-          },
-          "c": {
-            "type": "string"
-          },
-          "d": {
-            "type": "string"
-          },
-          "h": {
-            "type": "string"
-          },
-          "e": {
-            "type": "number",
-            "minimum": 0
-          },
-          "f": {
-            "description": "https://en.wikipedia.org/wiki/ISO_4217",
-            "_isIso4217CurrencyCode": true
-          },
-          "g": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["url", "altText"],
-              "properties": {
-                "url": {
-                  "type": "string"
-                },
-                "altText": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "i": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["ratingValue", "ratingCount", "ratingUrl"],
-            "properties": {
-              "ratingValue": {
-                "type": "number",
-                "minimum": 0
-              },
-              "ratingCount": {
-                "type": "number",
-                "minimum": 0
-              },
-              "ratingUrl": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+  recursive: 0,
+  a: 0,
+  b: 0,
+  c: 0,
+  d: 0,
+  h: 0,
+  e: 0,
+  f: 0,
+  g: 0,
+  i: 0
 };
 const func0 = Object.prototype.hasOwnProperty;
 const schema1 = {
-  "type": "array",
-  "items": {
-    "type": "object",
-    "additionalProperties": false,
-    "required": ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
-    "properties": {
-      "recursive": {
-        "$ref": "#/properties/items"
-      },
-      "a": {
-        "oneOf": [{
-          "type": "string"
-        }, {
-          "type": "number"
-        }]
-      },
-      "b": {
-        "$ref": "#/properties/items/items/properties/a/oneOf/1"
-      },
-      "c": {
-        "type": "string"
-      },
-      "d": {
-        "type": "string"
-      },
-      "h": {
-        "type": "string"
-      },
-      "e": {
-        "type": "number",
-        "minimum": 0
-      },
-      "f": {
-        "description": "https://en.wikipedia.org/wiki/ISO_4217",
-        "_isIso4217CurrencyCode": true
-      },
-      "g": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["url", "altText"],
-          "properties": {
-            "url": {
-              "type": "string"
-            },
-            "altText": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "i": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["ratingValue", "ratingCount", "ratingUrl"],
-        "properties": {
-          "ratingValue": {
-            "type": "number",
-            "minimum": 0
-          },
-          "ratingCount": {
-            "type": "number",
-            "minimum": 0
-          },
-          "ratingUrl": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  }
+  recursive: 0,
+  a: 0,
+  b: 0,
+  c: 0,
+  d: 0,
+  h: 0,
+  e: 0,
+  f: 0,
+  g: 0,
+  i: 0
 };
 const wrapper0 = {
   validate: validate1
-};
-const schema2 = {
-  "type": "number"
 };
 
 function validate2(data, instancePath = "") {
@@ -309,7 +171,7 @@ function validate1(data, instancePath = "") {
         }
 
         for (const key0 in data0) {
-          if (!func0.call(schema1.items.properties, key0)) {
+          if (!func0.call(schema1, key0)) {
             const err9 = (instancePath + "/" + i0 + ' ' + "must NOT have additional properties").trim();
 
             if (vErrors === null) {
@@ -917,7 +779,7 @@ function validate0(data, instancePath = "") {
             }
 
             for (const key1 in data2) {
-              if (!func0.call(schema0.properties.items.items.properties, key1)) {
+              if (!func0.call(schema0, key1)) {
                 const err11 = (instancePath + "/items/" + i0 + ' ' + "must NOT have additional properties").trim();
 
                 if (vErrors === null) {

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-complex/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-complex/output.mjs
@@ -1,7 +1,3 @@
-import { isIso4217CurrencyCode } from '#core/json-schema';
-"use strict";
-
-const _validate = validate0;
 const _schema = {
   recursive: 0,
   a: 0,
@@ -14,6 +10,10 @@ const _schema = {
   g: 0,
   i: 0
 };
+import { isIso4217CurrencyCode } from '#core/json-schema';
+"use strict";
+
+const _validate = validate0;
 const func0 = Object.prototype.hasOwnProperty;
 const wrapper0 = {
   validate: validate1

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-currency-code/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-currency-code/output.mjs
@@ -2,10 +2,6 @@ import { isIso4217CurrencyCode } from '#core/json-schema';
 "use strict";
 
 const validate = validate0;
-const schema0 = {
-  "description": "https://en.wikipedia.org/wiki/ISO_4217",
-  "_isIso4217CurrencyCode": true
-};
 
 function validate0(data, instancePath = "") {
   let vErrors = null;

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-format-date/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-format-date/output.mjs
@@ -1,17 +1,4 @@
 const validate = validate0;
-const schema0 = {
-  "properties": {
-    "my-date": {
-      "format": "date"
-    },
-    "my-date-time": {
-      "format": "date-time"
-    },
-    "my-time": {
-      "format": "time"
-    }
-  }
-};
 const formats0 = /^\d\d\d\d-[0-1]\d-[0-3]\d$/;
 const formats2 = /^\d\d\d\d-[0-1]\d-[0-3]\d[t\s](?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)$/i;
 const formats4 = /^(?:[0-2]\d:[0-5]\d:[0-5]\d|23:59:60)(?:\.\d+)?(?:z|[+-]\d\d(?::?\d\d)?)?$/i;

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-format/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-format/output.mjs
@@ -1,14 +1,4 @@
 const validate = validate0;
-const schema0 = {
-  "properties": {
-    "my-uri": {
-      "format": "uri"
-    },
-    "my-email": {
-      "format": "email"
-    }
-  }
-};
 const formats0 = /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/i;
 const formats2 = /^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i;
 

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/input.js
@@ -3,6 +3,9 @@ const validate0 = `
   ajv's should be renamed, and this assignment should be preserved.
 `;
 
+const _schema = '',
+  _schema2 = 'generated value should be _schema3';
+
 import validate from './name-collision.schema.json' assert {type: 'json-schema'};
 
 validate(`

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/name-collision.schema.json
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/name-collision.schema.json
@@ -1,3 +1,9 @@
 {
-  "type": "string"
+  "properties": {
+    "foo": {
+      "const": {
+        "bar": 123
+      }
+    }
+  }
 }

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/output.mjs
@@ -3,9 +3,6 @@ const validate0 = `
   ajv's should be renamed, and this assignment should be preserved.
 `;
 const _validate = _validate2;
-const schema0 = {
-  "type": "string"
-};
 
 function _validate2(data, instancePath = "") {
   let vErrors = null;

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-name-collision/output.mjs
@@ -1,23 +1,34 @@
+const _schema3 = {
+  bar: 123
+};
 const validate0 = `
   ajv creates a "validate0" identifier in module scope.
   ajv's should be renamed, and this assignment should be preserved.
 `;
+const _schema = '',
+      _schema2 = 'generated value should be _schema3';
 const _validate = _validate2;
+
+const func0 = require("ajv/dist/runtime/equal").default;
 
 function _validate2(data, instancePath = "") {
   let vErrors = null;
   let errors = 0;
 
-  if (typeof data !== "string") {
-    const err0 = (instancePath + ' ' + "must be string").trim();
+  if (data && typeof data == "object" && !Array.isArray(data)) {
+    if (data.foo !== undefined) {
+      if (!func0(data.foo, _schema3)) {
+        const err0 = (instancePath + "/foo" + ' ' + "must be equal to constant").trim();
 
-    if (vErrors === null) {
-      vErrors = [err0];
-    } else {
-      vErrors.push(err0);
+        if (vErrors === null) {
+          vErrors = [err0];
+        } else {
+          vErrors.push(err0);
+        }
+
+        errors++;
+      }
     }
-
-    errors++;
   }
 
   _validate2.errors = vErrors;

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/input.js
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/input.js
@@ -1,0 +1,3 @@
+import validate from './object-enum.schema.json' assert {type: 'json-schema'};
+
+console./*OK*/ log(validate({}));

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/object-enum.schema.json
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/object-enum.schema.json
@@ -1,0 +1,94 @@
+{
+  "description": "This description should NOT be included in the schema object",
+  "type": "array",
+  "items": {
+    "properties": {
+      "prop_a": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "description": "This description should NOT be included in the schema object",
+            "enum": [
+              123,
+              345,
+              {
+                "foo": "This object should be included in the schema object",
+                "bar": {
+                  "all keys are included": true
+                }
+              },
+              "this string should NOT be included in the schema object",
+              "this string should also NOT be included in the schema object",
+              {
+                "bar": "This object should also be included in the schema object"
+              }
+            ]
+          }
+        ]
+      },
+      "prop_b": {},
+      "prop_c": {
+        "description": "This description should NOT be included in the schema object",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "prop_x": {},
+          "prop_y": {},
+          "prop_z": {
+            "properties": {
+              "objectWithoutAditionalPropertiesA": {
+                "additionalProperties": false,
+                "properties": {
+                  "prop_a": {},
+                  "prop_b": {},
+                  "prop_c": {},
+                  "prop_d": {},
+                  "prop_e": {},
+                  "prop_f": {},
+                  "prop_g": {},
+                  "prop_h": {},
+                  "prop_i": {}
+                }
+              },
+              "objectWithoutAditionalPropertiesB": {
+                "additionalProperties": false,
+                "properties": {
+                  "prop_z": {},
+                  "prop_y": {},
+                  "prop_x": {},
+                  "prop_w": {
+                    "properties": {
+                      "prop_xyz": {
+                        "properties": {
+                          "prop_abc": {
+                            "enum": [
+                              "this string should NOT be included in the schema object",
+                              123,
+                              {
+                                "object": true,
+                                "bar": {
+                                  "all keys are included": true
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "prop_v": {},
+                  "prop_u": {},
+                  "prop_t": {},
+                  "prop_s": {},
+                  "prop_r": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/options.json
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "../../../.."
+  ],
+  "sourceType": "module"
+}

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/output.mjs
@@ -1,0 +1,251 @@
+const _validate = validate0;
+const schema0 = [[{
+  foo: "This object should be included in the schema object",
+  bar: {
+    "all keys are included": true
+  }
+}, {
+  bar: "This object should also be included in the schema object"
+}], [{
+  prop_a: 0,
+  prop_b: 0,
+  prop_c: 0,
+  prop_d: 0,
+  prop_e: 0,
+  prop_f: 0,
+  prop_g: 0,
+  prop_h: 0,
+  prop_i: 0
+}, {
+  prop_z: 0,
+  prop_y: 0,
+  prop_x: 0,
+  prop_w: {
+    object: true,
+    bar: {
+      "all keys are included": true
+    }
+  },
+  prop_v: 0,
+  prop_u: 0,
+  prop_t: 0,
+  prop_s: 0,
+  prop_r: 0
+}]];
+
+const func0 = require("ajv/dist/runtime/equal").default;
+
+const func1 = Object.prototype.hasOwnProperty;
+
+function validate0(data, instancePath = "") {
+  let vErrors = null;
+  let errors = 0;
+
+  if (Array.isArray(data)) {
+    const len0 = data.length;
+
+    for (let i0 = 0; i0 < len0; i0++) {
+      let data0 = data[i0];
+
+      if (data0 && typeof data0 == "object" && !Array.isArray(data0)) {
+        if (data0.prop_a !== undefined) {
+          let data1 = data0.prop_a;
+          const _errs3 = errors;
+          let valid3 = false;
+          let passing0 = null;
+          const _errs4 = errors;
+
+          if (typeof data1 !== "boolean") {
+            const err0 = (instancePath + "/" + i0 + "/prop_a" + ' ' + "must be boolean").trim();
+
+            if (vErrors === null) {
+              vErrors = [err0];
+            } else {
+              vErrors.push(err0);
+            }
+
+            errors++;
+          }
+
+          var _valid0 = _errs4 === errors;
+
+          if (_valid0) {
+            valid3 = true;
+            passing0 = 0;
+          }
+
+          const _errs6 = errors;
+
+          if (!(data1 === 123 || data1 === 345 || func0(data1, schema0[0][0]) || data1 === "this string should NOT be included in the schema object" || data1 === "this string should also NOT be included in the schema object" || func0(data1, schema0[0][1]))) {
+            const err1 = (instancePath + "/" + i0 + "/prop_a" + ' ' + "must be equal to one of the allowed values").trim();
+
+            if (vErrors === null) {
+              vErrors = [err1];
+            } else {
+              vErrors.push(err1);
+            }
+
+            errors++;
+          }
+
+          var _valid0 = _errs6 === errors;
+
+          if (_valid0 && valid3) {
+            valid3 = false;
+            passing0 = [passing0, 1];
+          } else {
+            if (_valid0) {
+              valid3 = true;
+              passing0 = 1;
+            }
+          }
+
+          if (!valid3) {
+            const err2 = (instancePath + "/" + i0 + "/prop_a" + ' ' + "must match exactly one schema in oneOf").trim();
+
+            if (vErrors === null) {
+              vErrors = [err2];
+            } else {
+              vErrors.push(err2);
+            }
+
+            errors++;
+          } else {
+            errors = _errs3;
+
+            if (vErrors !== null) {
+              if (_errs3) {
+                vErrors.length = _errs3;
+              } else {
+                vErrors = null;
+              }
+            }
+          }
+        }
+
+        if (data0.prop_c !== undefined) {
+          let data2 = data0.prop_c;
+
+          if (data2 && typeof data2 == "object" && !Array.isArray(data2)) {
+            for (const key0 in data2) {
+              if (!(key0 === "prop_x" || key0 === "prop_y" || key0 === "prop_z")) {
+                const err3 = (instancePath + "/" + i0 + "/prop_c" + ' ' + "must NOT have additional properties").trim();
+
+                if (vErrors === null) {
+                  vErrors = [err3];
+                } else {
+                  vErrors.push(err3);
+                }
+
+                errors++;
+              }
+            }
+
+            if (data2.prop_z !== undefined) {
+              let data3 = data2.prop_z;
+
+              if (data3 && typeof data3 == "object" && !Array.isArray(data3)) {
+                if (data3.objectWithoutAditionalPropertiesA !== undefined) {
+                  let data4 = data3.objectWithoutAditionalPropertiesA;
+
+                  if (data4 && typeof data4 == "object" && !Array.isArray(data4)) {
+                    for (const key1 in data4) {
+                      if (!func1.call(schema0[1][0], key1)) {
+                        const err4 = (instancePath + "/" + i0 + "/prop_c/prop_z/objectWithoutAditionalPropertiesA" + ' ' + "must NOT have additional properties").trim();
+
+                        if (vErrors === null) {
+                          vErrors = [err4];
+                        } else {
+                          vErrors.push(err4);
+                        }
+
+                        errors++;
+                      }
+                    }
+                  }
+                }
+
+                if (data3.objectWithoutAditionalPropertiesB !== undefined) {
+                  let data5 = data3.objectWithoutAditionalPropertiesB;
+
+                  if (data5 && typeof data5 == "object" && !Array.isArray(data5)) {
+                    for (const key2 in data5) {
+                      if (!func1.call(schema0[1][1], key2)) {
+                        const err5 = (instancePath + "/" + i0 + "/prop_c/prop_z/objectWithoutAditionalPropertiesB" + ' ' + "must NOT have additional properties").trim();
+
+                        if (vErrors === null) {
+                          vErrors = [err5];
+                        } else {
+                          vErrors.push(err5);
+                        }
+
+                        errors++;
+                      }
+                    }
+
+                    if (data5.prop_w !== undefined) {
+                      let data6 = data5.prop_w;
+
+                      if (data6 && typeof data6 == "object" && !Array.isArray(data6)) {
+                        if (data6.prop_xyz !== undefined) {
+                          let data7 = data6.prop_xyz;
+
+                          if (data7 && typeof data7 == "object" && !Array.isArray(data7)) {
+                            if (data7.prop_abc !== undefined) {
+                              let data8 = data7.prop_abc;
+
+                              if (!(data8 === "this string should NOT be included in the schema object" || data8 === 123 || func0(data8, schema0[1][1].prop_w))) {
+                                const err6 = (instancePath + "/" + i0 + "/prop_c/prop_z/objectWithoutAditionalPropertiesB/prop_w/prop_xyz/prop_abc" + ' ' + "must be equal to one of the allowed values").trim();
+
+                                if (vErrors === null) {
+                                  vErrors = [err6];
+                                } else {
+                                  vErrors.push(err6);
+                                }
+
+                                errors++;
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          } else {
+            const err7 = (instancePath + "/" + i0 + "/prop_c" + ' ' + "must be object").trim();
+
+            if (vErrors === null) {
+              vErrors = [err7];
+            } else {
+              vErrors.push(err7);
+            }
+
+            errors++;
+          }
+        }
+      }
+    }
+  } else {
+    const err8 = (instancePath + ' ' + "must be array").trim();
+
+    if (vErrors === null) {
+      vErrors = [err8];
+    } else {
+      vErrors.push(err8);
+    }
+
+    errors++;
+  }
+
+  validate0.errors = vErrors;
+  return errors === 0;
+}
+
+const validate = (data, schemaName = "object-enum") => _validate(data, schemaName) ? [] : _validate.errors;
+
+console.
+/*OK*/
+log(validate({}));

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-object-enum/output.mjs
@@ -1,4 +1,3 @@
-const _validate = validate0;
 const _schema = {
   prop_a: 0,
   prop_b: 0,
@@ -9,8 +8,8 @@ const _schema = {
   prop_g: 0,
   prop_h: 0,
   prop_i: 0
-};
-const _schema2 = {
+},
+      _schema2 = {
   prop_z: 0,
   prop_y: 0,
   prop_x: 0,
@@ -20,22 +19,23 @@ const _schema2 = {
   prop_t: 0,
   prop_s: 0,
   prop_r: 0
-};
-const _schema3 = {
+},
+      _schema3 = {
   foo: "This object should be included in the schema object",
   bar: {
     "all keys are included": true
   }
-};
-const _schema4 = {
+},
+      _schema4 = {
   bar: "This object should also be included in the schema object"
-};
-const _schema5 = {
+},
+      _schema5 = {
   object: true,
   bar: {
     "all keys are included": true
   }
 };
+const _validate = validate0;
 
 const func0 = require("ajv/dist/runtime/equal").default;
 

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-one-of/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-one-of/output.mjs
@@ -1,11 +1,4 @@
 const validate = validate0;
-const schema0 = {
-  "oneOf": [{
-    "const": 0
-  }, {
-    "type": "string"
-  }]
-};
 
 function validate0(data, instancePath = "") {
   let vErrors = null;

--- a/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-refs/output.mjs
+++ b/build-system/babel-plugins/babel-plugin-transform-json-import/test/fixtures/transform-assertions/schema-refs/output.mjs
@@ -1,26 +1,4 @@
 const validate = validate0;
-const schema0 = {
-  "$defs": {
-    "https": {
-      "type": "string",
-      "format": "uri",
-      "pattern": "^https://"
-    }
-  },
-  "properties": {
-    "foo": {
-      "$ref": "#/$defs/https"
-    },
-    "bar": {
-      "$ref": "#/$defs/https"
-    }
-  }
-};
-const schema1 = {
-  "type": "string",
-  "format": "uri",
-  "pattern": "^https://"
-};
 const formats0 = /^(?:[a-z][a-z0-9+\-.]*:)(?:\/?\/)?[^\s]*$/i;
 const pattern0 = new RegExp("^https://", "u");
 

--- a/build-system/compile/json-schema/index.js
+++ b/build-system/compile/json-schema/index.js
@@ -274,20 +274,21 @@ function transformAjvCode(code, taken, config) {
       for (let referencePath of referencePaths) {
         // Navigate MemberExpression to find deepest value to insert.
         let value = startValue;
-        while (referencePath.parentPath?.isMemberExpression()) {
-          referencePath = referencePath.parentPath;
-          const key = evaluatePropertyKey(referencePath.get('property'));
+        let {parentPath} = referencePath;
+        while (parentPath?.isMemberExpression()) {
+          const key = evaluatePropertyKey(parentPath.get('property'));
           if (key == null) {
             break;
           }
           value = value[key];
+          referencePath = parentPath;
+          parentPath = referencePath.parentPath;
         }
         // deopt full schema if we can't resolve at least one key deep
         if (value === original) {
           return;
         }
         // Add declarator references to queue.
-        const {parentPath} = referencePath;
         if (
           parentPath?.isVariableDeclarator() &&
           t.isIdentifier(parentPath.node.id)

--- a/build-system/compile/json-schema/index.js
+++ b/build-system/compile/json-schema/index.js
@@ -162,15 +162,15 @@ function getImportCode(validatorFns) {
  *  - Creates strings for error messages instead of an object.
  *  - If provided a "scope" of used names, it will rescope the current code
  *    to prevent collisions, and remove `export`.
+ *  - Strips down included schemas so that they only contain the referenced
+ *    portions.
  * @param {string} code
  * @param {string[]=} scope
  * @param {babel.TransformOptions=} config
  * @return {{result: babel.BabelFileResult | null, name: string}}
  */
 function transformAjvCode(code, scope, config) {
-  const {types: t} = babel;
-
-  const scopeSet = scope ? new Set(scope) : null;
+  const {template, types: t} = babel;
 
   // ajvCompile's generated name
   let name = 'validate';
@@ -182,27 +182,254 @@ function transformAjvCode(code, scope, config) {
   const findProperty = (properties, name) =>
     properties.find((node) => isObjectProperty(node, name));
 
+  const evaluatePropertyKey = (property) =>
+    property.isIdentifier() ? property.node.name : property.evaluate().value;
+
+  const schemaVariableDeclaratorRe = /^schema[0-9]*$/;
+
+  /**
+   * @param {babel.NodePath} path
+   * @return {boolean}
+   */
+  function parentIsHasOwnPropertyCall(path) {
+    const {parentPath} = path;
+    if (
+      !parentPath?.isCallExpression() ||
+      parentPath.node.arguments[0] !== path.node
+    ) {
+      return false;
+    }
+    const callee = parentPath.get('callee');
+    if (
+      !callee.isMemberExpression() ||
+      !callee.get('property').isIdentifier({name: 'call'})
+    ) {
+      return false;
+    }
+    /** @type {babel.NodePath<any>} */
+    let resolved = callee.get('object');
+    while (resolved.isIdentifier()) {
+      const binding = path.scope.getBinding(resolved.node.name);
+      if (!binding) {
+        break;
+      }
+      resolved = binding.path;
+      if (resolved.isVariableDeclarator()) {
+        resolved = resolved.get('init');
+      }
+    }
+    return resolved.getSource().trim() === 'Object.prototype.hasOwnProperty';
+  }
+
+  /**
+   * Strips down an included schema binding so that it only contains the
+   * referenced portions.
+   * @param {import('@babel/traverse').Binding} binding
+   */
+  function treeShakeSchema(binding) {
+    const {path, referencePaths} = binding;
+    if (
+      !binding.constant ||
+      !path.isVariableDeclarator() ||
+      !t.isIdentifier(path.node.id) ||
+      !schemaVariableDeclaratorRe.test(path.node.id.name)
+    ) {
+      return;
+    }
+    const init = path.get('init');
+    if (!init.isObjectExpression()) {
+      return;
+    }
+    if (!referencePaths.length) {
+      path.remove();
+      return;
+    }
+    // Re-construct schema from references
+    const original = init.evaluate().value;
+    const replacement = {};
+    if (original == null) {
+      // original is dynamic, deopt
+      return;
+    }
+    /**
+     * Maps container objects to their member expressions.
+     * A container object is one that we create during traversal, and is never
+     * referenced directly. At the point a container is referenced, its mapping
+     * is set as `false`.
+     * @type {Map<Object, Set<babel.NodePath<babel.types.MemberExpression>> | false>}
+     */
+    const containers = new Map();
+    const queue = [...referencePaths];
+    for (const referencePath of queue) {
+      // Navigate MemberExpression to find deepest key to insert.
+      // We create necessary depth in replacement object as we go along.
+      let key;
+      let originalAt = original;
+      let replacementAt = replacement;
+      let containersAt;
+      let memberExpression;
+      let {parentPath} = referencePath;
+      while (replacementAt !== originalAt && parentPath?.isMemberExpression()) {
+        memberExpression = parentPath;
+        parentPath = memberExpression.parentPath;
+        const nextKey = evaluatePropertyKey(memberExpression.get('property'));
+        if (nextKey == null) {
+          break;
+        }
+        if (key != null) {
+          if (!replacementAt[key]) {
+            // Even though the original container may be an array, we first
+            // create it as an object in order to insert sparse keys.
+            // Container objects are all converted to arrays later.
+            replacementAt[key] = {};
+          }
+          replacementAt = replacementAt[key];
+          originalAt = originalAt[key];
+        }
+        key = nextKey;
+        containersAt = containers.get(replacementAt);
+        if (containersAt == null) {
+          containersAt = new Set();
+          containers.set(replacementAt, containersAt);
+        }
+        if (containersAt !== false) {
+          containersAt.add(memberExpression);
+        }
+      }
+      // deopt full schema if we can't resolve at least one key deep
+      if (key == null) {
+        return;
+      }
+      // already inserted as-is
+      if (replacementAt[key] === originalAt[key]) {
+        continue;
+      }
+      // Fill indirect references with fully qualified paths, and add those
+      // to the queue.
+      if (
+        memberExpression &&
+        parentPath?.isVariableDeclarator() &&
+        parentPath.node.init &&
+        t.isIdentifier(parentPath.node.id)
+      ) {
+        const {name} = parentPath.node.id;
+        const localBinding = parentPath.scope.getBinding(name);
+        if (localBinding?.constant) {
+          const {referencePaths} = localBinding;
+          for (const referencePath of referencePaths) {
+            const [replacedWithMemberExpression] = referencePath.replaceWith(
+              t.cloneNode(memberExpression.node)
+            );
+            let object = replacedWithMemberExpression.get('object');
+            while (object.isMemberExpression()) {
+              object = object.get('object');
+            }
+            queue.push(object);
+          }
+          parentPath.remove();
+          if (containersAt) {
+            containersAt.delete(memberExpression);
+          }
+          continue;
+        }
+      }
+      // Objects may in some cases be referenced only for their key list, in
+      // which we define each unset value as a zero rather than the original.
+      // If the original value is needed, it will be included during a
+      // different loop pass.
+      if (memberExpression && parentIsHasOwnPropertyCall(memberExpression)) {
+        if (typeof replacementAt[key] !== 'object') {
+          replacementAt[key] = {};
+        }
+        // Can no longer consider this level a container, since we require
+        // its keys
+        containers.set(replacementAt[key], false);
+        for (const j in originalAt[key]) {
+          if (!(j in replacementAt[key])) {
+            replacementAt[key][j] = 0;
+          }
+        }
+      } else {
+        replacementAt[key] = originalAt[key];
+      }
+    }
+    /**
+     * Simplify containers so that the full schema is as shallow as possible.
+     * We update container's references to match these changes.
+     * 1. If the container is an object, convert it to an array.
+     * 2. If the container only has one item, replace the container with the
+     *    item.
+     * @param {any} value
+     * @return {any}
+     */
+    function simplifyContainers(value) {
+      const memberExpressions = containers.get(value);
+      if (!memberExpressions) {
+        return value;
+      }
+      const indices = {};
+      const array = [];
+      for (const memberExpression of memberExpressions) {
+        const property = memberExpression.get('property');
+        const key = evaluatePropertyKey(property);
+        const subValue = value[key];
+        if (indices[key] == null) {
+          indices[key] = array.length;
+          array.push(subValue);
+        }
+        memberExpression.node.computed = true;
+        memberExpression.node.property = t.numericLiteral(indices[key]);
+      }
+      if (array.length === 1) {
+        for (const memberExpression of memberExpressions) {
+          const object = memberExpression.get('object');
+          memberExpression.replaceWith(object);
+        }
+        return simplifyContainers(array[0]);
+      }
+      return array.map(simplifyContainers);
+    }
+    const simplified = JSON.parse(
+      JSON.stringify(replacement, (_, value) => {
+        return simplifyContainers(value);
+      })
+    );
+    init.replaceWith(t.valueToNode(simplified));
+  }
+
+  /**
+   * Prevents collisions with outer scope
+   * @param {babel.NodePath<babel.types.Program>} path
+   * @param {Set<string>|null} taken
+   * @param {string} id
+   */
+  function rescope(path, taken, id) {
+    if (!taken) {
+      return;
+    }
+    let renamed = id;
+    while (taken.has(renamed)) {
+      renamed = path.scope.generateUid(id);
+    }
+    if (renamed === id) {
+      return;
+    }
+    path.scope.rename(id, renamed);
+    if (id === name) {
+      name = renamed;
+    }
+  }
+
   /** @type {babel.PluginObj} */
   const plugin = {
     visitor: {
       Program: {
         exit(path) {
-          // Prevent collisions with outer scope
-          if (!scopeSet) {
-            return;
-          }
-          for (const binding in path.scope.bindings) {
-            let renamed = binding;
-            while (scopeSet.has(renamed)) {
-              renamed = path.scope.generateUid(binding);
-            }
-            if (renamed === binding) {
-              continue;
-            }
-            path.scope.rename(binding, renamed);
-            if (binding === name) {
-              name = renamed;
-            }
+          path.scope.crawl();
+          const taken = scope ? new Set(scope) : null;
+          for (const id in path.scope.bindings) {
+            treeShakeSchema(path.scope.bindings[id]);
+            rescope(path, taken, id);
           }
         },
       },
@@ -237,7 +464,7 @@ function transformAjvCode(code, scope, config) {
           path.replaceWith(instancePath.value);
           return;
         }
-        path.replaceWith(babel.template.expression.ast`
+        path.replaceWith(template.expression.ast`
           (${instancePath.value} + ' ' + ${message.value}).trim()
         `);
       },

--- a/build-system/compile/json-schema/index.js
+++ b/build-system/compile/json-schema/index.js
@@ -234,7 +234,7 @@ function transformAjvCode(code, taken, config) {
       return valueReferences[serial];
     }
     const name = path.scope.generateUid('schema');
-    path.getStatementParent()?.insertBefore(babel.template.statement.ast`
+    path.getStatementParent()?.insertBefore(template.statement.ast`
       const ${name} = ${t.valueToNode(value)};
     `);
     return (valueReferences[serial] = name);

--- a/build-system/compile/json-schema/index.js
+++ b/build-system/compile/json-schema/index.js
@@ -228,7 +228,7 @@ function transformAjvCode(code, taken, config) {
    * @param {any} value
    * @return {string}
    */
-  function getValueReference(statement, value) {
+  function getOrInsertValueReference(statement, value) {
     const serial = JSON.stringify(value);
     if (valueReferences[serial]) {
       return valueReferences[serial];
@@ -319,7 +319,7 @@ function transformAjvCode(code, taken, config) {
       if (parentIsHasOwnPropertyCall(memberExpression)) {
         value = Object.fromEntries(Object.keys(value).map((k) => [k, 0]));
       }
-      const name = getValueReference(statement, value);
+      const name = getOrInsertValueReference(statement, value);
       memberExpression.replaceWith(t.identifier(name));
     }
     path.remove();

--- a/build-system/compile/json-schema/index.js
+++ b/build-system/compile/json-schema/index.js
@@ -188,9 +188,13 @@ function transformAjvCode(code, taken, config) {
    */
   function evaluatePropertyKey(memberExpression) {
     const property = memberExpression.get('property');
-    return property.isIdentifier()
-      ? property.node.name
-      : property.evaluate().value;
+    if (property.isIdentifier()) {
+      return property.node.name;
+    }
+    if (memberExpression.node.computed) {
+      return property.evaluate().value;
+    }
+    return null;
   }
 
   const schemaIdRegexp = /^schema[0-9]*$/;
@@ -240,7 +244,10 @@ function transformAjvCode(code, taken, config) {
         parentPath.parentPath?.isCallExpression()
       );
     }
-    if (parentPath?.isCallExpression() && path.key === 0) {
+    if (
+      parentPath?.isCallExpression() &&
+      parentPath.node.arguments[0] === path.node
+    ) {
       const callee = parentPath.get('callee');
       return (
         isMemberExpressionLeftwards(callee, ['Object', 'keys']) ||


### PR DESCRIPTION
ajv's output may sometimes reference a part of the schema object, in which case the entire schema is included in the bundl.

This change follows the references made to each schema object, in order to only preserve the portions required. This is a big culprit of compiled size, since the schema varies in length and may include a lot of unnecessary information.