### PR TITLE
add us-co (Colorado) and us-ct (Connecticut) docs and test for geo detection support

### DIFF
--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -24,7 +24,7 @@ describes.realWin(
         unknown: ['unknown'],
         eea: ['preset-eea'],
         myGroup: ['preset-eea', 'us'],
-        usSubdivisions: ['us-al', 'us-ny', 'us-va'],
+        usSubdivisions: ['us-al', 'us-ny', 'us-va', 'us-co', 'us-ct'],
         usVA: ['us-va'],
         usCO: ['us-co'],
         usCT: ['us-ct'],
@@ -403,7 +403,7 @@ describes.realWin(
       geo.buildCallback();
 
       return Services.geoForDocOrNull(el).then((geo) => {
-        expect(geo.ISOSubdivision).to.equal('us-co');
+        expect(geo.ISOSubdivision).to.equal('us-ct');
         expectElementHasClass(
           doc.body,
           [
@@ -1068,6 +1068,8 @@ describes.realWin(
           'myGroup',
           'usSubdivisions',
           'usVA',
+          'usCO',
+          'usCT',
           'canadaSubdivisions',
           'anz',
           'uscaGroup',

--- a/extensions/amp-geo/0.1/test/test-amp-geo.js
+++ b/extensions/amp-geo/0.1/test/test-amp-geo.js
@@ -26,6 +26,8 @@ describes.realWin(
         myGroup: ['preset-eea', 'us'],
         usSubdivisions: ['us-al', 'us-ny', 'us-va'],
         usVA: ['us-va'],
+        usCO: ['us-co'],
+        usCT: ['us-ct'],
         canadaSubdivisions: ['ca-mb', 'ca-nb'],
         anz: ['au', 'nz'],
         uscaGroup: ['preset-us-ca'],
@@ -361,6 +363,62 @@ describes.realWin(
             'amp-geo-group-uscaGroup',
             'amp-geo-group-california',
             'amp-iso-subdivision-us-ca',
+          ],
+          true
+        );
+      });
+    });
+
+    it('should allow us-co subdivision', () => {
+      setGeoOverrideHash('us us-co');
+      addConfigElement('script', 'application/json', JSON.stringify(config));
+      geo.buildCallback();
+
+      return Services.geoForDocOrNull(el).then((geo) => {
+        expect(geo.ISOSubdivision).to.equal('us-co');
+        expectElementHasClass(
+          doc.body,
+          [
+            'amp-geo-group-usCO',
+            'amp-geo-group-usSubdivisions',
+            'amp-iso-subdivision-us-co',
+          ],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          [
+            'amp-geo-group-usCO',
+            'amp-geo-group-usSubdivisions',
+            'amp-iso-subdivision-us-co',
+          ],
+          true
+        );
+      });
+    });
+
+    it('should allow us-ct subdivision', () => {
+      setGeoOverrideHash('us us-ct');
+      addConfigElement('script', 'application/json', JSON.stringify(config));
+      geo.buildCallback();
+
+      return Services.geoForDocOrNull(el).then((geo) => {
+        expect(geo.ISOSubdivision).to.equal('us-co');
+        expectElementHasClass(
+          doc.body,
+          [
+            'amp-geo-group-usCT',
+            'amp-geo-group-usSubdivisions',
+            'amp-iso-subdivision-us-ct',
+          ],
+          true
+        );
+        expectElementHasClass(
+          doc.documentElement,
+          [
+            'amp-geo-group-usCT',
+            'amp-geo-group-usSubdivisions',
+            'amp-iso-subdivision-us-ct',
           ],
           true
         );

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -175,9 +175,9 @@ determines a request is from Virginia, Colorado, or Connecticut.
 The values are in a `${country}-${subdivision}` format and the following codes
 are supported.
 
-  * `us-co` - Colorado
-  * `us-ct` - Connecticut
-  * `us-va` - Virginia
+- `us-co` - Colorado
+- `us-ct` - Connecticut
+- `us-va` - Virginia
 
 Additional countries/subdivision may be included with the preset list as in the `usWithSubdivisions`
 example below.

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -167,12 +167,17 @@ example below.
 </amp-geo>
 ```
 
-#### U.S. Virginia Detection
+#### U.S. Virginia, Colorado, Connecticut Detection
 
 The `amp-geo` component provides the
 [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) information when it
-determines a request is from Virginia. The `us-va` (`${country}-${subdivision}` format) value from the
-list supports this feature.
+determines a request is from Virginia, Colorado, or Connecticut.
+The values are in a `${country}-${subdivision}` format and the following codes
+are supported.
+
+  * `us-co` - Colorado
+  * `us-ct` - Connecticut
+  * `us-va` - Virginia
 
 Additional countries/subdivision may be included with the preset list as in the `usWithSubdivisions`
 example below.
@@ -183,8 +188,10 @@ example below.
     {
       "ISOCountryGroups": {
         "usca": ["preset-us-ca"],
+        "usco":["us-co"],
+        "usct":["us-ct"],
         "usva":["us-va"],
-        "usWithSubdivisions": ["us-ca", "us-va"]
+        "usWithSubdivisions": ["us-ca", "us-co", "us-ct", "us-va"]
       }
     }
   </script>

--- a/extensions/amp-geo/amp-geo.md
+++ b/extensions/amp-geo/amp-geo.md
@@ -175,9 +175,9 @@ determines a request is from Virginia, Colorado, or Connecticut.
 The values are in a `${country}-${subdivision}` format and the following codes
 are supported.
 
-- `us-co` - Colorado
-- `us-ct` - Connecticut
-- `us-va` - Virginia
+-   `us-co` - Colorado
+-   `us-ct` - Connecticut
+-   `us-va` - Virginia
 
 Additional countries/subdivision may be included with the preset list as in the `usWithSubdivisions`
 example below.


### PR DESCRIPTION
add documentation that we support Colorado and Connecticut geo detection for amp-geo

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
