### PR TITLE
Except Google Translate from the font-stylesheet timeout

### DIFF
--- a/src/font-stylesheet-timeout.js
+++ b/src/font-stylesheet-timeout.js
@@ -54,7 +54,7 @@ function maybeTimeoutFonts(win) {
     // Find all stylesheets that aren't loaded from the AMP CDN (those are
     // critical if they are present).
     const styleLinkElements = win.document.querySelectorAll(
-      `link[rel~="stylesheet"]:not([href^="${escapeCssSelectorIdent(
+      `link[rel~="stylesheet"]:not([href^="https://translate.googleapis.com/translate_static/css/"]):not([href^="${escapeCssSelectorIdent(
         urls.cdn
       )}"])`
     );


### PR DESCRIPTION
We're seeing a huge number of CSP violations because of Chrome's translate features injects this stylesheet dynamically. Somehow, they've privileged it to run regardless of our strict CSP. But when we try to force the first render of the page by toggling it's `media` attribute, the CSP fails and the stylesheet is prevented from loading.