### PR TITLE
🏗 Add `process.exit(0)` to task runner when tasks finish

### DIFF
--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -93,6 +93,7 @@ async function runTask(taskName, taskFunc) {
     log(`Starting '${cyan(taskName)}'...`);
     await taskFunc();
     log('Finished', `'${cyan(taskName)}'`, 'after', magenta(getTime(start)));
+    process.exit(0);
   } catch (err) {
     log(`'${cyan(taskName)}'`, red('errored after'), magenta(getTime(start)));
     log(err);

--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -83,7 +83,7 @@ function ensureUpdatedPackages(taskSourceFileName) {
  * Runs an AMP task with logging and timing after installing its subpackages.
  * @param {string} taskName
  * @param {TaskFuncDef} taskFunc
- * @return {Promise<void>}
+ * @return {Promise<boolean>} true if task finished successfully.
  */
 async function runTask(taskName, taskFunc) {
   const taskFile = path.relative(os.homedir(), 'amp.js');
@@ -93,11 +93,11 @@ async function runTask(taskName, taskFunc) {
     log(`Starting '${cyan(taskName)}'...`);
     await taskFunc();
     log('Finished', `'${cyan(taskName)}'`, 'after', magenta(getTime(start)));
-    process.exit(0);
+    return true;
   } catch (err) {
     log(`'${cyan(taskName)}'`, red('errored after'), magenta(getTime(start)));
     log(err);
-    process.exit(1);
+    return false;
   }
 }
 
@@ -229,7 +229,8 @@ function createTask(
     }
     task.action(async () => {
       validateUsage(task, taskName, taskFunc);
-      await runTask(taskName, taskFunc);
+      const success = await runTask(taskName, taskFunc);
+      process.exit(Number(!success));
     });
   }
 }


### PR DESCRIPTION
Hopefully this will get around the problem where occasionally a job hangs on CircleCI after it finishes