### PR TITLE
🐛 Add missing type to `productImages[].url` field in amp-story-shopping JSON Schema

### DIFF
--- a/examples/amp-story/shopping/product.schema.json
+++ b/examples/amp-story/shopping/product.schema.json
@@ -217,7 +217,7 @@
         "type": "object",
         "properties": {
           "url": {
-            "type": "string"
+            "type": "string",
             "$ref": "#/$defs/https"
           },
           "alt": {


### PR DESCRIPTION
Some JSON schema validators don't like it if `type` is omitted.
