### PR TITLE
✨ Allow amp-consent iframe to trigger navigate-to events

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -431,6 +431,29 @@ export class ConsentUI {
   }
 
   /**
+   * Handle the navigate-to event from the CMP iframe
+   * @param {!JsonObject} data
+   */
+  handleNavigateTo_(data) {
+    if (!data['url'] || typeof data['url'] !== 'string') {
+      user().error(TAG, 'No valid url provided in navigate-to event');
+      return;
+    }
+
+    const url = data['url'];
+    const options = {};
+    if (typeof data['opener'] === 'boolean') {
+      options.opener = data['opener'];
+    }
+    if (typeof data['target'] === 'string') {
+      options.target = data['target'];
+    }
+
+    const navigator = Services.navigationForDoc(this.ampdoc_);
+    navigator.navigateTo(this.win_, url, undefined, options);
+  }
+
+  /**
    * Enter the fullscreen state for the UI
    */
   enterFullscreen_() {
@@ -815,6 +838,15 @@ export class ConsentUI {
    *   action: 'enter-fullscreen'
    * }
    *
+   * Navigate top frame to URL
+   * {
+   *   type: 'consent-ui',
+   *   action: 'navigate-to',
+   *   url: 'https://example.com',
+   *   target: '_top',
+   *   opener: false,
+   * }
+   *
    * @param {!Event} event
    */
   handleIframeMessages_(event) {
@@ -855,6 +887,10 @@ export class ConsentUI {
       this.baseInstance_.mutateElement(() => {
         this.enterFullscreen_();
       });
+    }
+
+    if (requestAction === 'navigate-to') {
+      this.handleNavigateTo_(/** @type {!JsonObject} */ (data));
     }
   }
 

--- a/extensions/amp-consent/integrating-consent.md
+++ b/extensions/amp-consent/integrating-consent.md
@@ -76,6 +76,23 @@ Action `'enter-fullscreen'` requests the AMP runtime to expand the iframe to ful
   }
 ```
 
+##### navigate-to
+
+```javascript
+window.parent.postMessage(
+  {
+    type: 'consent-ui',
+    action: 'navigate-to',
+    url: 'https://example.com',
+    target: (optional string, default '_top'),
+    opener: (optional boolean, default false),
+  },
+  '*'
+);
+```
+
+Action `'navigate-to'` will trigger an `AMP.navigateTo` event with the provided parameters. See [Actions and events in AMP](https://github.com/ampproject/amphtml/blob/main/docs/spec/amp-actions-and-events.md#target-amp-) for more details on how to use `AMP.navigateTo`.
+
 #### Informing Consent response
 
 Iframes can send a `consent-response` message to the parent AMP page to inform the user [actions](https://github.com/ampproject/amphtml/blob/main/extensions/amp-consent/amp-consent.md#prompt-actions) along with additional consent information.


### PR DESCRIPTION
In #38183 @alanorozco and I discussed options how to allow amp-consent's consent-ui iframe to trigger navigation events in the top window. This pull request introduces a new `navigate-to` event which can be fired by the `consent-ui` iframe to trigger an `AMP.naviateTo` event.

Context: it is possible to load the consent ui in `amp-consent` from an external URL. The URL provided via `promptUISrc` is loaded inside an iFrame. The code inside that iFrame can communicate with the parent page via `postMessage` calls to e.g. signal ready or fullscreen events. The iFrame is instantiated with limited sandbox attributes (`allow-scripts`, `allow-popups` and optionally `allow-same-origin`). Since neither `allow-top-navigation` nor `allow-top-navigation-by-user-activation` are added, the iFrame is not allowed to trigger a navigation event in the top frame. There are cases though where triggering a navigation event from within that iFrame is useful (see #38183 for details).

This PR does not touch the `sandbox` attribute, but instead just allows the very specific use-case of navigating to a URL. And by leveraging the `AMP.navigateTo` event, we inherit all of its features (URL validation, check for relative URLs, etc.). This way the iframe does not have to copy that logic when directly setting `window.top.location`.
