### PR TITLE
🐛 Fix xdomain ad not clickable

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
+++ b/extensions/amp-story-auto-ads/0.1/amp-story-auto-ads.css
@@ -9,6 +9,7 @@
   height: 100% !important;
   width: 100% !important;
   z-index: 1 !important;
+  pointer-events: auto !important;
 }
 
 amp-story-page[xdomain-ad] .i-amphtml-glass-pane {

--- a/extensions/amp-story/1.0/amp-story.css
+++ b/extensions/amp-story/1.0/amp-story.css
@@ -338,7 +338,8 @@ amp-story-page[active]:not(.i-amphtml-layout) amp-video.i-amphtml-poolbound:not(
 }
 
 /** Make clickable elements in light dom accept pointer events */
-amp-story-grid-layer a, amp-story-grid-layer amp-twitter {
+amp-story-grid-layer a, amp-story-grid-layer amp-twitter,
+amp-story-grid-layer amp-ad {
   pointer-events: auto !important;
 }
 


### PR DESCRIPTION
Need to make `amp-ad` clickable after https://github.com/ampproject/amphtml/pull/38377 by adding `pointer-events: auto`. Also, glass-pane on top of the ad should be clickable so that it catches unwanted clicks on the top of the page.

Closes https://github.com/ampproject/amphtml/issues/38552