### PR TITLE
Turn back on the "amp boilerplate animation test" for Microsoft Edge

### DIFF
--- a/test/integration/test-boilerplates.js
+++ b/test/integration/test-boilerplates.js
@@ -39,7 +39,7 @@ describes.sandboxed('New Visibility Boilerplate', {}, () => {
       expect(getStyle(fixture.win.document.body, 'visibility')).to.equal(
         'visible'
       );
-      expect(isAnimationNone(fixture.win.document.body)).to.be.true;
+      expect(isAnimationNone(fixture.win.document.body, true)).to.be.true;
     });
   });
 });

--- a/test/integration/test-boilerplates.js
+++ b/test/integration/test-boilerplates.js
@@ -1,5 +1,6 @@
 import {getStyle} from '#core/dom/style';
 
+import {isAnimationNone} from '#testing/helpers/service';
 import {createFixtureIframe, expectBodyToBecomeVisible} from '#testing/iframe';
 
 const timeout = window.ampTestRuntimeConfig.mochaTimeout;
@@ -38,8 +39,7 @@ describes.sandboxed('New Visibility Boilerplate', {}, () => {
       expect(getStyle(fixture.win.document.body, 'visibility')).to.equal(
         'visible'
       );
-      // TODO(#39152): this breaks in Microsoft Edge.
-      // expect(isAnimationNone(fixture.win.document.body)).to.be.true;
+      expect(isAnimationNone(fixture.win.document.body)).to.be.true;
     });
   });
 });

--- a/testing/helpers/service.js
+++ b/testing/helpers/service.js
@@ -90,13 +90,14 @@ export function waitFor(callback, errorMessage) {
 
 const noneValues = {
   'animation-name': ['none', 'initial'],
-  'animation-duration': ['0s', 'initial'],
+  'animation-duration': ['0s', 'auto', 'initial'],
   'animation-timing-function': ['ease', 'initial'],
   'animation-delay': ['0s', 'initial'],
   'animation-iteration-count': ['1', 'initial'],
   'animation-direction': ['normal', 'initial'],
   'animation-fill-mode': ['none', 'initial'],
   'animation-play-state': ['running', 'initial', /* IE11 */ ''],
+  'animation-timeline': ['auto', 'initial'],
 };
 
 /**

--- a/testing/helpers/service.js
+++ b/testing/helpers/service.js
@@ -97,7 +97,6 @@ const noneValues = {
   'animation-direction': ['normal', 'initial'],
   'animation-fill-mode': ['none', 'initial'],
   'animation-play-state': ['running', 'initial', /* IE11 */ ''],
-  'animation-timeline': ['auto', 'initial'],
 };
 
 /**

--- a/testing/helpers/service.js
+++ b/testing/helpers/service.js
@@ -88,25 +88,40 @@ export function waitFor(callback, errorMessage) {
   );
 }
 
-const noneValues = {
-  'animation-name': ['none', 'initial'],
-  'animation-duration': ['0s', 'auto', 'initial'],
-  'animation-timing-function': ['ease', 'initial'],
-  'animation-delay': ['0s', 'initial'],
-  'animation-iteration-count': ['1', 'initial'],
-  'animation-direction': ['normal', 'initial'],
-  'animation-fill-mode': ['none', 'initial'],
-  'animation-play-state': ['running', 'initial', /* IE11 */ ''],
-};
+/**
+ * Gets the initial values of an Element's animation state.
+ * For time-based animations, auto is equivalent to a value of 0s.
+ *
+ * @param {boolean} isTimeBasedAnimation
+ */
+function getInitialNoneValues(isTimeBasedAnimation) {
+  const initialValues = {
+    'animation-name': ['none', 'initial'],
+    'animation-duration': ['0s', 'auto', 'initial'],
+    'animation-timing-function': ['ease', 'initial'],
+    'animation-delay': ['0s', 'initial'],
+    'animation-iteration-count': ['1', 'initial'],
+    'animation-direction': ['normal', 'initial'],
+    'animation-fill-mode': ['none', 'initial'],
+    'animation-play-state': ['running', 'initial', /* IE11 */ ''],
+  };
+  if (isTimeBasedAnimation) {
+    initialValues['animation-duration'].unshift('auto');
+  }
+  return initialValues;
+}
 
 /**
  * Browsers are inconsistent when accessing the value for 'animation: none'.
  * Some return 'none', some return the full shorthand, some give the full
  * shorthand in a different order.
+ *
  * @param {!Element} element
+ * @param {boolean=} opt_isTimeBasedAnimation
  * @return {boolean}
  */
-export function isAnimationNone(element) {
+export function isAnimationNone(element, opt_isTimeBasedAnimation = true) {
+  const noneValues = getInitialNoneValues(opt_isTimeBasedAnimation);
   for (const property in noneValues) {
     const value = getStyle(element, property);
     const expectedValues = noneValues[property];


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/CSS/animation-duration "For time-based animations, auto is equivalent to a value of 0s".

I added an option to add "auto" as one of the initial value states for `animation-duration`. It seems this is implemented differently across browsers which is why there is a helper function for this check.

Fixes https://github.com/ampproject/amphtml/issues/39152

---

Revert "Disable broken test `should show the body in boilerplate test` (#39151)"

This reverts commit 927c884cb6b5634e556668652c37805af740c7cc.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
