### PR TITLE
♻️🚀 Simpler attribute copying while swapping MediaPool elements

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -202,8 +202,7 @@ export class MediaPool {
         const audioEl = this.win_.document.createElement('audio');
         audioEl.setAttribute('muted', '');
         audioEl.muted = true;
-        audioEl.classList.add('i-amphtml-pool-media');
-        audioEl.classList.add('i-amphtml-pool-audio');
+        audioEl.classList.add('i-amphtml-pool');
         return audioEl;
       },
       [MediaType_Enum.VIDEO]: () => {
@@ -211,8 +210,7 @@ export class MediaPool {
         videoEl.setAttribute('muted', '');
         videoEl.muted = true;
         videoEl.setAttribute('playsinline', '');
-        videoEl.classList.add('i-amphtml-pool-media');
-        videoEl.classList.add('i-amphtml-pool-video');
+        videoEl.classList.add('i-amphtml-pool');
         return videoEl;
       },
     };

--- a/extensions/amp-story/1.0/media-tasks.js
+++ b/extensions/amp-story/1.0/media-tasks.js
@@ -38,14 +38,14 @@ function swapMediaElements(replaced, inserted) {
 
   // Remove inserted element's unprotected attributes, and add those of the
   // replaced element.
-  for (const {name} of inserted.attributes) {
-    if (!isProtectedAttributeName(name)) {
-      inserted.removeAttribute(name);
+  for (const attr of inserted.attributes) {
+    if (!isProtectedAttributeName(attr.name)) {
+      inserted.removeAttribute(attr.name);
     }
   }
-  for (const {name, value} of replaced.attributes) {
-    if (!isProtectedAttributeName(name)) {
-      inserted.setAttribute(name, value);
+  for (const attr of replaced.attributes) {
+    if (!isProtectedAttributeName(attr.name)) {
+      inserted.setAttribute(attr.name, attr.value);
     }
   }
 

--- a/extensions/amp-video/0.1/test-e2e/test-amp-video-flexible-bitrate.js
+++ b/extensions/amp-video/0.1/test-e2e/test-amp-video-flexible-bitrate.js
@@ -86,7 +86,7 @@ describes.endtoend(
         await forceEventOnVideo(VIDEO_EVENTS.DOWNGRADE, 1);
 
         const video1El = await controller.findElement(
-          '#video1 video.i-amphtml-pool-video'
+          '#video1 video.i-amphtml-pool'
         );
 
         await expect(
@@ -127,7 +127,7 @@ describes.endtoend(
         await forceEventOnVideo(VIDEO_EVENTS.DOWNGRADE, 1);
 
         const video4El = await controller.findElement(
-          '#video2 video.i-amphtml-pool-video'
+          '#video2 video.i-amphtml-pool'
         );
 
         await expect(
@@ -144,7 +144,7 @@ describes.endtoend(
         await controller.findElement('amp-story-page#page-3[active]');
 
         const sources = await controller.findElements(
-          '#video3 video.i-amphtml-pool-media source'
+          '#video3 video.i-amphtml-pool source'
         );
 
         await testElementForSrcAndBitrate(
@@ -177,7 +177,7 @@ describes.endtoend(
         await controller.findElement('amp-story-page#page-6[active]');
 
         const sources = await controller.findElements(
-          '#video6 video.i-amphtml-pool-media source'
+          '#video6 video.i-amphtml-pool source'
         );
 
         await testElementForSrcAndBitrate(
@@ -227,7 +227,7 @@ describes.endtoend(
         await controller.findElement('amp-story-page#page-4[active]');
 
         const video4El = await controller.findElement(
-          '#video4 video.i-amphtml-pool-media'
+          '#video4 video.i-amphtml-pool'
         );
 
         await expect(
@@ -248,7 +248,7 @@ describes.endtoend(
         await afterRenderPromise();
 
         const video4El = await controller.findElement(
-          '#video4 video.i-amphtml-pool-video'
+          '#video4 video.i-amphtml-pool'
         );
 
         await expect(


### PR DESCRIPTION
Replace three "protected classnames" with only one. Instead of looping through classnames to excluded protected class names, allow `class` attribute to be copied and restore original value of protected classname.