### PR TITLE
Fix variable decalaration bug

### DIFF
--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -96,10 +96,7 @@ class AmpWorker {
     };
 
     if (self.trustedTypes && self.trustedTypes.createPolicy) {
-      const policy = self.trustedTypes.createPolicy(
-        'amp-worker#fetchUrl',
-        policy
-      );
+      policy = self.trustedTypes.createPolicy('amp-worker#fetchUrl', policy);
     }
 
     url = policy

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -75,7 +75,7 @@ class AmpWorker {
 
     let url = '';
 
-    const policy = {
+    let policy = {
       createScriptURL: function (url) {
         // Only allow the correct webworker url to pass through
         const regexURL =


### PR DESCRIPTION
This causes a "Cannot access 'policy' before initialization bug in modern JS syntax. This does not break with `var` because of function scoping.

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
