### PR TITLE
✨ [Snowplow]: Add optional capability to track consent context

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -1682,7 +1682,7 @@ For complete documentation and additional examples please see: https://marketing
   {
     "vars": {
       "collectorHost": "collector.snplow.net",
-      "appId": "amp-examples-v2.1.0",
+      "appId": "amp-examples-v2.2.0",
       "userId": "someUserId",
       "nameTracker": "testName",
       "customContexts":  "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/gdpr/jsonschema/1-0-0\",\"data\":{\"basisForProcessing\":\"legitimate_interests\"}}"

--- a/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
+++ b/extensions/amp-analytics/0.1/vendors/snowplow_v2.json
@@ -17,15 +17,16 @@
     }
   },
   "vars": {
-    "trackerVersion": "amp-1.1.0",
+    "trackerVersion": "amp-1.2.0",
     "ampVistorId": "CLIENT_ID(_sp_ampid)",
     "duid": "$IF($SUBSTR(QUERY_PARAM(_sp),0,36), $SUBSTR(QUERY_PARAM(_sp),0,36), $IF(LINKER_PARAM(sp_amp_linker,_sp_duid), LINKER_PARAM(sp_amp_linker,_sp_duid), COOKIE(_sp_duid)))",
     "nullString": "null",
+    "consentContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_consent/jsonschema/1-0-0\",\"data\":{\"consentState\":\"${consentState}\",\"gdprApplies\": $IF($CONSENT_METADATA(gdprApplies), true, false),\"consentType\": \"$CONSENT_METADATA(consentStringType)\",\"purposeOne\":$IF($CONSENT_METADATA(purposeOne), true, false)}}",
     "customEventTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:${customEventSchemaVendor}/${customEventSchemaName}/jsonschema/${customEventSchemaVersion}\",\"data\":${customEventSchemaData}}}",
     "sessionContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_session/jsonschema/1-0-0\",\"data\":{\"ampSessionId\":${sessionId},\"ampSessionIndex\":${sessionCount},\"sessionEngaged\":$IF(${sessionEngaged}, true, false),\"sessionCreationTimestamp\":${sessionTimestamp}$IF(${sessionEventTimestamp},`,\"lastSessionEventTimestamp\":${sessionEventTimestamp}`)}}",
     "idContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0\",\"data\":{\"ampClientId\":\"${ampVistorId}\",\"domainUserid\":\"${duid}\",\"userId\":\"${userId}\"}}",
     "webPageContext": "{\"schema\":\"iglu:dev.amp.snowplow/amp_web_page/jsonschema/1-0-0\",\"data\":{\"ampPageViewId\":\"PAGE_VIEW_ID_64\"}}",
-    "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[${idContext},${sessionContext},$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",
+    "contextsHead": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0\",\"data\":[${idContext},${sessionContext}$IF(${trackConsent},`,${consentContext}`),$REPLACE(`${customContexts}`, `^,*(.+?),*$`, `$1,`)",
     "contextsTail": "${webPageContext}]}",
     "ampPagePingTemplate": "{\"schema\":\"iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0\",\"data\":{\"schema\":\"iglu:dev.amp.snowplow/amp_page_ping/jsonschema/1-0-0\",\"data\":{\"scrollLeft\":${scrollLeft},\"scrollWidth\":${scrollWidth},\"viewportWidth\":${viewportWidth},\"scrollTop\":${scrollTop},\"scrollHeight\":${scrollHeight},\"viewportHeight\":${viewportHeight},\"totalEngagedTime\":${totalEngagedTime}}}}"
   },


### PR DESCRIPTION
- Add an optional capability to collect a consent context on the AMP tracker. The context is controlled by the truthiness/existence of a `trackConsent` variable in the `vars` object.
- Update to new version

Draft mode until https://github.com/snowplow/iglu-central/pull/1329 is released.

cc @alanorozco _(as was involved in the previous PR)_