### PR TITLE
SwG Release 0.1.22.232

### DIFF
--- a/third_party/subscriptions-project/config.js
+++ b/third_party/subscriptions-project/config.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.231 */
+/** Version: 0.1.22.232 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *

--- a/third_party/subscriptions-project/swg.js
+++ b/third_party/subscriptions-project/swg.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Version: 0.1.22.231 */
+/** Version: 0.1.22.232 */
 /**
  * Copyright 2018 The Subscribe with Google Authors. All Rights Reserved.
  *
@@ -162,6 +162,7 @@ const AnalyticsEvent = {
   EVENT_REGWALL_OPTED_IN: 3023,
   EVENT_NEWSLETTER_OPTED_IN: 3024,
   EVENT_SHOWCASE_METERING_INIT: 3025,
+  EVENT_DISABLE_MINIPROMPT_DESKTOP: 3026,
   EVENT_SUBSCRIPTION_STATE: 4000,
 };
 /** @enum {number} */
@@ -5070,7 +5071,7 @@ function feCached(url) {
  */
 function feArgs(args) {
   return Object.assign(args, {
-    '_client': 'SwG 0.1.22.231',
+    '_client': 'SwG 0.1.22.232',
   });
 }
 
@@ -5928,7 +5929,10 @@ class OffersFlow {
           return this.dialogManager_.openView(
             this.activityIframeView_,
             /* hidden */ false,
-            this.getDialogConfig_(clientConfig)
+            this.getDialogConfig_(
+              clientConfig,
+              this.clientConfigManager_.shouldAllowScroll()
+            )
           );
         });
       });
@@ -5950,15 +5954,16 @@ class OffersFlow {
   /**
    * Gets display configuration options for the opened dialog. Uses the
    * responsive desktop design properties if the updated offer flows UI (for
-   * SwG Basic) is enabled.
+   * SwG Basic) is enabled. Permits override to allow scrolling.
    * @param {!../model/client-config.ClientConfig} clientConfig
+   * @param {boolean} shouldAllowScroll
    * @return {!../components/dialog.DialogConfig}
    */
-  getDialogConfig_(clientConfig) {
+  getDialogConfig_(clientConfig, shouldAllowScroll) {
     return clientConfig.useUpdatedOfferFlows
       ? {
           desktopConfig: {isCenterPositioned: true, supportsWideScreen: true},
-          shouldDisableBodyScrolling: true,
+          shouldDisableBodyScrolling: !shouldAllowScroll,
         }
       : {};
   }
@@ -6404,7 +6409,7 @@ class ActivityPorts$1 {
         'analyticsContext': context.toArray(),
         'publicationId': pageConfig.getPublicationId(),
         'productId': pageConfig.getProductId(),
-        '_client': 'SwG 0.1.22.231',
+        '_client': 'SwG 0.1.22.232',
         'supportsEventManager': true,
       },
       args || {}
@@ -6841,6 +6846,11 @@ const ExperimentFlags = {
    * Experiment flag for swapping the location of the counter and the main CTA in Amplio blogs.
    */
   TWG_SWAP_COUNTER_AND_CTA: 'counter_cta_swap_enable_experiment',
+
+  /**
+   * Experiment flag for disabling the miniprompt icon on desktop screens wider than 480px.
+   */
+  DISABLE_DESKTOP_MINIPROMPT: 'disable_desktop_miniprompt',
 };
 
 /**
@@ -7348,7 +7358,7 @@ class AnalyticsService {
       context.setTransactionId(getUuid());
     }
     context.setReferringOrigin(parseUrl(this.getReferrer_()).origin);
-    context.setClientVersion('SwG 0.1.22.231');
+    context.setClientVersion('SwG 0.1.22.232');
     context.setUrl(getCanonicalUrl(this.doc_));
 
     const utmParams = parseQueryString(this.getQueryString_());
@@ -7748,9 +7758,67 @@ const SWG_I18N_STRINGS = {
   },
   'REGWALL_REGISTER_FAILED_LANG_MAP': {
     'en': 'Registration failed. Try registering again.',
+    'ar': 'تعذَّرت عملية التسجيل. يُرجى إعادة المحاولة.',
+    'de': 'Registrierung fehlgeschlagen. Versuche es noch einmal.',
+    'en-au': 'Registration failed. Try registering again.',
+    'en-ca': 'Registration failed. Try registering again.',
+    'en-gb': 'Registration failed. Try registering again.',
+    'en-us': 'Registration failed. Try registering again.',
+    'es': 'No se ha podido completar el registro. Prueba a registrarte de nuevo.',
+    'es-419': 'No se pudo completar el registro. Vuelve a intentarlo.',
+    'fr': "Échec de l'enregistrement. Réessayez.",
+    'fr-ca': "Échec de l'inscription. Essayez de vous inscrire à nouveau.",
+    'hi': 'रजिस्ट्रेशन नहीं हो सका. फिर से रजिस्टर करने की कोशिश करें.',
+    'id': 'Pendaftaran gagal. Coba daftar lagi.',
+    'it': 'Registrazione non riuscita. Prova a registrarti di nuovo.',
+    'jp': '登録できませんでした。もう一度お試しください。',
+    'ko': '등록에 실패했습니다. 다시 등록해 보세요.',
+    'ms': 'Pendaftaran gagal. Cuba mendaftar lagi.',
+    'nl': 'Registratie mislukt. Probeer opnieuw te registreren.',
+    'no': 'Registreringen mislyktes. Prøv å registrere deg på nytt.',
+    'pl': 'Rejestracja się nie udała. Spróbuj jeszcze raz się zarejestrować.',
+    'pt': 'Falha no registo. Tente registar-se novamente.',
+    'pt-br': 'Não foi possível fazer o registro. Tente novamente.',
+    'ru': 'Ошибка регистрации. Повторите попытку.',
+    'se': 'Registreringen misslyckades. Försök att registrera dig igen.',
+    'th': 'ลงทะเบียนไม่สำเร็จ ลองลงทะเบียนอีกครั้ง',
+    'tr': 'Kayıt işlemi başarısız oldu. Tekrar kaydolmayı deneyin.',
+    'uk': 'Помилка реєстрації. Повторіть спробу.',
+    'zh-cn': '注册失败。请尝试重新注册。',
+    'zh-hk': '註冊失敗。請嘗試重新註冊。',
+    'zh-tw': '註冊失敗，請再試一次。',
   },
   'NEWSLETTER_SIGN_UP_FAILED_LANG_MAP': {
     'en': 'Signup failed. Try signing up again.',
+    'ar': 'تعذَّرت عملية الاشتراك. يُرجى إعادة المحاولة.',
+    'de': 'Anmeldung fehlgeschlagen. Versuche es noch einmal.',
+    'en-au': 'Sign-up failed. Try signing up again.',
+    'en-ca': 'Sign-up failed. Try signing up again.',
+    'en-gb': 'Sign-up failed. Try signing up again.',
+    'en-us': 'Sign-up failed. Try signing up again.',
+    'es': 'No se ha podido completar la suscripción. Prueba a suscribirte de nuevo.',
+    'es-419': 'Se produjo un error de registro. Vuelve a intentarlo.',
+    'fr': "Échec de l'inscription. Réessayez.",
+    'fr-ca': "Échec de l'inscription. Essayez de vous inscrire à nouveau.",
+    'hi': 'साइन अप नहीं किया जा सका. फिर से साइन अप करने की कोशिश करें.',
+    'id': 'Pendaftaran gagal. Coba daftar lagi.',
+    'it': 'Iscrizione non riuscita. Prova a iscriverti di nuovo.',
+    'jp': '登録できませんでした。もう一度お試しください。',
+    'ko': '가입에 실패했습니다. 다시 가입해 보세요.',
+    'ms': 'Daftar gagal. Cuba daftar lagi.',
+    'nl': 'Aanmelding mislukt. Probeer opnieuw aan te melden.',
+    'no': 'Registreringen mislyktes. Prøv å registrere deg på nytt.',
+    'pl': 'Rejestracja się nie udała. Spróbuj jeszcze raz się zarejestrować.',
+    'pt': 'Falha na inscrição. Tente inscrever-se novamente.',
+    'pt-br': 'Não foi possível se inscrever. Tente novamente.',
+    'ru': 'Не удалось зарегистрироваться. Повторите попытку.',
+    'se': 'Registreringen misslyckades. Försök att registrera dig igen.',
+    'th': 'ลงชื่อสมัครใช้ไม่สำเร็จ ลองลงชื่อสมัครใช้อีกครั้ง',
+    'tr': 'Kaydolma işlemi başarısız oldu. Tekrar kaydolmayı deneyin.',
+    'uk': 'Помилка реєстрації. Повторіть спробу.',
+    'zh-cn': '注册失败。请尝试重新注册。',
+    'zh-hk': '申請失敗。請嘗試重新申請。',
+    'zh-tw': '訂閱失敗，請再試一次。',
   },
   'REGWALL_ACCOUNT_CREATED_LANG_MAP': {
     'en': 'Created an account with <ph name="EMAIL"><ex>user@gmail.com</ex>%s</ph>',
@@ -9029,6 +9097,15 @@ class ClientConfigManager {
   }
 
   /**
+   * Returns whether scrolling on main page should be allowed when
+   * subscription or contribution dialog is displayed.
+   * @return {boolean}
+   */
+  shouldAllowScroll() {
+    return !!this.clientOptions_.allowScroll;
+  }
+
+  /**
    * Returns whether iframes should also use the language specified in the
    * client options, rather than the default of letting the iframes decide the
    * display language. Note that this will return false if the lang option is
@@ -9296,19 +9373,25 @@ class ContributionsFlow {
           return this.dialogManager_.openView(
             this.activityIframeView_,
             /* hidden */ false,
-            this.getDialogConfig_(clientConfig)
+            this.getDialogConfig_(
+              clientConfig,
+              this.clientConfigManager_.shouldAllowScroll()
+            )
           );
         });
     });
   }
 
   /**
-   *
+   * Gets display configuration options for the opened dialog. Uses the
+   * responsive desktop design properties if the updated offer flows UI (for
+   * SwG Basic) is enabled. Permits override to allow scrolling.
    * @param {!../model/client-config.ClientConfig} clientConfig
+   * @param {boolean} shouldAllowScroll
    * @return {!../components/dialog.DialogConfig}
    */
-  getDialogConfig_(clientConfig) {
-    return clientConfig.useUpdatedOfferFlows
+  getDialogConfig_(clientConfig, shouldAllowScroll) {
+    return clientConfig.useUpdatedOfferFlows && !shouldAllowScroll
       ? {shouldDisableBodyScrolling: true}
       : {};
   }
@@ -12454,6 +12537,18 @@ class EntitlementsManager {
         // Add swgUserToken param.
         if (swgUserToken) {
           url = addQueryParam(url, 'sut', swgUserToken);
+        }
+        // Add publisherProvidedId param for swg-basic.
+        if (this.config_.publisherProvidedId) {
+          url = addQueryParam(url, 'ppid', this.config_.publisherProvidedId);
+        }
+        // Add publisherProvidedId param for swg-classic.
+        else if (
+          params?.publisherProvidedId &&
+          typeof params.publisherProvidedId === 'string' &&
+          params.publisherProvidedId.length > 0
+        ) {
+          url = addQueryParam(url, 'ppid', params.publisherProvidedId);
         }
 
         /** @type {!GetEntitlementsParamsInternalDef|undefined} */
@@ -18184,6 +18279,9 @@ class ConfiguredRuntime {
     /** @private {?ContributionsFlow} */
     this.lastContributionsFlow_ = null;
 
+    /** @private {string|undefined} */
+    this.publisherProvidedId_ = undefined;
+
     // Start listening to Google Analytics events, if applicable.
     if (integr.enableGoogleAnalytics) {
       /** @private @const {!GoogleAnalyticsEventListener} */
@@ -18385,6 +18483,14 @@ class ConfiguredRuntime {
             error = 'Unknown skipAccountCreationScreen value: ' + value;
           }
           break;
+        case 'publisherProvidedId':
+          if (
+            value != undefined &&
+            !(typeof value === 'string' && value != '')
+          ) {
+            error = 'publisherProvidedId must be a string, value: ' + value;
+          }
+          break;
         default:
           error = 'Unknown config property: ' + key;
       }
@@ -18428,6 +18534,9 @@ class ConfiguredRuntime {
 
   /** @override */
   getEntitlements(params) {
+    if (params?.publisherProvidedId) {
+      params.publisherProvidedId = this.publisherProvidedId_;
+    }
     return this.entitlementsManager_
       .getEntitlements(params)
       .then((entitlements) => {
@@ -18753,6 +18862,11 @@ class ConfiguredRuntime {
   /** @override */
   showBestAudienceAction() {
     warn('Not implemented yet');
+  }
+
+  /** @override */
+  setPublisherProvidedId(publisherProvidedId) {
+    this.publisherProvidedId_ = publisherProvidedId;
   }
 }
 


### PR DESCRIPTION
## Version: 0.1.22.232

## Previous release: [0.1.22.231](https://github.com/subscriptions-project/swg-js/releases/tag/0.1.22.231)

  - Add experiment which disables miniprompt button for wide desktop screen. (#2382)
  - Opt in failure translations (#2387)
  - Update dependency selenium-webdriver to v4.4.0 (#2390)
  - Update dependency rollup to v2.79.0 (#2389)
  - Update dependency postcss to v8.4.16 (#2388)
  - Update dependency gulp-load-plugins to v2.0.8 (#2386)
  - Update dependency cssnano to v5.1.13 (#2385)
  - Update dependency @babel/core to v7.18.13 (#2384)
  - Add ppid as a query param for swg-basic and swg-classic (#2381)
  - add clientOption for allowScroll (#2378)
  - Logging 3P button click with new analytics event (#2380)