### PR TITLE
🏗 Upload built releases to Cloudflare R2

### DIFF
--- a/build-system/release-workflows/upload-release.js
+++ b/build-system/release-workflows/upload-release.js
@@ -4,9 +4,10 @@ const fastGlob = require('fast-glob');
 const fs = require('fs-extra');
 const klaw = require('klaw');
 const path = require('path');
-const {bgWhite, cyan} = require('kleur/colors');
+const {bgWhite, cyan, red, yellow} = require('kleur/colors');
 const {log} = require('../common/logging');
 const {runReleaseJob} = require('./release-job');
+const {S3} = require('@aws-sdk/client-s3');
 const {Storage} = require('@google-cloud/storage');
 const {ApiError} = require('@google-cloud/common');
 const {timedExecOrDie} = require('../pr-check/utils');
@@ -173,10 +174,65 @@ function ignoreErrorWhenFileAlreadyExists_(error) {
 }
 
 /**
+ * Uploads release files to Cloudflare R2.
+ * @return {Promise<void>}
+ */
+async function uploadFilesR2_() {
+  const {R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY} = process.env;
+  if (!R2_ACCESS_KEY_ID) {
+    throw new Error(
+      'CircleCI job is missing the R2_ACCESS_KEY_ID env variable'
+    );
+  }
+  if (!R2_SECRET_ACCESS_KEY) {
+    throw new Error(
+      'CircleCI job is missing the R2_SECRET_ACCESS_KEY env variable'
+    );
+  }
+
+  const s3 = new S3({
+    region: 'auto',
+    endpoint: `https://78e1d5140b47fc9dab18dc8b25351b7a.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId: R2_ACCESS_KEY_ID,
+      secretAccessKey: R2_SECRET_ACCESS_KEY,
+    },
+  });
+
+  let totalFiles = 0;
+  for await (const {stats} of klaw(DEST_DIR)) {
+    if (stats.isFile()) {
+      totalFiles++;
+    }
+  }
+
+  log('Uploading', cyan(totalFiles), 'files to R2:');
+  const uploadsPromises = [];
+  let uploadedFiles = 0;
+  for await (const {path, stats} of klaw(DEST_DIR)) {
+    if (!stats.isFile()) {
+      continue;
+    }
+
+    const key = path.slice(DEST_DIR.length + 1);
+    uploadsPromises.push(
+      s3
+        .putObject({Bucket: 'ampjs', Key: key, Body: fs.createReadStream(path)})
+        .then(() => {
+          logProgress_(totalFiles, ++uploadedFiles);
+        })
+    );
+  }
+
+  await Promise.all(uploadsPromises);
+  log('Finished uploading all files.');
+}
+
+/**
  * Uploads release files to Google Cloud Storage.
  * @return {Promise<void>}
  */
-async function uploadFiles_() {
+async function uploadFilesGCS_() {
   const {GCLOUD_SERVICE_KEY} = process.env;
   if (!GCLOUD_SERVICE_KEY) {
     throw new Error(
@@ -205,7 +261,7 @@ async function uploadFiles_() {
     }
   }
 
-  log('Uploading', cyan(totalFiles), 'files to storage:');
+  log('Uploading', cyan(totalFiles), 'files to GCS:');
   const uploadsPromises = [];
   let uploadedFiles = 0;
   for await (const {path, stats} of klaw(DEST_DIR)) {
@@ -237,7 +293,15 @@ runReleaseJob(jobName, async () => {
   }
 
   await brotliCompressAll_();
-  await uploadFiles_();
+  try {
+    await uploadFilesR2_();
+  } catch (error) {
+    log(red('R2 Error:'), error);
+    log(
+      yellow('Ignoring this error for now while R2 storage is in development')
+    );
+  }
+  await uploadFilesGCS_();
 
   log('Archiving releases to', cyan(ARTIFACT_FILE_NAME));
   timedExecOrDie(`cd ${DEST_DIR} && tar -czf ${ARTIFACT_FILE_NAME} *`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "devDependencies": {
         "@ampproject/filesize": "4.3.0",
         "@ampproject/remapping": "2.1.0",
+        "@aws-sdk/client-s3": "3.223.0",
         "@babel/core": "7.15.0",
         "@babel/helper-module-imports": "7.14.5",
         "@babel/helper-plugin-test-runner": "7.14.5",
@@ -260,6 +261,1799 @@
       "engines": {
         "node": ">=10.14"
       }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.222.0.tgz",
+      "integrity": "sha512-Ric2vJQEWrzz915wBeZlYLWAnIsnywOcZpzroPVTY/TNKRvM0GcSPVuD9vv1lOwybVnDHsipukzwQBAZXkNWVA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/abort-controller/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
+      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader-native/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.223.0.tgz",
+      "integrity": "sha512-hIQfiseFXf04jz14iyQhfV9eRz9XgiMihl9oQhKs3CpL7bFGkhCkCIwbqUrsheqcD1O2wcOSKTAt6QdYbDyhzg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.223.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-node": "3.223.0",
+        "@aws-sdk/eventstream-serde-browser": "3.222.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.222.0",
+        "@aws-sdk/eventstream-serde-node": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-blob-browser": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/hash-stream-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/md5-js": "3.222.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-expect-continue": "3.222.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-location-constraint": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-sdk-s3": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/middleware-ssec": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4-multi-region": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-stream-browser": "3.222.0",
+        "@aws-sdk/util-stream-node": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.222.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.223.0.tgz",
+      "integrity": "sha512-1gVmZ7XypZEWUeKnvjS/cZSL/cM1riOGrhp+dr+np58ZT5zSrpWAAeKE5+ftzC/vn770vnD5piLGdAZwg/Jf1g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.223.0.tgz",
+      "integrity": "sha512-MeXm6expqpBwwN5GWm8QedAxWGv1jpdxae5oSqsrfRSHFVcHVxWWQzx9/GMBpKqGLtXVmisex2vckBQa1MhybQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.223.0.tgz",
+      "integrity": "sha512-RYGx6SOT38MfX4Dm8lyEwZ/bEqhl3TZyGFqtFHGTEEgyqPkuqiZPfSSWNmsaf6HAVYKObp7kJUX6w8EeEw332w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-node": "3.223.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-sdk-sts": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.222.0.tgz",
+      "integrity": "sha512-rG/Yh0R+GQe86ofEb24QAjQ19tHb4HMCyCuMZUZCsIdgNmUfcaH21Ug5s7pJrAfEy/F2gwxs+VfBeXKjT0MqSQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.222.0.tgz",
+      "integrity": "sha512-xV6cmJ9zMi8nWySqBv1ze/EFlzXEfazu3i/T/5MpOufPvuGpXTQ3/PDEbC6mKBtvomoQ0fonc/cZrix7YcJV0Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.222.0.tgz",
+      "integrity": "sha512-n090ouw5AFhb0EfzRElUTmqCNOQ1zjlxau30oVM7+qKtXH85hEGMQOoRQAl9ch/pXcbjKLh1mbUhmonR97/Kvw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.223.0.tgz",
+      "integrity": "sha512-+jB0XIqAw7Cni1uqPV6SMQl7FlpUVELdHVnR+DYL3WOV4MJ4amTu9MAXrpvbEXbK3+7eFQ2/tDe+7i8qGXZFTw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/credential-provider-sso": "3.223.0",
+        "@aws-sdk/credential-provider-web-identity": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.223.0.tgz",
+      "integrity": "sha512-mvY96yX4xQ9/Aujr0HqMXhdToiEKg7fFUoN+NgV3yB/hj2q1Ry3j8WbiIfAcBvFLjNwHT7ae/8nVRHYYlNeXFw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/credential-provider-ini": "3.223.0",
+        "@aws-sdk/credential-provider-process": "3.222.0",
+        "@aws-sdk/credential-provider-sso": "3.223.0",
+        "@aws-sdk/credential-provider-web-identity": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.222.0.tgz",
+      "integrity": "sha512-IgEk8Tne1b2v2k/wVjuddKi+HEAFJWUoEcvLCnYRdlVX5l+Nnatw8vGYb+gTi9X7nKNqEGfMbifKCFoePKjC0Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.223.0.tgz",
+      "integrity": "sha512-sRxH6fhLYME+EIiHRqIzkUgPaAvc5+dV8+09jEZ1yBjum9AQycipXrbbDRNLXWJZJZTA/BsHfUpAScFOjyZf7A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.223.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/token-providers": "3.223.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.222.0.tgz",
+      "integrity": "sha512-dImqTEWt38nVcDe/wQqHWJ+R2zyNqVKwejfslgbH2YilUnDU43xq2KJhNe4s+YhCB6tHOTkbNnpZo7vPV5Zxog==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/eventstream-codec": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.222.0.tgz",
+      "integrity": "sha512-sxLpo3NYrvj8CnTkpLsb2uXvUU8jnAG5q22HIBxBrpeFzgvUA9uIfPD7yPZhe4+/C7v+ER19ysXetKjiAOrQMA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-codec/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.222.0.tgz",
+      "integrity": "sha512-owwgmkpuLM7UtNPRZjvCOp5fo6MKY8avygQA0VMsbQSCq1DJFpmDsk7yTRB+n7jQuoDGn8uVxER3S0oS/Y/xVQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.222.0.tgz",
+      "integrity": "sha512-zb8vMSbBEjUrHKpA2bZdAqfYp8oCsWgeBPOt0XJx+y6lzy67zyADs97Grl+lyZAoswao/zc2sxgm9yqcMDt7lQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.222.0.tgz",
+      "integrity": "sha512-rfDrTxcsYL0ZKc5MnoqbDTa0oQFiK7qTJOnQ7sASooexqoKTn3wVq68J7TZddbImmH/ENpkU+O0hcGuiwE9Ucg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-serde-universal": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.222.0.tgz",
+      "integrity": "sha512-+/Fc7+ZPuD6SwphYcuLJ/GU0RmVzG/M0dUYs1JL/JQJ8dkJ0AlH1fH3L5Fhm2RO/ACkE28kXAuyZ40TLeRLRNA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-codec": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.222.0.tgz",
+      "integrity": "sha512-0PWnOp47mNfwBFEZhuBpz5A+66jbvb2ySidnM5vWHRxu5yN7rCJEdEMSJKDzR6nH3GLZ9dHoOxTzQy21NoDTtA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/querystring-builder": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/hash-blob-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.222.0.tgz",
+      "integrity": "sha512-Z6y3JZPNp+os9vZdvsNkM6mIjDzeZNr9MYkQslANhGZ9WgQrzuI7xZN6XAyR83OGRCrDCorZdX+nnl5mzY1VwQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-blob-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.222.0.tgz",
+      "integrity": "sha512-Fw0acblG0LQT9tfD2/4j98QHNq+Crotig/M1/zPDcVoGb8OBHd2442zpeA0fYYjGnGGhy9psRHdJrjZGj1vDUw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/hash-stream-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.222.0.tgz",
+      "integrity": "sha512-PO/N0PsgJjRiH9WKSOnGjDP9tWNjwSvUezicT8ItWgkk7npd278MAe7G692TLACgf6sJr2jGQbs6xzZHq0/3Zg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-stream-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.222.0.tgz",
+      "integrity": "sha512-tWJWWTcL7DrhFiDmPBvLaw2lopHJMsF4Uj52yIQJskwd2IeBOxjl30zLo/oidmk73IFUB7TCObc85zJrtt/KcQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.222.0.tgz",
+      "integrity": "sha512-LI44dy+ECCL+vsIYJ/Ot4rNOl3Vpa4Nv8zxireKcQGmn547Cb6i3n/bEi/DkcfgHv6R84qOtOXsxt/ILuWNQ/g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/md5-js/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.222.0.tgz",
+      "integrity": "sha512-TP4mjEWsQ/JsACAFDUlltl/0sAe5dxqdhBDAPO6LHRHvROz2oYVjZwvcaK4F9x8QLWh09H0Sw501SndFK2+o3w==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.222.0.tgz",
+      "integrity": "sha512-Wlah+nrPhcq5qcwHiK1ymVRAvcKjV2py2RXhJsNZWgYwphdt5RHaZHPDKoodI27alrDJVyBBQWGzIm/Ag1bypQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.222.0.tgz",
+      "integrity": "sha512-e1bM+CvuUWmBdydQpV5sF8cxZrXQ++0G5s1M7pLimKdWXQvCQ1ZEwA3LLi2IWomXmS9a3BaH3iKAf87RTWjIXw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.222.0.tgz",
+      "integrity": "sha512-/nTCLXrau8jEyehsD7QM49gJQ6kmzQGw7plPDJzdFakfAwb2b/jLJ/Hj/ZSaaLWWEXAtZBiPzVXUJltPDoXv5g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.222.0.tgz",
+      "integrity": "sha512-P900+KLMUg0eOf75FK/wH/Gjz3rkNtB6iBfAG2Xg4DY5+78qh40deG0y0ZvtkHQP8YOqjLF3QMbEA90YXo4x9Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.222.0.tgz",
+      "integrity": "sha512-R4STwHkWgdxMRqOy6riYfXepsQURR5YhK6psPFZHkBYByIRc9JxJdLA0qZcfLRriQIAGmqEO2WWsqRmr8nkbBw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.222.0.tgz",
+      "integrity": "sha512-srrAkOHuvpXeaMG9a6kvfYrhzFFX/plBaZATy8iW6ethgvG1qdPeFj4ZVS9Eisx+13NbGFtydc1WkBZfx2nUWg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.222.0.tgz",
+      "integrity": "sha512-eAxGCcNXl1APMOFbkUaAC6pNBPUbajyGqsDf6GLdlrYHrMVAtJdYd988ov6C52h7k6iDZ+OPHwv8dwUz+PRfpw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.222.0.tgz",
+      "integrity": "sha512-4JRVs7y5JDXXjc5fkz0FCZJt/0HTP2vh3QyZsWRbCYesw2cWVqQlp/fUXp8w5KGqm5nYkTF4e5SQ7Ca8powJNA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.222.0.tgz",
+      "integrity": "sha512-8FZpGuJDtntjXZ/mfJ9EdP5mYiUunQHEmk6OERk3h4XW3D/e97denwDAcBBIK8iYYGic5PoWF4KgTFJWs1YOcw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/service-error-classification": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.222.0.tgz",
+      "integrity": "sha512-GCgbzWy3Dn9+dz/ZZjS5OiJ+feighHfMt461r1zjHNUXnb2tEf5kU+P80d3WqG8er4RRQg+Ao49SatOKgPcrlA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-bucket-endpoint": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.222.0.tgz",
+      "integrity": "sha512-YbL4lTBFgqyL2Ob+dMyw/UNd5K9IOnZHHxjpwWlYKMrfT+pp2bvrr7XUbRHnxSoDsOg9bf6IyTSRVnVxP4psJg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.222.0.tgz",
+      "integrity": "sha512-UoeLbgCJB07dX8tRByR0KzZaOwCoIyXj/SfFTuOhBUjkpKwqFCam/hofDlK3FR6kvl+xiURv57W/FtKV/9TDHg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.222.0.tgz",
+      "integrity": "sha512-MwMw2Lz7SBOniAc0slWXt65ocqL+E956bdW+LOvBin6OgkVWaLRbWI9nOzA6B2d8b65fCGEc+N15i0UdrEf+MQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.222.0.tgz",
+      "integrity": "sha512-WThCx/+UG4gIyqx0G3QKD1RM71+adh9Jv3Sh/KiS07Jjm+pb71wW+RRzBuNyhdjwB3aoKC/YKW8eFQg6M7eaQg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.222.0.tgz",
+      "integrity": "sha512-ASKbstAKbOBUZhFhst6/NCr11x94BDBiQn2zDs2Lvjo89n2efMeb4wEr17VCMZVeKI6ojtPFa1ZVLsH8AOn4Yw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.222.0.tgz",
+      "integrity": "sha512-fjdxCRIAhOTsI9OcEKwJp4lhsvyCSXoeYV49mO/bdG6pFyFRm3Jezx7TNVNeLTGuMHTTTvRrCTF8sgE5t17Pzw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.222.0.tgz",
+      "integrity": "sha512-hrbw90LlVa4xJJc4WiyAfaPMY/sJubSeTwuxTChLsFOavr6hSMCwLASrWmOiKRIj5hKdSfEA87n/q+DnKHlA8A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.222.0.tgz",
+      "integrity": "sha512-k3WqxUgZzGbiCQt1HyzDGlRzq8muGIOWZs9T3HtCa5LtACvl0qlNmiwCc+C/o7GRLyC9FuWkP3lOW6MiAFQUcA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/querystring-builder": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.222.0.tgz",
+      "integrity": "sha512-rEqAgQ7itmB7GB+WWLgyT7/YWJkjEBCfggxycccChWAeqg+gjpstIiGX2BjP2K/wnzwE0D91JsozSXcQIDOtNQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.222.0.tgz",
+      "integrity": "sha512-Zj+ytEgrOagCE7yczjdDan7W+1a0OL5DPAx69Z00NxGoBI2h0GRZD28dRYb3Pzs5/Ft4KbCedH/RUnyaYjaZxw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.222.0.tgz",
+      "integrity": "sha512-qrNUGDyDp9yVQMnBbz1T5YBQkA/u6D5o0PPzSwfZ9azdAcBLjHOEfsBrKhxP+K92L/nilbnmY89KrjMR8+BNtw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.222.0.tgz",
+      "integrity": "sha512-3KfkCA/753PlF5QqhGuQ7u+NOgLyiBFeV8R8ut/pfBmG8fF6l3RKrkbcu+87QpqXntRzG+RLHDqS7ryT3B2ICg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.222.0.tgz",
+      "integrity": "sha512-Dn/WGtm+v5nney0CaYZjdOtJmdEuI8EQiQ5J3eQ3G0jjT6mr1/tCajsNpq3ZqHXiwLtydwaVvsL3AKXn+oxFVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.222.0.tgz",
+      "integrity": "sha512-2dowzMXjvIf5gwX5gNCwpv/TzAbbXxrId3zYJgPdEtApsa7NxyFs5MfnHt1zZI6P3YORGheRnNUK9RUYOPKHgA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.222.0.tgz",
+      "integrity": "sha512-2qQZuKqx56b2uN2rdjdKL6u0Cvk82uTGNtIuetmySY9xPEAljSBdriaxTqNqK9Gs3M4obG22alUK4a85uwqS3g==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.222.0.tgz",
+      "integrity": "sha512-SF6Qi0KW69OzgLbA9q6AsZNFQCA+DI66SnAjW774sAE6aQyJmCbUsxETk37XodSymXzDOEDDC6QoY64HUoSoVw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.118.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/signature-v4-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/signature-v4/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.222.0.tgz",
+      "integrity": "sha512-4dnU7TvwKxVuOWduvFGClYe0EgNov5Ke1ef7O1bdKaj5MmlH6wBDgGJM4NKREBFapC2dUXkoPtwsihtYBci1Bw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.223.0.tgz",
+      "integrity": "sha512-ik6IYiZO9tTzYPJKzUob4U9faC9We6UtVZGynEGLMWSLETM+LefSHK0elEaJaCqx2F4NLodw+t9uvllR+8YUow==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.223.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.222.0.tgz",
+      "integrity": "sha512-yXRYptInkfEFaOvWFxlRXsRh9jWOmQc1sZeKqjfx2UCtzNJ7ebedN0VfCz4SaDotcw9Q4JWuN66qhRMJjDx7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.222.0.tgz",
+      "integrity": "sha512-1+QbVdT/phYDb5JDQRJWoZeCujkXaI5m8z3bIiPxcRRY3NPuluDGrfX3kfnFen5s9QGByLvJxWKWZS+i+iUFRg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
+      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.222.0.tgz",
+      "integrity": "sha512-+dGsp59lrEkDmK7OO5ecMYasrTGIKacFHjqZ6aqmbn1xtcUd/o3Qe7g5YSRXMGwtZ6xhvBD+NJLkEERI7U7cMw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.222.0.tgz",
+      "integrity": "sha512-W/duYMtmCCWdzHP+yscBB6yrARgAqWpFdxgBvMSlT8TjOTrh/F+aj4NPamiNMeUfqfMFGnboYfyWRr1avkcAGQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.222.0.tgz",
+      "integrity": "sha512-qujJQv8lFysAr1lOlBTJhz7949NZyq5cj74Q9dR99AcAMXXeI9CQayPKH7477AnXRGOTMahZ3mV0HZ1bCJoNTw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.222.0.tgz",
+      "integrity": "sha512-Y4BPtSa+6+qvg6OVW6RrdDx0OADfWa2Uxsxqdozpdnx2OQY0q+1diqsNgFMV+FIvdXqffE147KG7roG+/AfPeA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-stream-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.222.0.tgz",
+      "integrity": "sha512-GW9Y1/pLHS7WYHHdswcDd4vaM9mzxDwewcDVujCd/L9MRbG1nA/wfCL7hAAXT1AN2GbGfbfT+jjHQqzexpKBnA==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-stream-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.222.0.tgz",
+      "integrity": "sha512-iMwKG+RaGVAjzXDuzmMl63SnN6qVc+0VbbfaKW1eIK9Ihr5mko3GuYAFqKaECSQ+XdMNuMSVXzphveKw6t2zwg==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-stream-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.222.0.tgz",
+      "integrity": "sha512-DREMeL0XHl4QIS2GVSHFwVH4mJZ+Dr04R3U8WfiMktXdA93j5tDMJpU3+PNaCZPeaqz2QNwrVSBWKwbwA357zQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.222.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.222.0.tgz",
+      "integrity": "sha512-BMRMrPXL/HS3dSha9vcABkoANluKjB0pH78bc659EY2WUj9wCZdbUNQpACiYx8bwm7xKSxugCkmPd6NLWXUURw==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-node/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/util-waiter": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.222.0.tgz",
+      "integrity": "sha512-/07RkfxvDncsMeQ+GhigPdiSRd2v/1FJoCV4a5e9XDI1ZSMvUKm36wFqw5Bzts+AUY8f4HOPpGI9ZQeNb7u27Q==",
+      "dev": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-waiter/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
+      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -5708,6 +7502,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
+    },
     "node_modules/boxen": {
       "version": "5.0.0",
       "dev": true,
@@ -9666,6 +11466,22 @@
       "version": "1.0.3",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
     },
     "node_modules/fastparse": {
       "version": "1.1.2",
@@ -21196,6 +23012,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "dev": true
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "dev": true,
@@ -23018,6 +24840,1736 @@
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@ampproject/worker-dom/-/worker-dom-0.33.0.tgz",
       "integrity": "sha512-shTi1UldKehW2FGCr9owu9xiCsNONCyGCXLVWJQGGpioPcFSmwEI4Gvntj+QITxfkIXsmfFqT8si/PvwhwQGtA=="
+    },
+    "@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
+      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
+      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/sha256-js": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
+      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
+      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
+      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "^3.110.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.222.0.tgz",
+      "integrity": "sha512-Ric2vJQEWrzz915wBeZlYLWAnIsnywOcZpzroPVTY/TNKRvM0GcSPVuD9vv1lOwybVnDHsipukzwQBAZXkNWVA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.188.0.tgz",
+      "integrity": "sha512-zkPRFZZPL3eH+kH86LDYYXImiClA1/sW60zYOjse9Pgka+eDJlvBN6hcYxwDEKjcwATYiSRR1aVQHcfCinlGXg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.208.0.tgz",
+      "integrity": "sha512-JeOZ95PW+fJ6bbuqPySYqLqHk1n4+4ueEEraJsiUrPBV0S1ZtyvOGHcnGztKUjr2PYNaiexmpWuvUve9K12HRA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.223.0.tgz",
+      "integrity": "sha512-hIQfiseFXf04jz14iyQhfV9eRz9XgiMihl9oQhKs3CpL7bFGkhCkCIwbqUrsheqcD1O2wcOSKTAt6QdYbDyhzg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.223.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-node": "3.223.0",
+        "@aws-sdk/eventstream-serde-browser": "3.222.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.222.0",
+        "@aws-sdk/eventstream-serde-node": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-blob-browser": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/hash-stream-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/md5-js": "3.222.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-expect-continue": "3.222.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-location-constraint": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-sdk-s3": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/middleware-ssec": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4-multi-region": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-stream-browser": "3.222.0",
+        "@aws-sdk/util-stream-node": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "@aws-sdk/util-waiter": "3.222.0",
+        "@aws-sdk/xml-builder": "3.201.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.223.0.tgz",
+      "integrity": "sha512-1gVmZ7XypZEWUeKnvjS/cZSL/cM1riOGrhp+dr+np58ZT5zSrpWAAeKE5+ftzC/vn770vnD5piLGdAZwg/Jf1g==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.223.0.tgz",
+      "integrity": "sha512-MeXm6expqpBwwN5GWm8QedAxWGv1jpdxae5oSqsrfRSHFVcHVxWWQzx9/GMBpKqGLtXVmisex2vckBQa1MhybQ==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.223.0.tgz",
+      "integrity": "sha512-RYGx6SOT38MfX4Dm8lyEwZ/bEqhl3TZyGFqtFHGTEEgyqPkuqiZPfSSWNmsaf6HAVYKObp7kJUX6w8EeEw332w==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-node": "3.223.0",
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/hash-node": "3.222.0",
+        "@aws-sdk/invalid-dependency": "3.222.0",
+        "@aws-sdk/middleware-content-length": "3.222.0",
+        "@aws-sdk/middleware-endpoint": "3.222.0",
+        "@aws-sdk/middleware-host-header": "3.222.0",
+        "@aws-sdk/middleware-logger": "3.222.0",
+        "@aws-sdk/middleware-recursion-detection": "3.222.0",
+        "@aws-sdk/middleware-retry": "3.222.0",
+        "@aws-sdk/middleware-sdk-sts": "3.222.0",
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/middleware-user-agent": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/smithy-client": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-body-length-browser": "3.188.0",
+        "@aws-sdk/util-body-length-node": "3.208.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.222.0",
+        "@aws-sdk/util-defaults-mode-node": "3.222.0",
+        "@aws-sdk/util-endpoints": "3.222.0",
+        "@aws-sdk/util-user-agent-browser": "3.222.0",
+        "@aws-sdk/util-user-agent-node": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "fast-xml-parser": "4.0.11",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.222.0.tgz",
+      "integrity": "sha512-rG/Yh0R+GQe86ofEb24QAjQ19tHb4HMCyCuMZUZCsIdgNmUfcaH21Ug5s7pJrAfEy/F2gwxs+VfBeXKjT0MqSQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.222.0.tgz",
+      "integrity": "sha512-xV6cmJ9zMi8nWySqBv1ze/EFlzXEfazu3i/T/5MpOufPvuGpXTQ3/PDEbC6mKBtvomoQ0fonc/cZrix7YcJV0Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.222.0.tgz",
+      "integrity": "sha512-n090ouw5AFhb0EfzRElUTmqCNOQ1zjlxau30oVM7+qKtXH85hEGMQOoRQAl9ch/pXcbjKLh1mbUhmonR97/Kvw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.223.0.tgz",
+      "integrity": "sha512-+jB0XIqAw7Cni1uqPV6SMQl7FlpUVELdHVnR+DYL3WOV4MJ4amTu9MAXrpvbEXbK3+7eFQ2/tDe+7i8qGXZFTw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/credential-provider-sso": "3.223.0",
+        "@aws-sdk/credential-provider-web-identity": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.223.0.tgz",
+      "integrity": "sha512-mvY96yX4xQ9/Aujr0HqMXhdToiEKg7fFUoN+NgV3yB/hj2q1Ry3j8WbiIfAcBvFLjNwHT7ae/8nVRHYYlNeXFw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/credential-provider-ini": "3.223.0",
+        "@aws-sdk/credential-provider-process": "3.222.0",
+        "@aws-sdk/credential-provider-sso": "3.223.0",
+        "@aws-sdk/credential-provider-web-identity": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.222.0.tgz",
+      "integrity": "sha512-IgEk8Tne1b2v2k/wVjuddKi+HEAFJWUoEcvLCnYRdlVX5l+Nnatw8vGYb+gTi9X7nKNqEGfMbifKCFoePKjC0Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.223.0.tgz",
+      "integrity": "sha512-sRxH6fhLYME+EIiHRqIzkUgPaAvc5+dV8+09jEZ1yBjum9AQycipXrbbDRNLXWJZJZTA/BsHfUpAScFOjyZf7A==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.223.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/token-providers": "3.223.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.222.0.tgz",
+      "integrity": "sha512-dImqTEWt38nVcDe/wQqHWJ+R2zyNqVKwejfslgbH2YilUnDU43xq2KJhNe4s+YhCB6tHOTkbNnpZo7vPV5Zxog==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-codec": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.222.0.tgz",
+      "integrity": "sha512-sxLpo3NYrvj8CnTkpLsb2uXvUU8jnAG5q22HIBxBrpeFzgvUA9uIfPD7yPZhe4+/C7v+ER19ysXetKjiAOrQMA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.222.0.tgz",
+      "integrity": "sha512-owwgmkpuLM7UtNPRZjvCOp5fo6MKY8avygQA0VMsbQSCq1DJFpmDsk7yTRB+n7jQuoDGn8uVxER3S0oS/Y/xVQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.222.0.tgz",
+      "integrity": "sha512-zb8vMSbBEjUrHKpA2bZdAqfYp8oCsWgeBPOt0XJx+y6lzy67zyADs97Grl+lyZAoswao/zc2sxgm9yqcMDt7lQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.222.0.tgz",
+      "integrity": "sha512-rfDrTxcsYL0ZKc5MnoqbDTa0oQFiK7qTJOnQ7sASooexqoKTn3wVq68J7TZddbImmH/ENpkU+O0hcGuiwE9Ucg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.222.0.tgz",
+      "integrity": "sha512-+/Fc7+ZPuD6SwphYcuLJ/GU0RmVzG/M0dUYs1JL/JQJ8dkJ0AlH1fH3L5Fhm2RO/ACkE28kXAuyZ40TLeRLRNA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/eventstream-codec": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.222.0.tgz",
+      "integrity": "sha512-0PWnOp47mNfwBFEZhuBpz5A+66jbvb2ySidnM5vWHRxu5yN7rCJEdEMSJKDzR6nH3GLZ9dHoOxTzQy21NoDTtA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/querystring-builder": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.222.0.tgz",
+      "integrity": "sha512-Z6y3JZPNp+os9vZdvsNkM6mIjDzeZNr9MYkQslANhGZ9WgQrzuI7xZN6XAyR83OGRCrDCorZdX+nnl5mzY1VwQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.188.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.208.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.222.0.tgz",
+      "integrity": "sha512-Fw0acblG0LQT9tfD2/4j98QHNq+Crotig/M1/zPDcVoGb8OBHd2442zpeA0fYYjGnGGhy9psRHdJrjZGj1vDUw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.222.0.tgz",
+      "integrity": "sha512-PO/N0PsgJjRiH9WKSOnGjDP9tWNjwSvUezicT8ItWgkk7npd278MAe7G692TLACgf6sJr2jGQbs6xzZHq0/3Zg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.222.0.tgz",
+      "integrity": "sha512-tWJWWTcL7DrhFiDmPBvLaw2lopHJMsF4Uj52yIQJskwd2IeBOxjl30zLo/oidmk73IFUB7TCObc85zJrtt/KcQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
+      "integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.222.0.tgz",
+      "integrity": "sha512-LI44dy+ECCL+vsIYJ/Ot4rNOl3Vpa4Nv8zxireKcQGmn547Cb6i3n/bEi/DkcfgHv6R84qOtOXsxt/ILuWNQ/g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "@aws-sdk/util-utf8-node": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.222.0.tgz",
+      "integrity": "sha512-TP4mjEWsQ/JsACAFDUlltl/0sAe5dxqdhBDAPO6LHRHvROz2oYVjZwvcaK4F9x8QLWh09H0Sw501SndFK2+o3w==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.222.0.tgz",
+      "integrity": "sha512-Wlah+nrPhcq5qcwHiK1ymVRAvcKjV2py2RXhJsNZWgYwphdt5RHaZHPDKoodI27alrDJVyBBQWGzIm/Ag1bypQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.222.0.tgz",
+      "integrity": "sha512-e1bM+CvuUWmBdydQpV5sF8cxZrXQ++0G5s1M7pLimKdWXQvCQ1ZEwA3LLi2IWomXmS9a3BaH3iKAf87RTWjIXw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/url-parser": "3.222.0",
+        "@aws-sdk/util-config-provider": "3.208.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.222.0.tgz",
+      "integrity": "sha512-/nTCLXrau8jEyehsD7QM49gJQ6kmzQGw7plPDJzdFakfAwb2b/jLJ/Hj/ZSaaLWWEXAtZBiPzVXUJltPDoXv5g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.222.0.tgz",
+      "integrity": "sha512-P900+KLMUg0eOf75FK/wH/Gjz3rkNtB6iBfAG2Xg4DY5+78qh40deG0y0ZvtkHQP8YOqjLF3QMbEA90YXo4x9Q==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.222.0.tgz",
+      "integrity": "sha512-R4STwHkWgdxMRqOy6riYfXepsQURR5YhK6psPFZHkBYByIRc9JxJdLA0qZcfLRriQIAGmqEO2WWsqRmr8nkbBw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.222.0.tgz",
+      "integrity": "sha512-srrAkOHuvpXeaMG9a6kvfYrhzFFX/plBaZATy8iW6ethgvG1qdPeFj4ZVS9Eisx+13NbGFtydc1WkBZfx2nUWg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.222.0.tgz",
+      "integrity": "sha512-eAxGCcNXl1APMOFbkUaAC6pNBPUbajyGqsDf6GLdlrYHrMVAtJdYd988ov6C52h7k6iDZ+OPHwv8dwUz+PRfpw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.222.0.tgz",
+      "integrity": "sha512-4JRVs7y5JDXXjc5fkz0FCZJt/0HTP2vh3QyZsWRbCYesw2cWVqQlp/fUXp8w5KGqm5nYkTF4e5SQ7Ca8powJNA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.222.0.tgz",
+      "integrity": "sha512-8FZpGuJDtntjXZ/mfJ9EdP5mYiUunQHEmk6OERk3h4XW3D/e97denwDAcBBIK8iYYGic5PoWF4KgTFJWs1YOcw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/service-error-classification": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.222.0.tgz",
+      "integrity": "sha512-GCgbzWy3Dn9+dz/ZZjS5OiJ+feighHfMt461r1zjHNUXnb2tEf5kU+P80d3WqG8er4RRQg+Ao49SatOKgPcrlA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-bucket-endpoint": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.222.0.tgz",
+      "integrity": "sha512-YbL4lTBFgqyL2Ob+dMyw/UNd5K9IOnZHHxjpwWlYKMrfT+pp2bvrr7XUbRHnxSoDsOg9bf6IyTSRVnVxP4psJg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.222.0.tgz",
+      "integrity": "sha512-UoeLbgCJB07dX8tRByR0KzZaOwCoIyXj/SfFTuOhBUjkpKwqFCam/hofDlK3FR6kvl+xiURv57W/FtKV/9TDHg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.222.0.tgz",
+      "integrity": "sha512-MwMw2Lz7SBOniAc0slWXt65ocqL+E956bdW+LOvBin6OgkVWaLRbWI9nOzA6B2d8b65fCGEc+N15i0UdrEf+MQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.222.0.tgz",
+      "integrity": "sha512-WThCx/+UG4gIyqx0G3QKD1RM71+adh9Jv3Sh/KiS07Jjm+pb71wW+RRzBuNyhdjwB3aoKC/YKW8eFQg6M7eaQg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.222.0.tgz",
+      "integrity": "sha512-ASKbstAKbOBUZhFhst6/NCr11x94BDBiQn2zDs2Lvjo89n2efMeb4wEr17VCMZVeKI6ojtPFa1ZVLsH8AOn4Yw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.222.0.tgz",
+      "integrity": "sha512-fjdxCRIAhOTsI9OcEKwJp4lhsvyCSXoeYV49mO/bdG6pFyFRm3Jezx7TNVNeLTGuMHTTTvRrCTF8sgE5t17Pzw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.222.0.tgz",
+      "integrity": "sha512-hrbw90LlVa4xJJc4WiyAfaPMY/sJubSeTwuxTChLsFOavr6hSMCwLASrWmOiKRIj5hKdSfEA87n/q+DnKHlA8A==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.222.0.tgz",
+      "integrity": "sha512-k3WqxUgZzGbiCQt1HyzDGlRzq8muGIOWZs9T3HtCa5LtACvl0qlNmiwCc+C/o7GRLyC9FuWkP3lOW6MiAFQUcA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.222.0",
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/querystring-builder": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.222.0.tgz",
+      "integrity": "sha512-rEqAgQ7itmB7GB+WWLgyT7/YWJkjEBCfggxycccChWAeqg+gjpstIiGX2BjP2K/wnzwE0D91JsozSXcQIDOtNQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.222.0.tgz",
+      "integrity": "sha512-Zj+ytEgrOagCE7yczjdDan7W+1a0OL5DPAx69Z00NxGoBI2h0GRZD28dRYb3Pzs5/Ft4KbCedH/RUnyaYjaZxw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.222.0.tgz",
+      "integrity": "sha512-qrNUGDyDp9yVQMnBbz1T5YBQkA/u6D5o0PPzSwfZ9azdAcBLjHOEfsBrKhxP+K92L/nilbnmY89KrjMR8+BNtw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.222.0.tgz",
+      "integrity": "sha512-3KfkCA/753PlF5QqhGuQ7u+NOgLyiBFeV8R8ut/pfBmG8fF6l3RKrkbcu+87QpqXntRzG+RLHDqS7ryT3B2ICg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.222.0.tgz",
+      "integrity": "sha512-Dn/WGtm+v5nney0CaYZjdOtJmdEuI8EQiQ5J3eQ3G0jjT6mr1/tCajsNpq3ZqHXiwLtydwaVvsL3AKXn+oxFVA==",
+      "dev": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.222.0.tgz",
+      "integrity": "sha512-2dowzMXjvIf5gwX5gNCwpv/TzAbbXxrId3zYJgPdEtApsa7NxyFs5MfnHt1zZI6P3YORGheRnNUK9RUYOPKHgA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.222.0.tgz",
+      "integrity": "sha512-2qQZuKqx56b2uN2rdjdKL6u0Cvk82uTGNtIuetmySY9xPEAljSBdriaxTqNqK9Gs3M4obG22alUK4a85uwqS3g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-middleware": "3.222.0",
+        "@aws-sdk/util-uri-escape": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.222.0.tgz",
+      "integrity": "sha512-SF6Qi0KW69OzgLbA9q6AsZNFQCA+DI66SnAjW774sAE6aQyJmCbUsxETk37XodSymXzDOEDDC6QoY64HUoSoVw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.222.0",
+        "@aws-sdk/signature-v4": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-arn-parser": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.222.0.tgz",
+      "integrity": "sha512-4dnU7TvwKxVuOWduvFGClYe0EgNov5Ke1ef7O1bdKaj5MmlH6wBDgGJM4NKREBFapC2dUXkoPtwsihtYBci1Bw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.223.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.223.0.tgz",
+      "integrity": "sha512-ik6IYiZO9tTzYPJKzUob4U9faC9We6UtVZGynEGLMWSLETM+LefSHK0elEaJaCqx2F4NLodw+t9uvllR+8YUow==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.223.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/shared-ini-file-loader": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.222.0.tgz",
+      "integrity": "sha512-yXRYptInkfEFaOvWFxlRXsRh9jWOmQc1sZeKqjfx2UCtzNJ7ebedN0VfCz4SaDotcw9Q4JWuN66qhRMJjDx7/w==",
+      "dev": true
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.222.0.tgz",
+      "integrity": "sha512-1+QbVdT/phYDb5JDQRJWoZeCujkXaI5m8z3bIiPxcRRY3NPuluDGrfX3kfnFen5s9QGByLvJxWKWZS+i+iUFRg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.208.0.tgz",
+      "integrity": "sha512-QV4af+kscova9dv4VuHOgH8wEr/IIYHDGcnyVtkUEqahCejWr1Kuk+SBK0xMwnZY5LSycOtQ8aeqHOn9qOjZtA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
+      "integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
+      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
+      "integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
+      "integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.201.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
+      "integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.222.0.tgz",
+      "integrity": "sha512-+dGsp59lrEkDmK7OO5ecMYasrTGIKacFHjqZ6aqmbn1xtcUd/o3Qe7g5YSRXMGwtZ6xhvBD+NJLkEERI7U7cMw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.222.0.tgz",
+      "integrity": "sha512-W/duYMtmCCWdzHP+yscBB6yrARgAqWpFdxgBvMSlT8TjOTrh/F+aj4NPamiNMeUfqfMFGnboYfyWRr1avkcAGQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.222.0",
+        "@aws-sdk/credential-provider-imds": "3.222.0",
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/property-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.222.0.tgz",
+      "integrity": "sha512-qujJQv8lFysAr1lOlBTJhz7949NZyq5cj74Q9dR99AcAMXXeI9CQayPKH7477AnXRGOTMahZ3mV0HZ1bCJoNTw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
+      "integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
+      "integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.222.0.tgz",
+      "integrity": "sha512-Y4BPtSa+6+qvg6OVW6RrdDx0OADfWa2Uxsxqdozpdnx2OQY0q+1diqsNgFMV+FIvdXqffE147KG7roG+/AfPeA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.222.0.tgz",
+      "integrity": "sha512-GW9Y1/pLHS7WYHHdswcDd4vaM9mzxDwewcDVujCd/L9MRbG1nA/wfCL7hAAXT1AN2GbGfbfT+jjHQqzexpKBnA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/fetch-http-handler": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-base64": "3.208.0",
+        "@aws-sdk/util-hex-encoding": "3.201.0",
+        "@aws-sdk/util-utf8-browser": "3.188.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-stream-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.222.0.tgz",
+      "integrity": "sha512-iMwKG+RaGVAjzXDuzmMl63SnN6qVc+0VbbfaKW1eIK9Ihr5mko3GuYAFqKaECSQ+XdMNuMSVXzphveKw6t2zwg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/node-http-handler": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
+      "integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.222.0.tgz",
+      "integrity": "sha512-DREMeL0XHl4QIS2GVSHFwVH4mJZ+Dr04R3U8WfiMktXdA93j5tDMJpU3+PNaCZPeaqz2QNwrVSBWKwbwA357zQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.222.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.222.0.tgz",
+      "integrity": "sha512-BMRMrPXL/HS3dSha9vcABkoANluKjB0pH78bc659EY2WUj9wCZdbUNQpACiYx8bwm7xKSxugCkmPd6NLWXUURw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.188.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
+      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.208.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
+      "integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.208.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.222.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.222.0.tgz",
+      "integrity": "sha512-/07RkfxvDncsMeQ+GhigPdiSRd2v/1FJoCV4a5e9XDI1ZSMvUKm36wFqw5Bzts+AUY8f4HOPpGI9ZQeNb7u27Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.222.0",
+        "@aws-sdk/types": "3.222.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.201.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.201.0.tgz",
+      "integrity": "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+          "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+          "dev": true
+        }
+      }
     },
     "@babel/code-frame": {
       "version": "7.16.7",
@@ -26856,6 +30408,12 @@
         }
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "dev": true
+    },
     "boxen": {
       "version": "5.0.0",
       "dev": true,
@@ -29554,6 +33112,15 @@
     "fast-text-encoding": {
       "version": "1.0.3",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dev": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fastparse": {
       "version": "1.1.2",
@@ -37594,6 +41161,12 @@
     },
     "strip-json-comments": {
       "version": "2.0.1",
+      "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
       "dev": true
     },
     "stubs": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@ampproject/filesize": "4.3.0",
     "@ampproject/remapping": "2.1.0",
+    "@aws-sdk/client-s3": "3.223.0",
     "@babel/core": "7.15.0",
     "@babel/helper-module-imports": "7.14.5",
     "@babel/helper-plugin-test-runner": "7.14.5",


### PR DESCRIPTION
For now we upload to both GCS and R2. Once we have enough data in R2 I can start switching cdn-worker to use it as a backend instead of GCS, and we can sunset GCS then