### PR TITLE
Skip windows build check when cutting nightly

### DIFF
--- a/.github/workflows/cross-platform-builds.yml
+++ b/.github/workflows/cross-platform-builds.yml
@@ -15,6 +15,7 @@ jobs:
       matrix:
         platform: [ubuntu, macos, windows]
         flavor: [Build, Dist]
+      fail-fast: false
     runs-on: ${{ matrix.platform }}-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/cut-nightly.yml
+++ b/.github/workflows/cut-nightly.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     # 1 a.m. PST / 12 a.m. PDT, Tuesdays through Saturdays.
     - cron: '0 8 * * 2-6'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -14,15 +14,13 @@ const params = {owner: 'ampproject', repo: 'amphtml'};
 // Permanent external ID as assigned by the GitHub Actions runner.
 const GITHUB_EXTERNAL_ID = 'be30aa50-41df-5bf3-2e88-b5215679ea95';
 
-const CHECKS_TO_CHECK = [
-  'CircleCI',
-  'compile (macos, Dist)',
-  'compile (macos, Build)',
-  'compile (ubuntu, Dist)',
-  'compile (ubuntu, Build)',
+const CHECKS_TO_SKIP = [
+  'Cut Nightly Branch',
+  'create-issue-on-error',
+  'status-page',
   // TODO(wg-infra): fix Windows build
-  // 'compile (windows, Dist)',
-  // 'compile (windows, Build)',
+  'compile (windows, Dist)',
+  'compile (windows, Build)',
 ];
 
 /**
@@ -52,7 +50,7 @@ async function getCommit(octokit) {
       })
     ).filter(
       ({'external_id': id, name}) =>
-        id !== GITHUB_EXTERNAL_ID && CHECKS_TO_CHECK.includes(name)
+        id !== GITHUB_EXTERNAL_ID && !CHECKS_TO_SKIP.includes(name)
     );
 
     if (checkRuns.some(({status}) => status != 'completed')) {

--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -14,6 +14,17 @@ const params = {owner: 'ampproject', repo: 'amphtml'};
 // Permanent external ID as assigned by the GitHub Actions runner.
 const GITHUB_EXTERNAL_ID = 'be30aa50-41df-5bf3-2e88-b5215679ea95';
 
+const CHECKS_TO_CHECK = [
+  'CircleCI',
+  'compile (macos, Dist)',
+  'compile (macos, Build)',
+  'compile (ubuntu, Dist)',
+  'compile (ubuntu, Build)',
+  // TODO(wg-infra): fix Windows build
+  // 'compile (windows, Dist)',
+  // 'compile (windows, Build)',
+];
+
 /**
  * Get last green commit
  * @param {Octokit} octokit
@@ -33,15 +44,18 @@ async function getCommit(octokit) {
   );
 
   for (const {sha} of commits.data) {
-    const checkRuns = await octokit.paginate(octokit.rest.checks.listForRef, {
-      ...params,
-      ref: sha,
-    });
-    if (
-      checkRuns
-        .filter(({'external_id': id}) => id !== GITHUB_EXTERNAL_ID)
-        .some(({status}) => status != 'completed')
-    ) {
+    const checkRuns = (
+      await octokit.paginate(octokit.rest.checks.listForRef, {
+        ...params,
+        ref: sha,
+        'per_page': 100,
+      })
+    ).filter(
+      ({'external_id': id, name}) =>
+        id !== GITHUB_EXTERNAL_ID && CHECKS_TO_CHECK.includes(name)
+    );
+
+    if (checkRuns.some(({status}) => status != 'completed')) {
       log(
         'Not all check runs for commit',
         cyan(sha),


### PR DESCRIPTION
- don't fail fast in cross plat compile jobs
- increase check runs fetch from 30 (default) to 100
- explicitly say which check runs we care about
- add manual trigger to cut_nightly job