### PR TITLE
Allow `attributionsrc` on `<a />`

### DIFF
--- a/validator/testdata/amp4ads_feature_tests/anchor_attribution_reporting.html
+++ b/validator/testdata/amp4ads_feature_tests/anchor_attribution_reporting.html
@@ -1,0 +1,19 @@
+<!--
+  Test Description:
+  Enable the attribution reporting API for anchor elements
+  https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#api-overview
+-->
+<!doctype html>
+<html ⚡4ads>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp4ads-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+</head>
+<body>
+  Hello, world.
+  <a attributionsrc></a>
+  <a attributionsrc="https://adtech.example"></a>
+</body>
+</html>

--- a/validator/testdata/amp4ads_feature_tests/anchor_attribution_reporting.out
+++ b/validator/testdata/amp4ads_feature_tests/anchor_attribution_reporting.out
@@ -1,0 +1,20 @@
+PASS
+|  <!--
+|    Test Description:
+|    Enable the attribution reporting API for anchor elements
+|    https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#api-overview
+|  -->
+|  <!doctype html>
+|  <html ⚡4ads>
+|  <head>
+|    <meta charset="utf-8">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp4ads-boilerplate>body{visibility:hidden}</style>
+|    <script async src="https://cdn.ampproject.org/amp4ads-v0.js"></script>
+|  </head>
+|  <body>
+|    Hello, world.
+|    <a attributionsrc></a>
+|    <a attributionsrc="https://adtech.example"></a>
+|  </body>
+|  </html>

--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -1347,6 +1347,13 @@ tags: {
   html_format: AMP
   html_format: AMP4ADS
   tag_name: "A"
+  attrs: {
+    name: "attributionsrc"
+    value_url: {
+      protocol: "https"
+      allow_empty: true
+    }
+  }
   attrs: { name: "border" }  # Not valid html5 but commonly used and supported.
   attrs: { name: "download" }
   attrs: {


### PR DESCRIPTION
Partial https://github.com/ampproject/amphtml/issues/35347

See https://github.com/WICG/attribution-reporting-api/blob/main/EVENT.md#api-overview for more details around the chrome API.