### PR TITLE
✨ Allow allow-top-navigation in amp-consent

### DIFF
--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -38,6 +38,7 @@ const REQUEST_OVERLAY = 'requestFullOverlay';
 const ALLOWED_SANDBOX_ATTRIBUTES = [
   'allow-popups-to-escape-sandbox',
   'allow-top-navigation-by-user-activation',
+  'allow-top-navigation',
 ];
 
 const IFRAME_RUNNING_TIMEOUT = 1000;

--- a/extensions/amp-consent/0.1/test/test-consent-ui.js
+++ b/extensions/amp-consent/0.1/test/test-consent-ui.js
@@ -166,12 +166,12 @@ describes.realWin(
         const config = {
           'promptUISrc': 'https://promptUISrc',
           'sandbox':
-            'allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation',
+            'allow-popups-to-escape-sandbox allow-top-navigation allow-top-navigation-by-user-activation',
         };
         consentUI = new ConsentUI(mockInstance, config);
         expect(consentUI.ui_.tagName).to.equal('IFRAME');
         expect(consentUI.ui_.getAttribute('sandbox')).to.equal(
-          'allow-scripts allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation'
+          'allow-scripts allow-popups allow-same-origin allow-popups-to-escape-sandbox allow-top-navigation allow-top-navigation-by-user-activation'
         );
       });
 
@@ -180,7 +180,7 @@ describes.realWin(
 
         const config = {
           'promptUISrc': 'https://promptUISrc',
-          'sandbox': 'allow-top-navigation',
+          'sandbox': 'allow-forms',
         };
         consentUI = new ConsentUI(mockInstance, config);
 
@@ -191,7 +191,7 @@ describes.realWin(
 
         expect(errorSpy).to.be.calledOnce;
         expect(errorSpy.args[0][1]).to.match(
-          /The sandbox attribute "allow-top-navigation" is not allowed/
+          /The sandbox attribute "allow-forms" is not allowed/
         );
 
         errorSpy.resetHistory();


### PR DESCRIPTION
**Context**

In https://github.com/ampproject/amphtml/pull/38250 I added the feature to add additional sandbox attributes to the iframe generated by the `amp-consent` extension. Google's security team decided to allow `allow-top-navigation-by-user-activation` and `allow-popups-to-escape-sandbox`. The attribute `allow-top-navigation` was not allowed, even though it is allowed in the `amp-iframe` extension, for example.

This helped us move forward with our CMP integration in most cases already (just finished some tests using the latest pre-release). So thanks again for that!

We ran into one issue though: in case of the Sourcepoint CMP, the consent layer is displayed inside an iframe inside the iframe generated by the `amp-consent` extension. So there are two nested iframes. If you click on a button in the consent layer in the inner iframe, it triggers a `postMessage` to the parent iframe. There, the according button action is triggered (e.g. custom JavaScript code triggering a top navigation). Now, Google Chrome does detect that the JavaScript code called in the outer iframe is actually triggered by a postMessage which in turn was triggered by an user interaction inside the inner iframe (button click in this case). Unfortunately, Safari does not detect this. Even though I have the `allow-top-navigation-by-user-activation` sandbox attribute set, I get an error message that the top navigation was prevented, because the `allow-top-navigation` sandbox attribute is missing. Happens in latest desktop and mobile Safari, no matter whether I use private mode or not.

With this in mind, is it possible that the Google Security team revisits their security review and will allow the `allow-top-navigation` sandbox attribute as well? Can you please trigger this process @erwinmombay? If it is allowed, I kindly ask you to merge this PR where I add the `allow-top-navigation` sandbox attribute to the allowed list and update the tests accordingly.