### PR TITLE
Change stale bot duration to 1 year

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,4 @@
-daysUntilStale: 358 # 1.5Y - 7d
+daysUntilStale: 358 # 1Y - 7d
 daysUntilClose: 7
 staleLabel: Stale
 markComment: >

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,4 +1,4 @@
-daysUntilStale: 540 # 1.5Y - 7d
+daysUntilStale: 358 # 1.5Y - 7d
 daysUntilClose: 7
 staleLabel: Stale
 markComment: >


### PR DESCRIPTION
#27253 introduced the stale bot with plans to reduce to 1y if things go well.

This PR reduces the timespan to 1y; I think we could potentially reduce it further depending on usage.