### PR TITLE
🐛 amp-facebook broken: fix sdk version

### DIFF
--- a/3p/facebook.js
+++ b/3p/facebook.js
@@ -207,7 +207,7 @@ export function facebook(global, data) {
         );
       });
 
-      FB.init({xfbml: true, version: 'v2.5'});
+      FB.init({xfbml: true, version: 'v17.0'});
 
       // Report to parent that the SDK has loaded and is ready to paint
       const message = JSON.stringify({


### PR DESCRIPTION
SDK version was deprecated. This PR will fix https://github.com/ampproject/amphtml/issues/38368