### PR TITLE
🧪 Remove outdated `experimentB` from `experiments-config.json`

### DIFF
--- a/build-system/global-configs/experiments-config.json
+++ b/build-system/global-configs/experiments-config.json
@@ -1,11 +1,5 @@
 {
   "experimentA": {},
-  "experimentB": {
-    "name": "amp-img in the deferred mount mode",
-    "environment": "AMP",
-    "issue": "https://github.com/ampproject/amphtml/issues/31915",
-    "expiration_date_utc": "2021-06-30",
-    "define_experiment_constant": "R1_IMG_DEFERRED_BUILD"
-  },
+  "experimentB": {},
   "experimentC": {}
 }


### PR DESCRIPTION
This experiment is +2 years out of date. It's not being tested on CI, but our build platform still builds it (even though we don't use it). Might as well remove it!