### PR TITLE
Gate attributionsrc and trackingUrls on attribution reporting enabled ✨

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -390,19 +390,22 @@ export class AmpAdExit extends AMP.BaseElement {
         const /** !JsonObject */ target = config['targets'][name];
         this.targets_[name] = {
           finalUrl: target['finalUrl'],
-          trackingUrls: target['trackingUrls'] || [],
           vars: target['vars'] || {},
           filters: (target['filters'] || [])
             .map((f) => this.userFilters_[f])
             .filter(Boolean),
           behaviors: target['behaviors'] || {},
         };
-
-        if (this.isAttributionReportingSupported_) {
+        if (
+          this.isAttributionReportingSupported_ &&
+          target?.behaviors?.browserAdConversion
+        ) {
           this.targets_[name]['windowFeatures'] =
             this.getAttributionReportingValues_(
               target?.behaviors?.browserAdConversion
             );
+        } else {
+          this.targets_[name]['trackingUrls'] = target['trackingUrls'] || [];
         }
 
         // Build a map of {vendor, origin} for 3p custom variables in the config
@@ -441,7 +444,7 @@ export class AmpAdExit extends AMP.BaseElement {
    * @return {boolean}
    */
   detectAttributionReportingSupport() {
-    return isAttributionReportingAllowed(this.win.document);
+    return isAttributionReportingAllowed(this.win);
   }
 
   /**

--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -444,7 +444,7 @@ export class AmpAdExit extends AMP.BaseElement {
    * @return {boolean}
    */
   detectAttributionReportingSupport() {
-    return isAttributionReportingAllowed(this.win);
+    return isAttributionReportingAllowed(this.win.document);
   }
 
   /**


### PR DESCRIPTION
We have seen a few previous issues that when the attribution reporting feature policy is not enabled on the client side when we attempt to fire background ping via `attributionsrc` url, the click ping is eventually lost.
Our new behavior should not depend solely on the existence of the attributionsrc url. We should send trackingUrls for all traffic and either send the tracking ping to attributionsrc or trackingUrls depending on whether the feature policy is enabled on the browser.
Successor of https://github.com/ampproject/amphtml/issues/35347