### PR TITLE
✨[Amp story captions] Use amp-story-captions for captions from cache

### DIFF
--- a/examples/amp-story/amp-story-captions.html
+++ b/examples/amp-story/amp-story-captions.html
@@ -90,6 +90,7 @@
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
+
   </amp-story>
 </body>
 

--- a/examples/amp-story/amp-story-captions.html
+++ b/examples/amp-story/amp-story-captions.html
@@ -90,7 +90,6 @@
         </div>
       </amp-story-grid-layer>
     </amp-story-page>
-
   </amp-story>
 </body>
 

--- a/extensions/amp-video/0.1/test/test-video-cache.js
+++ b/extensions/amp-video/0.1/test/test-video-cache.js
@@ -503,6 +503,28 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
   });
 
   describe('captions field', async () => {
+    it('should install the story-captions extension if the cache responds with captions', async () => {
+      env.sandbox.stub(xhrService, 'fetch').resolves({
+        json: () =>
+          Promise.resolve({
+            'captions': {
+              'src': 'captions_src_response.vtt',
+              'srclang': 'en-us',
+            },
+            'sources': [
+              {'url': 'video.mp4', 'bitrate_kbps': 700, 'type': 'video/mp4'},
+            ],
+          }),
+      });
+      const videoEl = createVideo([{src: 'video.mp4'}]);
+      await fetchCachedSources(videoEl, env.ampdoc);
+
+      expect(extensionsService.installExtensionForDoc).to.have.been.calledWith(
+        env.sandbox.match.any,
+        'amp-story-captions',
+        '0.1'
+      );
+    });
     it('should append track element if the cache responds with captions', async () => {
       env.sandbox.stub(xhrService, 'fetch').resolves({
         json: () =>

--- a/extensions/amp-video/0.1/test/test-video-cache.js
+++ b/extensions/amp-video/0.1/test/test-video-cache.js
@@ -502,7 +502,7 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
     });
   });
 
-  function fetchSourcseWithCaptions() {
+  function stubSourcesWithCapionsRequest() {
     env.sandbox.stub(xhrService, 'fetch').resolves({
       json: () =>
         Promise.resolve({
@@ -518,7 +518,7 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
   }
   describe('captions field', async () => {
     it('should install the story-captions extension if the cache responds with captions', async () => {
-      fetchSourcseWithCaptions();
+      stubSourcesWithCapionsRequest();
       const videoEl = createVideo([{src: 'video.mp4'}]);
       await fetchCachedSources(videoEl, env.ampdoc);
 
@@ -529,7 +529,7 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
       );
     });
     it('should append track element if the cache responds with captions', async () => {
-      fetchSourcseWithCaptions();
+      stubSourcesWithCapionsRequest();
       const videoEl = createVideo([{src: 'video.mp4'}]);
       await fetchCachedSources(videoEl, env.ampdoc);
 
@@ -537,7 +537,7 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
       expect(trackEl).to.exist;
     });
     it('should append story-captions element if the cache responds with captions', async () => {
-      fetchSourcseWithCaptions();
+      stubSourcesWithCapionsRequest();
       const videoEl = createVideo([{src: 'video.mp4'}]);
       await fetchCachedSources(videoEl, env.ampdoc);
 
@@ -545,7 +545,7 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
       expect(captionsEl).to.exist;
     });
     it('should not append track element if video already has a track child', async () => {
-      fetchSourcseWithCaptions();
+      stubSourcesWithCapionsRequest();
       const videoEl = createVideo([{src: 'video.mp4'}]);
       videoEl.appendChild(<track />);
       await fetchCachedSources(videoEl, env.ampdoc);

--- a/extensions/amp-video/0.1/test/test-video-cache.js
+++ b/extensions/amp-video/0.1/test/test-video-cache.js
@@ -502,20 +502,23 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
     });
   });
 
+  function fetchSourcseWithCaptions() {
+    env.sandbox.stub(xhrService, 'fetch').resolves({
+      json: () =>
+        Promise.resolve({
+          'captions': {
+            'src': 'captions_src_response.vtt',
+            'srclang': 'en-us',
+          },
+          'sources': [
+            {'url': 'video.mp4', 'bitrate_kbps': 700, 'type': 'video/mp4'},
+          ],
+        }),
+    });
+  }
   describe('captions field', async () => {
     it('should install the story-captions extension if the cache responds with captions', async () => {
-      env.sandbox.stub(xhrService, 'fetch').resolves({
-        json: () =>
-          Promise.resolve({
-            'captions': {
-              'src': 'captions_src_response.vtt',
-              'srclang': 'en-us',
-            },
-            'sources': [
-              {'url': 'video.mp4', 'bitrate_kbps': 700, 'type': 'video/mp4'},
-            ],
-          }),
-      });
+      fetchSourcseWithCaptions();
       const videoEl = createVideo([{src: 'video.mp4'}]);
       await fetchCachedSources(videoEl, env.ampdoc);
 
@@ -526,37 +529,23 @@ describes.realWin('amp-video cached-sources', {amp: true}, (env) => {
       );
     });
     it('should append track element if the cache responds with captions', async () => {
-      env.sandbox.stub(xhrService, 'fetch').resolves({
-        json: () =>
-          Promise.resolve({
-            'captions': {
-              'src': 'captions_src_response.vtt',
-              'srclang': 'en-us',
-            },
-            'sources': [
-              {'url': 'video.mp4', 'bitrate_kbps': 700, 'type': 'video/mp4'},
-            ],
-          }),
-      });
+      fetchSourcseWithCaptions();
       const videoEl = createVideo([{src: 'video.mp4'}]);
       await fetchCachedSources(videoEl, env.ampdoc);
 
       const trackEl = videoEl.querySelector('track');
       expect(trackEl).to.exist;
     });
+    it('should append story-captions element if the cache responds with captions', async () => {
+      fetchSourcseWithCaptions();
+      const videoEl = createVideo([{src: 'video.mp4'}]);
+      await fetchCachedSources(videoEl, env.ampdoc);
+
+      const captionsEl = videoEl.querySelector('amp-story-captions');
+      expect(captionsEl).to.exist;
+    });
     it('should not append track element if video already has a track child', async () => {
-      env.sandbox.stub(xhrService, 'fetch').resolves({
-        json: () =>
-          Promise.resolve({
-            'captions': {
-              'src': 'captions_src_response.vtt',
-              'srclang': 'en-us',
-            },
-            'sources': [
-              {'url': 'video.mp4', 'bitrate_kbps': 700, 'type': 'video/mp4'},
-            ],
-          }),
-      });
+      fetchSourcseWithCaptions();
       const videoEl = createVideo([{src: 'video.mp4'}]);
       videoEl.appendChild(<track />);
       await fetchCachedSources(videoEl, env.ampdoc);

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -1,4 +1,5 @@
 import {createElementWithAttributes, removeElement} from '#core/dom';
+import * as Preact from '#core/dom/jsx';
 import {matches} from '#core/dom/query';
 import {toArray} from '#core/types/array';
 
@@ -7,8 +8,6 @@ import {Services} from '#service';
 import {user} from '#utils/log';
 
 import {addParamsToUrl, resolveRelativeUrl} from '../../../src/url';
-
-import * as Preact from '#core/dom/jsx';
 
 /** @const {!Array<string>} */
 const CODECS_IN_ASCENDING_PRIORITY = ['h264', 'vp09'];

--- a/extensions/amp-video/0.1/video-cache.js
+++ b/extensions/amp-video/0.1/video-cache.js
@@ -160,8 +160,9 @@ function applyAudioInfoToVideo(videoEl, hasAudio) {
 }
 
 /**
- * Appends captions track to video if captions url is defined and video
- * element doesn't have a track child specified in the document.
+ * Appends captions track and amp-story-captions to video if captions
+ * url is defined and video element doesn't have a track child
+ * specified in the document.
  * @param {!Element} videoEl
  * @param {!Object} captionsResponse
  * @param {!AmpDoc} ampdoc


### PR DESCRIPTION
When appending captions from cache this PR lazy loads the `amp-story-captions` component and appends it as a child to the video element with the `default` captions style (part of [#37900](https://github.com/ampproject/amphtml/issues/37900)).

Contributes to [#37899](https://github.com/ampproject/amphtml/issues/37899)