### PR TITLE
🏗 Bump chromedriver to 96 (smallest increment) and remove workaround from get_pinned_chrome_version.sh

### DIFF
--- a/.circleci/get_pinned_chrome_version.sh
+++ b/.circleci/get_pinned_chrome_version.sh
@@ -46,14 +46,7 @@ echo "$(GREEN "Chrome version history URL is") $(CYAN "${CHROME_VERSION_HISTORY_
 # Determine the Chrome version
 # See https://developer.chrome.com/docs/versionhistory/guide
 echo "$(GREEN "Determining Chrome version...")"
-# TODO(estherkim): remove bandaid
-# CHROME_VERSION_HISTORY_URL does not list a version over 88 for some reason
-if [[ "$CHROME_MAJOR_VERSION" == "95" ]]; then
-  CHROME_VERSION="95.0.4638.69"
-else
-  CHROME_VERSION="$(curl -sS --retry 3 ${CHROME_VERSION_HISTORY_URL} | jq -r ".versions[]|.version" | grep -m 1 "${CHROME_MAJOR_VERSION}\.[[:digit:]]\+.[[:digit:]]\+.[[:digit:]]\+")"
-fi
-
+CHROME_VERSION="$(curl -sS --retry 3 ${CHROME_VERSION_HISTORY_URL} | jq -r ".versions[]|.version" | grep -m 1 "${CHROME_MAJOR_VERSION}\.[[:digit:]]\+.[[:digit:]]\+.[[:digit:]]\+")"
 echo "$(GREEN "Chrome version is") $(CYAN "${CHROME_VERSION}")"
 
 echo "export CHROME_VERSION=$CHROME_VERSION" >> $BASH_ENV

--- a/build-system/tasks/e2e/package-lock.json
+++ b/build-system/tasks/e2e/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@babel/register": "7.15.3",
         "babel-regenerator-runtime": "6.5.0",
-        "chromedriver": "95.0.0",
+        "chromedriver": "96.0.0",
         "geckodriver": "2.0.4",
         "selenium-webdriver": "4.1.1"
       }
@@ -701,9 +701,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "95.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
-      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
+      "version": "96.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
+      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2686,9 +2686,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "95.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-95.0.0.tgz",
-      "integrity": "sha512-HwSg7S0ZZYsHTjULwxFHrrUqEpz1+ljDudJM3eOquvqD5QKnR5pSe/GlBTY9UU2tVFRYz8bEHYC4Y8qxciQiLQ==",
+      "version": "96.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-96.0.0.tgz",
+      "integrity": "sha512-4g6Hn5RHGsbaBmOrJbDlz/hdVPOc22eRsbvoAAMqkZxR2NJCcddHzCw2FAQeW8lX/C7xWVz3nyDsKX3fE9lIIw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",

--- a/build-system/tasks/e2e/package.json
+++ b/build-system/tasks/e2e/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@babel/register": "7.15.3",
     "babel-regenerator-runtime": "6.5.0",
-    "chromedriver": "95.0.0",
+    "chromedriver": "96.0.0",
     "geckodriver": "2.0.4",
     "selenium-webdriver": "4.1.1"
   }


### PR DESCRIPTION
Google removed v95 from the download site, so we have to bump to the next available version. #38762 attempts to bump this to the latest version (currently v112) but that breaks a lot of tests. For now let's merge this PR and then work on fixing the broken tests so we can merge #38762 later