### PR TITLE
✨ [AMP Story Paywall] Enable developers to specify a custom subscriptions page index

### DIFF
--- a/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.js
+++ b/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.js
@@ -20,6 +20,12 @@ import {getStoryAttributeSrc} from '../../amp-story/1.0/utils';
 const TAG = 'amp-story-subscriptions';
 
 /**
+ * The index of the page where the paywall would be triggered.
+ * @const {number}
+ */
+export const DEFAULT_SUBSCRIPTIONS_PAGE_INDEX = 2;
+
+/**
  * The number of milliseconds to wait before showing the skip button on dialog banner.
  * @const {number}
  */
@@ -61,6 +67,18 @@ export class AmpStorySubscriptions extends AMP.BaseElement {
       this.storeService_ = storeService;
       this.subscriptionService_ = subscriptionService;
       this.localizationService_ = localizationService;
+
+      const pages = this.win.document.querySelectorAll('amp-story-page');
+      const subscriptionsPageIndex = this.element.getAttribute(
+        'subscriptions-page-index'
+      );
+      this.storeService_.dispatch(
+        Action.SET_SUBSCRIPTIONS_PAGE_INDEX,
+        subscriptionsPageIndex > 2 &&
+          subscriptionsPageIndex !== pages.length - 1
+          ? subscriptionsPageIndex
+          : DEFAULT_SUBSCRIPTIONS_PAGE_INDEX
+      );
 
       // Get grant status immediately to set up the initial subscriptions state.
       this.getGrantStatusAndUpdateState_();

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -149,6 +149,7 @@ export let ShoppingDataDef;
  *    newPageAvailableId: string,
  *    pageSize: {width: number, height: number},
  *    subscriptionsDialogState: boolean,
+ *    subscriptionsPageIndex: number,
  * }}
  */
 export let State;
@@ -209,6 +210,7 @@ const StateProperty = mangleObjectValues({
   // AMP Story paywall states.
   SUBSCRIPTIONS_DIALOG_UI_STATE: 'subscriptionsDialogUiState',
   SUBSCRIPTIONS_STATE: 'subscriptionsState',
+  SUBSCRIPTIONS_PAGE_INDEX: 'subscriptionsPageIndex',
 });
 
 export {StateProperty};
@@ -228,6 +230,7 @@ const Action = mangleObjectValues({
   SET_PAGE_IDS: 'setPageIds',
   SET_PAGE_SIZE: 'updatePageSize',
   SET_VIEWER_CUSTOM_CONTROLS: 'setCustomControls',
+  SET_SUBSCRIPTIONS_PAGE_INDEX: 'setSubscriptionsPageIndex',
   TOGGLE_AD: 'toggleAd',
   TOGGLE_EDUCATION: 'toggleEducation',
   TOGGLE_INFO_DIALOG: 'toggleInfoDialog',
@@ -477,6 +480,11 @@ const actions = (state, action, data) => {
         ...state,
         [StateProperty.VIEWER_CUSTOM_CONTROLS]: data,
       });
+    case Action.SET_SUBSCRIPTIONS_PAGE_INDEX:
+      return /** @type {!State} */ ({
+        ...state,
+        [StateProperty.SUBSCRIPTIONS_PAGE_INDEX]: data,
+      });
     case Action.TOGGLE_SUBSCRIPTIONS_DIALOG_UI_STATE:
       return /** @type {!State} */ ({
         ...state,
@@ -629,6 +637,7 @@ export class AmpStoryStoreService {
       [StateProperty.PREVIEW_STATE]: false,
       [StateProperty.SUBSCRIPTIONS_DIALOG_UI_STATE]: false,
       [StateProperty.SUBSCRIPTIONS_STATE]: SubscriptionsState.DISABLED,
+      [StateProperty.SUBSCRIPTIONS_PAGE_INDEX]: -1,
     });
   }
 


### PR DESCRIPTION
Block the story if the index is not resolved yet. Normally amp-story-subscriptions element should instantiate faster than amp-story so this should happen only rarely. After amp-story-subscriptions retrieve the index specified by the developers, it would update it in store service for amp-story to unblock and conditionally show the paywall on the specified page.

From the product perspective, we decided that the index provided by developers has to be larger than 2 and not the last page of the story.
