### PR TITLE
Remove react-dates from package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,7 @@ commands:
       - node/install:
           lts: true
           install-npm: false
-      - node/install-packages:
-          override-ci-command: 'npm ci --legacy-peer-deps'
+      - node/install-packages
   setup_vm:
     parameters:
       save-git-cache:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "moment": "2.29.1",
         "obj-str": "1.1.0",
         "preact": "10.5.15",
-        "react-dates": "21.8.0",
         "react-day-picker": "8.0.0-beta.37",
         "react-jss": "10.8.2",
         "resize-observer-polyfill": "1.5.1",
@@ -4554,27 +4553,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/airbnb-prop-types": {
-      "version": "2.16.0",
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15.0.0 || ^16.0.0-alpha"
-      }
-    },
     "node_modules/ajv": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
@@ -4941,21 +4919,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/array.prototype.find": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/array.prototype.flat": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
       "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -5864,10 +5832,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/brcast": {
-      "version": "2.0.2",
-      "license": "MIT"
-    },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
       "dev": true,
@@ -6042,6 +6006,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -6849,10 +6814,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/consolidated-events": {
-      "version": "2.0.2",
-      "license": "MIT"
-    },
     "node_modules/content-disposition": {
       "version": "0.5.3",
       "dev": true,
@@ -7423,13 +7384,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/deepmerge": {
-      "version": "1.5.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/defaults": {
       "version": "1.0.3",
       "dev": true,
@@ -7461,6 +7415,7 @@
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-keys": "^1.0.12"
@@ -7653,17 +7608,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/direction": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "direction": "cli.js"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/discontinuous-range": {
       "version": "1.0.0",
       "dev": true,
@@ -7678,16 +7622,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/document.contains": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/dom-serialize": {
@@ -8007,6 +7941,7 @@
     },
     "node_modules/enzyme-shallow-equal": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3",
@@ -8043,6 +7978,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
       "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -8074,6 +8010,7 @@
     },
     "node_modules/es-abstract/node_modules/get-intrinsic": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -8086,6 +8023,7 @@
     },
     "node_modules/es-abstract/node_modules/is-negative-zero": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8096,6 +8034,7 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -10321,10 +10260,12 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.1.3",
@@ -10345,6 +10286,7 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10457,6 +10399,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -10496,6 +10439,7 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -10510,6 +10454,7 @@
     },
     "node_modules/get-symbol-description/node_modules/get-intrinsic": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -10610,17 +10555,6 @@
       "version": "0.4.1",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/global-cache": {
-      "version": "1.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.2",
-        "is-symbol": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/global-dirs": {
       "version": "3.0.0",
@@ -11020,6 +10954,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -11032,6 +10967,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
       "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11048,6 +10984,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11059,6 +10996,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -11471,6 +11409,7 @@
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.0",
@@ -11483,6 +11422,7 @@
     },
     "node_modules/internal-slot/node_modules/get-intrinsic": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -11578,6 +11518,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
       "dependencies": {
         "has-bigints": "^1.0.1"
       },
@@ -11600,6 +11541,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -11620,6 +11562,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
       "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11674,6 +11617,7 @@
     },
     "node_modules/is-date-object": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11845,6 +11789,7 @@
     },
     "node_modules/is-number-object": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11910,6 +11855,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -11952,6 +11898,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11971,6 +11918,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -11988,6 +11936,7 @@
     },
     "node_modules/is-symbol": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.1"
@@ -11998,10 +11947,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-touch-device": {
-      "version": "1.0.1",
-      "license": "MIT"
     },
     "node_modules/is-typed-array": {
       "version": "1.1.5",
@@ -12065,6 +12010,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
       "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0"
       },
@@ -16414,6 +16360,7 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -17931,12 +17878,14 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/object-is": {
       "version": "1.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -17951,6 +17900,7 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17969,6 +17919,7 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -17985,6 +17936,7 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -18040,6 +17992,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
       "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -18521,6 +18474,7 @@
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -19429,15 +19383,6 @@
         "react-is": "^16.8.1"
       }
     },
-    "node_modules/prop-types-exact": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "dev": true,
@@ -19568,6 +19513,7 @@
     },
     "node_modules/raf": {
       "version": "3.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "performance-now": "^2.1.0"
@@ -19657,7 +19603,6 @@
     },
     "node_modules/react": {
       "version": "17.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19665,34 +19610,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dates": {
-      "version": "21.8.0",
-      "license": "MIT",
-      "dependencies": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "enzyme-shallow-equal": "^1.0.0",
-        "is-touch-device": "^1.0.1",
-        "lodash": "^4.1.1",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "raf": "^3.4.1",
-        "react-moment-proptypes": "^1.6.0",
-        "react-outside-click-handler": "^1.2.4",
-        "react-portal": "^4.2.0",
-        "react-with-direction": "^1.3.1",
-        "react-with-styles": "^4.1.0",
-        "react-with-styles-interface-css": "^6.0.0"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.0.0",
-        "moment": "^2.18.1",
-        "react": "^0.14 || ^15.5.4 || ^16.1.1",
-        "react-dom": "^0.14 || ^15.5.4 || ^16.1.1",
-        "react-with-direction": "^1.3.1"
       }
     },
     "node_modules/react-day-picker": {
@@ -19717,7 +19634,6 @@
     },
     "node_modules/react-dom": {
       "version": "17.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -19751,87 +19667,6 @@
       },
       "peerDependencies": {
         "react": ">=16.8.6"
-      }
-    },
-    "node_modules/react-moment-proptypes": {
-      "version": "1.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "moment": ">=1.6.0"
-      },
-      "peerDependencies": {
-        "moment": ">=1.6.0"
-      }
-    },
-    "node_modules/react-outside-click-handler": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "document.contains": "^1.0.1",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || >=15",
-        "react-dom": "^0.14 || >=15"
-      }
-    },
-    "node_modules/react-portal": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0-0 || ^16.0.0-0 || ^17.0.0-0"
-      }
-    },
-    "node_modules/react-with-direction": {
-      "version": "1.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "airbnb-prop-types": "^2.10.0",
-        "brcast": "^2.0.2",
-        "deepmerge": "^1.5.2",
-        "direction": "^1.0.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.0.4",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": "^0.14 || ^15 || ^16",
-        "react-dom": "^0.14 || ^15 || ^16"
-      }
-    },
-    "node_modules/react-with-styles": {
-      "version": "4.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "airbnb-prop-types": "^2.14.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "object.assign": "^4.1.0",
-        "prop-types": "^15.7.2",
-        "react-with-direction": "^1.3.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react": ">=0.14",
-        "react-with-direction": "^1.3.1"
-      }
-    },
-    "node_modules/react-with-styles-interface-css": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flat": "^1.2.1",
-        "global-cache": "^1.2.1"
-      },
-      "peerDependencies": {
-        "@babel/runtime": "^7.0.0",
-        "react-with-styles": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/read-cache": {
@@ -19888,10 +19723,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/reflect.ownkeys": {
-      "version": "0.2.0",
-      "license": "MIT"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -20424,7 +20255,6 @@
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -20673,6 +20503,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
@@ -21338,6 +21169,7 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -21349,6 +21181,7 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -22234,6 +22067,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -22872,6 +22706,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "dependencies": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -25760,7 +25595,8 @@
     },
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -26263,7 +26099,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -26282,20 +26119,6 @@
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
-      }
-    },
-    "airbnb-prop-types": {
-      "version": "2.16.0",
-      "requires": {
-        "array.prototype.find": "^2.1.1",
-        "function.prototype.name": "^1.1.2",
-        "is-regex": "^1.1.0",
-        "object-is": "^1.1.2",
-        "object.assign": "^4.1.0",
-        "object.entries": "^1.1.2",
-        "prop-types": "^15.7.2",
-        "prop-types-exact": "^1.2.0",
-        "react-is": "^16.13.1"
       }
     },
     "ajv": {
@@ -26546,17 +26369,11 @@
       "version": "0.3.2",
       "dev": true
     },
-    "array.prototype.find": {
-      "version": "2.1.1",
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.4"
-      }
-    },
     "array.prototype.flat": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
       "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -27170,9 +26987,6 @@
         "fill-range": "^7.0.1"
       }
     },
-    "brcast": {
-      "version": "2.0.2"
-    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "dev": true
@@ -27302,6 +27116,7 @@
     },
     "call-bind": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -27854,9 +27669,6 @@
       "version": "0.6.1",
       "dev": true
     },
-    "consolidated-events": {
-      "version": "2.0.2"
-    },
     "content-disposition": {
       "version": "0.5.3",
       "dev": true,
@@ -28112,7 +27924,8 @@
     },
     "cssnano-utils": {
       "version": "2.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "csso": {
       "version": "4.2.0",
@@ -28235,9 +28048,6 @@
       "version": "0.1.3",
       "dev": true
     },
-    "deepmerge": {
-      "version": "1.5.2"
-    },
     "defaults": {
       "version": "1.0.3",
       "dev": true,
@@ -28261,6 +28071,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
+      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -28391,9 +28202,6 @@
         "path-type": "^4.0.0"
       }
     },
-    "direction": {
-      "version": "1.0.4"
-    },
     "discontinuous-range": {
       "version": "1.0.0",
       "dev": true
@@ -28403,12 +28211,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "document.contains": {
-      "version": "1.0.2",
-      "requires": {
-        "define-properties": "^1.1.3"
       }
     },
     "dom-serialize": {
@@ -28571,7 +28373,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -28636,6 +28439,7 @@
     },
     "enzyme-shallow-equal": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "has": "^1.0.3",
         "object-is": "^1.1.2"
@@ -28663,6 +28467,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
       "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -28688,6 +28493,7 @@
       "dependencies": {
         "get-intrinsic": {
           "version": "1.1.1",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -28695,12 +28501,14 @@
           }
         },
         "is-negative-zero": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "dev": true
         }
       }
     },
     "es-to-primitive": {
       "version": "1.2.1",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -29051,7 +28859,8 @@
     },
     "eslint-config-prettier": {
       "version": "8.3.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-babel-module": {
       "version": "5.3.1",
@@ -29154,7 +28963,8 @@
     },
     "eslint-plugin-chai-expect": {
       "version": "2.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-eslint-plugin": {
       "version": "3.6.1",
@@ -29296,7 +29106,8 @@
     },
     "eslint-plugin-react-hooks": {
       "version": "4.2.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-sort-destructure-keys": {
       "version": "1.4.0",
@@ -30219,10 +30030,12 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.2",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1",
@@ -30234,7 +30047,8 @@
       "dev": true
     },
     "functions-have-names": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "gaxios": {
       "version": "4.3.2",
@@ -30312,6 +30126,7 @@
     },
     "get-intrinsic": {
       "version": "1.0.2",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -30335,6 +30150,7 @@
     },
     "get-symbol-description": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -30342,6 +30158,7 @@
       "dependencies": {
         "get-intrinsic": {
           "version": "1.1.1",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -30416,13 +30233,6 @@
     "glob-to-regexp": {
       "version": "0.4.1",
       "dev": true
-    },
-    "global-cache": {
-      "version": "1.2.1",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "is-symbol": "^1.0.1"
-      }
     },
     "global-dirs": {
       "version": "3.0.0",
@@ -30712,6 +30522,7 @@
     },
     "has": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -30719,7 +30530,8 @@
     "has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -30728,12 +30540,14 @@
     "has-symbols": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       }
@@ -31015,6 +30829,7 @@
     },
     "internal-slot": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -31023,6 +30838,7 @@
       "dependencies": {
         "get-intrinsic": {
           "version": "1.1.1",
+          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -31085,6 +30901,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -31100,6 +30917,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -31112,7 +30930,8 @@
     "is-callable": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -31147,7 +30966,8 @@
       }
     },
     "is-date-object": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -31241,7 +31061,8 @@
       "dev": true
     },
     "is-number-object": {
-      "version": "1.0.4"
+      "version": "1.0.4",
+      "dev": true
     },
     "is-obj": {
       "version": "2.0.0",
@@ -31278,6 +31099,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -31304,7 +31126,8 @@
     "is-shared-array-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true
     },
     "is-stream": {
       "version": "2.0.1",
@@ -31314,6 +31137,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
       "requires": {
         "has-tostringtag": "^1.0.0"
       }
@@ -31324,12 +31148,10 @@
     },
     "is-symbol": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-touch-device": {
-      "version": "1.0.1"
     },
     "is-typed-array": {
       "version": "1.1.5",
@@ -31369,6 +31191,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
       "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0"
       }
@@ -32732,7 +32555,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-progress-bar-reporter": {
       "version": "1.0.21",
@@ -34290,7 +34114,8 @@
     },
     "karma-html2js-preprocessor": {
       "version": "1.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-junit-reporter": {
       "version": "2.0.1",
@@ -34338,7 +34163,8 @@
     },
     "karma-safarinative-launcher": {
       "version": "1.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-source-map-support": {
       "version": "1.4.0",
@@ -34624,7 +34450,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -35632,17 +35459,20 @@
     "object-inspect": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "dev": true
     },
     "object-is": {
       "version": "1.1.5",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
     "object-keys": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -35653,6 +35483,7 @@
     },
     "object.assign": {
       "version": "4.1.2",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -35662,6 +35493,7 @@
     },
     "object.entries": {
       "version": "1.1.3",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -35698,6 +35530,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
       "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -35994,7 +35827,8 @@
       }
     },
     "performance-now": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
     },
     "picocolors": {
       "version": "0.2.1",
@@ -36169,19 +36003,23 @@
     },
     "postcss-discard-comments": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-import": {
       "version": "14.0.2",
@@ -36249,7 +36087,8 @@
     },
     "postcss-normalize-charset": {
       "version": "5.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -36547,14 +36386,6 @@
         "react-is": "^16.8.1"
       }
     },
-    "prop-types-exact": {
-      "version": "1.2.0",
-      "requires": {
-        "has": "^1.0.3",
-        "object.assign": "^4.1.0",
-        "reflect.ownkeys": "^0.2.0"
-      }
-    },
     "propagate": {
       "version": "2.0.1",
       "dev": true
@@ -36633,6 +36464,7 @@
     },
     "raf": {
       "version": "3.4.1",
+      "dev": true,
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -36697,30 +36529,9 @@
     },
     "react": {
       "version": "17.0.2",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "react-dates": {
-      "version": "21.8.0",
-      "requires": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "enzyme-shallow-equal": "^1.0.0",
-        "is-touch-device": "^1.0.1",
-        "lodash": "^4.1.1",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "raf": "^3.4.1",
-        "react-moment-proptypes": "^1.6.0",
-        "react-outside-click-handler": "^1.2.4",
-        "react-portal": "^4.2.0",
-        "react-with-direction": "^1.3.1",
-        "react-with-styles": "^4.1.0",
-        "react-with-styles-interface-css": "^6.0.0"
       }
     },
     "react-day-picker": {
@@ -36736,7 +36547,6 @@
     },
     "react-dom": {
       "version": "17.0.2",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -36762,58 +36572,6 @@
         "shallow-equal": "^1.2.0",
         "theming": "^3.3.0",
         "tiny-warning": "^1.0.2"
-      }
-    },
-    "react-moment-proptypes": {
-      "version": "1.8.1",
-      "requires": {
-        "moment": ">=1.6.0"
-      }
-    },
-    "react-outside-click-handler": {
-      "version": "1.3.0",
-      "requires": {
-        "airbnb-prop-types": "^2.15.0",
-        "consolidated-events": "^1.1.1 || ^2.0.0",
-        "document.contains": "^1.0.1",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2"
-      }
-    },
-    "react-portal": {
-      "version": "4.2.1",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
-    "react-with-direction": {
-      "version": "1.3.1",
-      "requires": {
-        "airbnb-prop-types": "^2.10.0",
-        "brcast": "^2.0.2",
-        "deepmerge": "^1.5.2",
-        "direction": "^1.0.2",
-        "hoist-non-react-statics": "^3.3.0",
-        "object.assign": "^4.1.0",
-        "object.values": "^1.0.4",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-with-styles": {
-      "version": "4.2.0",
-      "requires": {
-        "airbnb-prop-types": "^2.14.0",
-        "hoist-non-react-statics": "^3.2.1",
-        "object.assign": "^4.1.0",
-        "prop-types": "^15.7.2",
-        "react-with-direction": "^1.3.1"
-      }
-    },
-    "react-with-styles-interface-css": {
-      "version": "6.0.0",
-      "requires": {
-        "array.prototype.flat": "^1.2.1",
-        "global-cache": "^1.2.1"
       }
     },
     "read-cache": {
@@ -36858,9 +36616,6 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
-    },
-    "reflect.ownkeys": {
-      "version": "0.2.0"
     },
     "regenerate": {
       "version": "1.4.2",
@@ -37206,7 +36961,6 @@
     },
     "scheduler": {
       "version": "0.20.2",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -37392,6 +37146,7 @@
     },
     "side-channel": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -37436,7 +37191,8 @@
     },
     "sinon-chai": {
       "version": "3.7.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "3.0.0",
@@ -37881,6 +37637,7 @@
     },
     "string.prototype.trimend": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -37888,6 +37645,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -38498,6 +38256,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -38945,6 +38704,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -39030,7 +38790,8 @@
     },
     "ws": {
       "version": "7.5.3",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "moment": "2.29.1",
     "obj-str": "1.1.0",
     "preact": "10.5.15",
-    "react-dates": "21.8.0",
     "react-day-picker": "8.0.0-beta.37",
     "react-jss": "10.8.2",
     "resize-observer-polyfill": "1.5.1",


### PR DESCRIPTION
`react-dates` is used by `amp-date-picker-0.1` but does not support `react>=17`, which is what the rest of amphtml uses. This means that `npm install` fails.

Turns out we install `react-dates` in `third_party/` so that means we can probably remove `react-dates` from `package.json`