### PR TITLE
🐛 [story-ads] Allow optional `src` attr

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads-remote.html
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads-remote.html
@@ -1,0 +1,28 @@
+<!--
+  Test Description:
+  Tests for the amp-story-auto-ads tag with remote config.
+-->
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>STAMP examples</title>
+  <link rel="canonical" href="http://nonblocking.io/" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-latest.js"></script>
+  <script async custom-element="amp-story-auto-ads" src="https://cdn.ampproject.org/v0/amp-story-auto-ads-latest.js"></script>
+</head>
+<body>
+  <amp-story standalone poster-portrait-src="portrait.png" poster-landscape-src="landscape.png" poster-square-src="square.png"
+      title="Example" publisher="The AMP Project" publisher-logo-src="amp.png">
+    <amp-story-page id="1">
+      <amp-story-grid-layer template="horizontal">
+      </amp-story-grid-layer>
+    </amp-story-page>
+    <amp-story-auto-ads src="https://remote.config">
+    </amp-story-auto-ads>
+  </amp-story>
+</body>
+</html>

--- a/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads-remote.out
+++ b/extensions/amp-story-auto-ads/0.1/test/validator-amp-story-auto-ads-remote.out
@@ -1,0 +1,29 @@
+PASS
+|  <!--
+|    Test Description:
+|    Tests for the amp-story-auto-ads tag with remote config.
+|  -->
+|  <!doctype html>
+|  <html ⚡ lang="en">
+|  <head>
+|    <meta charset="utf-8">
+|    <title>STAMP examples</title>
+|    <link rel="canonical" href="http://nonblocking.io/" >
+|    <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-latest.js"></script>
+|    <script async custom-element="amp-story-auto-ads" src="https://cdn.ampproject.org/v0/amp-story-auto-ads-latest.js"></script>
+|  </head>
+|  <body>
+|    <amp-story standalone poster-portrait-src="portrait.png" poster-landscape-src="landscape.png" poster-square-src="square.png"
+|        title="Example" publisher="The AMP Project" publisher-logo-src="amp.png">
+|      <amp-story-page id="1">
+|        <amp-story-grid-layer template="horizontal">
+|        </amp-story-grid-layer>
+|      </amp-story-page>
+|      <amp-story-auto-ads src="https://remote.config">
+|      </amp-story-auto-ads>
+|    </amp-story>
+|  </body>
+|  </html>

--- a/extensions/amp-story-auto-ads/validator-amp-story-auto-ads.protoascii
+++ b/extensions/amp-story-auto-ads/validator-amp-story-auto-ads.protoascii
@@ -19,6 +19,12 @@ tags: {  # <amp-story-auto-ads>
   mandatory_parent: "AMP-STORY"
   unique: true
   spec_url: "https://amp.dev/documentation/components/amp-story-auto-ads/"
+  attrs: {
+    name: "src"
+    value_url: {
+      protocol: "https"
+    }
+  }
 }
 tags: {  # amp-story-auto-ads (json config)
   html_format: AMP


### PR DESCRIPTION
Allow optional `src` attr on `<amp-story-auto-ads>` to specify remote config https://amp.dev/documentation/components/amp-story-auto-ads/?format=stories#remote-ad-config

This functionality was added very long ago, but the validator was never updated. This should be an optional `src` attribute that points to a publishers JSON endpoint.