### PR TITLE
Add support for additional variables to gtag vendor

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/gtag.json
+++ b/extensions/amp-analytics/0.1/vendors/gtag.json
@@ -13,6 +13,12 @@
         "hasExtRef": "$IF(EXTERNAL_REFERRER, 1, 0)",
         "hasDocRef": "$IF(DOCUMENT_REFERRER, 1, 0)",
         "enabled": true
+      },
+      "session": {
+        "st": "SESSION_TIMESTAMP",
+        "ct": "TIMESTAMP",
+        "sc": "SESSION_COUNT",
+        "enabled": true
       }
     }
   },


### PR DESCRIPTION
✨  Add support for sending session timestamp, session count and the current timestamp to gtag config rewriter to enable session tracking support.

