### PR TITLE
✨ Allow custom iframe sandbox attributes in amp-consent

### DIFF
--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -149,6 +149,53 @@ describes.realWin(
           'allow-scripts allow-popups allow-same-origin'
         );
       });
+
+      it('should allow additional sandbox restriction to be removed from iframe', function* () {
+        const config = {
+          'promptUISrc': 'https://promptUISrc',
+          'sandbox': 'allow-top-navigation-by-user-activation',
+        };
+        consentUI = new ConsentUI(mockInstance, config);
+        expect(consentUI.ui_.tagName).to.equal('IFRAME');
+        expect(consentUI.ui_.getAttribute('sandbox')).to.equal(
+          'allow-scripts allow-popups allow-same-origin allow-top-navigation-by-user-activation'
+        );
+      });
+
+      it('should allow multiple additional sandbox restrictions to be removed from iframe', function* () {
+        const config = {
+          'promptUISrc': 'https://promptUISrc',
+          'sandbox':
+            'allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation',
+        };
+        consentUI = new ConsentUI(mockInstance, config);
+        expect(consentUI.ui_.tagName).to.equal('IFRAME');
+        expect(consentUI.ui_.getAttribute('sandbox')).to.equal(
+          'allow-scripts allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation'
+        );
+      });
+
+      it('should show an error when invalid sandbox attributes are specified', function* () {
+        const errorSpy = env.sandbox.spy(user(), 'error');
+
+        const config = {
+          'promptUISrc': 'https://promptUISrc',
+          'sandbox': 'allow-top-navigation',
+        };
+        consentUI = new ConsentUI(mockInstance, config);
+
+        expect(consentUI.ui_.tagName).to.equal('IFRAME');
+        expect(consentUI.ui_.getAttribute('sandbox')).to.equal(
+          'allow-scripts allow-popups allow-same-origin'
+        );
+
+        expect(errorSpy).to.be.calledOnce;
+        expect(errorSpy.args[0][1]).to.match(
+          /The sandbox attribute "allow-top-navigation" is not allowed/
+        );
+
+        errorSpy.resetHistory();
+      });
     });
 
     describe('show/hide', () => {

--- a/extensions/amp-consent/integrating-consent.md
+++ b/extensions/amp-consent/integrating-consent.md
@@ -26,6 +26,8 @@ A remote endpoint is expected to tell the AMP runtime whether the user consent i
 
 The AMP runtime will embed the CMP's prompt in an iframe. `amp-consent` will create the iframe when it is necessary. A default placeholder will be displayed, and the prompt iframe will remain hidden until it has finished loading.
 
+In case you need to enable additional sandbox restrictions to be removeed for the generated iframe, specify them in the `sandbox` configuration variable. It takes a string with space-seperated sandbox restrictions. The restrictions `allow-scripts` and `allow-popups` are removed by default. Right now, the only allowed additional sandbox restrictions are `allow-popups-to-escape-sandbox` and `allow-top-navigation-by-user-activation`.
+
 The prompt iframe and the parent AMP page will communicate through `postMessages` and the iframe `name` attribute. In the case of using postMessage, messages from nested iframes will be ignored. The lists of support APIs are:
 
 #### Requesting UI state change


### PR DESCRIPTION
In #38183 @alanorozco and I discussed options how to allow amp-consent's consent-ui iframe to trigger navigation events in the top window. This pull request allows specifying additional sandbox attributes similar to how users can specify them for `amp-iframe` (see [amp-iframe v0.1](https://github.com/ampproject/amphtml/blob/main/extensions/amp-iframe/1.0/README.md#sandbox-optional-) and [amp-iframe v1.0](https://github.com/ampproject/amphtml/blob/main/extensions/amp-iframe/0.1/amp-iframe.md#sandbox-)).

Context: it is possible to load the consent ui in `amp-consent` from an external URL. The URL provided via `promptUISrc` is loaded inside an iFrame. The code inside that iFrame can communicate with the parent page via `postMessage` calls to e.g. signal ready or fullscreen events. The iFrame is instantiated with limited sandbox attributes (`allow-scripts`, `allow-popups` and optionally `allow-same-origin`). Since neither `allow-top-navigation` nor `allow-top-navigation-by-user-activation` are added, the iFrame is not allowed to trigger a navigation event in the top frame. There are cases though where triggering a navigation event from within that iFrame is useful (see #38183 for details).

This PR allows specifying additional sandbox attributes so users have full control over the auto-generated iframe element.

