### PR TITLE
♻️🐛 [Trusted Types] Make createNode Trusted Types compatible

### DIFF
--- a/src/core/dom/static-template.js
+++ b/src/core/dom/static-template.js
@@ -87,6 +87,9 @@ function createNode(container, strings) {
   );
 
   if (self.trustedTypes && self.trustedTypes.createPolicy) {
+    // Using an IIFE here to prevent the Trusted Types policy from 
+    // leaking outside its scope and being used to turn arbitrary 
+    // values into TrustedHTMLs.
     (function () {
       const policy = self.trustedTypes.createPolicy(
         'static-template#createNode',

--- a/src/core/dom/static-template.js
+++ b/src/core/dom/static-template.js
@@ -87,8 +87,8 @@ function createNode(container, strings) {
   );
 
   if (self.trustedTypes && self.trustedTypes.createPolicy) {
-    // Using an IIFE here to prevent the Trusted Types policy from 
-    // leaking outside its scope and being used to turn arbitrary 
+    // Using an IIFE here to prevent the Trusted Types policy from
+    // leaking outside its scope and being used to turn arbitrary
     // values into TrustedHTMLs.
     (function () {
       const policy = self.trustedTypes.createPolicy(

--- a/src/core/dom/static-template.js
+++ b/src/core/dom/static-template.js
@@ -1,5 +1,5 @@
 import {devAssert} from '#core/assert';
-import {map} from '#core/types/object';
+import {hasOwn, map} from '#core/types/object';
 
 /** @type {HTMLElement} */
 let htmlContainer;
@@ -81,7 +81,27 @@ function html(strings) {
  */
 function createNode(container, strings) {
   devAssert(strings.length === 1, 'Improper html template tag usage.');
-  container./*OK*/ innerHTML = strings[0];
+  devAssert(
+    Array.isArray(strings) || hasOwn(strings, 'raw'),
+    'Invalid template strings array'
+  );
+
+  if (self.trustedTypes && self.trustedTypes.createPolicy) {
+    (function () {
+      const policy = self.trustedTypes.createPolicy(
+        'static-template#createNode',
+        {
+          createHTML: function (unused) {
+            return strings[0];
+          },
+        }
+      );
+      // @ts-ignore
+      container./*OK*/ innerHTML = policy.createHTML('ignored');
+    })();
+  } else {
+    container./*OK*/ innerHTML = strings[0];
+  }
 
   const el = /** @type {HTMLElement} */ (container.firstElementChild);
   devAssert(el, 'No elements in template');

--- a/src/core/dom/static-template.js
+++ b/src/core/dom/static-template.js
@@ -87,21 +87,16 @@ function createNode(container, strings) {
   );
 
   if (self.trustedTypes && self.trustedTypes.createPolicy) {
-    // Using an IIFE here to prevent the Trusted Types policy from
-    // leaking outside its scope and being used to turn arbitrary
-    // values into TrustedHTMLs.
-    (function () {
-      const policy = self.trustedTypes.createPolicy(
-        'static-template#createNode',
-        {
-          createHTML: function (unused) {
-            return strings[0];
-          },
-        }
-      );
-      // @ts-ignore
-      container./*OK*/ innerHTML = policy.createHTML('ignored');
-    })();
+    const policy = self.trustedTypes.createPolicy(
+      'static-template#createNode',
+      {
+        createHTML: function (unused) {
+          return strings[0];
+        },
+      }
+    );
+    // @ts-ignore
+    container./*OK*/ innerHTML = policy.createHTML('ignored');
   } else {
     container./*OK*/ innerHTML = strings[0];
   }


### PR DESCRIPTION
This change updates AMP's `createNode` function to be [Trusted Types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compatible, partial fix to #37297. This was the most widely used [TT sink](https://www.w3.org/TR/2022/WD-trusted-types-20220927/#injection-sinks) in AMP. Since the value assigned to `innerHTML` was already using template tags and assigning the constant value, we've added an inline policy to make the values `TrustedHTML`s instead of plain strings. This will let the browser know the assignment is safe, so when Trusted Types is enforced, this call will not cause a violation and therefore won't be blocked. The Trusted Types policy creation and `TrustedHTML` generation happens in an anonymous function to minimize the risk of the Trusted Types policy leaking and being used elsewhere to generate `TrustedHTML`s.

