### PR TITLE
🖼️ (example - do not merge) Promise chain with reject

### DIFF
--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -83,7 +83,7 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
     );
 
     if (this.shoppingTags_.length === 0) {
-      return;
+      return Promise.reject('No shopping tags on the page.');
     }
 
     return getShoppingConfig(this.element, this.pageEl_.id)

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -88,7 +88,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
 
     return getShoppingConfig(this.element, this.pageEl_.id)
       .then((config) => {
-        // Do not build or layout component if no valid shopping data on page.
         if (Object.keys(config).length === 0) {
           return Promise.reject('No valid shopping data on page.');
         }

--- a/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
+++ b/extensions/amp-story-shopping/0.1/amp-story-shopping-attachment.js
@@ -82,17 +82,22 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
       this.pageEl_.querySelectorAll('amp-story-shopping-tag')
     );
 
-    getShoppingConfig(this.element, this.pageEl_.id).then((config) =>
-      storeShoppingConfig(this.pageEl_, config)
-    );
-
     if (this.shoppingTags_.length === 0) {
       return;
     }
 
-    return this.localizationService_
-      .getLocalizedStringAsync(
-        LocalizedStringId_Enum.AMP_STORY_SHOPPING_CTA_LABEL
+    return getShoppingConfig(this.element, this.pageEl_.id)
+      .then((config) => {
+        // Do not build or layout component if no valid shopping data on page.
+        if (Object.keys(config).length === 0) {
+          return Promise.reject('No valid shopping data on page.');
+        }
+        storeShoppingConfig(this.pageEl_, config);
+      })
+      .then(() =>
+        this.localizationService_.getLocalizedStringAsync(
+          LocalizedStringId_Enum.AMP_STORY_SHOPPING_CTA_LABEL
+        )
       )
       .then((ctaText) => {
         this.attachmentEl_ = (
@@ -110,9 +115,6 @@ export class AmpStoryShoppingAttachment extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    if (this.shoppingTags_.length === 0) {
-      return;
-    }
     loadFonts(this.win, FONTS_TO_LOAD);
     // Update template on attachment state update or shopping data update.
     this.storeService_.subscribe(


### PR DESCRIPTION
Do not merge. 
Demo PR for #38034 and #38040

Uses promise rejections in the `layoutCallback` to prevent rendering when data is not valid and there are no tags on the page.