### PR TITLE
🖍 [Story Preview] Prevent story previews from displaying with the desktop UI in the mobile SERP

### DIFF
--- a/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
+++ b/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
@@ -56,7 +56,7 @@ iframe.swg-dialog {
   margin-left: 0 !important;
 }
 
-@media(min-aspect-ratio: 3/4) {
+@media(min-aspect-ratio: 31/40) {
   amp-story:not([supports-landscape]) + amp-subscriptions-dialog.i-amphtml-story-subscriptions-dialog-wrapper,
   iframe.swg-dialog  {
     width: var(--i-amphtml-story-desktop-one-panel-width) !important;

--- a/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
+++ b/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
@@ -56,7 +56,7 @@ iframe.swg-dialog {
   margin-left: 0 !important;
 }
 
-@media(min-aspect-ratio: 4/5) {
+@media(min-aspect-ratio: 3/4) {
   amp-story:not([supports-landscape]) + amp-subscriptions-dialog.i-amphtml-story-subscriptions-dialog-wrapper,
   iframe.swg-dialog  {
     width: var(--i-amphtml-story-desktop-one-panel-width) !important;

--- a/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
+++ b/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
@@ -56,7 +56,7 @@ iframe.swg-dialog {
   margin-left: 0 !important;
 }
 
-@media(min-aspect-ratio: 3/4) {
+@media(min-aspect-ratio: 4/5) {
   amp-story:not([supports-landscape]) + amp-subscriptions-dialog.i-amphtml-story-subscriptions-dialog-wrapper,
   iframe.swg-dialog  {
     width: var(--i-amphtml-story-desktop-one-panel-width) !important;

--- a/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
+++ b/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
@@ -56,7 +56,7 @@ iframe.swg-dialog {
   margin-left: 0 !important;
 }
 
-@media(min-aspect-ratio: 41/50) {
+@media(min-aspect-ratio: 31/40) {
   amp-story:not([supports-landscape]) + amp-subscriptions-dialog.i-amphtml-story-subscriptions-dialog-wrapper,
   iframe.swg-dialog  {
     width: var(--i-amphtml-story-desktop-one-panel-width) !important;

--- a/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
+++ b/extensions/amp-story-subscriptions/0.1/amp-story-subscriptions.css
@@ -56,7 +56,7 @@ iframe.swg-dialog {
   margin-left: 0 !important;
 }
 
-@media(min-aspect-ratio: 31/40) {
+@media(min-aspect-ratio: 41/50) {
   amp-story:not([supports-landscape]) + amp-subscriptions-dialog.i-amphtml-story-subscriptions-dialog-wrapper,
   iframe.swg-dialog  {
     width: var(--i-amphtml-story-desktop-one-panel-width) !important;

--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -11,7 +11,7 @@ amp-story[standalone] {
  * css/amp-story-player-shadow.css
  */
 
-@media(min-aspect-ratio: 3/4) {
+@media(min-aspect-ratio: 4/5) {
   /** Variables shared between page, system layer and pagination buttons. */
   :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {
     --i-amphtml-story-desktop-one-panel-ratio: 69 / 116;

--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -10,12 +10,12 @@ amp-story[standalone] {
  * NOTE: If you change any variables or media queries change:
  * css/amp-story-player-shadow.css
  *
- * Story previews are shown on the mobile SERP in a viewer with a 3/4 aspect
- * ratio, so a 31/40 min-aspect-ratio here ensures that the mobile UI is
- * displayed instead of the desktop UI. 
+ * Story previews are shown on the mobile SERP in a viewer with a 4/5 aspect
+ * ratio, so a 41/50 min-aspect-ratio here ensures that the mobile UI is
+ * displayed instead of the desktop UI.
  */
 
-@media (min-aspect-ratio: 31/40) {
+@media (min-aspect-ratio: 41/50) {
   /** Variables shared between page, system layer and pagination buttons. */
   :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {
     --i-amphtml-story-desktop-one-panel-ratio: 69 / 116;

--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -10,12 +10,12 @@ amp-story[standalone] {
  * NOTE: If you change any variables or media queries change:
  * css/amp-story-player-shadow.css
  *
- * Story previews are shown on the mobile SERP in a viewer with a 4/5 aspect
- * ratio, so a 41/50 min-aspect-ratio here ensures that the mobile UI is
+ * Story previews are shown on the mobile SERP in a viewer with a 3/4 aspect
+ * ratio, so a 31/40 min-aspect-ratio here ensures that the mobile UI is
  * displayed instead of the desktop UI.
  */
 
-@media (min-aspect-ratio: 41/50) {
+@media (min-aspect-ratio: 31/40) {
   /** Variables shared between page, system layer and pagination buttons. */
   :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {
     --i-amphtml-story-desktop-one-panel-ratio: 69 / 116;

--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -9,6 +9,10 @@ amp-story[standalone] {
 /**
  * NOTE: If you change any variables or media queries change:
  * css/amp-story-player-shadow.css
+ *
+ * Story previews are shown on the mobile SERP in a viewer with a 3/4 aspect
+ * ratio, so a 31/40 min-aspect-ratio here ensures that the mobile UI is
+ * displayed instead of the desktop UI. 
  */
 @media (min-aspect-ratio: 31/40) {
   /** Variables shared between page, system layer and pagination buttons. */

--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -10,8 +10,7 @@ amp-story[standalone] {
  * NOTE: If you change any variables or media queries change:
  * css/amp-story-player-shadow.css
  */
-
-@media(min-aspect-ratio: 4/5) {
+@media (min-aspect-ratio: 31/40) {
   /** Variables shared between page, system layer and pagination buttons. */
   :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {
     --i-amphtml-story-desktop-one-panel-ratio: 69 / 116;

--- a/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
+++ b/extensions/amp-story/1.0/amp-story-desktop-one-panel.css
@@ -14,6 +14,7 @@ amp-story[standalone] {
  * ratio, so a 31/40 min-aspect-ratio here ensures that the mobile UI is
  * displayed instead of the desktop UI. 
  */
+
 @media (min-aspect-ratio: 31/40) {
   /** Variables shared between page, system layer and pagination buttons. */
   :root:not([data-story-supports-landscape]):not([i-amphtml-story-mobile]) {

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -143,7 +143,7 @@ const DESKTOP_HEIGHT_THRESHOLD = 550;
  * NOTE: If udpated here, update in amp-story-player-impl.js
  * @private @const {string}
  */
-const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '31 / 40';
+const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '41 / 50';
 
 /** @private @const {number} */
 const MIN_SWIPE_FOR_HINT_OVERLAY_PX = 50;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -143,7 +143,7 @@ const DESKTOP_HEIGHT_THRESHOLD = 550;
  * NOTE: If udpated here, update in amp-story-player-impl.js
  * @private @const {string}
  */
-const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '3 / 4';
+const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '4 / 5';
 
 /** @private @const {number} */
 const MIN_SWIPE_FOR_HINT_OVERLAY_PX = 50;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -143,7 +143,7 @@ const DESKTOP_HEIGHT_THRESHOLD = 550;
  * NOTE: If udpated here, update in amp-story-player-impl.js
  * @private @const {string}
  */
-const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '4 / 5';
+const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '31 / 40';
 
 /** @private @const {number} */
 const MIN_SWIPE_FOR_HINT_OVERLAY_PX = 50;

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -143,7 +143,7 @@ const DESKTOP_HEIGHT_THRESHOLD = 550;
  * NOTE: If udpated here, update in amp-story-player-impl.js
  * @private @const {string}
  */
-const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '41 / 50';
+const DESKTOP_ONE_PANEL_ASPECT_RATIO_THRESHOLD = '31 / 40';
 
 /** @private @const {number} */
 const MIN_SWIPE_FOR_HINT_OVERLAY_PX = 50;

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -176,7 +176,7 @@ const LOG_TYPE_ENUM = {
  * NOTE: If udpated here, update in amp-story.js
  * @private @const {number}
  */
-const PANEL_ASPECT_RATIO_THRESHOLD = 3 / 4;
+const PANEL_ASPECT_RATIO_THRESHOLD = 4 / 5;
 
 /**
  * Note that this is a vanilla JavaScript class and should not depend on AMP

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -176,7 +176,7 @@ const LOG_TYPE_ENUM = {
  * NOTE: If udpated here, update in amp-story.js
  * @private @const {number}
  */
-const PANEL_ASPECT_RATIO_THRESHOLD = 41 / 50;
+const PANEL_ASPECT_RATIO_THRESHOLD = 31 / 40;
 
 /**
  * Note that this is a vanilla JavaScript class and should not depend on AMP

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -176,7 +176,7 @@ const LOG_TYPE_ENUM = {
  * NOTE: If udpated here, update in amp-story.js
  * @private @const {number}
  */
-const PANEL_ASPECT_RATIO_THRESHOLD = 4 / 5;
+const PANEL_ASPECT_RATIO_THRESHOLD = 31 / 40;
 
 /**
  * Note that this is a vanilla JavaScript class and should not depend on AMP

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -176,7 +176,7 @@ const LOG_TYPE_ENUM = {
  * NOTE: If udpated here, update in amp-story.js
  * @private @const {number}
  */
-const PANEL_ASPECT_RATIO_THRESHOLD = 31 / 40;
+const PANEL_ASPECT_RATIO_THRESHOLD = 41 / 50;
 
 /**
  * Note that this is a vanilla JavaScript class and should not depend on AMP


### PR DESCRIPTION
- Part of #37129

---

This PR increases the aspect ratio threshold beyond which the desktop UI is displayed, from 3/4 to 31/40. Story previews are shown on the mobile SERP in a viewer with a 3/4 aspect ratio, so a 31/40 min-aspect-ratio here ensures that the mobile UI is displayed instead of the desktop UI. 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
