### PR TITLE
🐛 Yandex Metrika: Add uid generation to the template

### DIFF
--- a/extensions/amp-analytics/0.1/vendors/metrika.json
+++ b/extensions/amp-analytics/0.1/vendors/metrika.json
@@ -17,6 +17,14 @@
     "_pageUrl": "${sourceUrl}",
     "_goalUrl": "goal://${sourceHost}/${goalId}"
   },
+  "cookies": {
+    "enabled": true,
+    "_ym_uid": {
+      "value": "$IF($MATCH(COOKIE(_ym_uid),^\\d{17}\\d?\\d?$),COOKIE(_ym_uid),TIMESTAMP()$SUBSTR(RANDOM(),2,6))",
+      "cookieMaxAge": 525600,
+      "sameSite": "None"
+    }
+  },
   "requests": {
     "pageview": "${_prefix}${_pageViewBrInfo}${_brInfo}&${_siteInfo}&${_suffix}",
     "notBounce": "${_prefix}${_notBounceBrInfo}${_brInfo}&${_suffix}",


### PR DESCRIPTION
The update adds custom client ID generation and ensures the ID is compatible with the one created by regular metrika script: https://github.com/yandex/metrica-tag/blob/main/src/utils/uid/uid.ts#L51

Otherwise the reports provided by the vendor might not be accurate.
