### PR TITLE
🏗 Remove unused branch from `ciJobUrl` function

### DIFF
--- a/build-system/common/ci.js
+++ b/build-system/common/ci.js
@@ -170,13 +170,8 @@ function ciJobId() {
  * Returns the URL of the current job.
  * @return {string}
  */
-function ciJobUrl() {
-  return isGithubActions
-    ? // TODO(wg-infra): Try to reverse engineer the GH Actions job URL from the build URL.
-      `${env('GITHUB_SERVER_URL')}/${env('GITHUB_REPOSITORY')}/actions/runs/${env('GITHUB_RUN_ID')}` // prettier-ignore
-    : isCircleci
-    ? env('CIRCLE_BUILD_URL')
-    : '';
+function circleciJobUrl() {
+  return isCircleci ? env('CIRCLE_BUILD_URL') : '';
 }
 
 /**
@@ -223,7 +218,7 @@ module.exports = {
   ciBuildUrl,
   ciCommitSha,
   ciJobId,
-  ciJobUrl,
+  circleciJobUrl,
   ciPullRequestBranch,
   ciPullRequestSha,
   ciPushBranch,

--- a/build-system/tasks/test-report-upload.js
+++ b/build-system/tasks/test-report-upload.js
@@ -12,8 +12,8 @@ const {
   ciBuildUrl,
   ciCommitSha,
   ciJobId,
-  ciJobUrl,
   ciRepoSlug,
+  circleciJobUrl,
 } = require('../common/ci');
 const {log} = require('../common/logging');
 
@@ -67,7 +67,7 @@ function addJobAndBuildInfo(testType, reportJson) {
     job: {
       jobId,
       testSuiteType: testType,
-      url: ciJobUrl(),
+      url: circleciJobUrl(),
     },
   };
 }


### PR DESCRIPTION
Removes an old TODO. Renames the function to circleciJobUrl to emphasize that it's only relevant in CircleCI