### PR TITLE
amp-carousel-0.1: improve accessibility by showing prev/next buttons …

### DIFF
--- a/extensions/amp-carousel/0.1/carousel-controls.js
+++ b/extensions/amp-carousel/0.1/carousel-controls.js
@@ -55,9 +55,8 @@ export class CarouselControls {
       return;
     }
 
-    const input = Services.inputFor(this.win_);
-    input.onMouseDetected((mouseDetected) => {
-      if (mouseDetected) {
+    const handleInputDeviceDetected = (mouseOrKeyboardDetected) => {
+      if (mouseOrKeyboardDetected) {
         this.showControls_ = true;
         toggleAttribute(
           this.element_,
@@ -66,7 +65,10 @@ export class CarouselControls {
         );
         this.element_.classList.add(ClassNames.HAS_CONTROL);
       }
-    }, true);
+    };
+    const input = Services.inputFor(this.win_);
+    input.onMouseDetected(handleInputDeviceDetected, true);
+    input.onKeyboardStateChanged(handleInputDeviceDetected, true);
   }
 
   /**

--- a/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
+++ b/extensions/amp-carousel/0.1/test/test-scrollable-carousel.js
@@ -241,9 +241,10 @@ describes.realWin(
 
     describe('buildDom', () => {
       it('buildDom and buildCallback should result in the same outerHTML', async () => {
-        env.sandbox
-          .stub(Services, 'inputFor')
-          .returns({onMouseDetected: () => {}});
+        env.sandbox.stub(Services, 'inputFor').returns({
+          onMouseDetected: () => {},
+          onKeyboardStateChanged: () => {},
+        });
 
         const el1 = await getAmpScrollableCarousel(/* addToDom */ false);
         const el2 = el1.cloneNode(/* deep */ true);


### PR DESCRIPTION
**summary**
Followup fix for https://github.com/ampproject/amphtml/issues/29560. 
It is important to bring back the prev/next arrows in the face of keyboard input (For example, Tab/Shift-Tab).

cc @alanorozco 