### PR TITLE
❄️ Remove rtc publisher link from link checker

### DIFF
--- a/extensions/amp-a4a/rtc-publisher-implementation-guide.md
+++ b/extensions/amp-a4a/rtc-publisher-implementation-guide.md
@@ -17,6 +17,8 @@ To use RTC, you must meet the following requirements:
 -   Use an ad network that supports Fast Fetch and AMP RTC
 -   Set the `rtc-config` attribute on each amp-ad element for which RTC is to be used, as specified below.
 
+<!-- markdown-link-check-disable -->
+
 ### Supported Vendors
 
 -   Admax
@@ -52,6 +54,8 @@ To use RTC, you must meet the following requirements:
 -   The Ozone Project
 -   Yieldbot
 -   Yieldlab
+
+<!-- markdown-link-check-enable -->
 
 ### Overview
 


### PR DESCRIPTION
CircleCI is currently failing rtc-related changes because of highfivve.com failing the link check. Since we have no way of enforcing external links and, in case it happens, we cannot easily find the owner organization. I propose we disable these checks.