### PR TITLE
♻️Make loadScript function in validator-integration Trusted Types compatible 

### DIFF
--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -44,7 +44,27 @@ export function loadScript(doc, url) {
   const script = /** @type {!HTMLScriptElement} */ (
     doc.createElement('script')
   );
-  script.src = url;
+  // Make script.src assignment Trusted Types compatible for compatible browsers
+  if (self.trustedTypes && self.trustedTypes.createPolicy) {
+    const policy = self.trustedTypes.createPolicy(
+      'validator-integration#loadScript',
+      {
+        createScriptURL: function (url) {
+          // Only allow trusted URLs
+          if (
+            url === 'cdn.ampproject.org/v0/validator_wasm.js'
+          ) {
+            return url;
+          } else {
+            return '';
+          }
+        },
+      }
+    );
+    script.src = policy.createScriptURL(url);
+  } else {
+    script.src = url;
+  }
   propagateNonce(doc, script);
 
   const promise = loadPromise(script).then(

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -51,9 +51,7 @@ export function loadScript(doc, url) {
       {
         createScriptURL: function (url) {
           // Only allow trusted URLs
-          if (
-            url === 'cdn.ampproject.org/v0/validator_wasm.js'
-          ) {
+          if (url === 'cdn.ampproject.org/v0/validator_wasm.js') {
             return url;
           } else {
             return '';

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -52,7 +52,7 @@ export function loadScript(doc, url) {
         createScriptURL: function (url) {
           // Only allow trusted URLs
           // eslint-disable-next-line local/no-forbidden-terms
-          if (url === 'cdn.ampproject.org/v0/validator_wasm.js') {
+          if (url === 'https://cdn.ampproject.org/v0/validator_wasm.js') {
             return url;
           } else {
             return '';

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -51,6 +51,9 @@ export function loadScript(doc, url) {
       {
         createScriptURL: function (url) {
           // Only allow trusted URLs
+          // Using explicit cdn domain as no other AMP Cache hosts validator_
+          // wasm so we can assume the explicit cdn domain is cdn.ampproject.org
+          // instead of using the dynamic cdn value from src/config/urls.js
           // eslint-disable-next-line local/no-forbidden-terms
           if (url === 'https://cdn.ampproject.org/v0/validator_wasm.js') {
             return url;

--- a/src/validator-integration.js
+++ b/src/validator-integration.js
@@ -51,6 +51,7 @@ export function loadScript(doc, url) {
       {
         createScriptURL: function (url) {
           // Only allow trusted URLs
+          // eslint-disable-next-line local/no-forbidden-terms
           if (url === 'cdn.ampproject.org/v0/validator_wasm.js') {
             return url;
           } else {

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -71,7 +71,7 @@ describes.fakeWin('validator-integration', {}, (env) => {
         .stub(eventHelper, 'loadPromise')
         .returns(Promise.resolve());
 
-      loadScript(win.document, 'http://example.com');
+      loadScript(win.document, 'cdn.ampproject.org/v0/validator_wasm.js');
 
       expect(loadScriptStub).calledWith(
         env.sandbox.match((el) => el.nonce === '123')

--- a/test/unit/test-validator-integration.js
+++ b/test/unit/test-validator-integration.js
@@ -71,7 +71,10 @@ describes.fakeWin('validator-integration', {}, (env) => {
         .stub(eventHelper, 'loadPromise')
         .returns(Promise.resolve());
 
-      loadScript(win.document, 'cdn.ampproject.org/v0/validator_wasm.js');
+      loadScript(
+        win.document,
+        'https://cdn.ampproject.org/v0/validator_wasm.js'
+      );
 
       expect(loadScriptStub).calledWith(
         env.sandbox.match((el) => el.nonce === '123')


### PR DESCRIPTION
Adding an inline Trusted Types policy to validate the URL and generate a TrustedScriptURL object to avoid Trusted Types violations due to the `script.src` call. Also updated the test example to match the trusted URL pattern to simplify validation.
