### PR TITLE
✅ Remove most uses of the optional param from `sleep`/`macroTask`

### DIFF
--- a/extensions/amp-story-360/0.1/test/test-amp-story-360.js
+++ b/extensions/amp-story-360/0.1/test/test-amp-story-360.js
@@ -101,7 +101,7 @@ describes.realWin(
         '.i-amphtml-story-360-activate-button'
       );
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(activationEl.getAttribute('role')).to.eql('button');
     });

--- a/extensions/amp-story-subscriptions/0.1/test/test-amp-story-subscriptions.js
+++ b/extensions/amp-story-subscriptions/0.1/test/test-amp-story-subscriptions.js
@@ -201,7 +201,7 @@ describes.realWin(
         .stub(subscriptionService, 'getGrantStatus')
         .returns(Promise.resolve(false));
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(storeService.get(StateProperty.SUBSCRIPTIONS_STATE)).to.equal(
         SubscriptionsState.BLOCKED
@@ -213,7 +213,7 @@ describes.realWin(
         .stub(subscriptionService, 'getGrantStatus')
         .returns(Promise.resolve(true));
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(storeService.get(StateProperty.SUBSCRIPTIONS_STATE)).to.equal(
         SubscriptionsState.GRANTED
@@ -285,7 +285,7 @@ describes.realWin(
       buttonEl.click();
 
       doc.body.appendChild(<swg-popup-background></swg-popup-background>);
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const swgPopupBackgroundEl = doc.querySelector('swg-popup-background');
       expect(

--- a/extensions/amp-story/1.0/test/test-amp-story-page.js
+++ b/extensions/amp-story/1.0/test/test-amp-story-page.js
@@ -301,7 +301,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
 
     page.setState(PageState.PLAYING);
 
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const audioEl = scopedQuerySelectorAll(
       element,
@@ -331,7 +331,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
 
     page.setState(PageState.PLAYING);
 
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const audioEl = scopedQuerySelectorAll(
       element,
@@ -350,7 +350,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
 
     page.setState(PageState.PLAYING);
 
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const audioEl = scopedQuerySelectorAll(
       element,
@@ -380,7 +380,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     page.setState(PageState.PLAYING);
 
     deferred.resolve();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(mediaPoolRegister).to.have.been.calledOnceWithExactly(videoEl);
   });
@@ -407,7 +407,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
 
     // Not calling deferred.resolve();
 
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(mediaPoolRegister).to.not.have.been.called;
   });
@@ -620,7 +620,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     page.layoutCallback();
 
     page.setState(PageState.PLAYING);
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const playButtonEl = element.querySelector(
       '.i-amphtml-story-page-play-button'
@@ -668,7 +668,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     await page.layoutCallback();
     page.setState(PageState.PLAYING);
 
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const poolVideoEl = element.querySelector('video');
     // Not called with the original video.
@@ -693,7 +693,7 @@ describes.realWin('amp-story-page', {amp: {extensions}}, (env) => {
     page.buildCallback();
     await page.layoutCallback();
     page.setState(PageState.PLAYING);
-    await macroTask(win.setTimeout);
+    await macroTask();
     page.setState(PageState.NOT_ACTIVE);
 
     const poolVideoEl = element.querySelector('video');

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -1450,7 +1450,7 @@ describes.realWin(
             Action.TOGGLE_SUBSCRIPTIONS_STATE,
             SubscriptionsState.BLOCKED
           );
-          await macroTask(win.setTimeout);
+          await macroTask();
           const paywallPage = story.getPageById(
             storeService.get(StateProperty.CURRENT_PAGE_ID)
           );
@@ -1464,7 +1464,7 @@ describes.realWin(
             Action.TOGGLE_SUBSCRIPTIONS_STATE,
             SubscriptionsState.GRANTED
           );
-          await macroTask(win.setTimeout);
+          await macroTask();
           const paywallPage = story.getPageById(
             storeService.get(StateProperty.CURRENT_PAGE_ID)
           );
@@ -1494,7 +1494,7 @@ describes.realWin(
             Action.TOGGLE_SUBSCRIPTIONS_STATE,
             SubscriptionsState.BLOCKED
           );
-          await macroTask(win.setTimeout);
+          await macroTask();
 
           const paywallPage = story.getPageById(
             storeService.get(StateProperty.CURRENT_PAGE_ID)
@@ -1533,7 +1533,7 @@ describes.realWin(
           storeService.get(StateProperty.CURRENT_PAGE_ID)
         );
         paywallPage.element.dispatchEvent(clickRightEvent);
-        await macroTask(win.setTimeout);
+        await macroTask();
 
         it('should not show paywall', () => {
           expect(storeService.get(StateProperty.SUBSCRIPTIONS_DIALOG_UI_STATE))
@@ -2113,7 +2113,7 @@ describes.realWin(
         expect(pages[1].hasAttribute('distance')).to.be.false;
 
         signals.signal(CommonSignals_Enum.LOAD_END);
-        await macroTask(win.setTimeout);
+        await macroTask();
 
         // Check page 1 is loaded with distance 1.
         expect(pages[1].getAttribute('distance')).to.be.equal('1');

--- a/extensions/amp-story/1.0/test/test-animation.js
+++ b/extensions/amp-story/1.0/test/test-animation.js
@@ -220,7 +220,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         sequence
       );
 
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       expect(
         webAnimationBuilder.createRunner.withArgs(
@@ -265,7 +265,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         sequence
       );
 
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       expect(webAnimationBuilder.createRunner.withArgs(spec)).to.have.been
         .calledOnce;
@@ -303,7 +303,7 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       runner.start();
 
-      await macroTask(env.win.setTimeout);
+      await macroTask();
       expect(webAnimationRunner.start).to.have.been.calledOnce;
     });
 
@@ -345,14 +345,14 @@ describes.realWin('amp-story animations', {}, (env) => {
 
       runner.start();
 
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       expect(sequence.waitFor.withArgs(startAfterId)).to.have.been.calledOnce;
       expect(webAnimationRunner.start).to.not.have.been.called;
 
       resolveWaitFor();
 
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       expect(webAnimationRunner.start).to.have.been.calledOnce;
     });
@@ -393,7 +393,7 @@ describes.realWin('amp-story animations', {}, (env) => {
         sequence
       );
 
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       expect(sequence.notifyFinish).to.not.have.been.called;
 
@@ -439,7 +439,7 @@ describes.realWin('amp-story animations', {}, (env) => {
     it('creates WebAnimation Builder with options', async () => {
       const page = html`<div></div>`;
       new AnimationManager(page, ampdoc);
-      await macroTask(env.win.setTimeout);
+      await macroTask();
       expect(
         webAnimationService.createBuilder.withArgs(
           env.sandbox.match({
@@ -802,11 +802,11 @@ describes.realWin('amp-story animations', {}, (env) => {
       const notified = env.sandbox.spy();
 
       sequence.waitFor('test-notify-id').then(notified);
-      await macroTask(env.win.setTimeout);
+      await macroTask();
       expect(notified).to.not.have.been.called;
 
       sequence.notifyFinish('test-notify-id');
-      await macroTask(env.win.setTimeout);
+      await macroTask();
       expect(notified).to.have.been.calledOnce;
     });
 
@@ -815,16 +815,16 @@ describes.realWin('amp-story animations', {}, (env) => {
       const notified = env.sandbox.spy();
 
       sequence.waitFor('test-notify-id').then(notified);
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       sequence.notifyFinish('test-notify-id');
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       sequence.notifyFinish('test-notify-id');
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       sequence.notifyFinish('test-notify-id');
-      await macroTask(env.win.setTimeout);
+      await macroTask();
 
       expect(notified).to.have.been.calledOnce;
     });
@@ -834,11 +834,11 @@ describes.realWin('amp-story animations', {}, (env) => {
       const notified = env.sandbox.spy();
 
       sequence.waitFor('test-notify-id').then(notified);
-      await macroTask(env.win.setTimeout);
+      await macroTask();
       expect(notified).to.not.have.been.called;
 
       sequence.notifyFinish('a-different-test-notify-id');
-      await macroTask(env.win.setTimeout);
+      await macroTask();
       expect(notified).to.not.have.been.called;
     });
   });

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -157,7 +157,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should correctly append params at the end of the story url', async () => {
     buildStoryPlayer();
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const storyIframe = playerEl.querySelector('iframe');
 
@@ -174,7 +174,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(1, DEFAULT_CACHE_URL + existingQuery + existingHash);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const storyIframe = playerEl.querySelector('iframe');
 
@@ -193,7 +193,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     buildStoryPlayer(3);
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
       'state': 'visible',
@@ -203,10 +203,10 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should prerender next story after first one is loaded', async () => {
     buildStoryPlayer(3);
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     fireHandler['storyContentLoaded']('storyContentLoaded', {});
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const storyIframes = playerEl.querySelectorAll('iframe');
     expect(storyIframes[1].getAttribute('src')).to.include(
@@ -219,14 +219,14 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     const storyAspectRatios = ['0.75', '0.5'];
     buildStoryPlayer(numStories);
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     // Aspect ratio should be applied after the first story is loaded.
     fakeMessaging.sendRequest = () =>
       Promise.resolve({value: storyAspectRatios[0]});
     const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
     fireHandler['storyContentLoaded']('storyContentLoaded', {});
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(sendRequestSpy).to.have.been.calledWith('getDocumentState', {
       'state': 'DESKTOP_ASPECT_RATIO',
@@ -244,9 +244,9 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     fakeMessaging.sendRequest = () =>
       Promise.resolve({value: storyAspectRatios[1]});
     fireHandler['selectDocument']('selectDocument', {next: true});
-    await macroTask(win.setTimeout);
+    await macroTask();
     fireHandler['storyContentLoaded']('storyContentLoaded', {});
-    await macroTask(win.setTimeout);
+    await macroTask();
     playerContainer = win.document.querySelector(
       '.i-amphtml-story-player-main-container'
     );
@@ -258,7 +258,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     // Aspect ratio should be applied after navigating back to the already loaded first story.
     fireHandler['selectDocument']('selectDocument', {previous: true});
-    await macroTask(win.setTimeout);
+    await macroTask();
     playerContainer = win.document.querySelector(
       '.i-amphtml-story-player-main-container'
     );
@@ -272,7 +272,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should not load next story if first one has not finished loading', async () => {
     buildStoryPlayer(3);
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const storyIframes = playerEl.querySelectorAll('iframe');
 
@@ -282,11 +282,11 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should load new story if user navigated before first finished loading', async () => {
     buildStoryPlayer(3);
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     // Swiping without waiting for story loaded event.
     swipeLeft();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const storyIframes = playerEl.querySelectorAll('iframe');
     expect(storyIframes[1].getAttribute('src')).to.exist;
@@ -298,7 +298,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     async () => {
       buildStoryPlayer(4);
       await manager.loadPlayers();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const stories = playerEl.getStories();
 
@@ -320,7 +320,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     async () => {
       buildStoryPlayer(4);
       await manager.loadPlayers();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const stories = playerEl.getStories();
 
@@ -341,7 +341,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     buildStoryPlayer();
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(registerHandlerSpy).to.have.been.calledWith('touchstart');
     expect(registerHandlerSpy).to.have.been.calledWith('touchmove');
@@ -356,7 +356,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
     buildStoryPlayer();
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(sendRequestSpy).to.have.been.calledWith('onDocumentState', {
       'state': 'PAGE_ATTACHMENT_STATE',
@@ -370,7 +370,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(2);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const navigationSpy = env.sandbox.spy();
     playerEl.addEventListener('navigation', navigationSpy);
@@ -391,7 +391,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(1);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const noNextSpy = env.sandbox.spy();
     playerEl.addEventListener('noNextStory', noNextSpy);
@@ -405,7 +405,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(2);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const noNextSpy = env.sandbox.spy();
     playerEl.addEventListener('noNextStory', noNextSpy);
@@ -420,7 +420,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     playerEl.appendChild(buildCircularWrappingConfig());
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const noNextSpy = env.sandbox.spy();
     playerEl.addEventListener('noNextStory', noNextSpy);
@@ -441,10 +441,10 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     const touchEndSpy = env.sandbox.spy(PageScroller.prototype, 'onTouchEnd');
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     swipeDown();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(touchStartSpy).to.have.been.called;
     expect(touchMoveSpy).to.have.been.called;
@@ -463,10 +463,10 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     const touchEndSpy = env.sandbox.spy(PageScroller.prototype, 'onTouchEnd');
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     swipeDown();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(touchStartSpy).to.not.have.been.called;
     expect(touchMoveSpy).to.not.have.been.called;
@@ -480,7 +480,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(sendRequestSpy).to.not.have.been.calledWith('visibilitychange', {
       'state': 'visible',
@@ -493,10 +493,10 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     playerEl.appendChild(buildAutoplayConfig(/* autoplay */ false));
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     playerEl.play();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
       'state': 'visible',
@@ -510,7 +510,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(sendRequestSpy).to.have.been.calledWith('visibilitychange', {
       'state': 'visible',
@@ -521,7 +521,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(1);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const noPreviousSpy = env.sandbox.spy();
     playerEl.addEventListener('noPreviousStory', noPreviousSpy);
@@ -535,7 +535,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(2);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const noPreviousSpy = env.sandbox.spy();
     playerEl.addEventListener('noPreviousStory', noPreviousSpy);
@@ -551,7 +551,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     playerEl.appendChild(buildCircularWrappingConfig());
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const noPreviousSpy = env.sandbox.spy();
     playerEl.addEventListener('noPreviousStory', noPreviousSpy);
@@ -565,13 +565,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(1);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const touchSpy = env.sandbox.spy();
     playerEl.addEventListener('amp-story-player-touchstart', touchSpy);
 
     await swipeDown();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(touchSpy).to.have.been.called;
   });
@@ -580,13 +580,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(1);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const touchSpy = env.sandbox.spy();
     playerEl.addEventListener('amp-story-player-touchmove', touchSpy);
 
     await swipeLeft();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(touchSpy).to.have.been.calledWithMatch({
       type: 'amp-story-player-touchmove',
@@ -606,13 +606,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(1);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const touchSpy = env.sandbox.spy();
     playerEl.addEventListener('amp-story-player-touchmove', touchSpy);
 
     await swipeDown();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(touchSpy).to.have.been.calledWithMatch({
       type: 'amp-story-player-touchmove',
@@ -632,13 +632,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     buildStoryPlayer(1);
 
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const touchSpy = env.sandbox.spy();
     playerEl.addEventListener('amp-story-player-touchend', touchSpy);
 
     await swipeDown();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     expect(touchSpy).to.have.been.called;
   });
@@ -646,7 +646,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should navigate when swiping', async () => {
     buildStoryPlayer(4);
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const navigationSpy = env.sandbox.spy();
     playerEl.addEventListener('navigation', navigationSpy);
@@ -665,7 +665,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
   it('should not navigate when swiping last story', async () => {
     buildStoryPlayer(2);
     await manager.loadPlayers();
-    await macroTask(win.setTimeout);
+    await macroTask();
 
     const navigationSpy = env.sandbox.spy();
     playerEl.addEventListener('navigation', navigationSpy);
@@ -682,7 +682,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       buildStoryPlayer(1, DEFAULT_ORIGIN_URL, 'cdn.ampproject.org');
       await manager.loadPlayers();
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const storyIframe = playerEl.querySelector('iframe');
 
@@ -697,7 +697,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       buildStoryPlayer(1, DEFAULT_ORIGIN_URL);
       await manager.loadPlayers();
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const storyIframe = playerEl.querySelector('iframe');
 
@@ -715,7 +715,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       buildStoryPlayer(1, DEFAULT_ORIGIN_URL, 'www.tacos.org');
 
       await manager.loadPlayers();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(console.error).to.be.calledWithMatch(
         /\[amp-story-player\]/,
@@ -804,10 +804,10 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await player.load();
 
       player.show('https://example.com/story3.html');
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       fireHandler['storyContentLoaded']('storyContentLoaded', {});
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const stories = playerEl.getStories();
 
@@ -827,10 +827,10 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await player.load();
 
       player.show('https://example.com/story3.html');
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       fireHandler['storyContentLoaded']('storyContentLoaded', {});
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const storyIframes = playerEl.querySelectorAll('iframe');
 
@@ -852,12 +852,12 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
       player.rewind('https://example.com/story0.html');
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(sendRequestSpy).to.have.been.calledWith('rewind', {});
     });
@@ -869,7 +869,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       return expect(() =>
         player.rewind('https://example.com/story6.html')
@@ -885,13 +885,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
       player.rewind('https://example.com/story2.html');
 
       await player.go(2);
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(sendRequestSpy).to.have.been.calledWith('rewind', {});
     });
@@ -979,7 +979,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       async () => {
         buildStoryPlayer(3);
         await manager.loadPlayers();
-        await macroTask(win.setTimeout);
+        await macroTask();
 
         swipeLeft();
         swipeLeft();
@@ -1000,7 +1000,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await manager.loadPlayers();
 
       playerEl.pause();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(spy).to.have.been.calledWith('visibilitychange', {
         state: 'paused',
@@ -1013,7 +1013,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await manager.loadPlayers();
 
       playerEl.play();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(spy).to.have.been.calledWith('visibilitychange', {
         state: 'visible',
@@ -1026,7 +1026,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await manager.loadPlayers();
 
       await playerEl.mute();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(spy).to.have.been.calledWith('setDocumentState', {
         state: 'MUTED_STATE',
@@ -1040,7 +1040,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       await manager.loadPlayers();
 
       await playerEl.unmute();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(spy).to.have.been.calledWith('setDocumentState', {
         state: 'MUTED_STATE',
@@ -1133,7 +1133,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       fakeResponse = {value: true};
       await playerEl.getStoryState('page-attachment');
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(sendRequestSpy).to.have.been.calledWith('getDocumentState', {
         'state': 'PAGE_ATTACHMENT_STATE',
@@ -1156,7 +1156,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       buildStoryPlayer();
       playerEl.setAttribute('exit-control', 'back-button');
       await manager.loadPlayers();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       openPageAttachment();
 
@@ -1167,7 +1167,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('should fire page attachment open event once', async () => {
       buildStoryPlayer();
       await manager.loadPlayers();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const pageAttachmentSpy = env.sandbox.spy();
       playerEl.addEventListener('page-attachment-open', pageAttachmentSpy);
@@ -1180,7 +1180,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
     it('should fire page attachment close event once', async () => {
       buildStoryPlayer();
       await manager.loadPlayers();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const pageAttachmentSpy = env.sandbox.spy();
       playerEl.addEventListener('page-attachment-close', pageAttachmentSpy);
@@ -1197,7 +1197,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('navigation', navigationSpy);
@@ -1220,7 +1220,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('navigation', navigationSpy);
@@ -1244,7 +1244,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('navigation', navigationSpy);
@@ -1281,11 +1281,11 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
       player.go(0, 4);
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(sendRequestSpy).to.have.been.calledWith('selectPage', {
         'delta': 4,
@@ -1299,13 +1299,13 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
 
       player.show('', 'page-2');
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(sendRequestSpy).to.have.been.calledWith('selectPage', {
         'id': 'page-2',
@@ -1320,7 +1320,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('navigation', navigationSpy);
@@ -1345,7 +1345,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('navigation', navigationSpy);
@@ -1369,7 +1369,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('navigation', navigationSpy);
@@ -1394,7 +1394,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('navigation', navigationSpy);
@@ -1417,7 +1417,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const spy = env.sandbox.spy();
       playerEl.addEventListener('amp-story-muted-state', spy);
@@ -1425,7 +1425,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const fakeData = {state: 'MUTED_STATE', value: false};
       fireHandler['documentStateUpdate']('documentStateUpdate', fakeData);
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(spy).to.have.been.calledWithMatch({
         type: 'amp-story-muted-state',
@@ -1442,7 +1442,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const spy = env.sandbox.spy();
       playerEl.addEventListener('amp-story-muted-state', spy);
@@ -1450,7 +1450,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const fakeData = {state: 'MUTED_STATE', value: true};
       fireHandler['documentStateUpdate']('documentStateUpdate', fakeData);
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(spy).to.have.been.calledWithMatch({
         type: 'amp-story-muted-state',
@@ -1467,7 +1467,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       const navigationSpy = env.sandbox.spy();
       playerEl.addEventListener('storyNavigation', navigationSpy);
@@ -1476,7 +1476,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const fakeData = {state: 'CURRENT_PAGE_ID', value: 'page-2'};
       fireHandler['documentStateUpdate']('documentStateUpdate', fakeData);
 
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(navigationSpy).to.have.been.calledWithMatch({
         type: 'storyNavigation',
@@ -1495,7 +1495,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       player.go(1, 0, {animate: false});
 
@@ -1515,7 +1515,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       player.go(1, 0, {animate: true});
 
@@ -1535,7 +1535,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const player = new AmpStoryPlayer(win, playerEl);
 
       await player.load();
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       player.go(1, 0, {animate: false});
 
@@ -1545,7 +1545,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
 
       // Wait for event dispatched to be listened
       await listenOncePromise(playerEl, 'transitionend');
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(
         rootEl.classList.contains(
@@ -1581,7 +1581,7 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       const sendRequestSpy = env.sandbox.spy(fakeMessaging, 'sendRequest');
 
       win.dispatchEvent(createCustomEvent(win, 'resize', null));
-      await macroTask(win.setTimeout);
+      await macroTask();
 
       expect(sendRequestSpy).to.have.been.calledWith('onDocumentState', {
         'state': 'UI_STATE',

--- a/testing/helpers/index.js
+++ b/testing/helpers/index.js
@@ -3,6 +3,8 @@
  */
 let env_;
 
+/** @typedef {typeof setTimeout} SetTimeoutFunctionType */
+
 /**
  * Sets up the helper environment.
  * @param {*} env
@@ -13,7 +15,11 @@ export function configureHelpers(env) {
 
 /**
  * Returns a Promise that resolves after the specified number of milliseconds.
+ *
+ * Pass an optional alternative `setTimeout` function when using fake timers in
+ * your test environment, and you want to perform the sleep in that env.
  * @param {number} ms
+ * @param {SetTimeoutFunctionType} setTimeoutFunc
  * @return {Promise<void>}
  */
 export function sleep(ms, setTimeoutFunc = setTimeout) {
@@ -23,8 +29,12 @@ export function sleep(ms, setTimeoutFunc = setTimeout) {
 }
 
 /**
- * A convenient method so you can flush the event queue by doing
- * `yield macroTask()` in your test.
+ * A convenience method to flush the event queue by calling `await macroTask()`
+ * in your test.
+ *
+ * Pass an optional alternative `setTimeout` function when using fake timers in
+ * your test environment, and you want to perform the sleep in that env.
+ * @param {SetTimeoutFunctionType} setTimeoutFunc
  * @return {Promise<void>}
  */
 export function macroTask(setTimeoutFunc = setTimeout) {


### PR DESCRIPTION
Follow-up to #38964

The optional param only seems necessary when we use `useFakeTimers` on a test env, which makes it required in only a small handful of tests now