### PR TITLE
Add a 10ms delay when rewinding a media pool video

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -807,10 +807,12 @@ export class MediaPool {
     return this.enqueueMediaElementTask_(poolMediaEl, new PauseTask()).then(
       () => {
         if (rewindToBeginning) {
-          // We add a 10 second delay to rewinding as sometimes this causes
+          // We add a 10 second delay to rewinding as sometimes this causes an
           // interlacing/glitch/frame jump when a new video is starting to play.
           // A 0 delay isn't enough as we need to push the "seeking" event
           // to the next tick of the event loop.
+          // NOTE: Please note that this is not an ideal solution and a bit hacky.
+          // The more ideal fix would be to fix the the navigations animation frames.
           // See https://github.com/ampproject/amphtml/issues/38531
           this.timer_.delay(() => {
             this.enqueueMediaElementTask_(

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -807,10 +807,17 @@ export class MediaPool {
     return this.enqueueMediaElementTask_(poolMediaEl, new PauseTask()).then(
       () => {
         if (rewindToBeginning) {
-          this.enqueueMediaElementTask_(
-            /** @type {!PoolBoundElementDef} */ (poolMediaEl),
-            new SetCurrentTimeTask({currentTime: 0})
-          );
+          // We add a 10 second delay to rewinding as sometimes this causes
+          // interlacing/glitch/frame jump when a new video is starting to play.
+          // A 0 delay isn't enough as we need to push the "seeking" event
+          // to the next tick of the event loop.
+          // See https://github.com/ampproject/amphtml/issues/38531
+          this.timer_.delay(() => {
+            this.enqueueMediaElementTask_(
+              /** @type {!PoolBoundElementDef} */ (poolMediaEl),
+              new SetCurrentTimeTask({currentTime: 0})
+            );
+          }, 10);
         }
       }
     );


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/38531

Given two story pages with videos on each one, when amp-story transitions from page 1 to page 2 we start playing the video on page 2 as early as possible on the next animation frame (let's call this rAF1), and then amp-story rewinds the video on page 1 after rAF1 has executed in another rAF (lets call this rAF2). When the `seeking` event is triggered during the current tick of the event loop in rAF2 which is the [step 2 of the switchTo_ operation](https://github.com/ampproject/amphtml/blob/main/extensions/amp-story/1.0/amp-story.js#L1460-L1503) this glitch can occur. A quick fix is to push the `seeking` event to the next tick of the event loop.

Another fix for this might possibly be moving `oldPage.setState(PageState.NOT_ACTIVE);` to the 3rd step but i would need to retest to confirm.

I used the example given in https://github.com/ampproject/amphtml/issues/38531 and reduced it to 2 pages and got the bug to trigger consistently, applied the fix and tested it exactly 50 times (the bug did not show up in those 50 tries) and the fix seemed to have worked.

I made it a 10 ms delay as a 0 delay still has the `seeking` event on the current tick. 

The traces below show that "measure2" is the [2nd step](https://github.com/ampproject/amphtml/blob/main/extensions/amp-story/1.0/amp-story.js#L1460-L1503) and that `seeking` needs to happen after to fix the bug

---

### `seeking` event with the current code
<img width="785" alt="bug-exist" src="https://user-images.githubusercontent.com/354746/206662252-8f59f3e7-6901-4899-b0d1-a2e9031b146c.png">

---

### `seeking` event with 0 delay
<img width="620" alt="bug-with-zero-delay" src="https://user-images.githubusercontent.com/354746/206662554-2a5c942c-f60f-42da-8f91-9c895de61d57.png">

---

### `seeking` event with 10ms delay
<img width="1009" alt="bug-fixed" src="https://user-images.githubusercontent.com/354746/206662564-a4c82dd9-3279-4658-98ce-437c49cc9fee.png">





<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
