### PR TITLE
♻️🚀 `amp-story`: Use `Services.urlForDoc` instead of util functions

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/test/test-algorithm-count-pages.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-algorithm-count-pages.js
@@ -1,3 +1,5 @@
+import {Services} from '#service';
+
 import {macroTask} from '#testing/helpers';
 
 import {AmpStory} from '../../../amp-story/1.0/amp-story';
@@ -13,6 +15,8 @@ describes.realWin('CountPagesAlgorithm', {amp: true}, (env) => {
   let pageManager;
 
   beforeEach(() => {
+    const ampdocService = Services.ampdocServiceFor(env.win);
+    env.sandbox.stub(ampdocService, 'getAmpDoc').returns(env.ampdoc);
     storeService = getStoreService(env.win);
     const storyElement = env.win.document.createElement('amp-story');
     const ampStory = new AmpStory(storyElement);

--- a/extensions/amp-story-auto-ads/0.1/test/test-algorithm-predetermined.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-algorithm-predetermined.js
@@ -1,5 +1,7 @@
 import {StoryAdPlacements} from '#experiments/story-ad-placements';
 
+import {Services} from '#service';
+
 import {AmpStory} from '../../../amp-story/1.0/amp-story';
 import {
   Action,
@@ -17,6 +19,8 @@ describes.realWin('PredeterminedPositionAlgorithm', {amp: true}, (env) => {
   let pageManager;
 
   beforeEach(() => {
+    const ampdocService = Services.ampdocServiceFor(env.win);
+    env.sandbox.stub(ampdocService, 'getAmpDoc').returns(env.ampdoc);
     storeService = getStoreService(env.win);
     const storyElement = env.win.document.createElement('amp-story');
     const ampStory = new AmpStory(storyElement);

--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
@@ -22,11 +22,7 @@ import {deduplicateInteractiveIds} from './utils';
 
 import {CSS as hostCss} from '../../../build/amp-story-interactive-host-0.1.css';
 import {CSS as shadowCss} from '../../../build/amp-story-interactive-shadow-0.1.css';
-import {
-  addParamsToUrl,
-  appendPathToUrl,
-  assertAbsoluteHttpOrHttpsUrl,
-} from '../../../src/url';
+import {addParamsToUrl, appendPathToUrl} from '../../../src/url';
 import {
   Action,
   StateProperty,
@@ -710,7 +706,7 @@ export class AmpStoryInteractive extends AMP.BaseElement {
    */
   executeInteractiveRequest_(method, optionSelected = undefined) {
     let url = this.element.getAttribute('endpoint');
-    if (!assertAbsoluteHttpOrHttpsUrl(url)) {
+    if (!Services.urlForDoc(this.element).assertAbsoluteHttpOrHttpsUrl(url)) {
       return Promise.reject(ENDPOINT_INVALID_ERROR);
     }
 

--- a/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-page-attachment.js
@@ -25,7 +25,6 @@ import {
 
 import {CSS as pageAttachmentCss} from '../../../build/amp-story-open-page-attachment-0.1.css';
 import {CSS} from '../../../build/amp-story-page-attachment-0.1.css';
-import {getSourceOrigin} from '../../../src/url';
 import {
   Action,
   StateProperty,
@@ -605,7 +604,9 @@ export class AmpStoryPageAttachment extends DraggableDrawer {
    * @private
    */
   getPublisherOrigin_() {
-    const publisherOrigin = getSourceOrigin(this.getAmpDoc().getUrl());
+    const urlService = Services.urlForDoc(this.element);
+    const url = this.getAmpDoc().getUrl();
+    const publisherOrigin = urlService.getSourceOrigin(url);
     return publisherOrigin.replace(/^http(s)?:\/\/(www.)?/, '');
   }
 }

--- a/extensions/amp-story/1.0/amp-story-consent.js
+++ b/extensions/amp-story/1.0/amp-story-consent.js
@@ -28,12 +28,12 @@ import {
 import {
   createShadowRootWithStyle,
   getRGBFromCssColorValue,
+  getStoryAttributeSrc,
   getTextColorForRGB,
   triggerClickFromLightDom,
 } from './utils';
 
 import {CSS} from '../../../build/amp-story-consent-1.0.css';
-import {assertAbsoluteHttpOrHttpsUrl, assertHttpsUrl} from '../../../src/url';
 
 /** @const {string} */
 const TAG = 'amp-story-consent';
@@ -145,9 +145,6 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     this.assertAndParseConfig_();
 
-    const storyEl = dev().assertElement(
-      closestAncestorElementBySelector(this.element, 'AMP-STORY')
-    );
     const consentEl = closestAncestorElementBySelector(
       this.element,
       'AMP-CONSENT'
@@ -156,16 +153,11 @@ export class AmpStoryConsent extends AMP.BaseElement {
 
     this.storeConsentId_(consentId);
 
-    const logoSrc = storyEl && storyEl.getAttribute('publisher-logo-src');
-
-    if (logoSrc) {
-      assertHttpsUrl(logoSrc, storyEl, 'publisher-logo-src');
-    } else {
-      user().warn(
-        TAG,
-        'Expected "publisher-logo-src" attribute on <amp-story>'
-      );
-    }
+    const logoSrc = getStoryAttributeSrc(
+      this.element,
+      'publisher-logo-src',
+      /* warn */ true
+    );
 
     // Story consent config is set by the `assertAndParseConfig_` method.
     if (this.storyConsentConfig_) {
@@ -317,7 +309,9 @@ export class AmpStoryConsent extends AMP.BaseElement {
         this.storyConsentConfig_.externalLink.href,
         `${TAG}: config requires "externalLink.href" to be an absolute URL`
       );
-      assertAbsoluteHttpOrHttpsUrl(this.storyConsentConfig_.externalLink.href);
+      Services.urlForDoc(this.element).assertAbsoluteHttpOrHttpsUrl(
+        this.storyConsentConfig_.externalLink.href
+      );
     }
   }
 

--- a/extensions/amp-story/1.0/amp-story-embedded-component.js
+++ b/extensions/amp-story/1.0/amp-story-embedded-component.js
@@ -29,7 +29,6 @@ import {
 
 import {CSS} from '../../../build/amp-story-tooltip-1.0.css';
 import {getAmpdoc} from '../../../src/service-helpers';
-import {isProtocolValid, parseUrlDeprecated} from '../../../src/url';
 
 /** @private @const {string} */
 const LAUNCH_ICON_CLASS = 'i-amphtml-tooltip-action-icon-launch';
@@ -158,6 +157,9 @@ export class AmpStoryEmbeddedComponent {
 
     /** @private {!Element} */
     this.storyEl_ = storyEl;
+
+    /** @private @const {../../../src/service/url-impl.js.Url} */
+    this.urlService_ = Services.urlForDoc(storyEl);
 
     /** @private {?Element} */
     this.shadowRoot_ = null;
@@ -455,12 +457,12 @@ export class AmpStoryEmbeddedComponent {
       );
     }
     const elUrl = target.getAttribute('href');
-    if (!isProtocolValid(elUrl)) {
+    if (!this.urlService_.isProtocolValid(elUrl)) {
       user().error(TAG, 'The tooltip url is invalid');
       return '';
     }
 
-    return parseUrlDeprecated(elUrl).href;
+    return this.urlService_.parse(elUrl).href;
   }
 
   /**
@@ -518,7 +520,7 @@ export class AmpStoryEmbeddedComponent {
    */
   updateTooltipComponentIcon_(target, embedConfig) {
     const iconUrl = target.getAttribute('data-tooltip-icon');
-    if (!isProtocolValid(iconUrl)) {
+    if (!this.urlService_.isProtocolValid(iconUrl)) {
       user().error(TAG, 'The tooltip icon url is invalid');
       return;
     }
@@ -538,8 +540,9 @@ export class AmpStoryEmbeddedComponent {
       this.mutator_.mutateElement(
         dev().assertElement(tooltipCustomIcon),
         () => {
+          const {href} = this.urlService_.parse(iconUrl);
           setImportantStyles(dev().assertElement(tooltipCustomIcon), {
-            'background-image': `url(${parseUrlDeprecated(iconUrl).href})`,
+            'background-image': `url(${href})`,
           });
         }
       );

--- a/extensions/amp-story/1.0/amp-story-info-dialog.js
+++ b/extensions/amp-story/1.0/amp-story-info-dialog.js
@@ -20,7 +20,6 @@ import {
 import {createShadowRootWithStyle, triggerClickFromLightDom} from './utils';
 
 import {CSS} from '../../../build/amp-story-info-dialog-1.0.css';
-import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
 
 /** @const {string} Class to toggle the info dialog. */
 export const DIALOG_VISIBLE_CLASS = 'i-amphtml-story-info-dialog-visible';
@@ -197,7 +196,9 @@ export class InfoDialog {
         if (!moreInfoUrl) {
           return null;
         }
-        return assertAbsoluteHttpOrHttpsUrl(dev().assertString(moreInfoUrl));
+        return Services.urlForDoc(this.parentEl_).assertAbsoluteHttpOrHttpsUrl(
+          dev().assertString(moreInfoUrl)
+        );
       });
   }
 }

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -27,7 +27,6 @@ import {
 
 import {CSS} from '../../../build/amp-story-system-layer-1.0.css';
 import {AMP_STORY_PLAYER_EVENT} from '../../../src/amp-story-player/event';
-import {getSourceOrigin} from '../../../src/url';
 
 /** @private @const {string} */
 const AD_SHOWING_ATTRIBUTE = 'ad-showing';
@@ -340,7 +339,9 @@ export class SystemLayer {
 
     anchorEl.href =
       getStoryAttributeSrc(this.parentEl_, 'entity-url') ||
-      getSourceOrigin(Services.documentInfoForDoc(this.parentEl_).sourceUrl);
+      Services.urlForDoc(this.parentEl_).getSourceOrigin(
+        Services.documentInfoForDoc(this.parentEl_).sourceUrl
+      );
 
     this.systemLayerEl_.querySelector(
       '.i-amphtml-story-attribution-text'

--- a/extensions/amp-story/1.0/request-utils.js
+++ b/extensions/amp-story/1.0/request-utils.js
@@ -9,8 +9,6 @@ import {Services} from '#service';
 
 import {user, userAssert} from '#utils/log';
 
-import {isProtocolValid} from '../../../src/url';
-
 /** @private @const {string} */
 export const CONFIG_SRC_ATTRIBUTE_NAME = 'src';
 
@@ -26,7 +24,7 @@ const TAG = 'request-utils';
  * @return {(!Promise<!JsonObject>|!Promise<null>)}
  */
 export function executeRequest(el, rawUrl, opts = {}) {
-  if (!isProtocolValid(rawUrl)) {
+  if (!Services.urlForDoc(el).isProtocolValid(rawUrl)) {
     user().error(TAG, 'Invalid config url.');
     return Promise.resolve(null);
   }

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -206,12 +206,14 @@ export function userAssertValidProtocol(element, url) {
  */
 export function getSourceOriginForElement(element, url) {
   const urlService = Services.urlForDoc(element);
+  let parsed;
   try {
-    url = urlService.getSourceOrigin(url);
+    parsed = urlService.parse(urlService.getSourceOrigin(url));
   } catch (_) {
     // Unknown path prefix in url.
+    parsed = urlService.parse(url);
   }
-  return urlService.parse(url).hostname;
+  return parsed.hostname;
 }
 
 /**
@@ -239,32 +241,17 @@ export function getStoryAttributeSrc(element, attribute, warn) {
   const storyEl = dev().assertElement(
     closestAncestorElementBySelector(element, 'AMP-STORY')
   );
-  return getAttributeUrl(storyEl, attribute, warn);
-}
-
-/**
- *
- * @param {Element} element
- * @param {string} attribute
- * @param {boolean=} warn
- * @return {?string}
- */
-export function getAttributeUrl(element, attribute, warn) {
-  const attrSrc = element.getAttribute(attribute);
-  if (!attrSrc) {
+  const url = storyEl.getAttribute(attribute);
+  if (!url) {
     if (warn) {
       user().warn(
         'AMP-STORY',
-        `Expected ${attribute} attribute on <${element.localName}>`
+        `Expected ${attribute} attribute on <amp-story>`
       );
     }
     return null;
   }
-  return Services.urlForDoc(element).assertHttpsUrl(
-    attrSrc,
-    element,
-    attribute
-  );
+  return Services.urlForDoc(storyEl).assertHttpsUrl(url, storyEl, attribute);
 }
 
 /**

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -13,7 +13,6 @@ import {StateProperty} from './amp-story-store-service';
 
 import {getMode} from '../../../src/mode';
 import {createShadowRoot} from '../../../src/shadow-embed';
-import {assertHttpsUrl} from '../../../src/url';
 
 /**
  * Returns millis as number if given a string(e.g. 1s, 200ms etc)


### PR DESCRIPTION
Since the service is provided by the runtime, using it prevents us from including duplicate util implementations in the `amp-story` bundle. 

This reduces the size of `amp-story-1.0` by `0.41kB` in ESM and `0.82kB` (!!!) in nomodule.