### PR TITLE
🐛 Callout vendor update mediasquare - check width and height

### DIFF
--- a/src/service/real-time-config/callout-vendors.js
+++ b/src/service/real-time-config/callout-vendors.js
@@ -130,7 +130,7 @@ const RTC_VENDORS = jsonConfiguration({
     disableKeyAppend: true,
   },
   mediasquare: {
-    url: 'https://pbs-front.mediasquare.fr/msq_prebid?owner=OWNER&code=CODE&sizes=ATTR(data-multi-size)&adunit=ATTR(data-slot)&referer=HREF&gdpr_consent=CONSENT_STRING',
+    url: 'https://pbs-front.mediasquare.fr/msq_prebid?owner=OWNER&code=CODE&w=ATTR(width)&h=ATTR(height)&sizes=ATTR(data-multi-size)&adunit=ATTR(data-slot)&referer=HREF&gdpr_consent=CONSENT_STRING',
     macros: ['OWNER', 'CODE', 'CONSENT_STRING'],
     disableKeyAppend: true,
   },


### PR DESCRIPTION
Get attributes width and height for vendor mediasquare, in addition to `data-multi-size` for compatibility with publishers not using  `data-multi-size`

