### PR TITLE
♻️ Make innerHTML assignment in semantic-render Trusted Types compatible

### DIFF
--- a/extensions/amp-story/1.0/semantic-render.js
+++ b/extensions/amp-story/1.0/semantic-render.js
@@ -148,7 +148,22 @@ function extractTextContentWebVtt(text) {
     .join(' ');
   // Super loose HTML parsing to get HTML entity parsing and removal
   // of WebVTT elements.
-  const div = <div />;
-  div./* element is never added to DOM */ innerHTML = text;
-  return div.textContent;
+  // Assigning .innerHTML of a <template> node to prevent XSS risk.
+  const wrapperTemplate = <template />;
+  // Make innerHTML assignment Trusted Types compliant for compatible browsers
+  if (self.trustedTypes && self.trustedTypes.createPolicy) {
+    const policy = self.trustedTypes.createPolicy(
+      'semantic-render#extractTextContentWebVtt',
+      {
+        createHTML: function (unused) {
+          return text;
+        },
+      }
+    );
+    wrapperTemplate./* element is never added to DOM */ innerHTML =
+      policy.createHTML('ignored');
+  } else {
+    wrapperTemplate./* element is never added to DOM */ innerHTML = text;
+  }
+  return wrapperTemplate.content.textContent;
 }


### PR DESCRIPTION
This is a partial fix to #37297.

This change refactors the loose HTML parsing by assigning to a div that's never attached to the DOM, by replacing the use of `<div>` with a `<template>` node. This reduces XSS risk, as an `innerHTML` assignment on a `<div>` that's never attached can still lead to code execution (eg. `<img src=x onerror=alert()>`). This change also adds an inline policy to create a `TrustedHTML`  when assigning to `innerHTML` to avoid the Trusted Types violation.