### PR TITLE
🐛 Set slide events to high trust so that it can trigger amp-state update

### DIFF
--- a/extensions/amp-carousel/0.1/slidescroll.js
+++ b/extensions/amp-carousel/0.1/slidescroll.js
@@ -400,7 +400,7 @@ export class AmpSlideScroll extends AMP.BaseElement {
         if (this.hasNativeSnapPoints_) {
           this.updateOnScroll_(currentScrollLeft, ActionTrust_Enum.LOW);
         } else {
-          this.customSnap_(currentScrollLeft, undefined, ActionTrust_Enum.LOW);
+          this.customSnap_(currentScrollLeft, undefined, ActionTrust_Enum.HIGH);
         }
       }, timeout)
     );


### PR DESCRIPTION
Fixes  https://github.com/ampproject/amphtml/issues/36253

Root cause is that touch events are HIGH trust, and scroll-caused transitions are LOW trust. This would change them to HIGH trust so that it is able to trigger amp-state update.