### PR TITLE
🏗 Unskip Windows builds in cut-nightly.yml

### DIFF
--- a/build-system/release-workflows/cut-nightly.js
+++ b/build-system/release-workflows/cut-nightly.js
@@ -18,9 +18,6 @@ const CHECKS_TO_SKIP = [
   'Cut Nightly Branch',
   'create-issue-on-error',
   'status-page',
-  // TODO(wg-infra): fix Windows build
-  'compile (windows, Dist)',
-  'compile (windows, Build)',
 ];
 
 /**


### PR DESCRIPTION
Fixed in #38065