### PR TITLE
Install npm packages with `--legacy-peer-deps` on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ commands:
   setup_node_environment:
     steps:
       - node/install:
+          lts: true
           install-npm: false
       - node/install-packages:
           override-ci-command: 'npm ci --legacy-peer-deps'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ commands:
   setup_node_environment:
     steps:
       - node/install:
-          lts: true
+          node-version: '16.15.0'
           install-npm: false
       - node/install-packages
   setup_vm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,9 @@ commands:
   setup_node_environment:
     steps:
       - node/install:
-          node-version: '16.15.0'
           install-npm: false
-      - node/install-packages
+      - node/install-packages:
+          override-ci-command: 'npm ci --legacy-peer-deps'
   setup_vm:
     parameters:
       save-git-cache:

--- a/.circleci/install_validator_dependencies.sh
+++ b/.circleci/install_validator_dependencies.sh
@@ -16,4 +16,4 @@ echo $(GREEN "Updating and installing apt packages...")
 sudo apt update && sudo apt install bazel clang python3 python3-pip protobuf-compiler
 
 echo $(GREEN "Installing protobuf python module...")
-pip3 install protobuf
+pip3 install protobuf==3.19.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -19657,6 +19657,7 @@
     },
     "node_modules/react": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19716,6 +19717,7 @@
     },
     "node_modules/react-dom": {
       "version": "17.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -20422,6 +20424,7 @@
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -25757,8 +25760,7 @@
     },
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -26261,8 +26263,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -28111,8 +28112,7 @@
     },
     "cssnano-utils": {
       "version": "2.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -28571,8 +28571,7 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -29052,8 +29051,7 @@
     },
     "eslint-config-prettier": {
       "version": "8.3.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-babel-module": {
       "version": "5.3.1",
@@ -29156,8 +29154,7 @@
     },
     "eslint-plugin-chai-expect": {
       "version": "2.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-eslint-plugin": {
       "version": "3.6.1",
@@ -29299,8 +29296,7 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.2.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-sort-destructure-keys": {
       "version": "1.4.0",
@@ -32736,8 +32732,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-progress-bar-reporter": {
       "version": "1.0.21",
@@ -34295,8 +34290,7 @@
     },
     "karma-html2js-preprocessor": {
       "version": "1.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "karma-junit-reporter": {
       "version": "2.0.1",
@@ -34344,8 +34338,7 @@
     },
     "karma-safarinative-launcher": {
       "version": "1.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -36176,23 +36169,19 @@
     },
     "postcss-discard-comments": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-import": {
       "version": "14.0.2",
@@ -36260,8 +36249,7 @@
     },
     "postcss-normalize-charset": {
       "version": "5.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -36709,6 +36697,7 @@
     },
     "react": {
       "version": "17.0.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -36747,6 +36736,7 @@
     },
     "react-dom": {
       "version": "17.0.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -37216,6 +37206,7 @@
     },
     "scheduler": {
       "version": "0.20.2",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -37445,8 +37436,7 @@
     },
     "sinon-chai": {
       "version": "3.7.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "slash": {
       "version": "3.0.0",
@@ -39040,8 +39030,7 @@
     },
     "ws": {
       "version": "7.5.3",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",


### PR DESCRIPTION
Super temp workaround to avoid running `npm ci` on circleci that fails...

Also pin protobuf to v3.19.4 until `amp validator` can be fixed with new version
```
validator-tests.js Running amp validator...
[17:10:01] Using task file project/amp.js
[17:10:01] Starting 'validator'...
Traceback (most recent call last):
  File "build.py", line 620, in <module>
    Main(parser.parse_args())
  File "build.py", line 597, in Main
    GenValidatorProtoGeneratedJs(out_dir='dist')
  File "build.py", line 195, in GenValidatorProtoGeneratedJs
    from dist import validator_pb2
  File "/home/circleci/project/validator/dist/validator_pb2.py", line 33, in <module>
    _descriptor.EnumValueDescriptor(
  File "/home/circleci/.local/lib/python3.8/site-packages/google/protobuf/descriptor.py", line 755, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
 ```