### PR TITLE
🐛 amp-ad doubleclick & adsense: allow tfcd/tfua=0

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -405,8 +405,8 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
       'spsa': this.isSinglePageStoryAd
         ? `${this.size_.width}x${this.size_.height}`
         : null,
-      'tfcd': consentSharedData?.['adsense-tfcd'] || null,
-      'tfua': consentSharedData?.['adsense-tfua'] || null,
+      'tfcd': consentSharedData?.['adsense-tfcd'] ?? null,
+      'tfua': consentSharedData?.['adsense-tfua'] ?? null,
     };
 
     const experimentIds = [];

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -945,6 +945,7 @@ describes.realWin(
           'adsense-tfcd': 1,
         };
         return impl.getAdUrl({consentSharedData}).then((url) => {
+          expect(url).to.match(/(\?|&)tfua=0(&|$)/);
           expect(url).to.match(/(\?|&)tfcd=1(&|$)/);
         });
       });
@@ -957,6 +958,7 @@ describes.realWin(
         };
         return impl.getAdUrl({consentSharedData}).then((url) => {
           expect(url).to.match(/(\?|&)tfua=1(&|$)/);
+          expect(url).to.match(/(\?|&)tfcd=0(&|$)/);
         });
       });
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -653,8 +653,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         consentStringType == CONSENT_STRING_TYPE.US_PRIVACY_STRING
           ? consentString
           : null,
-      'tfcd': tfcdFromSharedData ?? tfcdFromJson ?? null,
-      'tfua': tfuaFromSharedData ?? tfuaFromJson ?? null,
+      'tfcd': combineConsentParams(tfcdFromSharedData, tfcdFromJson),
+      'tfua': combineConsentParams(tfuaFromSharedData, tfuaFromJson),
     };
   }
 
@@ -2057,4 +2057,22 @@ export function getPageviewStateTokensForAdRequest(instancesInAdRequest) {
  */
 export function resetTokensToInstancesMap() {
   tokensToInstances = {};
+}
+
+/**
+ * Function to handle the three-state boolean logic of tfcd/tfua params.
+ * - If any params are 1, return 1.
+ * - Else if any of them are 0, return 0.
+ * - Else return null
+ * @param {?number} param1
+ * @param {?number} param2
+ * @return {?string}
+ */
+function combineConsentParams(param1, param2) {
+  if (String(param1) === '1' || String(param2) === '1') {
+    return '1';
+  } else if (String(param1) === '0' || String(param2) === '0') {
+    return '0';
+  }
+  return null;
 }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -653,8 +653,8 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
         consentStringType == CONSENT_STRING_TYPE.US_PRIVACY_STRING
           ? consentString
           : null,
-      'tfcd': tfcdFromSharedData || tfcdFromJson || null,
-      'tfua': tfuaFromSharedData || tfuaFromJson || null,
+      'tfcd': tfcdFromSharedData ?? tfcdFromJson ?? null,
+      'tfua': tfuaFromSharedData ?? tfuaFromJson ?? null,
     };
   }
 

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1243,6 +1243,22 @@ for (const {config, name} of [
             expect(url).to.match(/(\?|&)tfcd=0(&|$)/);
           });
         });
+
+        it('default tfcd/tfua to 1 if conflicting data detected', () => {
+          element.setAttribute(
+            'json',
+            '{"tagForChildDirectedTreatment": 0,"tagForUnderAgeTreatment": 1}'
+          );
+          impl.uiHandler = {isStickyAd: () => false};
+          const consentSharedData = {
+            'doubleclick-tfua': 0,
+            'doubleclick-tfcd': 1,
+          };
+          return impl.getAdUrl({consentSharedData}).then((url) => {
+            expect(url).to.match(/(\?|&)tfua=1(&|$)/);
+            expect(url).to.match(/(\?|&)tfcd=1(&|$)/);
+          });
+        });
       });
 
       describe('#getPageParameters', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1227,6 +1227,7 @@ for (const {config, name} of [
             'doubleclick-tfcd': 1,
           };
           return impl.getAdUrl({consentSharedData}).then((url) => {
+            expect(url).to.match(/(\?|&)tfua=0(&|$)/);
             expect(url).to.match(/(\?|&)tfcd=1(&|$)/);
           });
         });
@@ -1239,6 +1240,7 @@ for (const {config, name} of [
           };
           return impl.getAdUrl({consentSharedData}).then((url) => {
             expect(url).to.match(/(\?|&)tfua=1(&|$)/);
+            expect(url).to.match(/(\?|&)tfcd=0(&|$)/);
           });
         });
       });


### PR DESCRIPTION
Currently, because `0` is treated the same as `null` the latter will take precedence because of the ordering of logic.

For AdSense, switch to `??`, while DoubleClick uses a more explicit logic because there are multiple possible sources for tfcd/tfua values.