### PR TITLE
✨ Expand variables in amp-iframe src

### DIFF
--- a/extensions/amp-iframe/0.1/amp-iframe.js
+++ b/extensions/amp-iframe/0.1/amp-iframe.js
@@ -209,12 +209,17 @@ export class AmpIframe extends AMP.BaseElement {
     if (protocol == 'data:') {
       return src;
     }
+
+    const expandedSrc = Services.urlReplacementsForDoc(
+      this.element
+    ).expandUrlSync(src);
+
     // If fragment already exists, it's not modified.
     if (hash && hash != '#') {
-      return src;
+      return expandedSrc;
     }
     // Add `#amp=1` fragment.
-    return removeFragment(src) + '#amp=1';
+    return removeFragment(expandedSrc) + '#amp=1';
   }
 
   /**

--- a/extensions/amp-iframe/0.1/test/test-amp-iframe.js
+++ b/extensions/amp-iframe/0.1/test/test-amp-iframe.js
@@ -553,6 +553,12 @@ describes.realWin(
       );
     });
 
+    it('should expand variables in src url', async () => {
+      const ampIframe = createAmpIframe(env);
+
+      // TODO add test for sync and async variable expansions
+    });
+
     it('should listen for resize events', async () => {
       const ampIframe = createAmpIframe(env, {
         src: iframeSrc,


### PR DESCRIPTION
Allow passing variables to the src URL of an `amp-iframe` as discussed in #38738. This PR implements the low hanging fruit of just expanding general sync (not async!) variables. 

The current state is just a draft and meant to sketch a potential implementation.

I would appreciate any feedback and pointers whether this is the right direction to go.