### PR TITLE
🐛 build: npm@9 compatibility fix for amp task runner

### DIFF
--- a/build-system/task-runner/install-amp-task-runner.js
+++ b/build-system/task-runner/install-amp-task-runner.js
@@ -20,8 +20,8 @@ const ampCliRunner = 'build-system/task-runner/amp-cli-runner.js';
  * @return {Promise<void>}
  */
 async function installAmpTaskRunner() {
-  const npmBinDir = getStdout('npm bin --global').trim();
-  const ampBinary = path.join(npmBinDir, 'amp');
+  const npmBinDir = getStdout('npm prefix --global').trim();
+  const ampBinary = path.join(npmBinDir, 'bin', 'amp');
   const ampBinaryExists = await fs.pathExists(ampBinary);
   if (ampBinaryExists) {
     const ampBinaryIsAScript = !(await fs.lstat(ampBinary)).isSymbolicLink();


### PR DESCRIPTION
npm version 9 dropped support for `npm bin`. The only place this command is used is in `install-amp-task-runner` to install the `amp` binary in the global node modules bin/ directory. Switch to `npm prefix` which is still supported and modify the target path to specify `bin` manually.

Fixes #38662 