### PR TITLE
📖 amp-story-shopping Added product json schema documentation

### DIFF
--- a/extensions/amp-story-shopping/amp-story-shopping.md
+++ b/extensions/amp-story-shopping/amp-story-shopping.md
@@ -132,6 +132,10 @@ Inline data may be served from cache which may take time to propogate. `src` JSO
 }
 ```
 
+### Product JSON Validation
+
+The Product's JSON configuration will be validated using ajv against a schema [defined here](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/shopping/product.schema.json). If validation fails on one or more of the shopping tags, an error message will be displayed, and the tag and product details / listing associated with the product(s) that have errors will not be rendered.
+
 ### amp-story-shopping-attachment attributes
 
 #### `src` {string} optional

--- a/extensions/amp-story-shopping/amp-story-shopping.md
+++ b/extensions/amp-story-shopping/amp-story-shopping.md
@@ -132,9 +132,11 @@ Inline data may be served from cache which may take time to propogate. `src` JSO
 }
 ```
 
-### Product JSON Validation
+### Product JSON Schema
 
-The Product's JSON configuration will be validated using ajv against a schema [defined here](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/shopping/product.schema.json). If validation fails on one or more of the shopping tags, an error message will be displayed, and the tag and product details / listing associated with the product(s) that have errors will not be rendered.
+See the schema for product JSON validation in [product.schema.json](https://github.com/ampproject/amphtml/blob/main/examples/amp-story/shopping/product.schema.json).
+If validation fails on one or more of the shopping tags, an error message will be displayed, and the tag and product details / listing associated with the product(s) that have errors will not be rendered.
+Validation is performed with [ajv](https://ajv.js.org/json-schema.html) using the default ajv JSON schema draft.
 
 ### amp-story-shopping-attachment attributes
 


### PR DESCRIPTION
Addresses some of the concerns that documentation pointing to the schema is not hosted publicly as brought up [here](https://github.com/GoogleForCreators/web-stories-wp/issues/11210)