### PR TITLE
🐛 [History] Wrap `pushState`/`replaceState` calls in `try`/`catch` blocks

### DIFF
--- a/src/service/history-impl.js
+++ b/src/service/history-impl.js
@@ -413,22 +413,30 @@ export class HistoryBindingNatural_ {
         history.originalReplaceState || history.replaceState.bind(history);
       pushState = (state, opt_title, opt_url) => {
         this.unsupportedState_ = state;
-        this.origPushState_(
-          state,
-          opt_title,
-          // A bug in edge causes paths to become undefined if URL is
-          // undefined, filed here: https://goo.gl/KlImZu
-          opt_url || null
-        );
+        try {
+          this.origPushState_(
+            state,
+            opt_title,
+            // A bug in edge causes paths to become undefined if URL is
+            // undefined, filed here: https://goo.gl/KlImZu
+            opt_url || null
+          );
+        } catch (e) {
+          dev().error(TAG_, 'pushState failed: ' + e.message);
+        }
       };
       replaceState = (state, opt_title, opt_url) => {
         this.unsupportedState_ = state;
         // NOTE: check for `undefined` since IE11 and Edge
         // unexpectedly coerces it into a `string`.
-        if (opt_url !== undefined) {
-          this.origReplaceState_(state, opt_title, opt_url);
-        } else {
-          this.origReplaceState_(state, opt_title);
+        try {
+          if (opt_url !== undefined) {
+            this.origReplaceState_(state, opt_title, opt_url);
+          } else {
+            this.origReplaceState_(state, opt_title);
+          }
+        } catch (e) {
+          dev().error(TAG_, 'replaceState failed: ' + e.message);
         }
       };
       if (!history.originalPushState) {


### PR DESCRIPTION
Fixes #38386.

This catches errors thrown when using the History API in a context where it is not supported (e.g. when in a document rendered inside `iframe[srcdoc]`.

The following screencrabs are taken from https://wave-cookie-error.glitch.me/container-iframe-srcdoc.html

# Before

Tapping to the next page fails:

https://user-images.githubusercontent.com/134745/183138274-2d144fcc-0e1c-4d84-b474-ead4f7b68060.mov

# After

Tapping to the next page succeeds, and reloads even restore the current page.

Changes applied via the Local AMP extension with changes in this PR. (Note some of the console errors reflect issues with the local server.)

https://user-images.githubusercontent.com/134745/183138327-7ec7b309-2d58-411c-9655-1c79b809f728.mov

