### PR TITLE
🚮 🐛 [amp story 360] Remove GL context handling

### DIFF
--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -42,12 +42,6 @@ const HAVE_CURRENT_DATA = 2;
 const CENTER_OFFSET = 90;
 
 /**
- * Minimum distance from active page to activate WebGL context.
- * @const {number}
- */
-const MIN_WEBGL_DISTANCE = 2;
-
-/**
  * Renders the template for the permission button.
  * @return {!Element}
  */
@@ -295,9 +289,6 @@ export class AmpStory360 extends AMP.BaseElement {
     /** @private {number} */
     this.headingOffset_ = 0;
 
-    /** @private WebGL extension for lost context. */
-    this.lostGlContext_ = null;
-
     /** @private {!Array<number>} */
     this.rot_ = null;
   }
@@ -348,18 +339,6 @@ export class AmpStory360 extends AMP.BaseElement {
     this.element.appendChild(container);
     container.appendChild(this.canvas_);
     applyFillContent(container, /* replacedContent */ true);
-
-    // Mutation observer for distance attribute
-    const config = {attributes: true, attributeFilter: ['distance']};
-    const callback = (mutationsList) => {
-      this.distance_ = parseInt(
-        mutationsList[0].target.getAttribute('distance'),
-        10
-      );
-      this.restoreOrLoseGlContext_();
-    };
-    const observer = new MutationObserver(callback);
-    this.getPage_() && observer.observe(this.getPage_(), config);
 
     // Initialize all services before proceeding
     return Promise.all([
@@ -431,20 +410,6 @@ export class AmpStory360 extends AMP.BaseElement {
     }
   }
 
-  /** @private */
-  restoreOrLoseGlContext_() {
-    if (!this.renderer_) {
-      return;
-    }
-    if (this.distance_ < MIN_WEBGL_DISTANCE) {
-      if (this.renderer_.gl.isContextLost()) {
-        this.lostGlContext_.restoreContext();
-      }
-    } else if (!this.renderer_.gl.isContextLost()) {
-      this.lostGlContext_.loseContext();
-    }
-  }
-
   /**
    * @param {string} permissionState
    * @private
@@ -510,7 +475,7 @@ export class AmpStory360 extends AMP.BaseElement {
       // Debounce onDeviceOrientation_ to rAF.
       let rafTimeout;
       this.win.addEventListener('deviceorientation', (e) => {
-        if (this.isReady_ && this.distance_ < MIN_WEBGL_DISTANCE) {
+        if (this.isReady_) {
           rafTimeout && this.win.cancelAnimationFrame(rafTimeout);
           rafTimeout = this.win.requestAnimationFrame(() => {
             if (!this.isOnActivePage_) {
@@ -711,7 +676,6 @@ export class AmpStory360 extends AMP.BaseElement {
       .then(
         () => {
           this.renderer_ = new Renderer(this.canvas_);
-          this.setupGlContextListeners_();
           this.image_ = this.checkImageReSize_(
             dev().assertElement(this.element.querySelector('img'))
           );
@@ -742,24 +706,10 @@ export class AmpStory360 extends AMP.BaseElement {
       .then(
         () => {
           this.renderer_ = new Renderer(this.canvas_);
-          this.setupGlContextListeners_();
           this.initRenderer_();
         },
         () => user().error(TAG, 'Failed to load the amp-video.')
       );
-  }
-
-  /** @private */
-  setupGlContextListeners_() {
-    this.lostGlContext_ = this.renderer_.gl.getExtension('WEBGL_lose_context');
-    this.renderer_.canvas.addEventListener('webglcontextlost', (e) => {
-      // Calling preventDefault is necessary for restoring context.
-      e.preventDefault();
-      this.isReady_ = false;
-    });
-    this.renderer_.canvas.addEventListener('webglcontextrestored', () =>
-      this.initRenderer_()
-    );
   }
 
   /** @private */

--- a/extensions/amp-story-360/0.1/amp-story-360.js
+++ b/extensions/amp-story-360/0.1/amp-story-360.js
@@ -268,9 +268,6 @@ export class AmpStory360 extends AMP.BaseElement {
     /** @private {boolean} */
     this.isOnActivePage_ = false;
 
-    /** @private {?number} */
-    this.distance_ = null;
-
     /** @private {number} */
     this.sceneHeading_ = 0;
 


### PR DESCRIPTION
This PR removes the context handling code from the 360 component. 
Removing this code is not a final solution but will allow 360 to work in most use cases until the root of the bug is resolved.

Additional context: 
GL context handling was implemented to lose and restore web gl context based on distance from the active page. Browsers limit contexts to 8-16. Web Stories that feature 360 such as [this one](https://www.google.com/search/static/gs/museum/m0d3c49.html) use less than the maximum. 

This context handling broke within the past several months. Context is not restored and a blank screen is displayed. In some cases context is created but then lost right after.

The [codepen example](https://codepen.io/philipbell/pen/RwRQGmo) still works which leads me to believe it's a race condition within the amp story codebase. I'm unable to identify the cause of this bug at this time.

cc @t0mg 