### PR TITLE
🐛 [Story interactives] Fix quiz rtl letter padding

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-quiz.css
@@ -71,7 +71,7 @@
   border-radius: 50% !important;
   border: solid 0.125em !important;
   padding: .31em !important;
-  margin-right: 1em !important;
+  margin-inline-end: 1em !important;
   color: var(--interactive-accent-color) !important;
   border-color: var(--i-amphtml-interactive-answer-choice-border) !important;
   font-size: 1em !important;
@@ -80,11 +80,6 @@
   background-repeat: no-repeat !important;
   background-position: center !important;
   background-size: 1.5em !important;
-}
-
-[dir='rtl'] .i-amphtml-story-interactive-quiz-answer-choice {
-  margin-left: 16px !important;
-  margin-right: 0px !important;
 }
 
 .i-amphtml-story-interactive-quiz-percentage-text {


### PR DESCRIPTION
Closes #38489

When dir=rtl is specified on the quiz element or context, the padding looks off (check issue above). Using `margin-inline-end` lets CSS add the margin in the natural direction of text.

This is how rtl quizzes (on ltr stories) look after this patch: 
![image](https://user-images.githubusercontent.com/22420856/195387384-8d6b86da-7947-4f0d-8706-ee04927cdd1c.png)


In general, having rules for dir=rtl is not great because issues will appear when the sub-tree has a different direction than the story (which is what we currently use to determine rtl-ness)

cc @danielstockton 