### PR TITLE
Remove privacy sandbox origin trial

### DIFF
--- a/ads/google/a4a/test/test-utils.js
+++ b/ads/google/a4a/test/test-utils.js
@@ -20,7 +20,6 @@ import {
   googleAdUrl,
   groupAmpAdsByType,
   maybeAppendErrorParameter,
-  maybeInsertOriginTrialToken,
   mergeExperimentIds,
 } from '#ads/google/a4a/utils';
 
@@ -1066,29 +1065,5 @@ describes.realWin('#groupAmpAdsByType', {amp: true}, (env) => {
           )
       );
     });
-  });
-});
-
-describes.realWin('maybeInsertOriginTrialToken', {}, (env) => {
-  let doc;
-  let win;
-  beforeEach(() => {
-    win = env.win;
-    doc = win.document;
-  });
-
-  it('should insert the token', () => {
-    expect(doc.querySelector('meta[http-equiv=origin-trial]')).to.not.exist;
-    maybeInsertOriginTrialToken(win);
-    expect(doc.querySelector('meta[http-equiv=origin-trial]')).to.exist;
-  });
-
-  it('should only insert the token once on multiple calls', () => {
-    maybeInsertOriginTrialToken(win);
-    maybeInsertOriginTrialToken(win);
-    maybeInsertOriginTrialToken(win);
-    expect(
-      doc.querySelectorAll('meta[http-equiv=origin-trial]').length
-    ).to.equal(1);
   });
 });

--- a/ads/google/a4a/utils.js
+++ b/ads/google/a4a/utils.js
@@ -1,4 +1,3 @@
-import {createElementWithAttributes} from '#core/dom';
 import {whenUpgradedToCustomElement} from '#core/dom/amp-element-helpers';
 import {DomFingerprint} from '#core/dom/fingerprint';
 import {getPageLayoutBoxBlocking} from '#core/dom/layout/page-layout-box';
@@ -99,26 +98,6 @@ export const TRUNCATION_PARAM = {name: 'trunc', value: '1'};
 /** @const {object} */
 const CDN_PROXY_REGEXP =
   /^https:\/\/([a-zA-Z0-9_-]+\.)?cdn\.ampproject\.org((\/.*)|($))+/;
-
-/** @const {string} */
-const TOKEN_VALUE_3P =
-  'A6WNTKQHktfckG5CFrBnDpo3z+BJBC5yt/DyQZMpawyLL5/vrGaDhna4gkc+aZ4bQ/zzE7lO357DTV7QtF96pgYAAACEeyJvcmlnaW4iOiJodHRwczovL2FtcHByb2plY3Qub3JnOjQ0MyIsImZlYXR1cmUiOiJQcml2YWN5U2FuZGJveEFkc0FQSXMiLCJleHBpcnkiOjE2OTUxNjc5OTksImlzU3ViZG9tYWluIjp0cnVlLCJpc1RoaXJkUGFydHkiOnRydWV9';
-
-/**
- * Inserts origin-trial token for `attribution-reporting` if not already
- * present in the DOM.
- * @param {!Window} win
- */
-export function maybeInsertOriginTrialToken(win) {
-  if (win.document.head.querySelector(`meta[content='${TOKEN_VALUE_3P}']`)) {
-    return;
-  }
-  const metaEl = createElementWithAttributes(win.document, 'meta', {
-    'http-equiv': 'origin-trial',
-    content: TOKEN_VALUE_3P,
-  });
-  win.document.head.appendChild(metaEl);
-}
 
 /**
  * Returns the value of some navigation timing parameter.

--- a/extensions/amp-a4a/0.1/secure-frame.js
+++ b/extensions/amp-a4a/0.1/secure-frame.js
@@ -27,9 +27,6 @@ const sandboxVals =
   'allow-scripts ' +
   'allow-top-navigation';
 
-const TOKEN_VALUE_1P =
-  'Akf/tuirtbNmVRwhMztVypuINFmk7s/DbLzDDhE/yJp/PJdlTchTrby3C2btx+7B9+Iw6LKILMZA7OL2/dL2KgIAAABweyJvcmlnaW4iOiJodHRwczovL2FtcHByb2plY3Qub3JnOjQ0MyIsImZlYXR1cmUiOiJQcml2YWN5U2FuZGJveEFkc0FQSXMiLCJleHBpcnkiOjE2OTUxNjc5OTksImlzU3ViZG9tYWluIjp0cnVlfQ==';
-
 /**
  * Create the starting html for all FIE ads. If streaming is supported body will be
  * piped in later.
@@ -55,7 +52,6 @@ export const createSecureDocSkeleton = (url, sanitizedHeadElements, body) =>
       default-src 'none';
       style-src ${fontProviderAllowList} 'unsafe-inline';
     ">
-    <meta http-equiv="origin-trial" content=${TOKEN_VALUE_1P}>
     ${sanitizedHeadElements}
   </head>
   <body>${body}</body>

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -24,7 +24,6 @@ import {
   isCdnProxy,
   isReportingEnabled,
   maybeAppendErrorParameter,
-  maybeInsertOriginTrialToken,
 } from '#ads/google/a4a/utils';
 
 import {
@@ -170,7 +169,6 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
   */
   buildCallback() {
     super.buildCallback();
-    maybeInsertOriginTrialToken(this.win);
 
     // Convert the full-width tag to container width for desktop users.
     if (

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -33,7 +33,6 @@ import {
   isCdnProxy,
   isReportingEnabled,
   maybeAppendErrorParameter,
-  maybeInsertOriginTrialToken,
   truncAndTimeUrl,
 } from '#ads/google/a4a/utils';
 import {getMultiSizeDimensions} from '#ads/google/utils';
@@ -566,7 +565,6 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
   buildCallback() {
     super.buildCallback();
     this.maybeDeprecationWarn_();
-    maybeInsertOriginTrialToken(this.win);
     this.setPageLevelExperiments(this.extractUrlExperimentId_());
     const pubEnabledSra = !!this.win.document.querySelector(
       'meta[name=amp-ad-doubleclick-sra]'

--- a/src/inabox/amp-inabox.js
+++ b/src/inabox/amp-inabox.js
@@ -3,7 +3,6 @@
  */
 
 import '#polyfills';
-import {maybeInsertOriginTrialToken} from '#ads/google/a4a/utils';
 
 import {TickLabel_Enum} from '#core/constants/enums';
 import * as mode from '#core/mode';
@@ -102,7 +101,6 @@ startupChunk(self.document, function initial() {
         self.document,
         function final() {
           Navigation.installAnchorClickInterceptor(ampdoc, self);
-          maybeInsertOriginTrialToken(self);
           maybeRenderInaboxAsStoryAd(ampdoc);
           maybeValidate(self);
           makeBodyVisible(self.document);


### PR DESCRIPTION
Chrome has removed the origin trial token requirement for enabling privacy sandbox, therefore it won't be necessary to send these token any more.