### PR TITLE
🐛 Updates to add the missing do-not-track attribute to <amp-vimeo> validator-amp-vimeo.protoascii

### DIFF
--- a/extensions/amp-vimeo/validator-amp-vimeo.protoascii
+++ b/extensions/amp-vimeo/validator-amp-vimeo.protoascii
@@ -35,6 +35,10 @@ tags: {  # <amp-vimeo>
     value: ""
   }
   attrs: {
+    name: "do-not-track"
+    value: ""
+  }
+  attrs: {
     name: "data-videoid"
     mandatory: true
     value_regex: "[0-9]+"


### PR DESCRIPTION
Fixes #38494 &  Fixes #37865

🐛 Bug fix

the `do-not-track` attribute is  [supported on the tag](https://amp.dev/documentation/components/amp-vimeo/) , but validators fail because this isn't added.

This pr adds the attribute.

