### PR TITLE
🐛 added minItems to amp-story-shopping productImages JSON Schema

### DIFF
--- a/examples/amp-story/shopping/product.schema.json
+++ b/examples/amp-story/shopping/product.schema.json
@@ -210,6 +210,7 @@
     "productImages": {
       "description": "A list of images for the product used in the carousel of the product page.",
       "type": "array",
+      "minItems": 1,
       "items": {
         "required": ["url", "alt"],
         "additionalProperties": false,


### PR DESCRIPTION
Closes #38174

Note: We are using minItems and NOT minContains as 
as ajv uses an earlier draft for performance reasons, see
https://ajv.js.org/json-schema.html#draft-07