### PR TITLE
✨ I2I: <amp-consent> Allow receiving TCF 2.2 consent string via TCF postmessage API (new TCF policy version support)

### DIFF
--- a/extensions/amp-consent/0.1/consent-info.js
+++ b/extensions/amp-consent/0.1/consent-info.js
@@ -9,22 +9,24 @@ const TAG = 'amp-consent';
 
 /**
  * Key values for retriving/storing consent info object.
- * STATE: Set when user accept or reject consent.
+ * VERSION: Set when a consent string is provided to store its version.
  * STRING: Set when a consent string is used to store more granular consent info
  * on vendors.
+ * STATE: Set when user accept or reject consent.
+ * PURPOSE_CONSENTS: Set when consents for purposes are passed in for client side
+ * granular consent. Only values ACCEPT and REJECT signals are stored.
  * METADATA: Set when consent metadata is passed in to store more granular consent info
  * on vendors.
  * DITRYBIT: Set when the stored consent info need to be revoked next time.
- * PURPOSE_CONSENTS: Set when consents for purposes are passed in for client side
- * granular consent. Only values ACCEPT and REJECT signals are stored.
  * @enum {string}
  */
 export const STORAGE_KEY = {
-  STATE: 's',
+  VERSION: 'e',
   STRING: 'r',
-  IS_DIRTY: 'd',
-  METADATA: 'm',
+  STATE: 's',
   PURPOSE_CONSENTS: 'pc',
+  METADATA: 'm',
+  IS_DIRTY: 'd',
 };
 
 /**
@@ -81,6 +83,7 @@ export const TCF_POST_MESSAGE_API_COMMANDS = {
  *  consentMetadata: (ConsentMetadataDef|undefined),
  *  purposeConsents: ({[key: string]: PURPOSE_CONSENT_STATE}|undefined),
  *  isDirty: (boolean|undefined),
+ *  tcfPolicyVersion: (number|undefined),
  * }}
  */
 export let ConsentInfoDef;
@@ -119,7 +122,8 @@ export function getStoredConsentInfo(value) {
     value[STORAGE_KEY.STRING],
     convertStorageMetadata(value[STORAGE_KEY.METADATA]),
     value[STORAGE_KEY.PURPOSE_CONSENTS],
-    value[STORAGE_KEY.IS_DIRTY] && value[STORAGE_KEY.IS_DIRTY] === 1
+    value[STORAGE_KEY.IS_DIRTY] && value[STORAGE_KEY.IS_DIRTY] === 1,
+    value[STORAGE_KEY.VERSION]
   );
 }
 
@@ -178,6 +182,10 @@ export function composeStoreValue(consentInfo) {
 
   if (consentInfo['consentString']) {
     obj[STORAGE_KEY.STRING] = consentInfo['consentString'];
+  }
+
+  if (consentInfo['tcfPolicyVersion']) {
+    obj[STORAGE_KEY.VERSION] = consentInfo['tcfPolicyVersion'];
   }
 
   if (consentInfo['isDirty'] === true) {
@@ -248,12 +256,15 @@ export function isConsentInfoStoredValueSame(infoA, infoB, opt_isDirty) {
       infoA['purposeConsents'],
       infoB['purposeConsents']
     );
+    const tcfPolicyVersionEqual =
+      infoA['tcfPolicyVersion'] == infoB['tcfPolicyVersion'];
     return (
       stateEqual &&
       stringEqual &&
       metadataEqual &&
       purposeConsentsEqual &&
-      isDirtyEqual
+      isDirtyEqual &&
+      tcfPolicyVersionEqual
     );
   }
   return false;
@@ -277,6 +288,7 @@ function getLegacyStoredConsentInfo(value) {
  * @param {ConsentMetadataDef=} opt_consentMetadata
  * @param {{[key: string]: PURPOSE_CONSENT_STATE}=} opt_purposeConsents
  * @param {boolean=} opt_isDirty
+ * @param {number=} opt_tcfPolicyVersion
  * @return {!ConsentInfoDef}
  */
 export function constructConsentInfo(
@@ -284,7 +296,8 @@ export function constructConsentInfo(
   opt_consentString,
   opt_consentMetadata,
   opt_purposeConsents,
-  opt_isDirty
+  opt_isDirty,
+  opt_tcfPolicyVersion
 ) {
   return {
     'consentState': consentState,
@@ -292,6 +305,7 @@ export function constructConsentInfo(
     'consentMetadata': opt_consentMetadata,
     'purposeConsents': opt_purposeConsents,
     'isDirty': opt_isDirty,
+    'tcfPolicyVersion': opt_tcfPolicyVersion,
   };
 }
 

--- a/extensions/amp-consent/0.1/consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/consent-policy-manager.js
@@ -68,6 +68,9 @@ export class ConsentPolicyManager {
     /** @private {?string} */
     this.consentString_ = null;
 
+    /** @private {?number} */
+    this.tcfPolicyVersion_ = null;
+
     /** @private {?Object|undefined} */
     this.consentMetadata_ = null;
 
@@ -179,15 +182,18 @@ export class ConsentPolicyManager {
   consentStateChangeHandler_(info) {
     const state = info['consentState'];
     const consentStr = info['consentString'];
+    const tcfPolicyVersion = info['tcfPolicyVersion'];
     const consentMetadata = info['consentMetadata'];
     const purposeConsents = info['purposeConsents'];
     const {
       consentMetadata_: prevConsentMetadata,
       consentString_: prevConsentStr,
       purposeConsents_: prevPurposeConsents,
+      tcfPolicyVersion_: prevTCFPolicyVersion,
     } = this;
 
     this.consentString_ = consentStr;
+    this.tcfPolicyVersion_ = tcfPolicyVersion;
     this.consentMetadata_ = consentMetadata;
     this.purposeConsents_ = purposeConsents;
     if (state === CONSENT_ITEM_STATE.UNKNOWN) {
@@ -210,6 +216,7 @@ export class ConsentPolicyManager {
       }
       // None of the supplementary consent data changes with dismiss action
       this.consentString_ = prevConsentStr;
+      this.tcfPolicyVersion_ = prevTCFPolicyVersion;
       this.consentMetadata_ = prevConsentMetadata;
       this.purposeConsents_ = prevPurposeConsents;
     } else {
@@ -302,6 +309,18 @@ export class ConsentPolicyManager {
   getConsentStringInfo(policyId) {
     return this.whenPolicyResolved(policyId).then(() => {
       return this.consentString_;
+    });
+  }
+
+  /**
+   * Get the tcf policy version of a policy. Return a promise that resolves
+   * when the policy resolves.
+   * @param {string} policyId
+   * @return {!Promise<?number>}
+   */
+  getTcfPolicyVersion(policyId) {
+    return this.whenPolicyResolved(policyId).then(() => {
+      return this.tcfPolicyVersion_;
     });
   }
 

--- a/extensions/amp-consent/0.1/consent-state-manager.js
+++ b/extensions/amp-consent/0.1/consent-state-manager.js
@@ -110,8 +110,14 @@ export class ConsentStateManager {
    * @param {CONSENT_ITEM_STATE} state
    * @param {string=} consentStr
    * @param {ConsentMetadataDef=} opt_consentMetadata
+   * @param {number=} opt_tcfPolicyVersion
    */
-  updateConsentInstanceState(state, consentStr, opt_consentMetadata) {
+  updateConsentInstanceState(
+    state,
+    consentStr,
+    opt_consentMetadata,
+    opt_tcfPolicyVersion
+  ) {
     if (!this.instance_) {
       dev().error(TAG, 'instance not registered');
       return;
@@ -121,7 +127,8 @@ export class ConsentStateManager {
       consentStr,
       this.purposeConsents_,
       opt_consentMetadata,
-      false
+      false,
+      opt_tcfPolicyVersion
     );
 
     if (this.consentChangeHandler_) {
@@ -130,7 +137,9 @@ export class ConsentStateManager {
           state,
           consentStr,
           opt_consentMetadata,
-          this.purposeConsents_
+          this.purposeConsents_,
+          undefined,
+          opt_tcfPolicyVersion
         )
       );
       // Need to be called after handler.
@@ -360,13 +369,15 @@ export class ConsentInstance {
    * @param {{[key: string]: PURPOSE_CONSENT_STATE}=} purposeConsents
    * @param {ConsentMetadataDef=} opt_consentMetadata
    * @param {boolean=} opt_systemUpdate
+   * @param {number=} opt_tcfPolicyVersion
    */
   update(
     state,
     consentString,
     purposeConsents,
     opt_consentMetadata,
-    opt_systemUpdate
+    opt_systemUpdate,
+    opt_tcfPolicyVersion
   ) {
     const localState =
       this.localConsentInfo_ && this.localConsentInfo_['consentState'];
@@ -379,7 +390,9 @@ export class ConsentInstance {
         calculatedState,
         this.localConsentInfo_?.consentString,
         this.localConsentInfo_?.consentMetadata,
-        this.localConsentInfo_?.purposeConsents
+        this.localConsentInfo_?.purposeConsents,
+        undefined,
+        this.localConsentInfo_?.tcfPolicyVersion
       );
       return;
     }
@@ -393,7 +406,8 @@ export class ConsentInstance {
         consentString,
         opt_consentMetadata,
         purposeConsents,
-        true
+        true,
+        opt_tcfPolicyVersion
       );
     } else {
       // Any user update makes the current state valid, thus remove dirtyBit
@@ -402,7 +416,9 @@ export class ConsentInstance {
         calculatedState,
         consentString,
         opt_consentMetadata,
-        purposeConsents
+        purposeConsents,
+        undefined,
+        opt_tcfPolicyVersion
       );
     }
 
@@ -411,7 +427,8 @@ export class ConsentInstance {
       consentString,
       opt_consentMetadata,
       purposeConsents,
-      this.hasDirtyBitNext_
+      this.hasDirtyBitNext_,
+      opt_tcfPolicyVersion
     );
 
     if (isConsentInfoStoredValueSame(newConsentInfo, this.savedConsentInfo_)) {
@@ -543,6 +560,9 @@ export class ConsentInstance {
       }
       if (consentInfo['purposeConsents']) {
         request['purposeConsents'] = consentInfo['purposeConsents'];
+      }
+      if (consentInfo['tcfPolicyVersion']) {
+        request['tcfPolicyVersion'] = consentInfo['tcfPolicyVersion'];
       }
       const init = {
         credentials: 'include',

--- a/extensions/amp-consent/0.1/consent-ui.js
+++ b/extensions/amp-consent/0.1/consent-ui.js
@@ -570,6 +570,7 @@ export class ConsentUI {
             'consentStateValue': getConsentStateValue(
               consentInfo['consentState']
             ),
+            'tcfPolicyVersion': consentInfo['tcfPolicyVersion'],
             'consentMetadata': consentInfo['consentMetadata'],
             'consentString': consentInfo['consentString'],
             'promptTrigger': this.isActionPromptTrigger_ ? 'action' : 'load',

--- a/extensions/amp-consent/0.1/tcf-api-command-manager.js
+++ b/extensions/amp-consent/0.1/tcf-api-command-manager.js
@@ -31,7 +31,9 @@ export let MinimalTcData;
 export let MinimalPingReturn;
 
 const TAG = 'amp-consent';
-const TCF_POLICY_VERSION = 2;
+//TODO: TCF_POLICY_VERSION_FALLBACK could be deleted after the full transition to the TCF v2.2
+const TCF_POLICY_VERSION_FALLBACK = 2;
+const TCF_API_VERSION = 2;
 const CMP_STATUS = 'loaded';
 const CMP_LOADED = true;
 const EVENT_STATUS = 'tcloaded';
@@ -153,7 +155,8 @@ export class TcfApiCommandManager {
           consentPromises[0],
           consentPromises[1],
           newTcString,
-          listenerId
+          listenerId,
+          consentPromises[3]
         );
 
         this.sendTcfApiReturn_(win, returnValue, callId, true);
@@ -171,11 +174,14 @@ export class TcfApiCommandManager {
       this.policyManager_.getConsentMetadataInfo('default');
     const sharedDataPromise =
       this.policyManager_.getMergedSharedData('default');
+    const tcfPolicyVersionPromise =
+      this.policyManager_.getTcfPolicyVersion('default');
 
     return Promise.all([
       metadataPromise,
       sharedDataPromise,
       consentStringInfoPromise,
+      tcfPolicyVersionPromise,
     ]);
   }
 
@@ -187,7 +193,13 @@ export class TcfApiCommandManager {
    */
   handleGetTcData_(payload, win) {
     this.getTcDataPromises_().then((arr) => {
-      const returnValue = this.getMinimalTcData_(arr[0], arr[1], arr[2]);
+      const returnValue = this.getMinimalTcData_(
+        arr[0],
+        arr[1],
+        arr[2],
+        undefined,
+        arr[3]
+      );
       const {callId} = payload;
 
       this.sendTcfApiReturn_(win, returnValue, callId, true);
@@ -201,9 +213,16 @@ export class TcfApiCommandManager {
    * @param {?Object} sharedData
    * @param {?string} tcString
    * @param {number=} opt_listenerId
+   * @param {number=} opt_tcfPolicyVersion
    * @return {!MinimalTcData} policyManager
    */
-  getMinimalTcData_(metadata, sharedData, tcString, opt_listenerId) {
+  getMinimalTcData_(
+    metadata,
+    sharedData,
+    tcString,
+    opt_listenerId,
+    opt_tcfPolicyVersion
+  ) {
     const purposeOneTreatment = metadata ? metadata['purposeOne'] : undefined;
     const gdprApplies = metadata ? metadata['gdprApplies'] : undefined;
     const additionalConsent = metadata
@@ -212,7 +231,10 @@ export class TcfApiCommandManager {
     const additionalData = {...sharedData, additionalConsent};
 
     return {
-      tcfPolicyVersion: TCF_POLICY_VERSION,
+      tcfPolicyVersion:
+        typeof opt_tcfPolicyVersion == 'number'
+          ? opt_tcfPolicyVersion
+          : TCF_POLICY_VERSION_FALLBACK,
       gdprApplies,
       tcString,
       listenerId: opt_listenerId,
@@ -249,7 +271,7 @@ export class TcfApiCommandManager {
       gdprApplies,
       cmpLoaded: CMP_LOADED,
       cmpStatus: CMP_STATUS,
-      tcfPolicyVersion: TCF_POLICY_VERSION,
+      tcfPolicyVersion: TCF_POLICY_VERSION_FALLBACK,
     };
   }
 
@@ -302,7 +324,7 @@ export class TcfApiCommandManager {
       );
       return false;
     }
-    if (version !== 2) {
+    if (version != TCF_API_VERSION) {
       user().error(TAG, `Found incorrect version in "tcfapiCall": ${version}`);
       return false;
     }
@@ -323,10 +345,23 @@ export class TcfApiCommandManager {
    * @param {?Object} sharedData
    * @param {?string} tcString
    * @param {number=} listenerId
+   * @param {number=} tcfPolicyVersion
    * @return {!MinimalPingReturn}
    * @visibleForTesting
    */
-  getMinimalTcDataForTesting(metadata, sharedData, tcString, listenerId) {
-    return this.getMinimalTcData_(metadata, sharedData, tcString, listenerId);
+  getMinimalTcDataForTesting(
+    metadata,
+    sharedData,
+    tcString,
+    listenerId,
+    tcfPolicyVersion
+  ) {
+    return this.getMinimalTcData_(
+      metadata,
+      sharedData,
+      tcString,
+      listenerId,
+      tcfPolicyVersion
+    );
   }
 }

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -470,6 +470,7 @@ describes.realWin(
               'abc': PURPOSE_CONSENT_STATE.ACCEPTED,
               'xyz': PURPOSE_CONSENT_STATE.REJECTED,
             },
+            'tcfPolicyVersion': undefined,
           });
         });
 
@@ -629,6 +630,7 @@ describes.realWin(
                   CONSENT_STRING_TYPE.TCF_V2,
                 [METADATA_STORAGE_KEY.ADDITIONAL_CONSENT]: '3~3.33.303',
               },
+              [STORAGE_KEY.VERSION]: 4,
             },
           };
           ampConsent = getAmpConsent(doc, inlineConfig);
@@ -653,6 +655,7 @@ describes.realWin(
               true
             ),
             'purposeConsents': undefined,
+            'tcfPolicyVersion': undefined,
           });
         });
 
@@ -717,6 +720,7 @@ describes.realWin(
                 [METADATA_STORAGE_KEY.CONSENT_STRING_TYPE]:
                   CONSENT_STRING_TYPE.TCF_V2,
               },
+              [STORAGE_KEY.VERSION]: 4,
             },
           };
           ampConsent = getAmpConsent(doc, inlineConfig);
@@ -736,6 +740,7 @@ describes.realWin(
             'isDirty': undefined,
             'consentMetadata': constructMetadata(CONSENT_STRING_TYPE.TCF_V2),
             'purposeConsents': undefined,
+            'tcfPolicyVersion': 4,
           });
         });
       });
@@ -785,6 +790,7 @@ describes.realWin(
             'isDirty': true,
             'consentMetadata': constructMetadata(CONSENT_STRING_TYPE.TCF_V2),
             'purposeConsents': {'abc': PURPOSE_CONSENT_STATE.ACCEPTED},
+            'tcfPolicyVersion': undefined,
           });
         });
 
@@ -822,8 +828,50 @@ describes.realWin(
             'isDirty': true,
             'consentMetadata': constructMetadata(CONSENT_STRING_TYPE.TCF_V2),
             'purposeConsents': undefined,
+            'tcfPolicyVersion': undefined,
           });
         });
+      });
+    });
+
+    describe('TCF Policy version', () => {
+      let ampConsent;
+
+      beforeEach(() => {
+        const defaultConfig = {
+          'consents': {
+            'ABC': {
+              'checkConsentHref': 'https://response1',
+            },
+          },
+        };
+        const consentElement = createConsentElement(doc, defaultConfig);
+        doc.body.appendChild(consentElement);
+        ampConsent = new AmpConsent(consentElement);
+      });
+
+      const invalidTCFPolicyVersionValues = [NaN, 2.2, 4.1, Infinity];
+
+      invalidTCFPolicyVersionValues.forEach((invalidTCFPolicyVersionValue) => {
+        it(
+          'should error and return undefined on invalid tcfPolicyVersion test with: ' +
+            invalidTCFPolicyVersionValue,
+          () => {
+            const spy = env.sandbox.stub(user(), 'error');
+            const tcfPolicyVersion = ampConsent.validateTCFPolicyVersion_(
+              invalidTCFPolicyVersionValue
+            );
+            expect(spy.args[0][1]).to.match(
+              /CMP tcfPolicyVersion must be a valid number \(integer\)\./
+            );
+            expect(tcfPolicyVersion).to.be.equal(undefined);
+          }
+        );
+      });
+
+      it('should return the value on invalid tcfPolicyVersion test', () => {
+        const tcfPolicyVersion = ampConsent.validateTCFPolicyVersion_(4);
+        expect(tcfPolicyVersion).to.be.equal(4);
       });
     });
 

--- a/extensions/amp-consent/0.1/test/test-consent-info.js
+++ b/extensions/amp-consent/0.1/test/test-consent-info.js
@@ -23,6 +23,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'consentMetadata': undefined,
         'purposeConsents': undefined,
         'isDirty': undefined,
+        'tcfPolicyVersion': undefined,
       });
     });
 
@@ -33,6 +34,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'consentMetadata': undefined,
         'purposeConsents': undefined,
         'isDirty': undefined,
+        'tcfPolicyVersion': undefined,
       });
       expect(getStoredConsentInfo(false)).to.deep.equal({
         'consentState': CONSENT_ITEM_STATE.REJECTED,
@@ -40,6 +42,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'consentMetadata': undefined,
         'purposeConsents': undefined,
         'isDirty': undefined,
+        'tcfPolicyVersion': undefined,
       });
     });
 
@@ -54,11 +57,13 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'consentMetadata': constructMetadata(),
         'purposeConsents': undefined,
         'isDirty': undefined,
+        'tcfPolicyVersion': undefined,
       });
       expect(
         getStoredConsentInfo({
           's': 0,
           'r': 'test',
+          'e': 4,
         })
       ).to.deep.equal({
         'consentState': CONSENT_ITEM_STATE.REJECTED,
@@ -66,6 +71,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'consentMetadata': constructMetadata(),
         'purposeConsents': undefined,
         'isDirty': undefined,
+        'tcfPolicyVersion': 4,
       });
       expect(
         getStoredConsentInfo({
@@ -79,11 +85,13 @@ describes.fakeWin('ConsentInfo', {}, () => {
         'isDirty': undefined,
         'purposeConsents': undefined,
         'consentMetadata': constructMetadata(),
+        'tcfPolicyVersion': undefined,
       });
       expect(
         getStoredConsentInfo({
           's': 0,
           'r': 'test',
+          'e': 4,
           'm': {
             [METADATA_STORAGE_KEY.CONSENT_STRING_TYPE]:
               CONSENT_STRING_TYPE.TCF_V2,
@@ -101,6 +109,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
           '1~1.35.41.101',
           false
         ),
+        'tcfPolicyVersion': 4,
       });
       expect(
         getStoredConsentInfo({
@@ -122,6 +131,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
           CONSENT_STRING_TYPE.TCF_V2,
           '1~1.35.41.101'
         ),
+        'tcfPolicyVersion': undefined,
       });
       expect(
         getStoredConsentInfo({
@@ -142,6 +152,7 @@ describes.fakeWin('ConsentInfo', {}, () => {
           'xyz': PURPOSE_CONSENT_STATE.REJECTED,
         },
         'consentMetadata': constructMetadata(),
+        'tcfPolicyVersion': undefined,
       });
     });
 
@@ -284,6 +295,19 @@ describes.fakeWin('ConsentInfo', {}, () => {
       );
       expect(composeStoreValue(consentInfo)).to.deep.equal({
         's': 0,
+        'r': 'test',
+        'd': 1,
+        'm': {
+          [METADATA_STORAGE_KEY.CONSENT_STRING_TYPE]:
+            CONSENT_STRING_TYPE.TCF_V1,
+          [METADATA_STORAGE_KEY.ADDITIONAL_CONSENT]: '1~1.35.41.101',
+          [METADATA_STORAGE_KEY.GDPR_APPLIES]: false,
+        },
+      });
+      consentInfo['tcfPolicyVersion'] = 4;
+      expect(composeStoreValue(consentInfo)).to.deep.equal({
+        's': 0,
+        'e': 4,
         'r': 'test',
         'd': 1,
         'm': {

--- a/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-policy-manager.js
@@ -639,6 +639,40 @@ describes.realWin(
       });
     });
 
+    describe('getTcfPolicyVersion', () => {
+      let manager;
+
+      beforeEach(() => {
+        manager = new ConsentPolicyManager(ampdoc);
+        manager.setLegacyConsentInstanceId('ABC');
+        env.sandbox
+          .stub(ConsentPolicyInstance.prototype, 'getReadyPromise')
+          .callsFake(() => {
+            return Promise.resolve();
+          });
+        consentInfo = constructConsentInfo(
+          CONSENT_ITEM_STATE.ACCEPTED,
+          'test',
+          undefined,
+          undefined,
+          undefined,
+          4
+        );
+      });
+
+      it('should return tcf policy version value from state manager', async () => {
+        manager.registerConsentPolicyInstance('default', {
+          'waitFor': {
+            'ABC': undefined,
+          },
+        });
+        await macroTask();
+        await expect(
+          manager.getTcfPolicyVersion('default')
+        ).to.eventually.be.equal(4);
+      });
+    });
+
     describe('getConsentMetadataInfo', () => {
       let manager;
 

--- a/extensions/amp-consent/0.1/test/test-consent-state-manager.js
+++ b/extensions/amp-consent/0.1/test/test-consent-state-manager.js
@@ -606,7 +606,9 @@ describes.realWin('ConsentStateManager', {amp: 1}, (env) => {
           constructMetadata(
             CONSENT_STRING_TYPE.US_PRIVACY_STRING,
             '3~3.33.33.303'
-          )
+          ),
+          undefined,
+          4
         );
         await macroTask();
         expect(requestSpy).to.be.calledTwice;
@@ -622,6 +624,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, (env) => {
             '3~3.33.33.303'
           )
         );
+        expect(requestBody.tcfPolicyVersion).to.equal(4);
       });
 
       it('support onUpdateHref expansion', function* () {
@@ -666,7 +669,7 @@ describes.realWin('ConsentStateManager', {amp: 1}, (env) => {
         expect(requestBody.consentString).to.undefined;
       });
 
-      it('send update request on local stroage removal', async () => {
+      it('send update request on local storage removal', async () => {
         const testConsentInfo = constructConsentInfo(
           CONSENT_ITEM_STATE.ACCEPTED,
           'test',

--- a/extensions/amp-consent/0.1/test/test-tcf-api-command-manager.js
+++ b/extensions/amp-consent/0.1/test/test-tcf-api-command-manager.js
@@ -119,12 +119,12 @@ describes.realWin(
           mockMetadata = getMetadata(false);
           tcfApiCommandManager = new TcfApiCommandManager(mockPolicyManager);
           expect(
-            tcfApiCommandManager.getMinimalPingReturnForTesting(mockMetadata)
+            tcfApiCommandManager.getMinimalPingReturnForTesting(mockMetadata, 4)
           ).to.deep.equals({
             gdprApplies: false,
             cmpLoaded: true,
             cmpStatus: 'loaded',
-            tcfPolicyVersion: 2,
+            tcfPolicyVersion: 4,
           });
         });
 

--- a/extensions/amp-consent/0.1/test/test-tcf-api-command-manager.js
+++ b/extensions/amp-consent/0.1/test/test-tcf-api-command-manager.js
@@ -22,6 +22,7 @@ describes.realWin(
       let msg;
       let tcfApiCommandManager;
       let mockTcString;
+      let mockTcfPolicyVersion;
       let mockSharedData;
       let callId;
 
@@ -31,6 +32,7 @@ describes.realWin(
         mockMetadata = {};
         mockSharedData = {};
         mockTcString = '';
+        mockTcfPolicyVersion = null;
         mockPolicyManager = {
           getConsentMetadataInfo: (opt_policy) => {
             return Promise.resolve(mockMetadata);
@@ -40,6 +42,9 @@ describes.realWin(
           },
           getMergedSharedData: (opt_policy) => {
             return Promise.resolve(mockSharedData);
+          },
+          getTcfPolicyVersion: (opt_policy) => {
+            return Promise.resolve(mockTcfPolicyVersion);
           },
           setOnPolicyChange: env.sandbox.spy(),
         };
@@ -189,16 +194,19 @@ describes.realWin(
           });
 
           mockTcString = 'abc123';
+          mockTcfPolicyVersion = 4;
           mockSharedData = {'data': 'data1'};
 
           expect(
             tcfApiCommandManager.getMinimalTcDataForTesting(
               mockMetadata,
               mockSharedData,
-              mockTcString
+              mockTcString,
+              undefined,
+              mockTcfPolicyVersion
             )
           ).to.deep.equals({
-            tcfPolicyVersion: 2,
+            tcfPolicyVersion: mockTcfPolicyVersion,
             gdprApplies: false,
             tcString: mockTcString,
             listenerId: undefined,
@@ -209,11 +217,40 @@ describes.realWin(
           });
         });
 
+        it('sends a minimal TcData via PostMessage without tcfPolicyVersion stored - fallback to tcfPolicyVersion 2', async () => {
+          callId = 'getTcDataId';
+          data = getData('getTCData', callId);
+          mockMetadata = getMetadata(false, 'xyz987', false);
+          mockTcString = 'abc123';
+          mockSharedData = {'data': 'data1'};
+          tcfApiCommandManager = new TcfApiCommandManager(mockPolicyManager);
+          tcfApiCommandManager.handleTcfCommand(data, mockWin);
+          await macroTask();
+
+          const postMessageArgs = mockWin.postMessage.args[0];
+          const tcfApiReturn = getTcfApiReturn(
+            callId,
+            tcfApiCommandManager.getMinimalTcDataForTesting(
+              mockMetadata,
+              mockSharedData,
+              mockTcString
+            ),
+            true
+          );
+          expect(
+            postMessageArgs[0]['__tcfapiReturn']['returnValue'][
+              'tcfPolicyVersion'
+            ]
+          ).to.be.equal(2);
+          expect(postMessageArgs[0]).to.deep.equals(tcfApiReturn);
+        });
+
         it('sends a minimal TcData via PostMessage', async () => {
           callId = 'getTcDataId';
           data = getData('getTCData', callId);
           mockMetadata = getMetadata(false, 'xyz987', false);
           mockTcString = 'abc123';
+          mockTcfPolicyVersion = 4;
           mockSharedData = {'data': 'data1'};
           tcfApiCommandManager = new TcfApiCommandManager(mockPolicyManager);
           tcfApiCommandManager.handleTcfCommand(data, mockWin);
@@ -226,7 +263,9 @@ describes.realWin(
               tcfApiCommandManager.getMinimalTcDataForTesting(
                 mockMetadata,
                 mockSharedData,
-                mockTcString
+                mockTcString,
+                undefined,
+                mockTcfPolicyVersion
               ),
               true
             )

--- a/extensions/amp-consent/amp-consent.md
+++ b/extensions/amp-consent/amp-consent.md
@@ -620,8 +620,12 @@ Yes. See example [here](https://amp.dev/documentation/examples/user-consent/geol
 
 ##### Does AMP support the IAB TCF?
 
-AMP supports popular transparency consent frameworks including the IAB TCF v1, TCF v2 and the IAB US Privacy String.
-Please check with your consent management platform (CMP) and ad networks on their AMP support. AMP will read and pass the strings passed by the frameworks (IAB TCF v1, TCF v2 and the IAB US Privacy String) when received by CMPs/ad networks.
+AMP supports popular transparency consent frameworks including the IAB TCF v1, TCF v2, TCF v2.2 and the IAB US Privacy String.
+Please check with your consent management platform (CMP) and ad networks on their AMP support. AMP will read and pass the strings passed by the frameworks (IAB TCF v1, TCF v2, TCF v2.2 and the IAB US Privacy String) when received by CMPs/ad networks.
+
+##### I have a CMP implemented with AMP but for TCF v2 what do I need to do to support TCF v2.2?
+
+For AMP integration, the only thing you need to do is provide the value of `tcfPolicyVersion` during the client-side `postMessage`, and in case you also use `checkConsentHref` you need to provide it in the response, and you can also update it directly from the response too via the `tcfPolicyVersion` field in the response from your server, this will allow you to update consents in case you have not added the tcfPolicyVersion field before the transaction to TCF v2.2.
 
 ##### I can't see feature X being supported, what can I do?
 

--- a/extensions/amp-consent/integrating-consent.md
+++ b/extensions/amp-consent/integrating-consent.md
@@ -95,6 +95,7 @@ window.parent.postMessage(
     action: 'accept',
     info: /string/ /* optional */,
     consentMetadata: /object/ /* optional */,
+    tcfPolicyVersion: /number/ /* optional (integer) - if not provided 2 is default */,
   },
   '*'
 );
@@ -111,6 +112,7 @@ window.parent.postMessage(
     action: 'reject',
     info: /string/ /* optional */,
     consentMetadata: /object/ /* optional */,
+    tcfPolicyVersion: /number/ /* optional (integer) - if not provided 2 is default */,
   },
   '*'
 );


### PR DESCRIPTION
The proposal is for the CMP to declare the tcf policy version (related to the GVL they are using).
to preserve the current behavior and as a fallback the tcf policy version will be 2. (As it's used in tcf v2.0). This will guarantee a free deploy of that thing in amp. And CMP can progressively update this without breaking changes.

closes #39410 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
