### PR TITLE
❄️ Disable flaky tests `BentoDatePicker preact`

### DIFF
--- a/extensions/amp-date-picker/1.0/test/test-component.js
+++ b/extensions/amp-date-picker/1.0/test/test-component.js
@@ -31,7 +31,8 @@ function DatePicker(props) {
   return <BentoDatePicker {...combinedProps}></BentoDatePicker>;
 }
 
-describes.sandboxed('BentoDatePicker preact component v1.0', {}, (env) => {
+// TODO(wg-components): either fix or remove these tests.
+describes.sandboxed.skip('BentoDatePicker preact component v1.0', {}, (env) => {
   it('should render', () => {
     const wrapper = mount(<DatePicker />);
 


### PR DESCRIPTION
These tests are flaky (and probably can be removed given that we don't build Bento components anymore) and prevent renovatebot's PR #37042 from passing CI