### PR TITLE
🐛 fix: sandboxed css feature detection

### DIFF
--- a/src/core/dom/web-components.js
+++ b/src/core/dom/web-components.js
@@ -49,12 +49,22 @@ export function isShadowDomSupported() {
  * @return {boolean}
  */
 export function isShadowCssSupported() {
-  if (shadowCssSupported === undefined) {
-    shadowCssSupported =
-      isShadowDomSupported() &&
-      (isNative(Element.prototype.attachShadow) ||
-        isNative(Element.prototype.createShadowRoot));
+  if (shadowCssSupported !== undefined) {
+    return shadowCssSupported;
   }
+
+  if (!isShadowDomSupported()) {
+    shadowCssSupported = false;
+  } else {
+    const shadowRoot =
+      getShadowDomSupportedVersion() === ShadowDomVersion_Enum.V0
+        ? self.document.createElement('div').createShadowRoot()
+        : self.document.createElement('div').attachShadow({mode: 'open'});
+
+    shadowCssSupported =
+      isNative(ShadowRoot) && shadowRoot instanceof ShadowRoot;
+  }
+
   return shadowCssSupported;
 }
 

--- a/test/unit/core/dom/test-web-components.js
+++ b/test/unit/core/dom/test-web-components.js
@@ -1,7 +1,9 @@
 import {
   ShadowDomVersion_Enum,
   getShadowDomSupportedVersion,
+  isShadowCssSupported,
   isShadowDomSupported,
+  setShadowCssSupportedForTesting,
   setShadowDomSupportedVersionForTesting,
 } from '#core/dom/web-components';
 
@@ -54,6 +56,38 @@ describes.realWin('Web Components spec', {}, (env) => {
           ShadowDomVersion_Enum.V0
         );
       }
+    });
+  });
+
+  describe('Shadow CSS', () => {
+    beforeEach(() => {
+      setShadowCssSupportedForTesting(undefined);
+    });
+
+    it('should report whether native shadow css supported', () => {
+      const shadowDomV0 = !!win.Element.prototype.createShadowRoot;
+      const shadowDomV1 = !!win.Element.prototype.attachShadow;
+      expect(isShadowCssSupported()).to.equal(shadowDomV0 || shadowDomV1);
+    });
+
+    it('should report whether native shadow css supported using proxied Elements', () => {
+      const shadowDomV0 = !!win.Element.prototype.createShadowRoot;
+      const shadowDomV1 = !!win.Element.prototype.attachShadow;
+
+      if (shadowDomV0) {
+        const {createShadowRoot} = win.Element.prototype;
+
+        win.Element.prototype.createShadowRoot = (...args) =>
+          createShadowRoot(...args);
+      }
+
+      if (shadowDomV1) {
+        const {attachShadow} = win.Element.prototype;
+
+        win.Element.prototype.attachShadow = (...args) => attachShadow(...args);
+      }
+
+      expect(isShadowCssSupported()).to.equal(shadowDomV0 || shadowDomV1);
     });
   });
 });


### PR DESCRIPTION
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->

shadow-v0 does not work properly with third party libraries proxing native methods, in this case `attachShadow`. For instance, clarity js proxies the method, calling at the end the native implementation https://github.com/microsoft/clarity/blob/db16d1b8281530c96e577fe64fb8a785f6142f8f/packages/clarity-js/src/layout/mutation.ts#LL65C1-L65C1.

In this scenario, amp shadow ends up in a inconsistent state, creating a shadow root but at the same time applying CSS scoping, breaking all the styles.

# Steps to reproduce
Go to https://www.xataka.com/#mrfexperiences=FC_6GZnd5W0S0SnvAaN76fjzw emulating a smartphone and scroll until the card appears.
![xataka](https://github.com/ampproject/amphtml/assets/9928519/bde0cb5e-440c-4bb6-ac40-6cda8b5ced66)

Drag it up to open it

![image](https://github.com/ampproject/amphtml/assets/9928519/0bcb900d-50f3-420e-a1ac-2b7146dac1c9)

You'll see custom styles are broken. Inspecting the element matching the following selector `marfeel-flowcards article [data-testid="amp-document-single"]`, we can see the following:
- amp document is sandboxed properly in a shadow root.
- custom css is prefixed with a class placed outside the shadow root.
Because of shadow root encapsulation, none of the styles are matching the proper target.

![image](https://github.com/ampproject/amphtml/assets/9928519/1695edb3-6f2b-4a33-bb8e-5f60b2104d3c)

# Solution

Change `isShadowCssSupported` feature check for checking if the output of `createShadowRoot|attachShadow` is a native ShadowRoot isntead of relying in the native implementation of the previous methods.
