### PR TITLE
🐛 Enable cross-origin copy url in <amp-story-player>

### DIFF
--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -243,6 +243,7 @@ exports.rules = [
       'extensions/amp-story-share-menu/0.1/amp-story-share-menu.js->extensions/amp-story/1.0/utils.js',
       'extensions/amp-story-share-menu/0.1/amp-story-share-menu.js->extensions/amp-story/1.0/request-utils.js',
       'extensions/amp-story-share-menu/0.1/amp-story-share-menu.js->extensions/amp-story/1.0/toast.js',
+      'extensions/amp-story-share-menu/0.1/amp-story-share-menu.js->extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js',
 
       // Story Shopping
       'extensions/amp-story-shopping/0.1/amp-story-shopping.js->extensions/amp-story/1.0/utils.js',

--- a/examples/amp-story/player-cross-origin-copy-link.html
+++ b/examples/amp-story/player-cross-origin-copy-link.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <title>Integrate stories in AMP pages - Example 1</title>
+  <meta name="viewport" content="width=device-width">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script
+    async
+    custom-element="amp-story-player"
+    src="https://cdn.ampproject.org/v0/amp-story-player-0.1.js"
+  ></script>
+</head>
+<body>
+  <amp-story-player layout="fixed" width="360" height="600">
+    <a href="http://localhost:8000/examples/amp-story/share.html"></a>
+  </amp-story-player>
+</body>
+</html>

--- a/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
+++ b/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
@@ -369,7 +369,7 @@ export class AmpStoryShareMenu extends AMP.BaseElement {
   }
 
   /**
-   * @param url
+   * @param {string} url
    * @private
    */
   showCopySuccessfulToast_(url) {
@@ -386,7 +386,6 @@ export class AmpStoryShareMenu extends AMP.BaseElement {
   }
 
   /**
-   * @param url
    * @private
    */
   showCopyFailedToast_() {

--- a/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
+++ b/extensions/amp-story-share-menu/0.1/amp-story-share-menu.js
@@ -18,6 +18,7 @@ import {user} from '#utils/log';
 import {localizeTemplate} from 'extensions/amp-story/1.0/amp-story-localization-service';
 import {getElementConfig} from 'extensions/amp-story/1.0/request-utils';
 import {Toast} from 'extensions/amp-story/1.0/toast';
+import {AMP_STORY_COPY_URL} from 'src/amp-story-player/event';
 
 import {CSS} from '../../../build/amp-story-share-menu-0.1.css';
 import {getAmpdoc} from '../../../src/service-helpers';
@@ -26,6 +27,7 @@ import {
   StateProperty,
   UIType_Enum,
 } from '../../amp-story/1.0/amp-story-store-service';
+import {AmpStoryViewerMessagingHandler} from '../../amp-story/1.0/amp-story-viewer-messaging-handler';
 import {
   createShadowRootWithStyle,
   dependsOnStoryServices,
@@ -97,6 +99,12 @@ export class AmpStoryShareMenu extends AMP.BaseElement {
 
     /** @private @const {!../../../extensions/amp-story/1.0/amp-story-store-service.AmpStoryStoreService} */
     this.storeService_ = Services.storyStoreService(this.win);
+
+    /** @private {?../../../src/service/viewer-interface.ViewerInterface} */
+    this.viewer_ = null;
+
+    /** @private {?AmpStoryViewerMessagingHandler} */
+    this.viewerMessagingHandler_ = null;
   }
 
   /**
@@ -114,6 +122,11 @@ export class AmpStoryShareMenu extends AMP.BaseElement {
     localizeTemplate(this.rootEl_, this.element);
     createShadowRootWithStyle(this.element, this.rootEl_, CSS);
     this.initializeListeners_();
+
+    this.viewer_ = Services.viewerForDoc(this.win.document.documentElement);
+    this.viewerMessagingHandler_ = this.viewer_.isEmbedded()
+      ? new AmpStoryViewerMessagingHandler(this.win, this.viewer_)
+      : null;
   }
 
   /**
@@ -333,29 +346,55 @@ export class AmpStoryShareMenu extends AMP.BaseElement {
       getAmpdoc(this.storyEl_)
     ).canonicalUrl;
 
-    copyTextToClipboard(
-      this.win,
-      url,
-      () => {
-        this.localizationService_
-          .getLocalizedStringAsync(
-            LocalizedStringId_Enum.AMP_STORY_SHARING_CLIPBOARD_SUCCESS_TEXT
-          )
-          .then((successString) =>
-            Toast.show(
-              this.storyEl_,
-              this.buildCopySuccessfulToast_(url, successString)
-            )
-          );
-      },
-      () => {
-        this.localizationService_
-          .getLocalizedStringAsync(
-            LocalizedStringId_Enum.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT
-          )
-          .then((failureString) => Toast.show(this.storyEl_, failureString));
-      }
-    );
+    if (this.viewerMessagingHandler_) {
+      this.viewerMessagingHandler_.onMessage('copyComplete', (data) => {
+        if (data.success) {
+          this.showCopySuccessfulToast_(data.url);
+        } else {
+          this.showCopyFailedToast_();
+        }
+      });
+      this.viewerMessagingHandler_.send('documentStateUpdate', {
+        'state': AMP_STORY_COPY_URL,
+        'value': url,
+      });
+    } else {
+      copyTextToClipboard(
+        this.win,
+        url,
+        this.showCopySuccessfulToast_.bind(this, url),
+        this.showCopyFailedToast_
+      );
+    }
+  }
+
+  /**
+   * @param url
+   * @private
+   */
+  showCopySuccessfulToast_(url) {
+    this.localizationService_
+      .getLocalizedStringAsync(
+        LocalizedStringId_Enum.AMP_STORY_SHARING_CLIPBOARD_SUCCESS_TEXT
+      )
+      .then((successString) =>
+        Toast.show(
+          this.storyEl_,
+          this.buildCopySuccessfulToast_(url, successString)
+        )
+      );
+  }
+
+  /**
+   * @param url
+   * @private
+   */
+  showCopyFailedToast_() {
+    this.localizationService_
+      .getLocalizedStringAsync(
+        LocalizedStringId_Enum.AMP_STORY_SHARING_CLIPBOARD_FAILURE_TEXT
+      )
+      .then((failureString) => Toast.show(this.storyEl_, failureString));
   }
 
   /**

--- a/extensions/amp-story-share-menu/0.1/test/test-amp-story-share-menu.js
+++ b/extensions/amp-story-share-menu/0.1/test/test-amp-story-share-menu.js
@@ -101,4 +101,25 @@ describes.realWin('amp-story-share-menu', {amp: true}, (env) => {
 
     expect(clickCallbackSpy).to.have.been.calledOnce;
   });
+
+  it('should send message to viewer to execute copy url if embedded', async () => {
+    const viewer = Services.viewerForDoc(env.ampdoc);
+    env.sandbox.stub(viewer, 'isEmbedded').returns(true);
+    env.sandbox.stub(Services, 'viewerForDoc').returns(viewer);
+
+    await shareMenu.buildCallback();
+
+    const onMessageSpy = env.sandbox.spy(
+      shareMenu.viewerMessagingHandler_,
+      'onMessage'
+    );
+    const sendSpy = env.sandbox.spy(shareMenu.viewerMessagingHandler_, 'send');
+
+    const shareLinkEl = win.document.querySelector(
+      '.i-amphtml-story-share-icon-link'
+    );
+    shareLinkEl.click();
+    expect(onMessageSpy).to.have.been.calledOnce;
+    expect(sendSpy).to.have.been.calledOnce;
+  });
 });

--- a/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
+++ b/extensions/amp-story/1.0/amp-story-viewer-messaging-handler.js
@@ -126,6 +126,15 @@ export class AmpStoryViewerMessagingHandler {
   }
 
   /**
+   * @param {string} eventType
+   * @param {function(!JsonObject)} handler
+   * @return {!UnlistenDef}
+   */
+  onMessage(eventType, handler) {
+    this.viewer_.onMessage(eventType, handler);
+  }
+
+  /**
    * Handles 'getDocumentState' viewer messages.
    * @param {!Object=} data
    * @return {!Promise}

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -15,8 +15,6 @@ import {copyTextToClipboard} from '#core/window/clipboard';
 
 import {createCustomEvent, listenOnce} from '#utils/event-helper';
 
-import {applyBreakpointClassname} from 'extensions/amp-video-docking/0.1/breakpoints';
-
 import {AmpStoryPlayerViewportObserver} from './amp-story-player-viewport-observer';
 import {AMP_STORY_COPY_URL, AMP_STORY_PLAYER_EVENT} from './event';
 import {PageScroller} from './page-scroller';

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -11,11 +11,14 @@ import {findIndex, toArray} from '#core/types/array';
 import {isEnumValue} from '#core/types/enum';
 import {parseJson} from '#core/types/object/json';
 import {parseQueryString} from '#core/types/string/url';
+import {copyTextToClipboard} from '#core/window/clipboard';
 
 import {createCustomEvent, listenOnce} from '#utils/event-helper';
 
+import {applyBreakpointClassname} from 'extensions/amp-video-docking/0.1/breakpoints';
+
 import {AmpStoryPlayerViewportObserver} from './amp-story-player-viewport-observer';
-import {AMP_STORY_PLAYER_EVENT} from './event';
+import {AMP_STORY_COPY_URL, AMP_STORY_PLAYER_EVENT} from './event';
 import {PageScroller} from './page-scroller';
 
 import {cssText} from '../../build/amp-story-player-shadow.css';
@@ -1599,6 +1602,9 @@ export class AmpStoryPlayer {
       case AMP_STORY_PLAYER_EVENT:
         this.onPlayerEvent_(/** @type {string} */ (data.value));
         break;
+      case AMP_STORY_COPY_URL:
+        this.onCopyUrl_(/** @type {string} */ (data.value), messaging);
+        break;
       default:
         break;
     }
@@ -1619,6 +1625,38 @@ export class AmpStoryPlayer {
         this.element_.dispatchEvent(createCustomEvent(this.win_, value, {}));
         break;
     }
+  }
+
+  /**
+   * Reacts to the copy url request coming from the story.
+   * @private
+   * @param {string} value
+   * @param {Messaging} messaging
+   */
+  onCopyUrl_(value, messaging) {
+    copyTextToClipboard(
+      this.win_,
+      value,
+      () => {
+        messaging.sendRequest(
+          'copyComplete',
+          {
+            'success': true,
+            'url': value,
+          },
+          false
+        );
+      },
+      () => {
+        messaging.sendRequest(
+          'copyComplete',
+          {
+            'success': false,
+          },
+          false
+        );
+      }
+    );
   }
 
   /**

--- a/src/amp-story-player/event.js
+++ b/src/amp-story-player/event.js
@@ -1,2 +1,3 @@
 /** @const {string} */
 export const AMP_STORY_PLAYER_EVENT = 'AMP_STORY_PLAYER_EVENT';
+export const AMP_STORY_COPY_URL = 'AMP_STORY_COPY_URL';


### PR DESCRIPTION
Context:
Currently in `<amp-story-player>`, if the embedded Story has a different origin than the hosting page's origin, the clicking on `Get Link` button would fail to copy URL to the clipboard. This is because `Get Link` button tries to write the URL of embedded story to the hosting page's clipboard, which is one kind of cross-origin referencing and not allowed.

Solution:
Use viewer's messaging object, e.g. `AmpStoryViewerMessagingHandler`, to pass URL from the embedded Story to the hosting page and copy it there.

Reported bug: #38936