### PR TITLE
🐛 [story-subscriptions] fix flaky visual diff test

### DIFF
--- a/examples/amp-story/amp-story-subscriptions.html
+++ b/examples/amp-story/amp-story-subscriptions.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <title>amp-story-subscriptions example</title>
-    <link rel="canonical" href="/examples/amp-story-subscriptions.html">
+    <link rel="canonical" href="/examples/amp-story/amp-story-subscriptions.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/examples/visual-tests/amp-story/amp-story-subscriptions.html
+++ b/examples/visual-tests/amp-story/amp-story-subscriptions.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <title>amp-story-subscriptions example</title>
-    <link rel="canonical" href="/examples/amp-story-subscriptions.html">
+    <link rel="canonical" href="/examples/visual-tests/amp-story/amp-story-subscriptions.html">
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
     <style amp-custom>

--- a/examples/visual-tests/amp-story/amp-story-subscriptions.html
+++ b/examples/visual-tests/amp-story/amp-story-subscriptions.html
@@ -185,7 +185,7 @@
   </head>
   <body>
     <amp-story standalone title="My story" publisher="Monocle" publisher-logo-src="https://res.cloudinary.com/crunchbase-production/image/upload/c_lpad,h_170,w_170,f_auto,b_white,q_auto:eco,dpr_1/tbvbvipimh2camf5nb2q" poster-portrait-src="POSTER-IMAGE-URL">
-      <amp-story-page id="cover" auto-advance-after="5s">
+      <amp-story-page id="cover">
         <amp-story-grid-layer template="fill">
           <amp-img src="https://images.unsplash.com/photo-1552650904-54d0c54b278f?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=987&q=80"
               width="720" height="1280"
@@ -199,7 +199,7 @@
         </amp-story-grid-layer>
       </amp-story-page>
 
-      <amp-story-page id="page-1" auto-advance-after="5s">
+      <amp-story-page id="page-1">
         <amp-story-grid-layer template="fill">
           <amp-img src="https://images.unsplash.com/photo-1544965563-bb8d8bce9791?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1011&q=80"
               width="720" height="1280"
@@ -216,7 +216,7 @@
         </amp-story-grid-layer>
       </amp-story-page>
 
-      <amp-story-page id="page-2" auto-advance-after="5s">
+      <amp-story-page id="page-2">
         <amp-story-grid-layer template="fill">
           <amp-img src="https://images.unsplash.com/photo-1599849913403-f45ef2181b49?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=3024&q=80"
               width="720" height="1280"

--- a/test/visual-diff/visual-tests.jsonc
+++ b/test/visual-diff/visual-tests.jsonc
@@ -808,7 +808,7 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-shopping.js"
     },
     {
-      "url": "examples/visual-tests/amp-story/amp-story-subscriptions.html#page=page-2",
+      "url": "examples/visual-tests/amp-story/amp-story-subscriptions.html",
       "name": "amp-story-subscriptions UI",
       "viewport": {"width": 400, "height": 800},
       "loading_complete_selectors": ["amp-subscriptions-dialog:not([hidden])"],


### PR DESCRIPTION
Flakiness appears to be caused by auto-advancing. Removes these attrs. [See this failure](https://percy.io/ampproject/amphtml/builds/17432298/changed/978168331?browser=chrome&browser_ids=23&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=400&widths=400)