### PR TITLE
✨ [amp-google-read-aloud-player] Adds support for the Read Aloud player Google Analytics 4.

### DIFF
--- a/extensions/amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html
+++ b/extensions/amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html
@@ -92,8 +92,20 @@
     data-voice="en.some-voice">
   </amp-google-read-aloud-player>
 
-  <!-- Valid: Multiple values for data-tracking-ids -->
+  <!-- Valid: GA4 ID value for data-tracking-ids -->
+  <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="G-1XXXXXXX" data-voice="en.some-voice">
+  </amp-google-read-aloud-player>
+
+  <!-- Valid: Multiple UA values for data-tracking-ids -->
   <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-168915890-1,UA-168915890-2" data-voice="en.some-voice">
+  </amp-google-read-aloud-player>
+
+  <!-- Valid: Multiple GA4 values for data-tracking-ids -->
+  <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="G-1XXXXXXX,G-2XXXXXXX" data-voice="en.some-voice">
+  </amp-google-read-aloud-player>
+
+  <!-- Valid: Mixed UA and GA4 values for data-tracking-ids -->
+  <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-168915890-1,G-1XXXXXXX" data-voice="en.some-voice">
   </amp-google-read-aloud-player>
 
   <!-- Valid: Opposite digits sections for data-tracking-ids -->

--- a/extensions/amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.out
+++ b/extensions/amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.out
@@ -93,8 +93,20 @@ FAIL
 |      data-voice="en.some-voice">
 |    </amp-google-read-aloud-player>
 |
-|    <!-- Valid: Multiple values for data-tracking-ids -->
+|    <!-- Valid: GA4 ID value for data-tracking-ids -->
+|    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="G-1XXXXXXX" data-voice="en.some-voice">
+|    </amp-google-read-aloud-player>
+|
+|    <!-- Valid: Multiple UA values for data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-168915890-1,UA-168915890-2" data-voice="en.some-voice">
+|    </amp-google-read-aloud-player>
+|
+|    <!-- Valid: Multiple GA4 values for data-tracking-ids -->
+|    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="G-1XXXXXXX,G-2XXXXXXX" data-voice="en.some-voice">
+|    </amp-google-read-aloud-player>
+|
+|    <!-- Valid: Mixed UA and GA4 values for data-tracking-ids -->
+|    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-168915890-1,G-1XXXXXXX" data-voice="en.some-voice">
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Valid: Opposite digits sections for data-tracking-ids -->
@@ -117,91 +129,91 @@ FAIL
 |    <!-- Invalid: No data-api-key -->
 |    <amp-google-read-aloud-player height="66" data-tracking-ids="UA-168915890-1" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:117:2 The mandatory attribute 'data-api-key' is missing in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:129:2 The mandatory attribute 'data-api-key' is missing in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Missing UA prefix data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="123" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:121:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value '123'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:133:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value '123'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: No UA prefix for data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="168915890-1" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:125:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value '168915890-1'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:137:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value '168915890-1'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Missing second number data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="ua-1" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:129:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value 'ua-1'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:141:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value 'ua-1'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Surplus digit data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-1-1.2" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:133:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value 'UA-1-1.2'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:145:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value 'UA-1-1.2'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Emptry data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:137:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:149:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value ''. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Surplus letters data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-1-1 XYZ" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:141:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value 'UA-1-1 XYZ'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:153:2 The attribute 'data-tracking-ids' in tag 'amp-google-read-aloud-player' is set to the invalid value 'UA-1-1 XYZ'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: No data-tracking-ids -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:145:2 The mandatory attribute 'data-tracking-ids' is missing in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:157:2 The mandatory attribute 'data-tracking-ids' is missing in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: No data-voice -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-168915890-1">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:149:2 The mandatory attribute 'data-voice' is missing in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:161:2 The mandatory attribute 'data-voice' is missing in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Local address value for data-url -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-url="index.html" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:153:2 The relative URL 'index.html' for attribute 'data-url' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:165:2 The relative URL 'index.html' for attribute 'data-url' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: http protocol for data-url -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-url="http://www.example.com/index.html" data-voice="en.some-voice">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:157:2 Invalid URL protocol 'http:' for attribute 'data-url' in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:169:2 Invalid URL protocol 'http:' for attribute 'data-url' in tag 'amp-google-read-aloud-player'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Valid: Four letters locale for data-locale -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-tracking-ids="UA-168915890-1" data-voice="en.some-voice" data-locale="en-US">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:161:2 The attribute 'data-locale' in tag 'amp-google-read-aloud-player' is set to the invalid value 'en-US'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:173:2 The attribute 'data-locale' in tag 'amp-google-read-aloud-player' is set to the invalid value 'en-US'. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Local address value for data-intro -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-voice="en.some-voice" data-intro="file.mp3">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:165:2 The relative URL 'file.mp3' for attribute 'data-intro' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:177:2 The relative URL 'file.mp3' for attribute 'data-intro' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Local address value for data-outro -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-voice="en.some-voice" data-outro="file.mp3">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:169:2 The relative URL 'file.mp3' for attribute 'data-outro' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:181:2 The relative URL 'file.mp3' for attribute 'data-outro' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |
 |    <!-- Invalid: Local address value for data-ad-tag-url -->
 |    <amp-google-read-aloud-player height="66" data-api-key="YOUR_API_KEY" data-voice="en.some-voice" data-ad-tag-url="index.html">
 >>   ^~~~~~~~~
-amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:173:2 The relative URL 'index.html' for attribute 'data-ad-tag-url' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
+amp-google-read-aloud-player/0.1/test/validator-amp-google-read-aloud-player.html:185:2 The relative URL 'index.html' for attribute 'data-ad-tag-url' in tag 'amp-google-read-aloud-player' is disallowed. (see https://amp.dev/documentation/components/amp-google-read-aloud-player)
 |    </amp-google-read-aloud-player>
 |  </body>
 |

--- a/extensions/amp-google-read-aloud-player/amp-google-read-aloud-player.md
+++ b/extensions/amp-google-read-aloud-player/amp-google-read-aloud-player.md
@@ -29,13 +29,13 @@ that were generated using the Google Cloud Console won’t work.
     <tr>
     <td width="20%"><strong>data-tracking-ids (required)</strong></td>
     <td>The list of the <a href="https://support.google.com/analytics/answer/7372977">
-Google Analytics tracking IDs</a> to send the player metrics to (comma separated).
+Google Analytics tracking IDs or measurement IDs</a> to send the player metrics to (comma separated).
 <br><br>
-You are required to have a Google Analytics tracking ID in order to use this player during the
-pilot period. The tracking ID will be provided to you by Google.
+You are required to have a Google Analytics tracking/measurement ID in order to use this player during 
+the pilot period. The tracking ID will be provided to you by Google.
 <br><br>
-If you want to send the player metrics also to your Google Analytics account, add your tracking ID 
-(or IDs) to this list.
+If you want to send the player metrics also to your Google Analytics account, add your 
+tracking/measurement ID (or IDs) to this list.
 </td>
   </tr>
   <tr>

--- a/extensions/amp-google-read-aloud-player/amp-google-read-aloud-player.md
+++ b/extensions/amp-google-read-aloud-player/amp-google-read-aloud-player.md
@@ -29,13 +29,14 @@ that were generated using the Google Cloud Console won’t work.
     <tr>
     <td width="20%"><strong>data-tracking-ids (required)</strong></td>
     <td>The list of the <a href="https://support.google.com/analytics/answer/7372977">
-Google Analytics tracking IDs or measurement IDs</a> to send the player metrics to (comma separated).
+Google Analytics tracking IDs</a> or <a href="https://support.google.com/analytics/answer/12270356">
+measurement IDs</a> to send the player metrics to (comma separated).
 <br><br>
-You are required to have a Google Analytics tracking/measurement ID in order to use this player during 
-the pilot period. The tracking ID will be provided to you by Google.
+You are required to have a Google Analytics ID in order to use this player during the pilot period. 
+The ID will be provided to you by Google.
 <br><br>
-If you want to send the player metrics also to your Google Analytics account, add your 
-tracking/measurement ID (or IDs) to this list.
+If you want to send the player metrics also to your Google Analytics account, add your ID (or IDs) 
+to this list.
 </td>
   </tr>
   <tr>

--- a/extensions/amp-google-read-aloud-player/validator-amp-google-read-aloud-player.protoascii
+++ b/extensions/amp-google-read-aloud-player/validator-amp-google-read-aloud-player.protoascii
@@ -19,7 +19,7 @@ tags: {  # <amp-google-read-aloud-player>
   attrs: {
     name: "data-tracking-ids"
     mandatory: true;
-    value_regex_casei: "^UA-\\d+-\\d+(\\s*,\\s*UA-\\d+-\\d+)*$";
+    value_regex_casei: "^((UA-\\d+-\\d+)|(G-\\w+))(\\s*,\\s*((UA-\\d+-\\d+)|(G-\\w+)))*$";
   }
   attrs: {
     name: "data-voice"

--- a/extensions/amp-google-read-aloud-player/validator-amp-google-read-aloud-player.protoascii
+++ b/extensions/amp-google-read-aloud-player/validator-amp-google-read-aloud-player.protoascii
@@ -19,7 +19,7 @@ tags: {  # <amp-google-read-aloud-player>
   attrs: {
     name: "data-tracking-ids"
     mandatory: true;
-    value_regex_casei: "^((UA-\\d+-\\d+)|(G-\\w+))(\\s*,\\s*((UA-\\d+-\\d+)|(G-\\w+)))*$";
+    value_regex_casei: "^?<id>((UA-\\d+-\\d+)|(G-[A-Z0-9]+))(\\s*,\\s*?&id)*$";
   }
   attrs: {
     name: "data-voice"

--- a/extensions/amp-google-read-aloud-player/validator-amp-google-read-aloud-player.protoascii
+++ b/extensions/amp-google-read-aloud-player/validator-amp-google-read-aloud-player.protoascii
@@ -19,7 +19,7 @@ tags: {  # <amp-google-read-aloud-player>
   attrs: {
     name: "data-tracking-ids"
     mandatory: true;
-    value_regex_casei: "^?<id>((UA-\\d+-\\d+)|(G-[A-Z0-9]+))(\\s*,\\s*?&id)*$";
+    value_regex_casei: "^((UA-\\d+-\\d+)|(G-[A-Z0-9]+))(\\s*,\\s*((UA-\\d+-\\d+)|(G-[A-Z0-9]+)))*$";
   }
   attrs: {
     name: "data-voice"


### PR DESCRIPTION
Modifies the validator of `amp-google-read-aloud-player` extension to also support Google Analytics 4 tracking IDs.
