### PR TITLE
✨ Add CANONICAL_URL to allowed list of consent iframe replacement variables

### DIFF
--- a/extensions/amp-consent/0.1/consent-config.js
+++ b/extensions/amp-consent/0.1/consent-config.js
@@ -25,6 +25,7 @@ const ALLOWED_DEPR_CONSENTINSTANCE_ATTRS = {
 
 /** @const @type {!Object<string, boolean>} */
 const CONSENT_VARS_ALLOWED_LIST = {
+  'CANONICAL_URL': true,
   'PAGE_VIEW_ID': true,
   'PAGE_VIEW_ID_64': true,
   'SOURCE_URL': true,

--- a/extensions/amp-consent/0.1/test/test-consent-config.js
+++ b/extensions/amp-consent/0.1/test/test-consent-config.js
@@ -11,7 +11,15 @@ import {
   expandPolicyConfig,
 } from '../consent-config';
 
-describes.realWin('ConsentConfig', {amp: 1}, (env) => {
+const realWinConfig = {
+  amp: {
+    canonicalUrl: 'https://foo.bar/baz',
+    runtimeOn: true,
+    ampdoc: 'single',
+  },
+};
+
+describes.realWin('ConsentConfig', realWinConfig, (env) => {
   let doc;
   let element;
   let defaultConfig;
@@ -506,6 +514,8 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
       const url = await expandConsentEndpointUrl(
         doc.body,
         'https://example.test?' +
+          // CANONICAL_URL is allowed
+          'canonicalurl=CANONICAL_URL&' +
           // CLIENT_ID is allowed
           'cid=CLIENT_ID&' +
           // PAGE_VIEW_ID is allowed
@@ -519,7 +529,7 @@ describes.realWin('ConsentConfig', {amp: 1}, (env) => {
       );
 
       expect(url).to.match(
-        /cid=amp-.{22}&pid=[0-9]+&pid64=.{22}&sourceurl=about%3Asrcdoc&r=RANDOM/
+        /canonicalurl=https%3A%2F%2Ffoo.bar%2Fbaz&cid=amp-.{22}&pid=[0-9]+&pid64=.{22}&sourceurl=about%3Asrcdoc&r=RANDOM/
       );
     });
 


### PR DESCRIPTION
**Note**: replaces #38207 as the original PR failed to trigger CI.

Allows passing the `CANONICAL_URL` variable into the `amp-consent` component, as proposed by @alanorozco in #38183.

Changing the parameters passed to the test suite changed the indentation of the whole file, unfortunately. I just touched the test `support expansion in allowed list`.