### PR TITLE
🔥 Fix progress bar overflow mode bug

### DIFF
--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -150,11 +150,12 @@ export class ProgressBar {
       StateProperty.PAGE_IDS,
       (pageIds) => {
         const attached = !!root.parentElement;
-        if (attached) {
-          this.clear_();
-        }
 
         this.segmentsAddedPromise_ = this.mutator_.mutateElement(root, () => {
+          if (attached) {
+            this.clear_();
+          }
+
           /** @type {!Array} */ (pageIds).forEach((id) => {
             if (
               // Do not show progress bar for the ad page.
@@ -164,6 +165,15 @@ export class ProgressBar {
               this.addSegment_(id);
             }
           });
+
+          if (this.segmentCount_ > MAX_SEGMENTS) {
+            this.getInitialFirstExpandedSegmentIndex_(this.activeSegmentIndex_);
+            this.render_(false /** shouldAnimate */);
+          }
+          root.classList.toggle(
+            'i-amphtml-progress-bar-overflow',
+            this.segmentCount_ > MAX_SEGMENTS
+          );
         });
 
         if (attached) {
@@ -482,6 +492,7 @@ export class ProgressBar {
     removeChildren(devAssert(this.root_));
     this.segmentIdMap_ = map();
     this.segmentCount_ = 0;
+    this.segments_ = [];
   }
 
   /**

--- a/extensions/amp-story/1.0/progress-bar.js
+++ b/extensions/amp-story/1.0/progress-bar.js
@@ -129,10 +129,10 @@ export class ProgressBar {
 
   /**
    * Builds the progress bar.
-   * @param {string} initialSegmentId
+   * @param {string} unusedInitialSegmentId
    * @return {!Element}
    */
-  build(initialSegmentId) {
+  build(unusedInitialSegmentId) {
     if (this.root_) {
       return this.root_;
     }
@@ -210,20 +210,6 @@ export class ProgressBar {
     Services.viewportForDoc(this.ampdoc_).onResize(
       debounce(this.win_, () => this.onResize_(), 300)
     );
-
-    this.segmentsAddedPromise_.then(() => {
-      if (this.segmentCount_ > MAX_SEGMENTS) {
-        this.getInitialFirstExpandedSegmentIndex_(
-          this.segmentIdMap_[initialSegmentId]
-        );
-
-        this.render_(false /** shouldAnimate */);
-      }
-      root.classList.toggle(
-        'i-amphtml-progress-bar-overflow',
-        this.segmentCount_ > MAX_SEGMENTS
-      );
-    });
 
     return root;
   }


### PR DESCRIPTION
Bug: when PAGE_IDS update, it does not force a `render_` which sets the proper overflow CSS. This PR would fix that.

This is exacerbated by https://github.com/ampproject/amphtml/pull/37940 because it forces updating of PAGE_IDS more often.
