### PR TITLE
Resolve `ATTRIBUTION_REPORTING_STATUS` in `attributionsrc`

### DIFF
--- a/examples/amp-ad-exit-conversion.html
+++ b/examples/amp-ad-exit-conversion.html
@@ -26,12 +26,10 @@
       {
         "targets": {
           "landingPage": {
-            "finalUrl": "https://example.com?nis=ATTRIBUTION_REPORTING_STATUS",
+            "finalUrl": "https://landingpage.example",
             "behaviors": {
               "browserAdConversion" : {
-                "attributiondestination": "https://example.com",
-                "attributionsourceeventid": "EFnZ8GunL1xrwNTIHbXrvQ==",
-                "attributionreportto": "https://google.com"
+                "attributionsrc": "https://tracker.example?nis=ATTRIBUTION_REPORTING_STATUS"
               }
             }
           }

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -44,9 +44,9 @@ let NavigationTargetDef;
  * @enum
  */
 const AttributionReportingStatus = {
-  ATTRIBUTION_MACRO_PRESENT: 1,
-  ATTRIBUTION_DATA_PRESENT: 2,
-  ATTRIBUTION_DATA_PRESENT_AND_POLICY_ENABLED: 3,
+  ATTRIBUTION_MACRO_PRESENT: 4,
+  ATTRIBUTION_DATA_PRESENT: 5,
+  ATTRIBUTION_DATA_PRESENT_AND_POLICY_ENABLED: 6,
 };
 
 export class AmpAdExit extends AMP.BaseElement {
@@ -170,7 +170,11 @@ export class AmpAdExit extends AMP.BaseElement {
         target.behaviors.clickTarget == '_top'
           ? '_top'
           : '_blank';
-      openWindowDialog(this.win, finalUrl, clickTarget, target.windowFeatures);
+
+      const substitutedFeatures = substituteVariables(
+        target.windowFeatures || ''
+      );
+      openWindowDialog(this.win, finalUrl, clickTarget, substitutedFeatures);
     }
   }
 
@@ -599,7 +603,7 @@ export function getAttributionReportingStatus(
     isAttributionReportingSupported
   ) {
     return AttributionReportingStatus.ATTRIBUTION_DATA_PRESENT_AND_POLICY_ENABLED;
-  } else if (target?.behaviors?.browserAdConversion) {
+  } else if (target?.behaviors?.browserAdConversion?.attributionsrc) {
     return AttributionReportingStatus.ATTRIBUTION_DATA_PRESENT;
   }
   return AttributionReportingStatus.ATTRIBUTION_MACRO_PRESENT;

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -1020,7 +1020,7 @@ describes.realWin(
             true /* isAttributionReportingSupported*/,
             target
           )
-        ).to.equal(3);
+        ).to.equal(6);
       });
 
       it('should return ATTRIBUTION_DATA_PRESENT if browserAdConfig is present and no browser support', () => {
@@ -1036,7 +1036,7 @@ describes.realWin(
             false /* isAttributionReportingSupported*/,
             target
           )
-        ).to.equal(2);
+        ).to.equal(5);
       });
 
       it('should return ATTRIBUTION_MACRO_PRESENT if browserAdConfig not present', () => {
@@ -1048,7 +1048,7 @@ describes.realWin(
             false /* isAttributionReportingSupported*/,
             target
           )
-        ).to.equal(1);
+        ).to.equal(4);
       });
     });
   }


### PR DESCRIPTION
We moved this macro from `finalUrl` to the `browserAdConfig.attributionsrc` in the most recent update but we were not running the variable substitution pattern on that value. 

Partial https://github.com/ampproject/amphtml/issues/35347
