### PR TITLE
Update cmps.js for new consentmanager domain

### DIFF
--- a/extensions/amp-consent/0.1/cmps.js
+++ b/extensions/amp-consent/0.1/cmps.js
@@ -29,8 +29,8 @@ CMP_CONFIG['appconsent'] = {
 CMP_CONFIG['ConsentManager'] = {
   'consentInstanceId': 'ConsentManager',
   'checkConsentHref':
-    'https://consentmanager.mgr.consensu.org/delivery/ampcheck.php',
-  'promptUISrc': 'https://consentmanager.mgr.consensu.org/delivery/ampui.php',
+    'https://delivery.consentmanager.net/delivery/ampcheck.php',
+  'promptUISrc': 'https://delivery.consentmanager.net/delivery/ampui.php',
 };
 
 CMP_CONFIG['didomi'] = {


### PR DESCRIPTION
Updated consentmanager domain to delivery.consentmanager.net. consensu.org domain will soon be deprecated by the IAB and all CMPs must switch to new domains.

---
This is a branch of the original PR https://github.com/ampproject/amphtml/pull/38371 to check if we need a rebase 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
