### PR TITLE
[amp-story-shopping] Mark flaky test in shopping rtl visual test

### DIFF
--- a/test/visual-diff/visual-tests.jsonc
+++ b/test/visual-diff/visual-tests.jsonc
@@ -788,6 +788,8 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-shopping.js"
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/20456391/changed/1146414036?browser=chrome&browser_ids=23&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=320&widths=320%2C400
       "url": "examples/visual-tests/amp-story/amp-story-shopping-rtl.html",
       "name": "amp-story-shopping UI RTL",
       "viewport": {"width": 320, "height": 900},


### PR DESCRIPTION
This may be due to an ordering race condition with this selector.
https://github.com/processprocess/amphtml/blob/main/examples/visual-tests/amp-story/amp-story-shopping.js#L92

As a follow up, an explicit selector may fix this. 
https://percy.io/ampproject/amphtml/builds/20456391/changed/1146414036?browser=chrome&browser_ids=23&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=320&widths=320%2C400