### PR TITLE
🐛 [Story Preview] Wait until the story is visible before pausing for consent resolution

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -1198,7 +1198,9 @@ export class AmpStory extends AMP.BaseElement {
       return;
     }
 
-    this.pauseStoryUntilConsentIsResolved_();
+    this.getAmpDoc()
+      .whenFirstVisible()
+      .then(() => this.pauseStoryUntilConsentIsResolved_());
     this.validateConsent_(consentEl);
   }
 


### PR DESCRIPTION
- Part of #37129

---

**Background**: Stories that include an `amp-consent` element are [paused](https://github.com/ampproject/amphtml/blob/0f6cdcebd462d3dcf580d8df0a7dfcdc02de9061/extensions/amp-story/1.0/amp-story.js#L1201) until the consent has been resolved.

**Issue**: The consent never resolves in preview mode because amp-consent doesn’t get built until the story is visible. This means that stories that contain `amp-consent` elements remain paused in preview mode until the story transitions to the visible state. 

**Fix**: Wait until the story is visible before calling `pauseStoryUntilConsentIsResolved_()`.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
