### PR TITLE
add rtv path when fetching story languages json

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -2668,10 +2668,14 @@ export class AmpStory extends AMP.BaseElement {
   fetchLocalizationStrings_(languageCode) {
     const localizationService = getLocalizationService(this.element);
 
-    const localizationUrl = `${calculateScriptBaseUrl(
+    const base = calculateScriptBaseUrl(
       this.win.location,
       getMode(this.win).localDev
-    )}/v0/amp-story.${languageCode}.json`;
+    );
+    const rtvPath = getMode(this.win).localDev
+      ? ''
+      : `rtv/${getMode(this.win).rtvVersion}/`;
+    const localizationUrl = `${base}/${rtvPath}v0/amp-story.${languageCode}.json`;
 
     // The cache fallbacks to english if language not found, locally it errors.
     Services.xhrFor(this.win)

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -2087,7 +2087,7 @@ describes.realWin(
           toggleExperiment(env.win, 'story-remote-localization', false);
         });
 
-        it('should fetch the localization strings for the default laguage from the cdn', async () => {
+        it('should fetch the localization strings for the default language from the cdn', async () => {
           const fetchStub = env.sandbox
             .stub(Services.xhrFor(env.win), 'fetchJson')
             .resolves({
@@ -2097,12 +2097,12 @@ describes.realWin(
           await createStoryWithPages(1, ['cover']);
 
           expect(fetchStub).to.be.calledOnceWithExactly(
-            'https://cdn.ampproject.org/v0/amp-story.en.json',
+            'https://cdn.ampproject.org/rtv/123/v0/amp-story.en.json',
             env.sandbox.match.any
           );
         });
 
-        it('should fetch the localization strings for the document laguage from the cdn', async () => {
+        it('should fetch the localization strings for the document language from the cdn', async () => {
           env.win.document.body.parentElement.setAttribute('lang', 'es-419');
 
           const fetchStub = env.sandbox
@@ -2114,12 +2114,12 @@ describes.realWin(
           await createStoryWithPages(1, ['cover']);
 
           expect(fetchStub).to.have.been.calledOnceWithExactly(
-            'https://cdn.ampproject.org/v0/amp-story.es-419.json',
+            'https://cdn.ampproject.org/rtv/123/v0/amp-story.es-419.json',
             env.sandbox.match.any
           );
         });
 
-        it('should fetch the localization strings for the document laguage from the local dist if testing locally', async () => {
+        it('should fetch the localization strings for the document language from the local dist if testing locally', async () => {
           env.win.document.body.parentElement.setAttribute('lang', 'es-419');
           env.win.__AMP_MODE.localDev = true;
 


### PR DESCRIPTION
We want to lock the versioning of the json with the runtime version

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
