### PR TITLE
Allowlist localhost for amp-worker and extensions in localDev

### DIFF
--- a/src/service/extension-script.js
+++ b/src/service/extension-script.js
@@ -164,7 +164,8 @@ export function createExtensionScript(win, extensionId, version) {
       // Only allow trusted URLs
       if (
         regexURL.test(url) ||
-        (getMode().test && testRegexURL.test(new URL(url).hostname)) ||
+        ((getMode().test || getMode().localDev) &&
+          testRegexURL.test(new URL(url).hostname)) ||
         new URL(url).host === 'fonts.googleapis.com'
       ) {
         return url;

--- a/src/web-worker/amp-worker.js
+++ b/src/web-worker/amp-worker.js
@@ -82,7 +82,7 @@ class AmpWorker {
           /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org(\/.*)?$/;
 
         if (
-          (regexURL.test(url) || getMode().test) &&
+          (regexURL.test(url) || getMode().test || getMode().localDev) &&
           (url.endsWith('ww.js') ||
             url.endsWith('ww.min.js') ||
             url.endsWith('ww.mjs') ||


### PR DESCRIPTION
Found this issue while debugging https://github.com/ampproject/amphtml/issues/36253

In local dev configuration, amp-worker won't even work because the regex is stringent.