### PR TITLE
🏗 Create an empty Visual Diff job from skipped "Module" builds, not "Nomodule"

### DIFF
--- a/build-system/pr-check/module-build.js
+++ b/build-system/pr-check/module-build.js
@@ -36,6 +36,7 @@ function prBuildWorkflow() {
     timedExecOrDie('amp dist --esm --fortesting');
     storeModuleBuildToWorkspace();
   } else {
+    timedExecOrDie('amp visual-diff --empty');
     skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, or visual diff tests'

--- a/build-system/pr-check/nomodule-build.js
+++ b/build-system/pr-check/nomodule-build.js
@@ -51,7 +51,6 @@ async function prBuildWorkflow() {
     }
     storeNomoduleBuildToWorkspace();
   } else {
-    timedExecOrDie('amp visual-diff --empty');
     skipDependentJobs(
       jobName,
       'this PR does not affect the runtime, integration tests, end-to-end tests, or visual diff tests'


### PR DESCRIPTION
Not sure how we missed this edge case for so long.

I created #39123 which only marks a single e2e test as flaky. The resulting build targets for CI were `E2E_TEST` and `LINT`, which means the Visual Diff task was skipped. This skip is triggered in the [`Module Build (Test)`](https://github.com/ampproject/amphtml/blob/2d2e54cd316d1aebf961f32901126a7e0aba9421/build-system/pr-check/module-build.js#L30-L42) job. However, the `Nomodule Build (Test)` is responsible for creating an empty visual diff check on Percy/GitHub, and that one wasn't skipped due to the [`E2E_TEST`](https://github.com/ampproject/amphtml/blob/13a6dbe2e20b55c716bd843a4b5c3491e065282f/build-system/pr-check/nomodule-build.js#L40) target

This PR moves the responsibility for an empty build to the former build job