### PR TITLE
Fix grep pattern when getting major chrome version for CI

### DIFF
--- a/.circleci/get_pinned_chrome_version.sh
+++ b/.circleci/get_pinned_chrome_version.sh
@@ -46,7 +46,7 @@ echo "$(GREEN "Chrome version history URL is") $(CYAN "${CHROME_VERSION_HISTORY_
 # Determine the Chrome version
 # See https://developer.chrome.com/docs/versionhistory/guide
 echo "$(GREEN "Determining Chrome version...")"
-CHROME_VERSION="$(curl -sS --retry 3 ${CHROME_VERSION_HISTORY_URL} | jq -r ".versions[]|.version" | grep -m 1 "${CHROME_MAJOR_VERSION}\.")"
+CHROME_VERSION="$(curl -sS --retry 3 ${CHROME_VERSION_HISTORY_URL} | jq -r ".versions[]|.version" | grep -m 1 "${CHROME_MAJOR_VERSION}\.[[:digit:]]\+.[[:digit:]]\+.[[:digit:]]\+")"
 if [[ -z "$CHROME_VERSION" ]]; then
   echo "$(RED "Could not determine Chrome version")"
   exit 1


### PR DESCRIPTION
Fixes bug where `CHROME_MAJOR_VERSION=95` was returning `105.0.5195.102` where it should return `95.0.4638.69`