### PR TITLE
🏗 Remove the `target` field from the server's tsconfig.json

### DIFF
--- a/build-system/server/new-server/transforms/tsconfig.json
+++ b/build-system/server/new-server/transforms/tsconfig.json
@@ -8,7 +8,6 @@
     "outDir": "dist",
     "sourceMap": true,
     "moduleResolution": "node",
-    "target": "ES2019",
     "module": "CommonJS",
     "allowJs": false,
     "noUnusedLocals": true,


### PR DESCRIPTION
New versions of esbuild ignore this field and fire off a warning ([example](https://app.circleci.com/pipelines/github/ampproject/amphtml/28191/workflows/e95db7e4-a51b-47f8-9490-c943d83c2036/jobs/597764?invite=true#step-114-37)). This PR removes the deprecation warning