### PR TITLE
🏗 Bump `@types/node` to v18

### DIFF
--- a/build-system/common/ctrlcHandler.js
+++ b/build-system/common/ctrlcHandler.js
@@ -38,9 +38,13 @@ exports.createCtrlcHandler = function (command, pid = process.pid) {
     trap 'ctrlcHandler' INT
     read _ # Waits until the process is terminated
   `;
-  return execScriptAsync(listenerCmd, {
+  const {pid: handlerPid} = execScriptAsync(listenerCmd, {
     'stdio': [null, process.stdout, process.stderr],
-  }).pid;
+  });
+  if (!handlerPid) {
+    throw new Error(`Failed to create ctrlcHandler for ${command}`);
+  }
+  return handlerPid;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@types/klaw": "3.0.3",
         "@types/minimist": "1.2.2",
         "@types/mocha": "8.2.3",
-        "@types/node": "14.17.32",
+        "@types/node": "18.16.14",
         "@types/tar": "6.1.5",
         "@typescript-eslint/eslint-plugin": "5.59.7",
         "@typescript-eslint/parser": "5.59.7",
@@ -5865,8 +5865,9 @@
     },
     "node_modules/@types/chai": {
       "version": "4.2.22",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
+      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
+      "dev": true
     },
     "node_modules/@types/component-emitter": {
       "version": "1.2.11",
@@ -5912,8 +5913,9 @@
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -5974,13 +5976,14 @@
     },
     "node_modules/@types/mocha": {
       "version": "8.2.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
+      "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+      "version": "18.16.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
+      "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -28445,6 +28448,8 @@
     },
     "@types/chai": {
       "version": "4.2.22",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.22.tgz",
+      "integrity": "sha512-tFfcE+DSTzWAgifkjik9AySNqIyNoYwmR+uecPwwD/XRNfvOjmC/FjCxpiUGDkDVDphPfCUecSQVFw+lN3M3kQ==",
       "dev": true
     },
     "@types/component-emitter": {
@@ -28490,6 +28495,8 @@
     },
     "@types/fs-extra": {
       "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -28545,12 +28552,14 @@
     },
     "@types/mocha": {
       "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
+      "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-      "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ==",
+      "version": "18.16.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.14.tgz",
+      "integrity": "sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==",
       "dev": true
     },
     "@types/prettier": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/klaw": "3.0.3",
     "@types/minimist": "1.2.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.32",
+    "@types/node": "18.16.14",
     "@types/tar": "6.1.5",
     "@typescript-eslint/eslint-plugin": "5.59.7",
     "@typescript-eslint/parser": "5.59.7",


### PR DESCRIPTION
Our current `@types/node` is long outdated

Tag-along:
* Fix `createCtrlcHandler` to work with minor changes in types