### PR TITLE
Bump `rrule` to v2.7.2 and remove its import workarounds

### DIFF
--- a/build-system/common/update-packages.js
+++ b/build-system/common/update-packages.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const checkDependencies = require('check-dependencies');
-const del = require('del');
 const fs = require('fs-extra');
 const path = require('path');
 const {cyan, red} = require('kleur/colors');
@@ -181,19 +180,6 @@ function patchShadowDom() {
 }
 
 /**
- * Deletes the map file for rrule, which breaks closure compiler.
- * TODO(wg-infra): Remove this workaround after a fix is merged for
- * https://github.com/google/closure-compiler/issues/3720.
- */
-function removeRruleSourcemap() {
-  const rruleMapFile = 'node_modules/rrule/dist/es5/rrule.js.map';
-  if (fs.existsSync(rruleMapFile)) {
-    del.sync(rruleMapFile);
-    logLocalDev('Deleted', cyan(rruleMapFile));
-  }
-}
-
-/**
  * Checks if all packages are current, and if not, runs `npm install`.
  */
 function updateDeps() {
@@ -227,7 +213,6 @@ function updatePackages() {
   patchIntersectionObserver();
   patchResizeObserver();
   patchShadowDom();
-  removeRruleSourcemap();
   if (isCiBuild()) {
     runNpmChecks();
   }

--- a/extensions/amp-date-picker/0.1/dates-list.js
+++ b/extensions/amp-date-picker/0.1/dates-list.js
@@ -1,7 +1,6 @@
-import * as rrule from '../../../node_modules/rrule/dist/es5/rrule';
-import {requireExternal} from '../../../src/module';
+import {rrulestr} from 'rrule';
 
-const rrulestr = rrule.default.rrulestr || rrule.rrulestr; // closure imports into .default, esbuild flattens a layer.
+import {requireExternal} from '../../../src/module';
 
 /** @enum {string} */
 const DateType = {

--- a/extensions/amp-date-picker/1.0/component/dates-list.js
+++ b/extensions/amp-date-picker/1.0/component/dates-list.js
@@ -1,7 +1,5 @@
 import {addDays, isSameDay, isValid} from 'date-fns';
-import * as rrule from 'rrule';
-
-const rrulestr = rrule.default.rrulestr || rrule.rrulestr; // closure imports into .default, esbuild flattens a layer.
+import {rrulestr} from 'rrule';
 
 /**
  * RRULE returns dates as local time formatted at UTC, so the

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-day-picker": "8.0.0-beta.37",
         "react-jss": "10.8.2",
         "resize-observer-polyfill": "1.5.1",
-        "rrule": "2.6.8",
+        "rrule": "2.7.2",
         "timeago.js": "4.0.2",
         "web-activities": "1.24.0",
         "web-animations-js": "2.3.2"
@@ -18532,14 +18532,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/luxon": {
-      "version": "1.26.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -21793,14 +21785,17 @@
       }
     },
     "node_modules/rrule": {
-      "version": "2.6.8",
-      "license": "BSD-3-Clause",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.7.2.tgz",
+      "integrity": "sha512-NkBsEEB6FIZOZ3T8frvEBOB243dm46SPufpDckY/Ap/YH24V1zLeMmDY8OA10lk452NdrF621+ynDThE7FQU2A==",
       "dependencies": {
-        "tslib": "^1.10.0"
-      },
-      "optionalDependencies": {
-        "luxon": "^1.21.3"
+        "tslib": "^2.4.0"
       }
+    },
+    "node_modules/rrule/node_modules/tslib": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/rrweb-cssom": {
       "version": "0.6.0",
@@ -23461,6 +23456,7 @@
     },
     "node_modules/tslib": {
       "version": "1.14.1",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -37824,10 +37820,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "luxon": {
-      "version": "1.26.0",
-      "optional": true
-    },
     "make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -39958,10 +39950,18 @@
       }
     },
     "rrule": {
-      "version": "2.6.8",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.7.2.tgz",
+      "integrity": "sha512-NkBsEEB6FIZOZ3T8frvEBOB243dm46SPufpDckY/Ap/YH24V1zLeMmDY8OA10lk452NdrF621+ynDThE7FQU2A==",
       "requires": {
-        "luxon": "^1.21.3",
-        "tslib": "^1.10.0"
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+          "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+        }
       }
     },
     "rrweb-cssom": {
@@ -41193,7 +41193,8 @@
       }
     },
     "tslib": {
-      "version": "1.14.1"
+      "version": "1.14.1",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-day-picker": "8.0.0-beta.37",
     "react-jss": "10.8.2",
     "resize-observer-polyfill": "1.5.1",
-    "rrule": "2.6.8",
+    "rrule": "2.7.2",
     "timeago.js": "4.0.2",
     "web-activities": "1.24.0",
     "web-animations-js": "2.3.2"


### PR DESCRIPTION
Separating this change out of #37042 so renovatebot can do its thing