### PR TITLE
🧪 Introduce structure for `attribution-reporting` client side experiment

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -155,6 +155,10 @@ exports.rules = [
       'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js->extensions/amp-a4a/0.1/signature-verifier.js',
       'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/signature-verifier.js',
 
+      // A4A impls using attribution-reporting API
+      'extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js->extensions/amp-a4a/0.1/privacy-sandbox-utils.js',
+      'extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js->extensions/amp-a4a/0.1/privacy-sandbox-utils.js',
+
       // And a few more things depend on a4a.
       'extensions/amp-ad-custom/0.1/amp-ad-custom.js->extensions/amp-a4a/0.1/amp-ad-network-base.js',
       'extensions/amp-ad-custom/0.1/amp-ad-custom.js->extensions/amp-a4a/0.1/amp-ad-type-defs.js',

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -32,11 +32,8 @@ import {dev, devAssert, logHashParam, user, userAssert} from '#utils/log';
 import {A4AVariableSource} from './a4a-variable-source';
 import {getExtensionsFromMetadata} from './amp-ad-utils';
 import {processHead} from './head-validation';
-import {
-  createSecureDocSkeleton,
-  createSecureFrame,
-  isAttributionReportingSupported,
-} from './secure-frame';
+import {isAttributionReportingAllowed} from './privacy-sandbox-utils';
+import {createSecureDocSkeleton, createSecureFrame} from './secure-frame';
 import {SignatureVerifier, VerificationStatus} from './signature-verifier';
 import {whenWithinViewport} from './within-viewport';
 
@@ -2037,7 +2034,7 @@ export class AmpA4A extends AMP.BaseElement {
     // request completes.
     let featurePolicies = "sync-xhr 'none';";
 
-    if (isAttributionReportingSupported(this.win.document)) {
+    if (isAttributionReportingAllowed(this.win.document)) {
       featurePolicies += "attribution-reporting 'src';";
     }
 

--- a/extensions/amp-a4a/0.1/privacy-sandbox-utils.js
+++ b/extensions/amp-a4a/0.1/privacy-sandbox-utils.js
@@ -1,0 +1,17 @@
+/**
+ * Determine if `attribution-reporting` API is available in browser.
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+export function isAttributionReportingAvailable(doc) {
+  return doc.featurePolicy?.features().includes('attribution-reporting');
+}
+
+/**
+ * Determine if `attribution-reporting` API is allowed in current context.
+ * @param {!Document} doc
+ * @return {boolean}
+ */
+export function isAttributionReportingAllowed(doc) {
+  return doc.featurePolicy?.allowedFeatures().includes('attribution-reporting');
+}

--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -1,5 +1,7 @@
 import {createElementWithAttributes, escapeHtml} from '#core/dom';
 
+import {isAttributionReportingAllowed} from './privacy-sandbox-utils';
+
 import {getFieSafeScriptSrcs} from '../../../src/friendly-iframe-embed';
 
 // If making changes also change ALLOWED_FONT_REGEX in head-validation.js
@@ -87,18 +89,9 @@ export function createSecureFrame(win, title, height, width) {
     })
   );
 
-  if (isAttributionReportingSupported(document)) {
+  if (isAttributionReportingAllowed(document)) {
     iframe.setAttribute('allow', `attribution-reporting 'src'`);
   }
 
   return iframe;
-}
-
-/**
- * Determine if `attribution-reporting` API is available in browser.
- * @param {!Document} doc
- * @return {boolean}
- */
-export function isAttributionReportingSupported(doc) {
-  return doc.featurePolicy?.features().includes('attribution-reporting');
 }

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a.js
@@ -50,7 +50,7 @@ import {
   assignAdUrlToError,
   protectFunctionWrapper,
 } from '../amp-a4a';
-import * as secureFrame from '../secure-frame';
+import * as privacySandboxUtils from '../privacy-sandbox-utils';
 import {AMP_SIGNATURE_HEADER, VerificationStatus} from '../signature-verifier';
 
 describes.realWin('amp-a4a: no signing', {amp: true}, (env) => {
@@ -923,7 +923,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       it('should set feature policy for attribution-reporting when supported', async () => {
         env.sandbox
-          .stub(secureFrame, 'isAttributionReportingSupported')
+          .stub(privacySandboxUtils, 'isAttributionReportingAllowed')
           .returns(true);
         a4a.sandboxHTMLCreativeFrame = () => true;
         a4a.onLayoutMeasure();
@@ -936,7 +936,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       it('should not set feature policy for attribution-reporting when not supported', async () => {
         env.sandbox
-          .stub(secureFrame, 'isAttributionReportingSupported')
+          .stub(privacySandboxUtils, 'isAttributionReportingAllowed')
           .returns(false);
         a4a.sandboxHTMLCreativeFrame = () => true;
         a4a.onLayoutMeasure();
@@ -1035,7 +1035,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       it('should set feature policy for attribution-reporting when supported', async () => {
         env.sandbox
-          .stub(secureFrame, 'isAttributionReportingSupported')
+          .stub(privacySandboxUtils, 'isAttributionReportingAllowed')
           .returns(true);
         a4a.sandboxHTMLCreativeFrame = () => false;
         a4a.onLayoutMeasure();
@@ -1048,7 +1048,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       it('should not set feature policy for attribution-reporting when not supported', async () => {
         env.sandbox
-          .stub(secureFrame, 'isAttributionReportingSupported')
+          .stub(privacySandboxUtils, 'isAttributionReportingAllowed')
           .returns(false);
         a4a.sandboxHTMLCreativeFrame = () => false;
         a4a.onLayoutMeasure();
@@ -1169,7 +1169,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       it('should set feature policy for attribution-reporting when supported', async () => {
         env.sandbox
-          .stub(secureFrame, 'isAttributionReportingSupported')
+          .stub(privacySandboxUtils, 'isAttributionReportingAllowed')
           .returns(true);
         a4a.sandboxHTMLCreativeFrame = () => false;
         a4a.onLayoutMeasure();
@@ -1186,7 +1186,7 @@ describes.realWin('amp-a4a', {amp: true}, (env) => {
 
       it('should not set feature policy for attribution-reporting when not supported', async () => {
         env.sandbox
-          .stub(secureFrame, 'isAttributionReportingSupported')
+          .stub(privacySandboxUtils, 'isAttributionReportingAllowed')
           .returns(false);
         a4a.sandboxHTMLCreativeFrame = () => false;
         a4a.onLayoutMeasure();

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -42,6 +42,7 @@ import {
   getExperimentBranch,
   randomlySelectUnsetExperiments,
 } from '#experiments';
+import {AttributionReporting} from '#experiments/attribution-reporting';
 import {StoryAdPlacements} from '#experiments/story-ad-placements';
 import {StoryAdSegmentExp} from '#experiments/story-ad-progress-segment';
 
@@ -50,6 +51,8 @@ import {Navigation} from '#service/navigation';
 
 import {getData} from '#utils/event-helper';
 import {dev, devAssert, user} from '#utils/log';
+
+import {isAttributionReportingAllowed} from 'extensions/amp-a4a/0.1/privacy-sandbox-utils';
 
 import {AdsenseSharedState} from './adsense-shared-state';
 import {ResponsiveState} from './responsive-state';
@@ -223,7 +226,19 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    */
   divertExperiments() {
     const experimentInfoList =
-      /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([]);
+      /** @type {!Array<!../../../src/experiments.ExperimentInfo>} */ ([
+        {
+          experimentId: AttributionReporting.ID,
+          isTrafficEligible: () =>
+            isAttributionReportingAllowed(this.win.document),
+          branches: [
+            AttributionReporting.ENABLE,
+            AttributionReporting.DISABLE,
+            AttributionReporting.ENABLE_NO_ASYNC,
+            AttributionReporting.DISABLE_NO_ASYNC,
+          ],
+        },
+      ]);
     const setExps = randomlySelectUnsetExperiments(
       this.win,
       experimentInfoList

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -67,6 +67,7 @@ import {
   isExperimentOn,
   randomlySelectUnsetExperiments,
 } from '#experiments';
+import {AttributionReporting} from '#experiments/attribution-reporting';
 import {StoryAdPlacements} from '#experiments/story-ad-placements';
 import {StoryAdSegmentExp} from '#experiments/story-ad-progress-segment';
 
@@ -75,6 +76,8 @@ import {Navigation} from '#service/navigation';
 import {RTC_VENDORS} from '#service/real-time-config/callout-vendors';
 
 import {dev, devAssert, user} from '#utils/log';
+
+import {isAttributionReportingAllowed} from 'extensions/amp-a4a/0.1/privacy-sandbox-utils';
 
 import {
   FlexibleAdSlotDataTypeDef,
@@ -474,6 +477,17 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
             );
           },
           branches: Object.values(IDLE_CWV_EXP_BRANCHES),
+        },
+        {
+          experimentId: AttributionReporting.ID,
+          isTrafficEligible: () =>
+            isAttributionReportingAllowed(this.win.document),
+          branches: [
+            AttributionReporting.ENABLE,
+            AttributionReporting.DISABLE,
+            AttributionReporting.ENABLE_NO_ASYNC,
+            AttributionReporting.DISABLE_NO_ASYNC,
+          ],
         },
       ]);
     const setExps = this.randomlySelectUnsetExperiments_(experimentInfoList);

--- a/src/experiments/attribution-reporting.js
+++ b/src/experiments/attribution-reporting.js
@@ -6,6 +6,6 @@ export const AttributionReporting = {
   ID: 'attribution-reporting',
   DISABLE: '44776500',
   ENABLE: '44776501',
-  ENABLE_NO_ASYNC: '44776502',
-  DISABLE_NO_ASYNC: '44776503',
+  DISABLE_NO_ASYNC: '44776502',
+  ENABLE_NO_ASYNC: '44776503',
 };

--- a/src/experiments/attribution-reporting.js
+++ b/src/experiments/attribution-reporting.js
@@ -1,0 +1,11 @@
+/**
+ * @const
+ * @type {Object<string, string>}
+ */
+export const AttributionReporting = {
+  ID: 'attribution-reporting',
+  DISABLE: '44776500',
+  ENABLE: '44776501',
+  ENABLE_NO_ASYNC: '44776502',
+  DISABLE_NO_ASYNC: '44776503',
+};

--- a/tools/experiments/experiments-config.js
+++ b/tools/experiments/experiments-config.js
@@ -193,4 +193,9 @@ export const EXPERIMENTS = [
     name: 'Enable paywall experiences in web stories by turning on amp-story-subscriptions extension',
     spec: 'https://github.com/ampproject/amphtml/pull/38179',
   },
+  {
+    id: 'attribution-reporting',
+    name: 'Enable new privacy preserving attribution reporting APIs',
+    spec: 'https://github.com/ampproject/amphtml/pull/35347',
+  },
 ];


### PR DESCRIPTION
Allows us to send requests opting into new api in ad response.

partial #35347 