### PR TITLE
🏗🐛 Fix compiling JSON Schema in ES5

### DIFF
--- a/build-system/compile/json-schema/index.js
+++ b/build-system/compile/json-schema/index.js
@@ -243,7 +243,7 @@ function transformAjvCode(code, scope, config) {
       },
       ObjectPattern(path) {
         // Replace destructuring of arguments with {instancePath} with just
-        // instancePath
+        // the assignment or id for instancePath
         const replacedPath = path.parentPath.isAssignmentPattern()
           ? path.parentPath
           : path;
@@ -251,9 +251,9 @@ function transformAjvCode(code, scope, config) {
           return;
         }
         const {properties} = path.node;
-        const instancePath = findProperty(properties, 'instancePath');
-        if (instancePath) {
-          replacedPath.replaceWith(instancePath);
+        const value = findProperty(properties, 'instancePath')?.value;
+        if (t.isIdentifier(value) || t.isAssignmentPattern(value)) {
+          replacedPath.replaceWith(value);
         }
       },
     },


### PR DESCRIPTION
Fixes the following `esbuild` error:

```
error: Transforming default arguments to the configured target environment ("es5") is not supported yet
```

This would occur due to this part of the transform:

```diff
  function validate(
    data,
-   {
-     instancePath = '',
-     foo: 'bar',
-   }
+   instancePath = ''
  ) {}
```

When replacing the `ObjectPattern` with `instancePath = ''`, we were previously inserting the `ObjectProperty` rather than its child `AssignmentPattern`.

This would create a tree that _looked_ right when generated, but which Babel did not how to transpile into ES5. Tests aren't updated with this change because the string output is exactly the same.
