### PR TITLE
🏗 Remove `node-fetch` as a dependency

### DIFF
--- a/build-system/server/app.js
+++ b/build-system/server/app.js
@@ -10,7 +10,6 @@ const bodyParser = require('body-parser');
 const cors = require('./amp-cors');
 const devDashboard = require('./app-index');
 const express = require('express');
-const fetch = require('node-fetch');
 const formidable = require('formidable');
 const fs = require('fs');
 const jsdom = require('jsdom');

--- a/build-system/server/routes/a4a-envelopes.js
+++ b/build-system/server/routes/a4a-envelopes.js
@@ -1,5 +1,4 @@
 const express = require('express');
-const fetch = require('node-fetch');
 const fs = require('fs');
 const {getServeMode, replaceUrls} = require('../app-utils');
 const {log} = require('../../common/logging');
@@ -129,7 +128,7 @@ async function requestFromUrl(template, url, query) {
   const response = await fetch(url);
   if (
     !response.headers.has('Content-Type') ||
-    response.headers.get('Content-Type').startsWith('text/html')
+    response.headers.get('Content-Type')?.startsWith('text/html')
   ) {
     return fillTemplate(template, url, query, await response.text());
   }

--- a/build-system/status-page/comment.js
+++ b/build-system/status-page/comment.js
@@ -3,7 +3,6 @@
  * Add progress comment for Stable and LTS cherry-picks
  */
 
-const fetch = require('node-fetch');
 const {getChannels, steps} = require('./common');
 const {log} = require('../common/logging');
 

--- a/build-system/status-page/incident.js
+++ b/build-system/status-page/incident.js
@@ -3,7 +3,6 @@
  * Sync status.amp.dev with cherry-pick progress
  */
 
-const fetch = require('node-fetch');
 const {getChannels, getFormats, steps} = require('./common');
 const {log} = require('../common/logging');
 

--- a/build-system/tasks/bundle-size/index.js
+++ b/build-system/tasks/bundle-size/index.js
@@ -2,7 +2,6 @@
 
 const argv = require('minimist')(process.argv.slice(2));
 const fastGlob = require('fast-glob');
-const fetch = require('node-fetch');
 const path = require('path');
 const url = require('url');
 const {

--- a/build-system/tasks/check-owners.js
+++ b/build-system/tasks/check-owners.js
@@ -6,7 +6,6 @@
 
 'use strict';
 
-const fetch = require('node-fetch');
 const fs = require('fs-extra');
 const JSON5 = require('json5');
 const {cyan, green, red} = require('kleur/colors');

--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -4,7 +4,6 @@ require('geckodriver');
 
 const argv = require('minimist')(process.argv.slice(2));
 const chrome = require('selenium-webdriver/chrome');
-const fetch = require('node-fetch');
 const firefox = require('selenium-webdriver/firefox');
 const selenium = require('selenium-webdriver');
 const {

--- a/build-system/tasks/performance/helpers.js
+++ b/build-system/tasks/performance/helpers.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const fs = require('fs');
 const path = require('path');
 

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -318,10 +318,19 @@ async function fetchAmpSw_(flavorType, tempDir) {
     filter: (path) => path.startsWith('package/dist'),
     strip: 2, // to strip "package/dist/".
   });
-  (await fetch(ampSwTarballUrl)).body.pipe(tarWritableStream);
-  await new Promise((resolve) => {
-    tarWritableStream.on('end', resolve);
-  });
+  const tarballResponse = await fetch(ampSwTarballUrl);
+  if (!tarballResponse.body) {
+    throw new Error(`Failed to fetch ${ampSwTarballUrl}`);
+  }
+  const reader = tarballResponse.body.getReader();
+  while (true) {
+    const {done, value} = await reader.read();
+    if (done) {
+      break;
+    }
+    tarWritableStream.write(value);
+  }
+  tarWritableStream.end();
 
   await fs.copy(ampSwTempDir, path.join(tempDir, flavorType, 'dist/sw'));
 

--- a/build-system/tasks/release/index.js
+++ b/build-system/tasks/release/index.js
@@ -32,7 +32,6 @@ let DistFlavorDef;
 const argv = require('minimist')(process.argv.slice(2));
 /** @type {ExperimentsConfigDef} */
 const experimentsConfig = require('../../global-configs/experiments-config.json');
-const fetch = require('node-fetch');
 const fs = require('fs-extra');
 const klaw = require('klaw');
 const path = require('path');

--- a/build-system/tasks/sweep-experiments/cleanup-branches.js
+++ b/build-system/tasks/sweep-experiments/cleanup-branches.js
@@ -1,6 +1,5 @@
 const argv = require('minimist')(process.argv.slice(2));
 const {cyan, red, yellow} = require('kleur/colors');
-const fetch = require('node-fetch');
 const {exec} = require('../../common/exec');
 const {log} = require('../../common/logging');
 

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-const fetch = require('node-fetch');
 const fs = require('fs').promises;
 const path = require('path');
 const {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/minimist": "1.2.2",
         "@types/mocha": "8.2.3",
         "@types/node": "14.17.32",
+        "@types/tar": "6.1.5",
         "@typescript-eslint/eslint-plugin": "5.59.7",
         "@typescript-eslint/parser": "5.59.7",
         "acorn-globals": "6.0.0",
@@ -5999,6 +6000,25 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/tar": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.5.tgz",
+      "integrity": "sha512-qm2I/RlZij5RofuY7vohTpYNaYcrSQlN2MyjucQc7ZweDwaEWkdN/EeNh6e9zjK6uEm6PwjdMXkcj05BxZdX1Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
+      }
+    },
+    "node_modules/@types/tar/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.2",
@@ -28550,6 +28570,24 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/tar": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.5.tgz",
+      "integrity": "sha512-qm2I/RlZij5RofuY7vohTpYNaYcrSQlN2MyjucQc7ZweDwaEWkdN/EeNh6e9zjK6uEm6PwjdMXkcj05BxZdX1Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+          "dev": true
+        }
+      }
     },
     "@types/trusted-types": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,7 +157,6 @@
         "mocha-silent-reporter": "1.0.0",
         "morgan": "1.10.0",
         "multer": "1.4.3",
-        "node-fetch": "2.6.7",
         "open": "8.4.0",
         "plugin-error": "1.0.1",
         "postcss": "8.3.11",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/minimist": "1.2.2",
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.32",
+    "@types/tar": "6.1.5",
     "@typescript-eslint/eslint-plugin": "5.59.7",
     "@typescript-eslint/parser": "5.59.7",
     "acorn-globals": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,6 @@
     "mocha-silent-reporter": "1.0.0",
     "morgan": "1.10.0",
     "multer": "1.4.3",
-    "node-fetch": "2.6.7",
     "open": "8.4.0",
     "plugin-error": "1.0.1",
     "postcss": "8.3.11",


### PR DESCRIPTION
`fetch` is built in to Node since v18, which we now require as a minimum.

`node-fetch` is currently preventing submitting #38981

Tag-along
* A few minor fixes to differences in API
* Added @types/tar as a devDep because I needed it to debug stuff while I was fixing some API differences :D