### PR TITLE
increase the rewind delay to 100ms

### DIFF
--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -807,7 +807,7 @@ export class MediaPool {
     return this.enqueueMediaElementTask_(poolMediaEl, new PauseTask()).then(
       () => {
         if (rewindToBeginning) {
-          // We add a 10 second delay to rewinding as sometimes this causes an
+          // We add a 100 second delay to rewinding as sometimes this causes an
           // interlacing/glitch/frame jump when a new video is starting to play.
           // A 0 delay isn't enough as we need to push the "seeking" event
           // to the next tick of the event loop.
@@ -819,7 +819,7 @@ export class MediaPool {
               /** @type {!PoolBoundElementDef} */ (poolMediaEl),
               new SetCurrentTimeTask({currentTime: 0})
             );
-          }, 10);
+          }, 100);
         }
       }
     );

--- a/extensions/amp-story/1.0/media-pool.js
+++ b/extensions/amp-story/1.0/media-pool.js
@@ -807,6 +807,8 @@ export class MediaPool {
     return this.enqueueMediaElementTask_(poolMediaEl, new PauseTask()).then(
       () => {
         if (rewindToBeginning) {
+          // TODO: https://github.com/ampproject/amphtml/issues/38595 implement
+          // proper fix to frame management.
           // We add a 100 second delay to rewinding as sometimes this causes an
           // interlacing/glitch/frame jump when a new video is starting to play.
           // A 0 delay isn't enough as we need to push the "seeking" event


### PR DESCRIPTION
Some devices, specifically iphone 12 and up are still having the video glitching issue with the 10ms delay. Bumping it up to 100ms seems to fix the issue.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
