### PR TITLE
🧪 Update ids in `attribution-reporting` experiment

### DIFF
--- a/src/experiments/attribution-reporting.js
+++ b/src/experiments/attribution-reporting.js
@@ -4,8 +4,8 @@
  */
 export const AttributionReporting = {
   ID: 'attribution-reporting',
-  DISABLE: '44776500',
-  ENABLE: '44776501',
-  DISABLE_NO_ASYNC: '44776502',
-  ENABLE_NO_ASYNC: '44776503',
+  DISABLE: '42531928',
+  ENABLE: '42531929',
+  DISABLE_NO_ASYNC: '42531930',
+  ENABLE_NO_ASYNC: '42531931',
 };


### PR DESCRIPTION
Original ids could not be shared between server side exp and client side, so we needed new ids.

Part of https://github.com/ampproject/amphtml/issues/35347