### PR TITLE
📖 Remove template under <div submitting> for email

### DIFF
--- a/extensions/amp-form/amp-form.md
+++ b/extensions/amp-form/amp-form.md
@@ -179,9 +179,7 @@ In the following example, the responses are rendered in an inline template insid
     ...
   </fieldset>
   <div submitting>
-    <template type="amp-mustache">
-      Form submitting... Thank you for waiting.
-    </template>
+    Form submitting... Thank you for waiting.
   </div>
   <div submit-success>
     <template type="amp-mustache">


### PR DESCRIPTION
`<template>` is not allowed there in the email format. #37698 didn't
update this doc properly, hence this follow-up fix.

/to @samouri 