### PR TITLE
✨ [RTC-Config]: add source_url and title to real-time-config global macros allowlist

### DIFF
--- a/src/service/real-time-config/real-time-config-impl.js
+++ b/src/service/real-time-config/real-time-config-impl.js
@@ -63,7 +63,11 @@ export const RTC_ERROR_ENUM = {
 };
 
 /** @const {!{[key: string]: boolean}} */
-const GLOBAL_MACRO_ALLOWLIST = {CLIENT_ID: true};
+const GLOBAL_MACRO_ALLOWLIST = {
+  CLIENT_ID: true,
+  TITLE: true,
+  SOURCE_URL: true,
+};
 
 export class RealTimeConfigService {
   /**

--- a/test/unit/test-real-time-config.js
+++ b/test/unit/test-real-time-config.js
@@ -812,7 +812,7 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
       expect(fetchJsonStub).to.be.called;
       expect(
         fetchJsonStub.calledWithMatch(
-          /https:\/\/www\.foo\.example\/\?title=[^&]+&src=https?:\/\/[\w\.\/]+&cid=amp-\S+/
+          /https:\/\/www\.foo\.example\/\?title=[^&]+&src=https?:\/\/[\w\.\/]+&cid=amp-\S+$/
         )
       ).to.be.true;
     });

--- a/test/unit/test-real-time-config.js
+++ b/test/unit/test-real-time-config.js
@@ -810,11 +810,9 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
       );
       await rtc.promiseArray_[0];
       expect(fetchJsonStub).to.be.called;
-      expect(
-        fetchJsonStub.calledWithMatch(
-          /https:\/\/www\.foo\.example\/\?title=[^&]+&src=https?:\/\/[\w\.\/]+&cid=amp-\S+$/
-        )
-      ).to.be.true;
+      expect(fetchJsonStub).to.be.calledWithMatch(
+        /https:\/\/www\.foo\.example\/\?title=[^&]*&src=[^&]*&cid=amp-\S+$/
+      );
     });
   });
 

--- a/test/unit/test-real-time-config.js
+++ b/test/unit/test-real-time-config.js
@@ -796,7 +796,8 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
        * Both save and retrieve to a cookie named `foo`. They should be isolated and the cookies should not be shared.
        * But, for some reason they are. So, for now use a cookie called bar here.
        */
-      const url = 'https://www.foo.example/?cid=CLIENT_ID(bar)';
+      const url =
+        'https://www.foo.example/?title=TITLE&src=SOURCE_URL&cid=CLIENT_ID(bar)';
       rtc.rtcConfig_ = {
         timeoutMillis: 1000,
       };
@@ -811,7 +812,7 @@ describes.realWin('real-time-config service', {amp: true}, (env) => {
       expect(fetchJsonStub).to.be.called;
       expect(
         fetchJsonStub.calledWithMatch(
-          /https:\/\/www.foo.example\/\?cid=amp-\S+$/
+          /https:\/\/www\.foo\.example\/\?title=[^&]+&src=https?:\/\/[\w\.\/]+&cid=amp-\S+/
         )
       ).to.be.true;
     });


### PR DESCRIPTION
Implements the changes proposed in #38627 by adding the TITLE and SOURCE_URL global macros to the allowlist for real-time-config