### PR TITLE
📖 [amp story shopping] CTA casing in docs. Remove "draft" from doc metadata.

### DIFF
--- a/extensions/amp-story-shopping/amp-story-shopping.md
+++ b/extensions/amp-story-shopping/amp-story-shopping.md
@@ -8,7 +8,6 @@ tags:
   - shopping
 author: philipbell
 toc: true
-draft: true
 $title: amp-story-shopping
 version: '0.1'
 versions:
@@ -148,8 +147,8 @@ A url for remote product JSON configuration. When defined it overrides inline JS
 
 Sets the color of the CTA button and drawer.
 "light" (default) and "dark" values are accepted.
-<img alt="theme" src="https://user-images.githubusercontent.com/3860311/161297644-f25837e0-82ec-4960-a219-edfaf7d09fd9.png"
-layout="intrinsic" width="800" height="135">
+<img alt="theme" src="https://user-images.githubusercontent.com/3860311/164291421-b2ec3044-0867-4dca-84a1-01985e9dc958.png"
+layout="intrinsic" width="920" height="141">
 
 #### `cta-text` {string} optional
 
@@ -157,7 +156,7 @@ String that customizes the call to action button text. The default is "Shop now"
 
 ### amp-story-shopping-attachment templates
 
-Two types of templated pages render within the shopping attachment. They automatically populate with the product data from the configured JSON. the Product listing page (PLP) is a list of all products on the active story page. The Product details page (PDP) displays in-depth detail about the product such as images, text and a "Buy Now" button.
+Two types of templated pages render within the shopping attachment. They automatically populate with the product data from the configured JSON. the Product listing page (PLP) is a list of all products on the active story page. The Product details page (PDP) displays in-depth detail about the product such as images, text and a "Buy now" button.
 
 #### Product listing page (PLP)
 


### PR DESCRIPTION
Make CTA casing in docs consistent with the code.
"Shop Now" => "Shop now"
"Buy Now" => "Buy now"

Removes "draft" from docs metadata.

Follow up from #38096