### PR TITLE
♻️ Refactor unoptimizable uses of `@enum` in `amp-story`

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.js
@@ -23,7 +23,7 @@ import {CSS as sharedCSS} from '../../../build/amp-story-auto-ads-shared-0.1.css
 import {getServicePromiseForDoc} from '../../../src/service-helpers';
 import {
   StateProperty,
-  UIType,
+  UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
 import {EventType, dispatch} from '../../amp-story/1.0/events';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
@@ -324,7 +324,7 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
   /**
    * Reacts to UI state updates and passes the information along as
    * attributes to the shadowed ad badge.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
@@ -333,10 +333,10 @@ export class AmpStoryAutoAds extends AMP.BaseElement {
       this.adBadgeContainer_.removeAttribute(DESKTOP_FULLBLEED);
       this.adBadgeContainer_.removeAttribute(DESKTOP_ONE_PANEL);
 
-      if (uiState === UIType.DESKTOP_FULLBLEED) {
+      if (uiState === UIType_Enum.DESKTOP_FULLBLEED) {
         this.adBadgeContainer_.setAttribute(DESKTOP_FULLBLEED, '');
       }
-      if (uiState === UIType.DESKTOP_ONE_PANEL) {
+      if (uiState === UIType_Enum.DESKTOP_ONE_PANEL) {
         this.adBadgeContainer_.setAttribute(DESKTOP_ONE_PANEL, '');
       }
     });

--- a/extensions/amp-story-auto-ads/0.1/story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-page.js
@@ -38,7 +38,7 @@ import {getServicePromiseForDoc} from '../../../src/service-helpers';
 import {assertConfig} from '../../amp-ad-exit/0.1/config';
 import {
   StateProperty,
-  UIType,
+  UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
 
 /** @const {string} */
@@ -499,7 +499,7 @@ export class StoryAdPage {
   /**
    * Reacts to UI state updates and passes the information along as
    * attributes to the shadowed attribution icon.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
@@ -509,7 +509,7 @@ export class StoryAdPage {
 
     this.adChoicesIcon_.classList.toggle(
       DESKTOP_FULLBLEED_CLASS,
-      uiState === UIType.DESKTOP_FULLBLEED
+      uiState === UIType_Enum.DESKTOP_FULLBLEED
     );
   }
 

--- a/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-amp-story-auto-ads.js
@@ -19,7 +19,7 @@ import {NavigationDirection} from '../../../amp-story/1.0/amp-story-page';
 import {
   Action,
   StateProperty,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from '../../../amp-story/1.0/amp-story-store-service';
 import * as storyEvents from '../../../amp-story/1.0/events';
@@ -348,11 +348,11 @@ describes.realWin(
         const adBadgeContainer = doc.querySelector(
           '.i-amphtml-ad-overlay-container'
         );
-        storeService.dispatch(Action.TOGGLE_UI, UIType.MOBILE);
+        storeService.dispatch(Action.TOGGLE_UI, UIType_Enum.MOBILE);
         expect(adBadgeContainer).not.to.have.attribute(
           Attributes.DESKTOP_ONE_PANEL
         );
-        storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_ONE_PANEL);
+        storeService.dispatch(Action.TOGGLE_UI, UIType_Enum.DESKTOP_ONE_PANEL);
         expect(adBadgeContainer).to.have.attribute(
           Attributes.DESKTOP_ONE_PANEL
         );

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-page.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-page.js
@@ -7,7 +7,7 @@ import * as openWindowDialog from '../../../../src/open-window-dialog';
 import * as service from '../../../../src/service-helpers';
 import {
   Action,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from '../../../amp-story/1.0/amp-story-store-service';
 import {StoryAdAnalytics} from '../story-ad-analytics';
@@ -389,7 +389,7 @@ describes.realWin('story-ad-page', {amp: true}, (env) => {
     });
 
     it('propagates fullbleed state to attribution icon', async () => {
-      storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_FULLBLEED);
+      storeService.dispatch(Action.TOGGLE_UI, UIType_Enum.DESKTOP_FULLBLEED);
 
       const iframe = doc.createElement('iframe');
       ampAdElement.appendChild(iframe);
@@ -407,10 +407,10 @@ describes.realWin('story-ad-page', {amp: true}, (env) => {
       const attribution = doc.querySelector('.i-amphtml-story-ad-attribution');
       expect(attribution).to.have.class('i-amphtml-story-ad-fullbleed');
 
-      storeService.dispatch(Action.TOGGLE_UI, UIType.MOBILE);
+      storeService.dispatch(Action.TOGGLE_UI, UIType_Enum.MOBILE);
       expect(attribution).not.to.have.class('i-amphtml-story-ad-fullbleed');
 
-      storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_FULLBLEED);
+      storeService.dispatch(Action.TOGGLE_UI, UIType_Enum.DESKTOP_FULLBLEED);
       expect(attribution).to.have.class('i-amphtml-story-ad-fullbleed');
     });
 

--- a/extensions/amp-story-education/0.1/amp-story-education.js
+++ b/extensions/amp-story-education/0.1/amp-story-education.js
@@ -17,7 +17,7 @@ import {
 import {
   Action,
   StateProperty,
-  UIType,
+  UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 
@@ -96,7 +96,7 @@ export class AmpStoryEducation extends AMP.BaseElement {
 
     this.viewer_ = Services.viewerForDoc(this.element);
     const isMobileUI =
-      this.storeService_.get(StateProperty.UI_STATE) === UIType.MOBILE;
+      this.storeService_.get(StateProperty.UI_STATE) === UIType_Enum.MOBILE;
     if (this.viewer_.isEmbedded() && isMobileUI) {
       const screen = this.viewer_.hasCapability('swipe')
         ? Screen.ONBOARDING_NAVIGATION_TAP_AND_SWIPE

--- a/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
@@ -18,7 +18,7 @@ import {CSS} from '../../../build/amp-story-draggable-drawer-header-0.1.css';
 import {
   Action,
   StateProperty,
-  UIType,
+  UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
 import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
 
@@ -242,11 +242,11 @@ export class DraggableDrawer extends AMP.BaseElement {
 
   /**
    * Reacts to UI state updates.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @protected
    */
   onUIStateUpdate_(uiState) {
-    const isMobile = uiState === UIType.MOBILE;
+    const isMobile = uiState === UIType_Enum.MOBILE;
     isMobile
       ? this.startListeningForTouchEvents_()
       : this.stopListeningForTouchEvents_();

--- a/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
@@ -29,7 +29,7 @@ import {getSourceOrigin} from '../../../src/url';
 import {
   Action,
   StateProperty,
-  UIType,
+  UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
 import {HistoryState, setHistoryState} from '../../amp-story/1.0/history';
 import {StoryAnalyticsEvent} from '../../amp-story/1.0/story-analytics';
@@ -464,7 +464,7 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
     };
 
     const isMobileUI =
-      this.storeService.get(StateProperty.UI_STATE) === UIType.MOBILE;
+      this.storeService.get(StateProperty.UI_STATE) === UIType_Enum.MOBILE;
     if (!isMobileUI) {
       programaticallyClickOnTarget();
     } else {

--- a/extensions/amp-story-page-attachment/0.1/test/test-amp-story-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/test/test-amp-story-page-attachment.js
@@ -9,7 +9,7 @@ import {LocalizationService} from '#service/localization';
 import {
   Action,
   AmpStoryStoreService,
-  UIType,
+  UIType_Enum,
 } from 'extensions/amp-story/1.0/amp-story-store-service';
 import {registerServiceBuilder} from 'src/service-helpers';
 
@@ -135,7 +135,7 @@ describes.realWin('amp-story-page-attachment', {amp: true}, (env) => {
   });
 
   it('should click on anchor when outlink open method is called', async () => {
-    storeService.dispatch(Action.TOGGLE_UI, UIType.DESKTOP_ONE_PANEL);
+    storeService.dispatch(Action.TOGGLE_UI, UIType_Enum.DESKTOP_ONE_PANEL);
     const anchorEl = outlinkEl.querySelector('amp-story-page-outlink a');
 
     const clickSpy = env.sandbox.spy(anchorEl, 'click');

--- a/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
+++ b/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
@@ -24,7 +24,7 @@ import {getAmpdoc} from '../../../src/service-helpers';
 import {
   Action,
   StateProperty,
-  UIType,
+  UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
 import {
   createShadowRootWithStyle,
@@ -158,12 +158,12 @@ export class AmpStoryShareMenu extends AMP.BaseElement {
 
   /**
    * Reacts to UI state updates and triggers the right UI.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
     this.vsync_.mutate(() => {
-      uiState !== UIType.MOBILE
+      uiState !== UIType_Enum.MOBILE
         ? this.rootEl_.setAttribute('desktop', '')
         : this.rootEl_.removeAttribute('desktop');
     });

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -12,7 +12,7 @@ import {
   EmbeddedComponentState,
   InteractiveComponentDef,
   StateProperty,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from './amp-story-store-service';
 import {EventType, dispatch} from './events';
@@ -387,17 +387,16 @@ export class AmpStoryEmbeddedComponent {
   /**
    * Reacts to desktop state updates and hides navigation buttons since we
    * already have in the desktop UI.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
     this.mutator_.mutateElement(
       dev().assertElement(this.focusedStateOverlay_),
       () => {
-        const isDesktop = [
-          UIType.DESKTOP_FULLBLEED,
-          UIType.DESKTOP_ONE_PANEL,
-        ].includes(uiState);
+        const isDesktop =
+          uiState === UIType_Enum.DESKTOP_FULLBLEED ||
+          uiState === UIType_Enum.DESKTOP_ONE_PANEL;
         toggleAttribute(this.focusedStateOverlay_, 'desktop', isDesktop);
       }
     );

--- a/extensions/amp-story/1.0/amp-story-hint.js
+++ b/extensions/amp-story/1.0/amp-story-hint.js
@@ -7,7 +7,7 @@ import {localizeTemplate} from './amp-story-localization-service';
 import {
   EmbeddedComponentState,
   StateProperty,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from './amp-story-store-service';
 import {createShadowRootWithStyle} from './utils';
@@ -148,7 +148,7 @@ export class AmpStoryHint {
    * @private
    */
   showHint_(hintClass) {
-    if (this.storeService_.get(StateProperty.UI_STATE) !== UIType.MOBILE) {
+    if (this.storeService_.get(StateProperty.UI_STATE) !== UIType_Enum.MOBILE) {
       return;
     }
 

--- a/extensions/amp-story/1.0/amp-story-page.js
+++ b/extensions/amp-story/1.0/amp-story-page.js
@@ -37,7 +37,7 @@ import {localizeTemplate} from './amp-story-localization-service';
 import {
   Action,
   StateProperty,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from './amp-story-store-service';
 import {AnimationManager, hasAnimations} from './animation';
@@ -553,12 +553,12 @@ export class AmpStoryPage extends AMP.BaseElement {
 
   /**
    * Reacts to UI state updates.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
     // On vertical rendering, render all the animations with their final state.
-    if (uiState === UIType.VERTICAL) {
+    if (uiState === UIType_Enum.VERTICAL) {
       this.maybeFinishAnimations_();
     }
   }

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -38,7 +38,7 @@ export const getStoreService = (win) => {
  * Different UI experiences to display the story.
  * @const @enum {number}
  */
-export const UIType = {
+export const UIType_Enum = {
   MOBILE: 0,
   DESKTOP_FULLBLEED: 2, // Desktop UI if landscape mode is enabled.
   DESKTOP_ONE_PANEL: 4, // Desktop UI with one panel and space around story.
@@ -137,7 +137,7 @@ export let ShoppingDataDef;
  *    storyHasPlaybackUiState: boolean,
  *    storyHasBackgroundAudioState: boolean,
  *    systemUiIsVisibleState: boolean,
- *    uiState: !UIType,
+ *    uiState: !UIType_Enum,
  *    viewportWarningState: boolean,
  *    actionsAllowlist: !Array<{tagOrTarget: string, method: string}>,
  *    consentId: ?string,
@@ -410,10 +410,10 @@ const actions = (state, action, data) => {
       });
     case Action.TOGGLE_UI:
       if (
-        state[StateProperty.UI_STATE] === UIType.VERTICAL &&
-        data !== UIType.VERTICAL
+        state[StateProperty.UI_STATE] === UIType_Enum.VERTICAL &&
+        data !== UIType_Enum.VERTICAL
       ) {
-        dev().error(TAG, 'Cannot switch away from UIType.VERTICAL');
+        dev().error(TAG, 'Cannot switch away from UIType_Enum.VERTICAL');
         return state;
       }
       return /** @type {!State} */ ({
@@ -596,7 +596,7 @@ export class AmpStoryStoreService {
       [StateProperty.STORY_HAS_BACKGROUND_AUDIO_STATE]: false,
       [StateProperty.STORY_HAS_PLAYBACK_UI_STATE]: false,
       [StateProperty.SYSTEM_UI_IS_VISIBLE_STATE]: true,
-      [StateProperty.UI_STATE]: UIType.MOBILE,
+      [StateProperty.UI_STATE]: UIType_Enum.MOBILE,
       // amp-story only allows actions on a case-by-case basis to preserve UX
       // behaviors. By default, no actions are allowed.
       [StateProperty.ACTIONS_ALLOWLIST]: [],

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -13,7 +13,7 @@ import {localizeTemplate} from './amp-story-localization-service';
 import {
   Action,
   StateProperty,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from './amp-story-store-service';
 import {AmpStoryViewerMessagingHandler} from './amp-story-viewer-messaging-handler';
@@ -656,7 +656,7 @@ export class SystemLayer {
   /**
    * Reacts to UI state updates and triggers the expected UI.
    * Called inside a mutate context if not initializing.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
@@ -667,11 +667,11 @@ export class SystemLayer {
     shadowRoot.removeAttribute('desktop');
 
     switch (uiState) {
-      case UIType.DESKTOP_FULLBLEED:
+      case UIType_Enum.DESKTOP_FULLBLEED:
         shadowRoot.setAttribute('desktop', '');
         shadowRoot.classList.add('i-amphtml-story-desktop-fullbleed');
         break;
-      case UIType.DESKTOP_ONE_PANEL:
+      case UIType_Enum.DESKTOP_ONE_PANEL:
         shadowRoot.classList.add('i-amphtml-story-desktop-one-panel');
         break;
     }

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -97,7 +97,7 @@ import {
   InteractiveComponentDef,
   StateProperty,
   SubscriptionsState,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from './amp-story-store-service';
 import {SystemLayer} from './amp-story-system-layer';
@@ -109,7 +109,7 @@ import {isPreviewMode} from './embed-mode';
 import {EventType, dispatch} from './events';
 import {HistoryState, getHistoryState, setHistoryState} from './history';
 import {LiveStoryManager} from './live-story-manager';
-import {MediaPool, MediaType} from './media-pool';
+import {MediaPool, MediaType_Enum} from './media-pool';
 import {AdvancementConfig, TapNavigationDirection} from './page-advancement';
 import {PaginationButtons} from './pagination-buttons';
 import {
@@ -186,8 +186,8 @@ const STORY_LOADED_CLASS_NAME = 'i-amphtml-story-loaded';
 
 /** @const {!Object<string, number>} */
 const MAX_MEDIA_ELEMENT_COUNTS = {
-  [MediaType.AUDIO]: 4,
-  [MediaType.VIDEO]: 8,
+  [MediaType_Enum.AUDIO]: 4,
+  [MediaType_Enum.VIDEO]: 8,
 };
 
 /**
@@ -310,7 +310,7 @@ export class AmpStory extends AMP.BaseElement {
     /** @private {?BackgroundBlur} */
     this.backgroundBlur_ = null;
 
-    /** @private {?UIType} */
+    /** @private {?UIType_Enum} */
     this.uiState_ = null;
 
     /** @private {boolean} whether the styles were rewritten */
@@ -746,7 +746,7 @@ export class AmpStory extends AMP.BaseElement {
 
     this.win.document.addEventListener('contextmenu', (e) => {
       const uiState = this.storeService_.get(StateProperty.UI_STATE);
-      if (uiState === UIType.MOBILE) {
+      if (uiState === UIType_Enum.MOBILE) {
         if (!this.allowContextMenuOnMobile_(e.target)) {
           e.preventDefault();
         }
@@ -1695,14 +1695,14 @@ export class AmpStory extends AMP.BaseElement {
 
   /**
    * Reacts to UI state updates.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
     this.backgroundBlur_?.detach();
     this.backgroundBlur_ = null;
     switch (uiState) {
-      case UIType.MOBILE:
+      case UIType_Enum.MOBILE:
         this.vsync_.mutate(() => {
           this.win.document.documentElement.setAttribute(
             'i-amphtml-story-mobile',
@@ -1713,7 +1713,7 @@ export class AmpStory extends AMP.BaseElement {
           this.element.classList.remove('i-amphtml-story-desktop-one-panel');
         });
         break;
-      case UIType.DESKTOP_ONE_PANEL:
+      case UIType_Enum.DESKTOP_ONE_PANEL:
         if (!this.backgroundBlur_) {
           this.backgroundBlur_ = new BackgroundBlur(this.win, this.element);
           this.backgroundBlur_.attach();
@@ -1731,7 +1731,7 @@ export class AmpStory extends AMP.BaseElement {
           this.element.classList.remove('i-amphtml-story-desktop-fullbleed');
         });
         break;
-      case UIType.DESKTOP_FULLBLEED:
+      case UIType_Enum.DESKTOP_FULLBLEED:
         this.vsync_.mutate(() => {
           this.win.document.documentElement.removeAttribute(
             'i-amphtml-story-mobile'
@@ -1743,7 +1743,7 @@ export class AmpStory extends AMP.BaseElement {
         break;
       // Because of the DOM mutations, switching from this mode to another is
       // not allowed, and prevented within the store service.
-      case UIType.VERTICAL:
+      case UIType_Enum.VERTICAL:
         const pageAttachments = scopedQuerySelectorAll(
           this.element,
           'amp-story-page amp-story-page-attachment'
@@ -1789,12 +1789,12 @@ export class AmpStory extends AMP.BaseElement {
 
   /**
    * Retrieves the UI type that should be used to view the story.
-   * @return {!UIType}
+   * @return {!UIType_Enum}
    * @private
    */
   getUIType_() {
     if (
-      this.uiState_ === UIType.MOBILE &&
+      this.uiState_ === UIType_Enum.MOBILE &&
       this.androidSoftKeyboardIsProbablyOpen_()
     ) {
       // The opening of the Android soft keyboard triggers a viewport resize
@@ -1802,23 +1802,23 @@ export class AmpStory extends AMP.BaseElement {
       // desktop. Here, we assume that the soft keyboard is open if the latest
       // UI state is mobile while an input element has focus, and we then
       // ensure that the UI type does not unintentionally alter.
-      return UIType.MOBILE;
+      return UIType_Enum.MOBILE;
     }
 
     if (this.platform_.isBot()) {
-      return UIType.VERTICAL;
+      return UIType_Enum.VERTICAL;
     }
 
     if (!this.isDesktop_()) {
-      return UIType.MOBILE;
+      return UIType_Enum.MOBILE;
     }
 
     if (this.isLandscapeSupported_()) {
-      return UIType.DESKTOP_FULLBLEED;
+      return UIType_Enum.DESKTOP_FULLBLEED;
     }
 
     // Desktop one panel UI (default).
-    return UIType.DESKTOP_ONE_PANEL;
+    return UIType_Enum.DESKTOP_ONE_PANEL;
   }
 
   /**
@@ -2203,13 +2203,13 @@ export class AmpStory extends AMP.BaseElement {
     }
 
     return {
-      [MediaType.AUDIO]: Math.min(
+      [MediaType_Enum.AUDIO]: Math.min(
         audioMediaElementsCount + MINIMUM_AD_MEDIA_ELEMENTS,
-        MAX_MEDIA_ELEMENT_COUNTS[MediaType.AUDIO]
+        MAX_MEDIA_ELEMENT_COUNTS[MediaType_Enum.AUDIO]
       ),
-      [MediaType.VIDEO]: Math.min(
+      [MediaType_Enum.VIDEO]: Math.min(
         videoMediaElementsCount + MINIMUM_AD_MEDIA_ELEMENTS,
-        MAX_MEDIA_ELEMENT_COUNTS[MediaType.VIDEO]
+        MAX_MEDIA_ELEMENT_COUNTS[MediaType_Enum.VIDEO]
       ),
     };
   }

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -232,12 +232,8 @@ export class MediaPool {
   initializeMediaPool_(maxCounts) {
     let poolIdCounter = 0;
 
-    this.forEachMediaType_((type) => {
-      const count = maxCounts[type] || 0;
-
-      if (count <= 0) {
-        return;
-      }
+    for (const type in maxCounts) {
+      const count = maxCounts[type];
 
       const ctor = devAssert(
         this.mediaFactory_[type],
@@ -267,7 +263,7 @@ export class MediaPool {
         mediaEl[MEDIA_ELEMENT_ORIGIN_PROPERTY_NAME] = MediaElementOrigin.POOL;
         this.unallocated[type].push(mediaEl);
       }
-    });
+    }
   }
 
   /**
@@ -600,15 +596,6 @@ export class MediaPool {
   }
 
   /**
-   * @param {function(string)} callbackFn
-   * @private
-   */
-  forEachMediaType_(callbackFn) {
-    callbackFn(MediaType_Enum.AUDIO);
-    callbackFn(MediaType_Enum.VIDEO);
-  }
-
-  /**
    * Preloads the content of the specified media element in the DOM and returns
    * a media element that can be used in its stead for playback.
    * @param {!DomElementDef} domMediaEl The media element, found in the
@@ -931,11 +918,12 @@ export class MediaPool {
 
     this.ampElementsToBless_ = null; // GC
 
-    const elements = [];
-    this.forEachMediaType_((type) => {
-      elements.push(...this.allocated[type]);
-      elements.push(...this.unallocated[type]);
-    });
+    const elements = [
+      ...this.allocated[MediaType_Enum.AUDIO],
+      ...this.unallocated[MediaType_Enum.VIDEO],
+      ...this.allocated[MediaType_Enum.AUDIO],
+      ...this.unallocated[MediaType_Enum.VIDEO],
+    ];
 
     const blessPromises = elements.map((element) => this.bless_(element));
     return Promise.all(blessPromises).then(

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -26,9 +26,9 @@ import {ampMediaElementFor} from './utils';
 
 import {userInteractedWith} from '../../../src/video-interface';
 
-/** @const @enum {string} */
-export const MediaType = {
-  UNSUPPORTED: 'unsupported',
+/** @const @enum {string|number} */
+export const MediaType_Enum = {
+  UNSUPPORTED: 0,
   AUDIO: 'audio',
   VIDEO: 'video',
 };
@@ -120,7 +120,7 @@ let nextInstanceId = 0;
 export class MediaPool {
   /**
    * @param {!Window} win The window object.
-   * @param {!Object<!MediaType, number>} maxCounts The maximum amount of each
+   * @param {!Object<!MediaType_Enum, number>} maxCounts The maximum amount of each
    *     media element that can be allocated by the pool.
    * @param {!ElementDistanceFnDef} distanceFn A function that, given an
    *     element, returns the distance of that element from the current position
@@ -143,14 +143,14 @@ export class MediaPool {
 
     /**
      * Holds all of the pool-bound media elements that have been allocated.
-     * @const {!Object<!MediaType, !Array<!PoolBoundElementDef>>}
+     * @const {!Object<!MediaType_Enum, !Array<!PoolBoundElementDef>>}
      * @visibleForTesting
      */
     this.allocated = {};
 
     /**
      * Holds all of the pool-bound media elements that have not been allocated.
-     * @const {!Object<!MediaType, !Array<!PoolBoundElementDef>>}
+     * @const {!Object<!MediaType_Enum, !Array<!PoolBoundElementDef>>}
      * @visibleForTesting
      */
     this.unallocated = {};
@@ -198,7 +198,7 @@ export class MediaPool {
 
     /** @const {!Object<string, (function(): !PoolBoundElementDef)>} */
     this.mediaFactory_ = {
-      [MediaType.AUDIO]: () => {
+      [MediaType_Enum.AUDIO]: () => {
         const audioEl = this.win_.document.createElement('audio');
         audioEl.setAttribute('muted', '');
         audioEl.muted = true;
@@ -206,7 +206,7 @@ export class MediaPool {
         audioEl.classList.add('i-amphtml-pool-audio');
         return audioEl;
       },
-      [MediaType.VIDEO]: () => {
+      [MediaType_Enum.VIDEO]: () => {
         const videoEl = this.win_.document.createElement('video');
         videoEl.setAttribute('muted', '');
         videoEl.muted = true;
@@ -225,15 +225,14 @@ export class MediaPool {
    * each of the types of media elements.  We need to create these eagerly so
    * that all media elements exist by the time that blessAll() is invoked,
    * thereby "blessing" all media elements for playback without user gesture.
-   * @param {!Object<!MediaType, number>} maxCounts The maximum amount of each
+   * @param {!Object<!MediaType_Enum, number>} maxCounts The maximum amount of each
    *     media element that can be allocated by the pool.
    * @private
    */
   initializeMediaPool_(maxCounts) {
     let poolIdCounter = 0;
 
-    this.forEachMediaType_((key) => {
-      const type = MediaType[key];
+    this.forEachMediaType_((type) => {
       const count = maxCounts[type] || 0;
 
       if (count <= 0) {
@@ -333,25 +332,25 @@ export class MediaPool {
    * Gets the media type from a given element.
    * @param {!PoolBoundElementDef|!PlaceholderElementDef} mediaElement The
    *     element whose media type should be retrieved.
-   * @return {!MediaType}
+   * @return {!MediaType_Enum}
    * @private
    */
   getMediaType_(mediaElement) {
     const tagName = mediaElement.tagName.toLowerCase();
     switch (tagName) {
       case 'audio':
-        return MediaType.AUDIO;
+        return MediaType_Enum.AUDIO;
       case 'video':
-        return MediaType.VIDEO;
+        return MediaType_Enum.VIDEO;
       default:
-        return MediaType.UNSUPPORTED;
+        return MediaType_Enum.UNSUPPORTED;
     }
   }
 
   /**
    * Reserves an element of the specified type by removing it from the set of
    * unallocated elements and returning it.
-   * @param {!MediaType} mediaType The type of media element to reserve.
+   * @param {!MediaType_Enum} mediaType The type of media element to reserve.
    * @return {?PoolBoundElementDef} The reserved element, if one exists.
    * @private
    */
@@ -362,7 +361,7 @@ export class MediaPool {
   /**
    * Retrieves the media element from the pool that matches the specified
    * element, if one exists.
-   * @param {!MediaType} mediaType The type of media element to get.
+   * @param {!MediaType_Enum} mediaType The type of media element to get.
    * @param {!DomElementDef} domMediaEl The element whose matching media
    *     element should be retrieved.
    * @return {?PoolBoundElementDef} The media element in the pool that
@@ -384,7 +383,7 @@ export class MediaPool {
 
   /**
    * Allocates the specified media element of the specified type.
-   * @param {!MediaType} mediaType The type of media element to allocate.
+   * @param {!MediaType_Enum} mediaType The type of media element to allocate.
    * @param {!PoolBoundElementDef} poolMediaEl The element to be allocated.
    * @private
    */
@@ -402,7 +401,7 @@ export class MediaPool {
   /**
    * Deallocates and returns the media element of the specified type furthest
    * from the current position in the document.
-   * @param {!MediaType} mediaType The type of media element to deallocate.
+   * @param {!MediaType_Enum} mediaType The type of media element to deallocate.
    * @param {!PlaceholderElementDef=} opt_elToAllocate If specified, the element
    *     that is trying to be allocated, such that another element must be
    *     evicted.
@@ -460,7 +459,7 @@ export class MediaPool {
   /**
    * Evicts an element of the specified type, replaces it in the DOM with the
    * original media element, and returns it.
-   * @param {!MediaType} mediaType The type of media element to evict.
+   * @param {!MediaType_Enum} mediaType The type of media element to evict.
    * @param {!PlaceholderElementDef=} opt_elToAllocate If specified, the element
    *     that is trying to be allocated, such that another element must be
    *     evicted.
@@ -481,7 +480,7 @@ export class MediaPool {
   }
 
   /**
-   * @param {!MediaType} mediaType The media type to check.
+   * @param {!MediaType_Enum} mediaType The media type to check.
    * @param {!DomElementDef} domMediaEl The element to check.
    * @return {boolean} true, if the specified element has already been allocated
    *     as the specified type of media element.
@@ -605,7 +604,8 @@ export class MediaPool {
    * @private
    */
   forEachMediaType_(callbackFn) {
-    Object.keys(MediaType).forEach(callbackFn);
+    callbackFn(MediaType_Enum.AUDIO);
+    callbackFn(MediaType_Enum.VIDEO);
   }
 
   /**
@@ -615,16 +615,10 @@ export class MediaPool {
    * @private
    */
   forEachMediaElement_(callbackFn) {
-    [this.allocated, this.unallocated].forEach((mediaSet) => {
-      this.forEachMediaType_((key) => {
-        const type = MediaType[key];
-        const els = /** @type {!Array} */ (mediaSet[type]);
-        if (!els) {
-          return;
-        }
-        els.forEach(callbackFn);
-      });
-    });
+    callbackFn(this.allocated[MediaType_Enum.AUDIO]);
+    callbackFn(this.allocated[MediaType_Enum.VIDEO]);
+    callbackFn(this.unallocated[MediaType_Enum.AUDIO]);
+    callbackFn(this.unallocated[MediaType_Enum.VIDEO]);
   }
 
   /**
@@ -891,7 +885,7 @@ export class MediaPool {
       return Promise.resolve();
     }
 
-    if (mediaType == MediaType.VIDEO) {
+    if (mediaType == MediaType_Enum.VIDEO) {
       const ampVideoEl = domMediaEl.parentElement;
       if (ampVideoEl) {
         if (ampVideoEl.hasAttribute('noaudio')) {
@@ -1071,7 +1065,7 @@ export class MediaPoolRoot {
   getElementDistance(unusedElement) {}
 
   /**
-   * @return {!Object<!MediaType, number>} The maximum amount of each media
+   * @return {!Object<!MediaType_Enum, number>} The maximum amount of each media
    *     type to allow within this element.
    */
   getMaxMediaElementCounts() {}

--- a/extensions/amp-story/1.0/page-advancement.js
+++ b/extensions/amp-story/1.0/page-advancement.js
@@ -13,7 +13,7 @@ import {
   EmbeddedComponentState,
   InteractiveComponentDef,
   StateProperty,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from './amp-story-store-service';
 import {AdvancementMode} from './story-analytics';
@@ -704,7 +704,7 @@ export class ManualAdvancement extends AdvancementConfig {
   }
 
   /**
-   * Calculates the pageRect based on the UIType.
+   * Calculates the pageRect based on the UIType_Enum.
    * We can an use LayoutBox for mobile since the story page occupies entire screen.
    * Desktop UI needs the most recent value from the getBoundingClientRect function.
    * @return {DOMRect | LayoutBox}
@@ -712,7 +712,7 @@ export class ManualAdvancement extends AdvancementConfig {
    */
   getStoryPageRect_() {
     const uiState = this.storeService_.get(StateProperty.UI_STATE);
-    if (uiState !== UIType.DESKTOP_ONE_PANEL) {
+    if (uiState !== UIType_Enum.DESKTOP_ONE_PANEL) {
       return this.element_.getLayoutBox();
     } else {
       return this.element_

--- a/extensions/amp-story/1.0/pagination-buttons.js
+++ b/extensions/amp-story/1.0/pagination-buttons.js
@@ -18,28 +18,32 @@ import {AdvancementMode} from './story-analytics';
 /** @struct @typedef {{className: string, triggers: string, label: LocalizedStringId_Enum}} */
 let PaginationButtonStateDef;
 
-/** @const {!Object<string, !PaginationButtonStateDef>} */
-const ButtonStates = {
-  PREVIOUS_PAGE: {
-    className: 'i-amphtml-story-back-prev',
-    triggers: EventType.PREVIOUS_PAGE,
-    label: LocalizedStringId_Enum.AMP_STORY_PREVIOUS_PAGE,
-  },
-  NEXT_PAGE: {
-    className: 'i-amphtml-story-fwd-next',
-    triggers: EventType.NEXT_PAGE,
-    label: LocalizedStringId_Enum.AMP_STORY_NEXT_PAGE,
-  },
-  NEXT_STORY: {
-    className: 'i-amphtml-story-fwd-next',
-    triggers: EventType.NEXT_PAGE,
-    label: LocalizedStringId_Enum.AMP_STORY_NEXT_STORY,
-  },
-  REPLAY: {
-    className: 'i-amphtml-story-fwd-replay',
-    triggers: EventType.REPLAY,
-    label: LocalizedStringId_Enum.AMP_STORY_REPLAY,
-  },
+/** @const {PaginationButtonStateDef} */
+const BUTTON_STATE_PREVIOUS_PAGE = {
+  className: 'i-amphtml-story-back-prev',
+  triggers: EventType.PREVIOUS_PAGE,
+  label: LocalizedStringId_Enum.AMP_STORY_PREVIOUS_PAGE,
+};
+
+/** @const {PaginationButtonStateDef} */
+const BUTTON_STATE_NEXT_PAGE = {
+  className: 'i-amphtml-story-fwd-next',
+  triggers: EventType.NEXT_PAGE,
+  label: LocalizedStringId_Enum.AMP_STORY_NEXT_PAGE,
+};
+
+/** @const {PaginationButtonStateDef} */
+const BUTTON_STATE_NEXT_STORY = {
+  className: 'i-amphtml-story-fwd-next',
+  triggers: EventType.NEXT_PAGE,
+  label: LocalizedStringId_Enum.AMP_STORY_NEXT_STORY,
+};
+
+/** @const {PaginationButtonStateDef} */
+const BUTTON_STATE_REPLAY = {
+  className: 'i-amphtml-story-fwd-replay',
+  triggers: EventType.REPLAY,
+  label: LocalizedStringId_Enum.AMP_STORY_REPLAY,
 };
 
 /**
@@ -174,7 +178,7 @@ export class PaginationButtons {
     /** @private @const {!PaginationButton} */
     this.forwardButton_ = new PaginationButton(
       doc,
-      ButtonStates.NEXT_PAGE,
+      BUTTON_STATE_NEXT_PAGE,
       this.storeService_,
       win
     );
@@ -182,7 +186,7 @@ export class PaginationButtons {
     /** @private @const {!PaginationButton} */
     this.backButton_ = new PaginationButton(
       doc,
-      ButtonStates.PREVIOUS_PAGE,
+      BUTTON_STATE_PREVIOUS_PAGE,
       this.storeService_,
       win
     );
@@ -233,13 +237,13 @@ export class PaginationButtons {
     this.backButton_.setEnabled(pageIndex > 0);
 
     if (pageIndex < totalPages - 1) {
-      this.forwardButton_.updateState(ButtonStates.NEXT_PAGE);
+      this.forwardButton_.updateState(BUTTON_STATE_NEXT_PAGE);
     } else {
       const viewer = Services.viewerForDoc(this.ampStory_.element);
       if (viewer.hasCapability('swipe')) {
-        this.forwardButton_.updateState(ButtonStates.NEXT_STORY);
+        this.forwardButton_.updateState(BUTTON_STATE_NEXT_STORY);
       } else {
-        this.forwardButton_.updateState(ButtonStates.REPLAY);
+        this.forwardButton_.updateState(BUTTON_STATE_REPLAY);
       }
     }
   }

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -14,7 +14,7 @@ import {isExperimentOn} from 'src/experiments';
 
 import {
   StateProperty,
-  UIType,
+  UIType_Enum,
   getStoreService,
 } from './amp-story-store-service';
 import {EventType} from './events';
@@ -395,16 +395,16 @@ export class ProgressBar {
 
   /**
    * Reacts to UI state updates.
-   * @param {!UIType} uiState
+   * @param {!UIType_Enum} uiState
    * @private
    */
   onUIStateUpdate_(uiState) {
     switch (uiState) {
-      case UIType.DESKTOP_FULLBLEED:
+      case UIType_Enum.DESKTOP_FULLBLEED:
         MAX_SEGMENTS = 70;
         ELLIPSE_WIDTH_PX = 3;
         break;
-      case UIType.MOBILE:
+      case UIType_Enum.MOBILE:
         MAX_SEGMENTS = 20;
         ELLIPSE_WIDTH_PX = 2;
         break;

--- a/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-grid-layer.js
@@ -8,7 +8,7 @@ import {registerServiceBuilder} from '../../../../src/service-helpers';
 import {AmpStoryGridLayer} from '../amp-story-grid-layer';
 import {AmpStoryPage} from '../amp-story-page';
 import {Action, AmpStoryStoreService} from '../amp-story-store-service';
-import {MediaType} from '../media-pool';
+import {MediaType_Enum} from '../media-pool';
 
 describes.realWin('amp-story-grid-layer', {amp: true}, (env) => {
   let win;
@@ -28,8 +28,8 @@ describes.realWin('amp-story-grid-layer', {amp: true}, (env) => {
     const mediaPoolRoot = {
       getElement: () => win.document.createElement('div'),
       getMaxMediaElementCounts: () => ({
-        [MediaType.VIDEO]: 8,
-        [MediaType.AUDIO]: 8,
+        [MediaType_Enum.VIDEO]: 8,
+        [MediaType_Enum.AUDIO]: 8,
       }),
     };
 

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -19,7 +19,7 @@ import {AmpAudio} from '../../../amp-audio/0.1/amp-audio';
 import LocalizedStringsEn from '../_locales/en.json' assert {type: 'json'}; // lgtm[js/syntax-error]
 import {AmpStoryPage, PageState, Selectors} from '../amp-story-page';
 import {Action, AmpStoryStoreService} from '../amp-story-store-service';
-import {MediaType} from '../media-pool';
+import {MediaType_Enum} from '../media-pool';
 
 const extensions = ['amp-story:1.0', 'amp-audio'];
 
@@ -43,8 +43,8 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     const mediaPoolRoot = {
       getElement: () => win.document.createElement('div'),
       getMaxMediaElementCounts: () => ({
-        [MediaType.VIDEO]: 8,
-        [MediaType.AUDIO]: 8,
+        [MediaType_Enum.VIDEO]: 8,
+        [MediaType_Enum.AUDIO]: 8,
       }),
     };
 

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -29,7 +29,7 @@ import {
   AmpStoryStoreService,
   StateProperty,
   SubscriptionsState,
-  UIType,
+  UIType_Enum,
 } from '../amp-story-store-service';
 import {EventType, dispatch} from '../events';
 import {MediaType_Enum} from '../media-pool';
@@ -349,7 +349,7 @@ describes.realWin(
 
       await story.layoutCallback();
       expect(story.storeService_.get(StateProperty.UI_STATE)).to.equals(
-        UIType.DESKTOP_ONE_PANEL
+        UIType_Enum.DESKTOP_ONE_PANEL
       );
     });
 
@@ -364,7 +364,7 @@ describes.realWin(
 
       await story.layoutCallback();
       expect(story.storeService_.get(StateProperty.UI_STATE)).to.equals(
-        UIType.DESKTOP_FULLBLEED
+        UIType_Enum.DESKTOP_FULLBLEED
       );
     });
 
@@ -1226,7 +1226,7 @@ describes.realWin(
 
         const dispatchSwipeEvent = (deltaX, deltaY) => {
           // Triggers mobile UI so hint overlay can attach.
-          story.storeService_.dispatch(Action.TOGGLE_UI, UIType.MOBILE);
+          story.storeService_.dispatch(Action.TOGGLE_UI, UIType_Enum.MOBILE);
 
           story.element.dispatchEvent(
             new TouchEvent('touchstart', getTouchOptions(-10, -10))

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -32,7 +32,7 @@ import {
   UIType,
 } from '../amp-story-store-service';
 import {EventType, dispatch} from '../events';
-import {MediaType} from '../media-pool';
+import {MediaType_Enum} from '../media-pool';
 import {AdvancementMode} from '../story-analytics';
 import * as utils from '../utils';
 
@@ -978,8 +978,8 @@ describes.realWin(
 
           await story.layoutCallback();
           const expected = {
-            [MediaType.AUDIO]: 2,
-            [MediaType.VIDEO]: 2,
+            [MediaType_Enum.AUDIO]: 2,
+            [MediaType_Enum.VIDEO]: 2,
           };
           expect(story.getMaxMediaElementCounts()).to.deep.equal(expected);
         });
@@ -998,8 +998,8 @@ describes.realWin(
           story.element.appendChild(ampAudoEl);
 
           const expected = {
-            [MediaType.AUDIO]: 3,
-            [MediaType.VIDEO]: 3,
+            [MediaType_Enum.AUDIO]: 3,
+            [MediaType_Enum.VIDEO]: 3,
           };
           expect(story.getMaxMediaElementCounts()).to.deep.equal(expected);
         });
@@ -1021,8 +1021,8 @@ describes.realWin(
           }
 
           const expected = {
-            [MediaType.AUDIO]: 4,
-            [MediaType.VIDEO]: 8,
+            [MediaType_Enum.AUDIO]: 4,
+            [MediaType_Enum.VIDEO]: 8,
           };
           expect(story.getMaxMediaElementCounts()).to.deep.equal(expected);
         });

--- a/extensions/amp-story/1.0/test/test-media-pool.js
+++ b/extensions/amp-story/1.0/test/test-media-pool.js
@@ -2,7 +2,7 @@ import {findIndex} from '#core/types/array';
 
 import {Services} from '#service';
 
-import {MediaPool, MediaType} from '../media-pool';
+import {MediaPool, MediaType_Enum} from '../media-pool';
 
 const NOOP = () => {};
 
@@ -11,8 +11,8 @@ describes.realWin('media-pool', {}, (env) => {
   let mediaPool;
   let distanceFnStub;
   const COUNTS = {
-    [MediaType.AUDIO]: 2,
-    [MediaType.VIDEO]: 2,
+    [MediaType_Enum.AUDIO]: 2,
+    [MediaType_Enum.VIDEO]: 2,
   };
 
   beforeEach(() => {


### PR DESCRIPTION
Updates some `enums` in `amp-story` so that their values are inlined, removing their keys. This reduces compressed size by ~0.20kb.