### PR TITLE
🐛 stop formatting npm imports as local modules

### DIFF
--- a/build-system/compile/bento-remap.js
+++ b/build-system/compile/bento-remap.js
@@ -100,7 +100,7 @@ const getAllRemappings = once(() => {
           return {
             source: resolved,
             cdn: formatPathLikeSource(cdn),
-            npm: formatPathLikeSource(npm),
+            npm,
           };
         }
       })


### PR DESCRIPTION
There's currently a bug that produces bundles with malformed imports - they import npm modules with a `./` prefix (ie. `import {..} from "./@bentoproject/core"`)

this fixes that

 <!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
