### PR TITLE
❄️ 🐛 [amp-story-shopping] Remove animations on visual tests

### DIFF
--- a/examples/visual-tests/amp-story/amp-story-shopping-landscape.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-landscape.html
@@ -27,6 +27,10 @@
         top: 46%;
         left: 83%;
       }
+      /* Prevents CSS animations from running. */
+      * {
+        animation-duration: 0s !important
+      }
     </style>
   </head>
   <body>

--- a/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-lang-de.html
@@ -27,6 +27,10 @@
         top: 46%;
         left: 83%;
       }
+      /* Prevents CSS animations from running. */
+      * {
+        animation-duration: 0s !important
+      }
     </style>
   </head>
   <body>

--- a/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping-rtl.html
@@ -27,6 +27,10 @@
         top: 46%;
         left: 83%;
       }
+      /* Prevents CSS animations from running. */
+      * {
+        animation-duration: 0s !important
+      }
     </style>
   </head>
   <body>

--- a/examples/visual-tests/amp-story/amp-story-shopping.html
+++ b/examples/visual-tests/amp-story/amp-story-shopping.html
@@ -25,6 +25,10 @@
         top: 46%;
         left: 83%;
       }
+      /* Prevents CSS animations from running. */
+      * {
+        animation-duration: 0s !important
+      }
     </style>
   </head>
   <body>


### PR DESCRIPTION
Removes animations on `amp-story-shopping` visual diff tests to prevent flakes such as [this one](https://percy.io/ampproject/amphtml/builds/18680083/changed/1047950639?browser=chrome&browser_ids=23&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=320&widths=320).

This should be able to target elements in shadow dom since Percy runs in [test mode](https://github.com/ampproject/amphtml/blob/main/extensions/amp-story/1.0/utils.js#L91-L93).

Percy may be disabling CSS animations by going to the last keyframe by default. This element has two animations so it may not be targeting [both animations](https://github.com/ampproject/amphtml/blob/main/extensions/amp-story-shopping/0.1/amp-story-shopping-tag.css#L171-L173). 