### PR TITLE
🚮 Remove prebidappnexus RTC Vendor

### DIFF
--- a/extensions/amp-a4a/rtc-documentation.md
+++ b/extensions/amp-a4a/rtc-documentation.md
@@ -125,7 +125,6 @@ The `errorReportingUrl` property is optional. The only available macros are ERRO
 
 -   Admax
 -   Adpushup
--   AppNexus
 -   AppNexus PSP
 -   APS
 -   Automatad

--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -23,7 +23,6 @@ To use RTC, you must meet the following requirements:
 
 -   Admax
 -   Adpushup
--   AppNexus
 -   AppNexus PSP
 -   APS
 -   Automatad

--- a/extensions/amp-ad-network-smartadserver-impl/0.1/test/test-amp-ad-network-smartadserver-impl.js
+++ b/extensions/amp-ad-network-smartadserver-impl/0.1/test/test-amp-ad-network-smartadserver-impl.js
@@ -37,7 +37,7 @@ const realWinConfig = {
 describes.realWin('amp-ad-network-smartadserver-impl', realWinConfig, (env) => {
   const rtcConfig = {
     vendors: {
-      prebidappnexus: {
+      prebidappnexuspsp: {
         PLACEMENT_ID: 13133382,
         ACCOUNT_ID: 101010,
       },
@@ -374,7 +374,7 @@ describes.realWin('amp-ad-network-smartadserver-impl', realWinConfig, (env) => {
               'hb_size': '300x250',
             },
           },
-          callout: 'prebidappnexus',
+          callout: 'prebidappnexuspsp',
           rtcTime: 184,
         },
         {
@@ -567,7 +567,7 @@ describes.realWin('amp-ad-network-smartadserver-impl', realWinConfig, (env) => {
             },
           },
           rtcTime: 134,
-          callout: 'prebidappnexus',
+          callout: 'prebidappnexuspsp',
         },
         {
           response: {},
@@ -600,7 +600,7 @@ describes.realWin('amp-ad-network-smartadserver-impl', realWinConfig, (env) => {
         {
           'response': {},
           'rtcTime': 92,
-          'callout': 'prebidappnexus',
+          'callout': 'prebidappnexuspsp',
         },
         {
           'response': {},

--- a/src/service/real-time-config/callout-vendors.js
+++ b/src/service/real-time-config/callout-vendors.js
@@ -179,11 +179,6 @@ const RTC_VENDORS = jsonConfiguration({
       'https://elb.the-ozone-project.com/amp_error?err=ERROR_TYPE&url=HREF',
     disableKeyAppend: true,
   },
-  prebidappnexus: {
-    url: 'https://prebid.adnxs.com/pbs/v1/openrtb2/amp?tag_id=PLACEMENT_ID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&consent_string=CONSENT_STRING&account=ACCOUNT_ID&gdpr_applies=CONSENT_METADATA(gdprApplies)&addtl_consent=CONSENT_METADATA(additionalConsent)&consent_type=CONSENT_METADATA(consentStringType)&pvid=PAGEVIEWID',
-    macros: ['PLACEMENT_ID', 'CONSENT_STRING', 'ACCOUNT_ID'],
-    disableKeyAppend: true,
-  },
   prebidappnexuspsp: {
     url: 'https://ib.adnxs.com/prebid/amp?tag_id=PLACEMENT_ID&w=ATTR(width)&h=ATTR(height)&ow=ATTR(data-override-width)&oh=ATTR(data-override-height)&ms=ATTR(data-multi-size)&slot=ATTR(data-slot)&targeting=TGT&curl=CANONICAL_URL&timeout=TIMEOUT&adcid=ADCID&purl=HREF&consent_string=CONSENT_STRING&account=ACCOUNT_ID&gdpr_applies=CONSENT_METADATA(gdprApplies)&addtl_consent=CONSENT_METADATA(additionalConsent)&consent_type=CONSENT_METADATA(consentStringType)&pvid=PAGEVIEWID',
     macros: ['PLACEMENT_ID', 'CONSENT_STRING', 'ACCOUNT_ID'],


### PR DESCRIPTION
Hi. I'm from Xandr/AppNexus.

The `prebidappnexus` RTC vendor is deprecated in favor of `prebidappnexuspsp`. Cleaning up our integration now that that publishers have migrated to our new vendor code.