### PR TITLE
🏗 Ignore extension test files in CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+paths-ignore:
+  - 'extensions/**/test/**'
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Currently these files generate a lot of false-positives, e.g.: https://github.com/ampproject/amphtml/security/code-scanning/148