### PR TITLE
🐛  Fix native share by matching the newest iframe API

### DIFF
--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -559,7 +559,7 @@ export class AmpStoryPlayer {
       setStyle(iframeEl, 'backgroundImage', story.posterImage);
     }
     iframeEl.classList.add('story-player-iframe');
-    iframeEl.setAttribute('allow', 'autoplay');
+    iframeEl.setAttribute('allow', 'autoplay; web-share');
 
     applySandbox(iframeEl);
     this.addSandboxFlags_(iframeEl);


### PR DESCRIPTION
Newest iframe API for triggering the native share menu: https://developer.chrome.com/blog/web-share-api-in-third-party-iframes/

#39181
