### PR TITLE
🐛 Fix incorrect regex in `remapDependenciesPlugin`

### DIFF
--- a/build-system/tasks/remap-dependencies-plugin/remap-dependencies.js
+++ b/build-system/tasks/remap-dependencies-plugin/remap-dependencies.js
@@ -17,7 +17,7 @@ const {resolvePath} = require('../../babel-config/import-resolver');
  */
 function remapDependenciesPlugin({externals, remaps, resolve}) {
   const remapArr = Object.entries(remaps).map(([path, value]) => ({
-    regex: new RegExp(`^${path}(\.js|\.jsx|\.ts|\.tsx)?$`),
+    regex: new RegExp(`^${path}(\\.[jt]sx?)?$`),
     value,
   }));
   const rootDir = process.cwd();


### PR DESCRIPTION
And make it infinitesimally more efficient :D

This should fix security advisories:
* https://github.com/ampproject/amphtml/security/code-scanning/56
* https://github.com/ampproject/amphtml/security/code-scanning/57
* https://github.com/ampproject/amphtml/security/code-scanning/58
* https://github.com/ampproject/amphtml/security/code-scanning/59