### PR TITLE
✨ Add `aria-roledescription` in validator spec

### DIFF
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -5237,6 +5237,7 @@ attr_lists: {
   attrs: { name: "aria-readonly" }
   attrs: { name: "aria-relevant" }
   attrs: { name: "aria-required" }
+  attrs: { name: "aria-roledescription" }
   attrs: { name: "aria-selected" }
   attrs: { name: "aria-setsize" }
   attrs: { name: "aria-sort" }


### PR DESCRIPTION
This PR adds `aria-roledescription` to global attributes in the
validator spec.

This attribute allows AMP/AMP4Email authors to add screenreader
verbalization for the role of an element.

The following is an exerpt from
https://www.w3.org/TR/wai-aria-1.1/#aria-roledescription:

> The `aria-roledescription` property gives authors the ability to override
> how assistive technologies localize and express the name of a role.
>
> Example:
>
> ```
> <div role="region" aria-roledescription="slide" id="slide42" aria-labelledby="slide42heading">
>   <h1 id="slide42heading">Quarterly Report</h1>
>   <!-- remaining slide contents -->
> </div>
> ```
>
> In this example, a screen reader user may hear "Quarterly Report, slide"
> rather than the more vague "Quarterly Report, region" or "Quarterly
> Report, group."

/cc @zhangsu @bill97819 