### PR TITLE
Revert "🏗 Remove the `target` field from the server's tsconfig.json"

### DIFF
--- a/build-system/server/new-server/transforms/tsconfig.json
+++ b/build-system/server/new-server/transforms/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "dist",
     "sourceMap": true,
     "moduleResolution": "node",
+    "target": "ES2019",
     "module": "CommonJS",
     "allowJs": false,
     "noUnusedLocals": true,


### PR DESCRIPTION
Reverts ampproject/amphtml#39164

It causes failures 
```
build-system/server/new-server/transforms/utilities/lazy.ts:9:14 - error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.

9   public get value(): T {
               ~~~~~


Found 1 error.
```