### PR TITLE
🐛 Fix overly permissive regex in ads vendors' code

### DIFF
--- a/ads/vendors/adskeeper.js
+++ b/ads/vendors/adskeeper.js
@@ -34,7 +34,7 @@ export function adskeeper(global, data) {
    * @return {string} Path to provided filename.
    */
   function getResourceFilePath(publisher) {
-    const publisherStr = publisher.replace(/[^A-z0-9]/g, '');
+    const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
     return `${publisherStr[0]}/${publisherStr[1]}`;
   }
 

--- a/ads/vendors/idealmedia.js
+++ b/ads/vendors/idealmedia.js
@@ -18,7 +18,7 @@ export function idealmedia(global, data) {
    * @return {string} Path to provided filename.
    */
   function getResourceFilePath(publisher) {
-    const publisherStr = publisher.replace(/[^A-z0-9]/g, '');
+    const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
     return `${publisherStr[0]}/${publisherStr[1]}`;
   }
 

--- a/ads/vendors/lentainform.js
+++ b/ads/vendors/lentainform.js
@@ -12,7 +12,7 @@ export function lentainform(global, data) {
 
   document.body.appendChild(scriptRoot);
 
-  const publisherStr = data.publisher.replace(/[^A-z0-9]/g, '');
+  const publisherStr = data.publisher.replace(/[^a-zA-Z0-9]/g, '');
 
   const url =
     `https://jsc.lentainform.com/${encodeURIComponent(publisherStr[0])}/` +

--- a/ads/vendors/mgid.js
+++ b/ads/vendors/mgid.js
@@ -18,7 +18,7 @@ export function mgid(global, data) {
    * @return {string} Path to provided filename.
    */
   function getResourceFilePath(publisher) {
-    const publisherStr = publisher.replace(/[^A-z0-9]/g, '');
+    const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
     return `${publisherStr[0]}/${publisherStr[1]}`;
   }
 

--- a/extensions/amp-ad-network-mgid-impl/0.1/test/test-amp-ad-network-mgid-impl.js
+++ b/extensions/amp-ad-network-mgid-impl/0.1/test/test-amp-ad-network-mgid-impl.js
@@ -57,8 +57,8 @@ describes.realWin(
           /(\?|&)dpr=\d+(&|$)/,
           /(\?|&)cxurl=http%3A%2F%2Fcanonical.example%2F%3Fabc%3Dxyz(&|$)/,
           /(\?|&)pr=fake.example(&|$)/,
-          /(\?|&)pvid=[A-z0-9\-_]+(&|$)/,
-          /(\?|&)muid=amp-[A-z0-9\-_]+(&|$)/,
+          /(\?|&)pvid=[a-zA-Z0-9\-_]+(&|$)/,
+          /(\?|&)muid=amp-[a-zA-Z0-9\-_]+(&|$)/,
           /(\?|&)implVersion=15(&|$)/,
         ].forEach((regexp) => {
           expect(url).to.match(regexp);


### PR DESCRIPTION
Should fix security advisories:

* https://github.com/ampproject/amphtml/security/code-scanning/52
* https://github.com/ampproject/amphtml/security/code-scanning/53
* https://github.com/ampproject/amphtml/security/code-scanning/54
* https://github.com/ampproject/amphtml/security/code-scanning/55