### PR TITLE
Fix `attribution-reporting` browser support detection

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -441,7 +441,7 @@ export class AmpAdExit extends AMP.BaseElement {
    * @return {boolean}
    */
   detectAttributionReportingSupport() {
-    return isAttributionReportingAllowed(this.win);
+    return isAttributionReportingAllowed(this.win.document);
   }
 
   /**

--- a/src/pixel.js
+++ b/src/pixel.js
@@ -68,7 +68,7 @@ function createImagePixel(win, src, noReferrer = false, attributionSrc) {
     image.referrerPolicy = 'no-referrer';
   }
   image.src = src;
-  if (isAttributionReportingAllowed(win)) {
+  if (isAttributionReportingAllowed(win.document)) {
     image.attributionsrc = attributionSrc;
   }
   return image;


### PR DESCRIPTION
#38619 used the shared `isAttributionReportingAllowed` helper but passes `win` in a couple places that should be `document`.  `win.featurePolicy?.allowedFeatures().includes('attribution-reporting');` will always return `undefined`. 