### PR TITLE
♿ 🐛 [Story a11y] When drawer is open hide content outside of drawer

### DIFF
--- a/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
@@ -5,6 +5,7 @@ import * as Preact from '#core/dom/jsx';
 import {Layout_Enum} from '#core/dom/layout';
 import {closest} from '#core/dom/query';
 import {resetStyles, setImportantStyles, toggle} from '#core/dom/style';
+import {toArray} from '#core/types/array';
 
 import {Services} from '#service';
 import {LocalizedStringId_Enum} from '#service/localization/strings';
@@ -20,10 +21,16 @@ import {
   StateProperty,
   UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
-import {createShadowRootWithStyle} from '../../amp-story/1.0/utils';
+import {
+  createShadowRootWithStyle,
+  toggleA11yReadable,
+} from '../../amp-story/1.0/utils';
 
 /** @const {number} */
 const TOGGLE_THRESHOLD_PX = 50;
+
+/** @const {number} */
+const DRAWER_ANIMATE_IN_TIME = 250;
 
 /**
  * @enum {number}
@@ -578,11 +585,39 @@ export class DraggableDrawer extends AMP.BaseElement {
       }
 
       this.element.classList.add('i-amphtml-story-draggable-drawer-open');
+
+      this.hideOrShowSiblingContent();
+      // Focus spacer after transition for screen readers to be in
+      // position to read drawer content.
+      setTimeout(() => {
+        dev()
+          .assertElement(
+            this.element.querySelector(
+              '.i-amphtml-story-draggable-drawer-spacer'
+            )
+          )
+          ./*OK*/ focus();
+      }, DRAWER_ANIMATE_IN_TIME);
+
       toggle(dev().assertElement(this.containerEl), true);
     }).then(() => {
       const owners = Services.ownersForDoc(this.element);
       owners.scheduleLayout(this.element, this.ampComponents_);
       owners.scheduleResume(this.element, this.ampComponents_);
+    });
+  }
+
+  /**
+   * Handles hiding page content from assistive technology.
+   * @protected
+   */
+  hideOrShowSiblingContent() {
+    this.mutateElement(() => {
+      toArray(this.element.parentElement.children).forEach((siblingEl) => {
+        if (siblingEl !== this.element) {
+          toggleA11yReadable(siblingEl, this.state === DrawerState.CLOSED);
+        }
+      });
     });
   }
 
@@ -609,6 +644,7 @@ export class DraggableDrawer extends AMP.BaseElement {
 
     this.storeService.dispatch(Action.TOGGLE_PAUSED, false);
     this.handleSoftKeyboardOnDrawerClose_();
+    this.hideOrShowSiblingContent();
 
     this.mutateElement(() => {
       this.element.setAttribute('aria-hidden', true);

--- a/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-draggable-drawer.js
@@ -30,7 +30,7 @@ import {
 const TOGGLE_THRESHOLD_PX = 50;
 
 /** @const {number} */
-const DRAWER_ANIMATE_IN_TIME = 250;
+const DRAWER_ANIMATE_IN_TIME = 400;
 
 /**
  * @enum {number}

--- a/extensions/amp-story/1.0/amp-story-system-layer.js
+++ b/extensions/amp-story/1.0/amp-story-system-layer.js
@@ -23,6 +23,7 @@ import {
   createShadowRootWithStyle,
   getStoryAttributeSrc,
   shouldShowStoryUrlInfo,
+  toggleA11yReadable,
   triggerClickFromLightDom,
 } from './utils';
 
@@ -765,9 +766,11 @@ export class SystemLayer {
    */
   onSystemUiIsVisibleStateUpdate_(isVisible) {
     this.vsync_.mutate(() => {
-      this.getShadowRoot().classList.toggle(
-        'i-amphtml-story-hidden',
-        !isVisible
+      const shadowRoot = this.getShadowRoot();
+      shadowRoot.classList.toggle('i-amphtml-story-hidden', !isVisible);
+
+      toArray(shadowRoot.querySelectorAll('button')).forEach((button) =>
+        toggleA11yReadable(button, isVisible)
       );
     });
   }

--- a/extensions/amp-story/1.0/utils.js
+++ b/extensions/amp-story/1.0/utils.js
@@ -358,3 +358,18 @@ export function dependsOnStoryServices(klass) {
     }
   };
 }
+
+/**
+ * Handles hiding or showing content from screen readers.
+ * @param {!Element} el
+ * @param {boolean} isVisible
+ */
+export function toggleA11yReadable(el, isVisible) {
+  if (isVisible) {
+    el.removeAttribute('tab-index');
+    el.removeAttribute('aria-hidden');
+  } else {
+    el.setAttribute('tab-index', '-1');
+    el.setAttribute('aria-hidden', 'true');
+  }
+}

--- a/test/visual-diff/visual-tests.jsonc
+++ b/test/visual-diff/visual-tests.jsonc
@@ -781,6 +781,8 @@
       "interactive_tests": "examples/visual-tests/amp-story/amp-story-page-attachment.js"
     },
     {
+      "flaky": true,
+      // See https://percy.io/ampproject/amphtml/builds/21369889/changed/1191157503?browser=chrome&browser_ids=23&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=320&widths=320%2C375
       "url": "examples/visual-tests/amp-story/amp-story-shopping.html",
       "name": "amp-story-shopping UI",
       "viewport": {"width": 320, "height": 900},


### PR DESCRIPTION
This allows for a screen reader experience that matches the intended UX by not allowing the content behind the draggable drawer to be readable.

Fixes #38433

Screen capture with TalkBack:
https://user-images.githubusercontent.com/3860311/188980971-1d8df100-3874-4eea-b9da-8e3d211ecafc.mp4

A note that `aria-modal=true` should hide content underneath the dialog however in [this example](https://codepen.io/philipbell/live/jOxbjOV) The "Add Delivery Address" button is still selectable when the modal is open.
https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/dialog
Other examples [work with tabbing](https://codepen.io/anqa/full/EEdOQY) but not with screen readers.
For this reason I used `aria-hidden` and `tab-index`.