### PR TITLE
✨ amp-script: implement new size limits for sandboxed scripts

### DIFF
--- a/extensions/amp-script/0.1/amp-script.js
+++ b/extensions/amp-script/0.1/amp-script.js
@@ -42,10 +42,16 @@ const TAG = 'amp-script';
 let WorkerDOMWorkerDef;
 
 /**
- * Max cumulative size of author scripts from all amp-script elements on page.
+ * Max cumulative size of author scripts from all amp-script elements on page that are not using sandboxed mode.
  * @const {number}
  */
-const MAX_TOTAL_SCRIPT_SIZE = 150000;
+const MAX_TOTAL_NONSANDBOXED_SCRIPT_SIZE = 150000;
+
+/**
+ * Max cumulative size of author scripts from all amp-script elements on page that are using sandboxed mode.
+ * @const {number}
+ */
+const MAX_TOTAL_SANDBOXED_SCRIPT_SIZE = 300000;
 
 /**
  * See src/transfer/Phase.ts in worker-dom.
@@ -281,13 +287,15 @@ export class AmpScript extends AMP.BaseElement {
 
       if (
         !this.development_ &&
-        this.service_.sizeLimitExceeded(authorScript.length)
+        this.service_.sizeLimitExceeded(authorScript.length, this.sandboxed_)
       ) {
         user().error(
           TAG,
           'Maximum total script size exceeded (%s). %s is disabled. ' +
             'See https://amp.dev/documentation/components/amp-script/#size-of-javascript-code.',
-          MAX_TOTAL_SCRIPT_SIZE,
+          this.sandboxed_
+            ? MAX_TOTAL_SANDBOXED_SCRIPT_SIZE
+            : MAX_TOTAL_NONSANDBOXED_SCRIPT_SIZE,
           this.debugId_
         );
         this.element.classList.add('i-amphtml-broken');
@@ -584,7 +592,10 @@ export class AmpScriptService {
     this.ampdoc_ = ampdoc;
 
     /** @private {number} */
-    this.cumulativeSize_ = 0;
+    this.cumulativeNonSandboxedSize_ = 0;
+
+    /** @private {number} */
+    this.cumulativeSandboxedSize_ = 0;
 
     /** @private {!Array<string>} */
     this.sources_ = [];
@@ -625,14 +636,19 @@ export class AmpScriptService {
   }
 
   /**
-   * Adds `size` to current total. Returns true iff new total is <= size cap.
+   * Adds `size` to current total. Returns true if new total is <= size cap.
    *
    * @param {number} size
+   * @param {boolean} isSandboxed
    * @return {boolean}
    */
-  sizeLimitExceeded(size) {
-    this.cumulativeSize_ += size;
-    return this.cumulativeSize_ > MAX_TOTAL_SCRIPT_SIZE;
+  sizeLimitExceeded(size, isSandboxed) {
+    isSandboxed
+      ? (this.cumulativeSandboxedSize_ += size)
+      : (this.cumulativeNonSandboxedSize_ += size);
+    return isSandboxed
+      ? this.cumulativeSandboxedSize_ > MAX_TOTAL_SANDBOXED_SCRIPT_SIZE
+      : this.cumulativeNonSandboxedSize_ > MAX_TOTAL_NONSANDBOXED_SCRIPT_SIZE;
   }
 
   /**

--- a/extensions/amp-script/amp-script.md
+++ b/extensions/amp-script/amp-script.md
@@ -242,6 +242,7 @@ In order to maintain AMP's guarantees of performance and layout stability, `amp-
 
 -   Each inline script can contain up to 10,000 bytes
 -   The scripts on a page can contain a total of up to 150,000 bytes
+-   The scripts running in sandboxed mode on a page can contain a total of up to 300,000 bytes
 
 ### User gestures
 
@@ -411,6 +412,12 @@ If you don't publish signed exchanges, `max-age` does nothing.
 
 The optional `nodom` attribute optimizes `<amp-script>` for use as a data-layer rather than as a UI layer. It removes the ability for the `<amp-script>` to make DOM modifications, in favor of a signficantly smaller bundle size and therefore better performance. It also automatically hides the `<amp-script>`, so you may omit the height and width attributes.
 
+### sandboxed
+
+Note: Not to be confused with the **sandbox** attribute.
+
+If set, this will signal that worker-dom should activate sandboxed mode. In this mode the Worker lives in its own crossorigin iframe, creating a strong security boundary. It also forces **nodom** mode. Because of the strong security boundary, sandboxed scripts do not need to provide a script hash.
+
 ### common attributes
 
 This element includes [common attributes](https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes) extended to AMP components.
@@ -425,7 +432,9 @@ No inline script can exceed 10,000 bytes. See [Size of JavaScript code](#size-of
 
 **Maximum total script size exceeded (...)**
 
-The total of all scripts used by a page cannot exceed 150,000 bytes. See [Size of JavaScript code](#size-of-javascript-code) above.
+The total of all non-sandboxed scripts used by a page cannot exceed 150,000 bytes. See [Size of JavaScript code](#size-of-javascript-code) above.
+
+The total of all sandboxed scripts (see [Sandboxed Mode](#sandboxed)) used by a page cannot exceed 300,000 bytes. See [Size of JavaScript code](#size-of-javascript-code) above.
 
 **Script hash not found.**
 
@@ -434,6 +443,8 @@ For local scripts and cross-origin scripts, you need to add a [script hash](#cal
 **(...) must have "sha384-(...)" in meta[name="amp-script-src"]**
 
 Again, you need the [script hash](#calculating-the-script-hash). Simply copy the value in this error into your `<meta>` tag.
+
+**JavaScript script hash requirements are disabled in sandboxed mode.**
 
 **JavaScript size and script hash requirements are disabled in development mode.**
 


### PR DESCRIPTION
Fixes: #38173

Creates a separate size limit for scripts running in `sandboxed` mode. Includes updating the `sizeLimitExceeded` function to correctly accumulate and calculate size limit based on whether the script being checked is running in `sandboxed` mode or not.

Also updates the documentation to reflect this change.