### PR TITLE
🏗🚀 Disable `@babel/plugin-transform-for-of`

### DIFF
--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -71,7 +71,7 @@ function getMinifiedConfig(buildFor = 'preact') {
       modules: false,
       targets: argv.esm || argv.sxg ? {esmodules: true} : {ie: 11, chrome: 41},
       shippedProposals: true,
-      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : null,
+      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : [],
     },
   ];
   const presetTypescript = [

--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -60,7 +60,6 @@ function getMinifiedConfig(buildFor = 'preact') {
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
       BUILD_CONSTANTS,
     ],
-    ['@babel/plugin-transform-for-of', {loose: true, allowArrayLike: true}],
   ].filter(Boolean);
   const presetEnv = [
     '@babel/preset-env',
@@ -69,6 +68,7 @@ function getMinifiedConfig(buildFor = 'preact') {
       modules: false,
       targets: argv.esm || argv.sxg ? {esmodules: true} : {ie: 11, chrome: 41},
       shippedProposals: true,
+      exclude: ['@babel/plugin-transform-for-of'],
     },
   ];
   const presetTypescript = [

--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -60,6 +60,9 @@ function getMinifiedConfig(buildFor = 'preact') {
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
       BUILD_CONSTANTS,
     ],
+    !(argv.esm || argv.sxg)
+      ? ['@babel/plugin-transform-for-of', {loose: true, allowArrayLike: true}]
+      : null,
   ].filter(Boolean);
   const presetEnv = [
     '@babel/preset-env',
@@ -68,7 +71,7 @@ function getMinifiedConfig(buildFor = 'preact') {
       modules: false,
       targets: argv.esm || argv.sxg ? {esmodules: true} : {ie: 11, chrome: 41},
       shippedProposals: true,
-      exclude: ['@babel/plugin-transform-for-of'],
+      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : null,
     },
   ];
   const presetTypescript = [

--- a/build-system/babel-config/minified-config.js
+++ b/build-system/babel-config/minified-config.js
@@ -12,6 +12,7 @@ const {getReplacePlugin} = require('./helpers');
  * @return {!Object}
  */
 function getMinifiedConfig(buildFor = 'preact') {
+  const isEsmBuild = argv.esm || argv.sxg;
   const isProd = argv._.includes('dist') && !argv.fortesting;
 
   const reactJsxPlugin = [
@@ -38,7 +39,7 @@ function getMinifiedConfig(buildFor = 'preact') {
     './build-system/babel-plugins/babel-plugin-transform-rename-privates',
     './build-system/babel-plugins/babel-plugin-dom-jsx-svg-namespace',
     reactJsxPlugin,
-    (argv.esm || argv.sxg) &&
+    isEsmBuild &&
       './build-system/babel-plugins/babel-plugin-transform-dev-methods',
     // TODO(alanorozco): Remove `replaceCallArguments` once serving infra is up.
     [
@@ -60,7 +61,7 @@ function getMinifiedConfig(buildFor = 'preact') {
       './build-system/babel-plugins/babel-plugin-amp-mode-transformer',
       BUILD_CONSTANTS,
     ],
-    !(argv.esm || argv.sxg)
+    !isEsmBuild
       ? ['@babel/plugin-transform-for-of', {loose: true, allowArrayLike: true}]
       : null,
   ].filter(Boolean);
@@ -69,9 +70,9 @@ function getMinifiedConfig(buildFor = 'preact') {
     {
       bugfixes: true,
       modules: false,
-      targets: argv.esm || argv.sxg ? {esmodules: true} : {ie: 11, chrome: 41},
+      targets: isEsmBuild ? {esmodules: true} : {ie: 11, chrome: 41},
       shippedProposals: true,
-      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : [],
+      exclude: isEsmBuild ? ['@babel/plugin-transform-for-of'] : [],
     },
   ];
   const presetTypescript = [

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -11,6 +11,8 @@ const {getReplacePlugin} = require('./helpers');
  * @return {!Object}
  */
 function getUnminifiedConfig(buildFor = 'preact') {
+  const isEsmBuild = argv.esm || argv.sxg;
+
   const reactJsxPlugin = [
     '@babel/plugin-transform-react-jsx',
     {
@@ -20,17 +22,15 @@ function getUnminifiedConfig(buildFor = 'preact') {
     },
   ];
 
-  const targets =
-    argv.esm || argv.sxg ? {esmodules: true} : {browsers: ['Last 2 versions']};
   const presetEnv = [
     '@babel/preset-env',
     {
       bugfixes: true,
       modules: false,
       loose: true,
-      targets,
+      targets: isEsmBuild ? {esmodules: true} : {browsers: ['Last 2 versions']},
       shippedProposals: true,
-      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : [],
+      exclude: isEsmBuild ? ['@babel/plugin-transform-for-of'] : [],
     },
   ];
   const presetTypescript = [

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -30,7 +30,7 @@ function getUnminifiedConfig(buildFor = 'preact') {
       loose: true,
       targets,
       shippedProposals: true,
-      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : null,
+      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : [],
     },
   ];
   const presetTypescript = [

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -30,7 +30,7 @@ function getUnminifiedConfig(buildFor = 'preact') {
       loose: true,
       targets,
       shippedProposals: true,
-      exclude: ['@babel/plugin-transform-for-of'],
+      exclude: argv.esm || argv.sxg ? ['@babel/plugin-transform-for-of'] : null,
     },
   ];
   const presetTypescript = [

--- a/build-system/babel-config/unminified-config.js
+++ b/build-system/babel-config/unminified-config.js
@@ -30,6 +30,7 @@ function getUnminifiedConfig(buildFor = 'preact') {
       loose: true,
       targets,
       shippedProposals: true,
+      exclude: ['@babel/plugin-transform-for-of'],
     },
   ];
   const presetTypescript = [

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -363,8 +363,7 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
             : options.outputFormat,
         banner,
         footer,
-        // For es5 builds, ensure esbuild-injected code is transpiled.
-        target: argv.esm ? 'es6' : 'es5',
+        target: 'es6',
         incremental: !!options.watch,
         logLevel: 'silent',
         external: options.externalDependencies,

--- a/build-system/tasks/helpers.js
+++ b/build-system/tasks/helpers.js
@@ -363,7 +363,8 @@ async function esbuildCompile(srcDir, srcFilename, destDir, options) {
             : options.outputFormat,
         banner,
         footer,
-        target: 'es6',
+        // For es5 builds, ensure esbuild-injected code is transpiled.
+        target: argv.esm ? 'es6' : 'es5',
         incremental: !!options.watch,
         logLevel: 'silent',
         external: options.externalDependencies,


### PR DESCRIPTION
`for...of` has been [available](https://caniuse.com/mdn-javascript_statements_for_of) in all our supported browsers since 2015. By disabling the babel plugin, we're able to remove a runtime helper from the bundle.