### PR TITLE
🌐 [amp story shopping] i18n "reviews"  string capitalization description

### DIFF
--- a/extensions/amp-story/1.0/_locales/en.json
+++ b/extensions/amp-story/1.0/_locales/en.json
@@ -229,7 +229,7 @@
   },
   "104": {
     "string": "reviews",
-    "description": "Button label prompting users to read about peoples assessments of an item."
+    "description": "Button label prompting users to read about peoples assessments of an item. It is not capitalized since it is after a number."
   },
   "105": {
     "string": "Details",

--- a/extensions/amp-story/1.0/_locales/en.json
+++ b/extensions/amp-story/1.0/_locales/en.json
@@ -229,7 +229,7 @@
   },
   "104": {
     "string": "reviews",
-    "description": "Button label prompting users to read about peoples assessments of an item. It is not capitalized since it is after a number."
+    "description": "Button label prompting users to read about peoples assessments of an item. It is not capitalized since it is after a number (eg: '87 reviews')."
   },
   "105": {
     "string": "Details",


### PR DESCRIPTION
Provides clarity in the string description on why the "reviews" string is not capitalized. This was asked during code review and in a [comment](https://github.com/ampproject/amphtml/commit/dbc28dcdd9e70712a45e47c0c38b932826845536#r70691662).

<img width="350" alt="Screen Shot 2022-04-07 at 10 15 05 AM" src="https://user-images.githubusercontent.com/3860311/162234528-c84f3885-fada-462c-b00c-7e37b0a6e5ee.png">