### PR TITLE
🏗 Fix temporary workaround for e2e tests in CircleCI

### DIFF
--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -99,7 +99,7 @@ async function runTask(taskName, taskFunc) {
     // understand exactly why and fix the root cause.
     // TODO(@ampproject/wg-infra): fix this.
     if (isCircleciBuild() && taskName === 'e2e') {
-      process.exit(0);
+      process.exit(); // process.exitCode is set in ../tasks/e2e/index.js:171
     }
   } catch (err) {
     log(`'${cyan(taskName)}'`, red('errored after'), magenta(getTime(start)));


### PR DESCRIPTION
`process.exitCode` is set explicitly in build-system/tasks/e2e/index.js:171, so the workaround introduced in #39102 incorrectly always exits with `0` instead of the explicitly set value.

Tested this in 700a73a, forcing a test to fail (`expect(1).to.equal(0);`): https://app.circleci.com/pipelines/github/ampproject/amphtml/28032/workflows/631dd486-297d-45fa-bbe6-21d2a1e1ad89/jobs/593162/parallel-runs/2?filterBy=ALL