### PR TITLE
🐛[amp-ad smartadserver] Removes duplicate calls

### DIFF
--- a/extensions/amp-ad-network-smartadserver-impl/0.1/amp-ad-network-smartadserver-impl.js
+++ b/extensions/amp-ad-network-smartadserver-impl/0.1/amp-ad-network-smartadserver-impl.js
@@ -122,6 +122,11 @@ export class AmpAdNetworkSmartadserverImpl extends AmpA4A {
   }
 
   /** @override */
+  isXhrAllowed() {
+    return false;
+  }
+
+  /** @override */
   sendXhrRequest(adUrl) {
     return super.sendXhrRequest(adUrl).then((response) => {
       return response.text().then((responseText) => {

--- a/extensions/amp-ad-network-smartadserver-impl/0.1/test/test-amp-ad-network-smartadserver-impl.js
+++ b/extensions/amp-ad-network-smartadserver-impl/0.1/test/test-amp-ad-network-smartadserver-impl.js
@@ -62,6 +62,16 @@ describes.realWin('amp-ad-network-smartadserver-impl', realWinConfig, (env) => {
     });
   });
 
+  describe('isXhrAllowed', () => {
+    it('should be not allowed', async () => {
+      impl = new AmpAdNetworkSmartadserverImpl(
+        createElementWithAttributes(doc, 'amp-ad', {})
+      );
+
+      expect(impl.isXhrAllowed()).to.be.false;
+    });
+  });
+
   describe('getCustomRealTimeConfigMacros', () => {
     it('should return correct macros', () => {
       const macros = {


### PR DESCRIPTION
The change blocks XHR calls that duplicate iframe source requests. Currently, the extension sends two similar calls but the XHR one is useless.