### PR TITLE
❄️ Fix flaky amp-auto-ads placement tests

### DIFF
--- a/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
+++ b/extensions/amp-auto-ads/0.1/test/test-ad-strategy.js
@@ -1,3 +1,5 @@
+import {AmpAd} from 'extensions/amp-ad/0.1/amp-ad';
+
 import {AdStrategy} from '../ad-strategy';
 import {AdTracker} from '../ad-tracker';
 import {PlacementState, getPlacementsFromConfigObj} from '../placement';
@@ -33,6 +35,10 @@ describes.realWin(
       env.sandbox
         .stub(win.__AMP_BASE_CE_CLASS.prototype, 'whenBuilt')
         .callsFake(() => Promise.resolve());
+
+      // Stub actual amp-ad creation since we don't care about its behavior
+      // here, only that they are created.
+      env.sandbox.stub(AmpAd.prototype, 'buildCallback').resolves();
     });
 
     it('should call placeAd with correct parameters', () => {


### PR DESCRIPTION
These were timing out on waiting for amp-ad to build, but that is irrelevant for the tests.