### PR TITLE
🐛 Disallow empty CTA string in page attachment

### DIFF
--- a/examples/amp-story/amp-story-shopping.html
+++ b/examples/amp-story/amp-story-shopping.html
@@ -10,6 +10,7 @@
     <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
     <script async custom-element="amp-story-auto-analytics" src="https://cdn.ampproject.org/v0/amp-story-auto-analytics-0.1.js"></script>
     <script async custom-element="amp-story-shopping" src="https://cdn.ampproject.org/v0/amp-story-shopping-0.1.js"></script>
+    <script async custom-element="amp-story-page-attachment" src="https://cdn.ampproject.org/v0/amp-story-page-attachment-0.1.js"></script>
     <style amp-custom>
       [data-product-id="lamp"] {
         top: 31%;

--- a/examples/amp-story/attachment.html
+++ b/examples/amp-story/attachment.html
@@ -5,6 +5,7 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script async custom-element="amp-form" src="https://cdn.ampproject.org/v0/amp-form-0.1.js"></script>
     <script async custom-element="amp-story" src="https://cdn.ampproject.org/v0/amp-story-1.0.js"></script>
+    <script async custom-element="amp-story-page-attachment" src="https://cdn.ampproject.org/v0/amp-story-page-attachment-0.1.js"></script>
     <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Condensed" rel="stylesheet">
     <title>Attachments</title>

--- a/extensions/amp-story-page-attachment/0.1/amp-story-open-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/amp-story-open-page-attachment.js
@@ -102,9 +102,14 @@ const ctaLabelFromAttr = (element) =>
  * @return {!Promise<string>}
  */
 const openLabelOrFallback = (element, label) => {
+  // Disallow empty label
   if (label) {
-    return Promise.resolve(label.trim());
+    const trimmedLabel = label.trim();
+    if (trimmedLabel) {
+      return Promise.resolve(trimmedLabel);
+    }
   }
+
   const localizationService = Services.localizationForDoc(element);
   return localizationService.getLocalizedStringAsync(
     LocalizedStringId_Enum.AMP_STORY_PAGE_ATTACHMENT_OPEN_LABEL

--- a/extensions/amp-story-page-attachment/0.1/test/test-amp-story-open-page-attachment.js
+++ b/extensions/amp-story-page-attachment/0.1/test/test-amp-story-open-page-attachment.js
@@ -211,6 +211,19 @@ describes.realWin(
       expect(openAttachmentLabelEl.textContent).to.equal('Custom text');
     });
 
+    it('should build the open attachment UI with default text if the custom text is empty', async () => {
+      attachmentEl.setAttribute('layout', 'nodisplay');
+      attachmentEl.setAttribute('cta-text', ' ');
+
+      await attachment.buildCallback();
+      await attachment.layoutCallback();
+
+      const openAttachmentLabelEl = page.querySelector(
+        '.i-amphtml-story-page-attachment-label'
+      );
+      expect(openAttachmentLabelEl.textContent).to.equal('Swipe up');
+    });
+
     it('should use the correct outlink text', async () => {
       const firstPage = win.document.createElement('amp-story-page');
       storyEl.insertBefore(firstPage, page);


### PR DESCRIPTION
Also manually add page-attachment script to the template htmls, which is to avoid the script installation errors that only happen in local dev environment.

Context: #39299