### PR TITLE
📖🐛 [amp story page attachment][amp story page outlink] add path metadata docs

### DIFF
--- a/extensions/amp-story-page-attachment/amp-story-page-attachment.md
+++ b/extensions/amp-story-page-attachment/amp-story-page-attachment.md
@@ -4,6 +4,18 @@ formats:
   - stories
 teaser:
   text: A panel of content that opens inline with an AMP story page.
+toc: true
+$title: amp-story-page-attachment
+version: '0.1'
+versions:
+  - '0.1'
+latest_version: '0.1'
+is_current: true
+$path: /documentation/components/amp-story-page-attachment.html
+$localization:
+  path: '/{locale}/documentation/components/amp-story-page-attachment.html'
+layouts:
+  - nodisplay  
 ---
 
 # amp-story-page-attachment

--- a/extensions/amp-story-page-attachment/amp-story-page-outlink.md
+++ b/extensions/amp-story-page-attachment/amp-story-page-outlink.md
@@ -4,6 +4,17 @@ formats:
   - stories
 teaser:
   text: A CTA button for opening external links with one tap in AMP story pages.
+$title: amp-story-page-outlink
+version: '0.1'
+versions:
+  - '0.1'
+latest_version: '0.1'
+is_current: true
+$path: /documentation/components/amp-story-page-outlink.html
+$localization:
+  path: '/{locale}/documentation/components/amp-story-page-outlink.html'
+layouts:
+  - nodisplay
 ---
 
 # amp-story-page-outlink


### PR DESCRIPTION
Adds missing metadata to outlink and attachment docs.
This example was taken from [amp-story-360 docs](https://github.com/ampproject/amphtml/blob/main/extensions/amp-story-360/0.1/amp-story-360.md?plain=1#L22) and may fix the docs [linking problem](https://amp.dev/documentation/components/amp-story-page-attachment/?format=stories).