### PR TITLE
🐛  amp-consent should ignore parameter if not supported by specific command of the tcf api 

### DIFF
--- a/extensions/amp-consent/0.1/test/test-tcf-api-command-manager.js
+++ b/extensions/amp-consent/0.1/test/test-tcf-api-command-manager.js
@@ -68,16 +68,17 @@ describes.realWin(
           );
           errorSpy.resetHistory();
 
-          msg.__tcfapiCall.command = 'ping';
+          msg.__tcfapiCall.command = 'removeEventListener';
           msg.__tcfapiCall.parameter = [1, 2, 3];
           expect(tcfApiCommandManager.isValidTcfApiCall_(msg.__tcfapiCall)).to
             .be.false;
           expect(errorSpy.args[0][1]).to.match(
-            /Unsupported parameter found in "tcfapiCall": [1,2,3]/
+            /Found incorrect parameter in "tcfapiCall": 1,2,3. Please provide a valid number./
           );
           errorSpy.resetHistory();
 
-          msg.__tcfapiCall.parameter = undefined;
+          msg.__tcfapiCall.command = 'getTCData';
+          msg.__tcfapiCall.parameter = [1, 2, 3];
           msg.__tcfapiCall.version = 1;
           expect(tcfApiCommandManager.isValidTcfApiCall_(msg.__tcfapiCall)).to
             .be.false;
@@ -87,6 +88,34 @@ describes.realWin(
           errorSpy.resetHistory();
 
           msg.__tcfapiCall.version = 2;
+          expect(tcfApiCommandManager.isValidTcfApiCall_(msg.__tcfapiCall)).to
+            .be.true;
+          expect(errorSpy).to.not.be.called;
+        });
+
+        it('parameter value should be ignore if command is different from removeEventListener', () => {
+          tcfApiCommandManager = new TcfApiCommandManager(mockPolicyManager);
+          msg = {
+            __tcfapiCall: {
+              'command': 'getTCData',
+              'parameter': '30',
+              'version': 2,
+              'callId': 'callId',
+            },
+          };
+          const errorSpy = env.sandbox.stub(user(), 'error');
+          expect(tcfApiCommandManager.isValidTcfApiCall_(msg.__tcfapiCall)).to
+            .be.true;
+          expect(errorSpy).to.not.be.called;
+          errorSpy.resetHistory();
+
+          msg.__tcfapiCall.command = 'ping';
+          expect(tcfApiCommandManager.isValidTcfApiCall_(msg.__tcfapiCall)).to
+            .be.true;
+          expect(errorSpy).to.not.be.called;
+          errorSpy.resetHistory();
+
+          msg.__tcfapiCall.command = 'addEventListener';
           expect(tcfApiCommandManager.isValidTcfApiCall_(msg.__tcfapiCall)).to
             .be.true;
           expect(errorSpy).to.not.be.called;


### PR DESCRIPTION
closes: #36014 

The goal of this PR is to make the handling command logic of the `TcfApiCommandManager` more robust.

The are several vendor that are running in the error described in #36014.
I think this logic could be improved by ignoring the usage of the `parameter` value unless the command is `removeEventListener`.

Basically these vendors try to put their ID on the 'getTCData' command but amp-consent can't understand the request because it doesn't integrate the [@iabtcf](https://github.com/InteractiveAdvertisingBureau/iabtcf-es) project (cmp api sub project). In fact `amp-consent` on the `getTCData` command simply returns the information previously acquired from the used `CMP`. Precisely for this reason the logic that I have implemented is slightly more permissive because in reality that parameter is not a problem for the commands that don't support it.

Plus:
Since these commands support only the version 2, I think we can add a warn and remove also the check of the version value of the `__tcfapiCall` payload and take it for granted if not provided at all. (let me know what you think)
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
