### PR TITLE
✨ [Story interactive] Allow no options to skip showing results

### DIFF
--- a/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
+++ b/extensions/amp-story-interactive/0.1/amp-story-interactive-abstract.js
@@ -763,7 +763,7 @@ export class AmpStoryInteractive extends AMP.BaseElement {
     }
     const numOptions = this.getNumberOfOptions();
     // Only keep the visible options to ensure visible percentages add up to 100.
-    this.updateComponentWithData(response['options'].slice(0, numOptions));
+    response["options"] && this.updateComponentWithData(response['options'].slice(0, numOptions));
   }
 
   /**


### PR DESCRIPTION
Currently if the response from the backend is not valid, the percentages won't get shown. However, that can result in a console error, which this PR gets rid of.

This allows backends to receive data from quizzes/polls but don't show the aggregated numbers to users (eg: on a customer satisfaction survey), and not have console errors. (Note that previously, invalid backend responses would do this, but show an error)