### PR TITLE
fix(sec): upgrade formidable to 3.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,7 @@
         "express": "4.17.1",
         "fast-glob": "3.2.7",
         "fetch-mock": "9.11.0",
-        "formidable": "1.2.2",
+        "formidable": "3.2.4",
         "fs-extra": "10.0.0",
         "gulp-connect": "5.7.0",
         "html-minifier": "4.0.0",
@@ -9309,6 +9309,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/di": {
       "version": "0.0.1",
       "dev": true,
@@ -11923,9 +11933,15 @@
       }
     },
     "node_modules/formidable": {
-      "version": "1.2.2",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.2.4.tgz",
+      "integrity": "sha512-8/5nJsq+o2o1+Dryx1k5gLTDaw0dNE9kL4P3srKArO6zhoerGm42/R8zq+L5EkV7kckNTvJpJke0kI8JseL3RQ==",
       "dev": true,
-      "license": "MIT",
+      "dependencies": {
+        "dezalgo": "1.0.3",
+        "hexoid": "1.0.0",
+        "once": "1.4.0"
+      },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
@@ -12861,6 +12877,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/highlight.js": {
@@ -31637,6 +31662,16 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "di": {
       "version": "0.0.1",
       "dev": true
@@ -33448,8 +33483,15 @@
       }
     },
     "formidable": {
-      "version": "1.2.2",
-      "dev": true
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.2.4.tgz",
+      "integrity": "sha512-8/5nJsq+o2o1+Dryx1k5gLTDaw0dNE9kL4P3srKArO6zhoerGm42/R8zq+L5EkV7kckNTvJpJke0kI8JseL3RQ==",
+      "dev": true,
+      "requires": {
+        "dezalgo": "1.0.3",
+        "hexoid": "1.0.0",
+        "once": "1.4.0"
+      }
     },
     "forwarded": {
       "version": "0.1.2",
@@ -34088,6 +34130,12 @@
     },
     "he": {
       "version": "1.2.0",
+      "dev": true
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
     },
     "highlight.js": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "express": "4.17.1",
     "fast-glob": "3.2.7",
     "fetch-mock": "9.11.0",
-    "formidable": "1.2.2",
+    "formidable": "3.2.4",
     "fs-extra": "10.0.0",
     "gulp-connect": "5.7.0",
     "html-minifier": "4.0.0",


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in formidable 1.2.2
- [CVE-2022-29622](https://www.oscs1024.com/hd/CVE-2022-29622)


### What did I do？
Upgrade formidable from 1.2.2 to 3.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS