### PR TITLE
🏗 Attempt to fetch pinned chrome version up to 3 times per CI job

### DIFF
--- a/.circleci/get_pinned_chrome_version.sh
+++ b/.circleci/get_pinned_chrome_version.sh
@@ -6,7 +6,6 @@ set -e
 
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 RED() { echo -e "\033[0;31m$1\033[0m"; }
-YELLOW() { echo -e "\033[0;33m$1\033[0m"; }
 CYAN() { echo -e "\033[0;36m$1\033[0m"; }
 
 # Extract the chromedriver version used by AMP's E2E tests
@@ -47,18 +46,7 @@ echo "$(GREEN "Chrome version history URL is") $(CYAN "${CHROME_VERSION_HISTORY_
 # Determine the Chrome version
 # See https://developer.chrome.com/docs/versionhistory/guide
 echo "$(GREEN "Determining Chrome version...")"
-for attempt in {2..0}
-do
-  CHROME_VERSION_HISTORY_JSON="$(curl -sS ${CHROME_VERSION_HISTORY_URL})"
-  if [[ $(echo ${CHROME_VERSION_HISTORY_JSON} | jq -r .error) == "null" ]]; then
-    break
-  fi
-
-  echo "$(YELLOW "Error fetching Chrome version history due to rate limit.") $(GREEN "${attempt}") $(YELLOW "attempt(s) remaining...")"
-  sleep 3
-done
-
-CHROME_VERSION="$(echo ${CHROME_VERSION_HISTORY_JSON} | jq -r ".versions[]|.version" | grep -m 1 "${CHROME_MAJOR_VERSION}\.")"
+CHROME_VERSION="$(curl -sS --retry 3 ${CHROME_VERSION_HISTORY_URL} | jq -r ".versions[]|.version" | grep -m 1 "${CHROME_MAJOR_VERSION}\.")"
 if [[ -z "$CHROME_VERSION" ]]; then
   echo "$(RED "Could not determine Chrome version")"
   exit 1


### PR DESCRIPTION
Looks like we're stumbling on `429 Resource Exhausted` HTTP errors on occasion; this PR should mitigate that for now

e.g. before this PR (broken): https://app.circleci.com/pipelines/github/ampproject/amphtml/24690/workflows/ac9e9719-1277-4650-a6a7-ccdbde7729ec/jobs/506132?invite=true#step-113-10
with this PR (fixed): https://app.circleci.com/pipelines/github/ampproject/amphtml/24696/workflows/356fd8f7-8bc4-4a29-9678-6ba8f7a34020/jobs/506258/parallel-runs/1?filterBy=ALL&invite=true#step-113-10