### PR TITLE
🐛Allowing cookies to be set with self hosted runtime #38561 (pt: 2) 

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -253,8 +253,9 @@ function checkOriginForSettingCookie(win, options, name) {
   );
   const current = parseUrlDeprecated(win.location.href).hostname.toLowerCase();
   const proxy = parseUrlDeprecated(urls.cdn).hostname.toLowerCase();
+  const metaTag = win.document.querySelector("meta[name='runtime-host']");
   userAssert(
-    !(current == proxy || endsWith(current, '.' + proxy)),
+    !(current == proxy || endsWith(current, '.' + proxy)) || metaTag != null,
     'Should never attempt to set cookie on proxy origin. (in depth check): ' +
       name
   );


### PR DESCRIPTION
This PR was created to fix issue https://github.com/ampproject/amphtml/issues/38437. Created an exception when setting cookies in order to enable cookies to be set when there is a self hosted runtime specified within the documents head. In order to use this exception; you must specify your self hosted runtime as so... ensure the name specifies "runtime-host" .
