### PR TITLE
allow ssr-css query param for parseExtensionUrl

### DIFF
--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -105,7 +105,7 @@ export function parseExtensionUrl(scriptUrl) {
   }
   // Note that the "(\.max)?" group only applies to local dev.
   const matches = scriptUrl.match(
-    /^(.*)\/(.*)-([0-9.]+|latest)(\.max)?\.(?:js|mjs)$/i
+    /^(.*)\/(.*)-([0-9.]+|latest)(\.max)?\.(?:js|mjs)(?:\?ssr-css=[0|1])?$/i
   );
   const extensionId = matches ? matches[2] : undefined;
   const extensionVersion = matches ? matches[3] : undefined;

--- a/test/unit/test-extension-script.js
+++ b/test/unit/test-extension-script.js
@@ -413,6 +413,22 @@ describes.fakeWin('getExtensionScripts', {}, (env) => {
 
     doc.head.appendChild(
       createElementWithAttributes(doc, 'script', {
+        'id': 'amp-ext3-with-ssr-css-query-param-on',
+        'custom-element': 'amp-ext3',
+        'src': 'https://cdn.ampproject.org/v0/amp-ext3-0.3.js?ssr-css=1',
+      })
+    );
+
+    doc.head.appendChild(
+      createElementWithAttributes(doc, 'script', {
+        'id': 'amp-ext3-with-ssr-css-query-param-off',
+        'custom-element': 'amp-ext3',
+        'src': 'https://cdn.ampproject.org/v0/amp-ext3-0.3.js?ssr-css=0',
+      })
+    );
+
+    doc.head.appendChild(
+      createElementWithAttributes(doc, 'script', {
         'id': 'amp-ext2-latest',
         'custom-element': 'amp-ext2',
         'src': 'https://cdn.ampproject.org/v0/amp-ext2-latest.js',
@@ -453,6 +469,15 @@ describes.fakeWin('getExtensionScripts', {}, (env) => {
     expect(
       ids(getExtensionScripts(win, 'amp-ext2', '0.1', true))
     ).to.deep.equal(['amp-ext2-latest']);
+  });
+
+  it('should find a specific version with ssr-css query param', () => {
+    expect(
+      ids(getExtensionScripts(win, 'amp-ext3', '0.3', true))
+    ).to.deep.equal([
+      'amp-ext3-with-ssr-css-query-param-on',
+      'amp-ext3-with-ssr-css-query-param-off',
+    ]);
   });
 
   it('should find an intermediate extension', () => {


### PR DESCRIPTION
This caused a bug with the `ssr-css` experiment where extensions that were dependent on amp-story to load first and initialize its services, to break on some occasions. This is because `waitWhenReady` for extensions breaks as it uses `parseExtensionUrl` to detect if an extension even exists on the page to wait on.

This was detected on manual testing prior to turning on the experiment so this issue does not exist on production. I might need to ask for a cherry pick for this
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
