### PR TITLE
⏪ Temporarily pin Node to v18.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ commands:
   setup_node_environment:
     steps:
       - node/install:
-          node-version: 'lts'
+          node-version: '18.17.1'
       - node/install-packages:
           with-cache: false
   setup_vm:


### PR DESCRIPTION
Node v18.18.0 broke the build, while we investigate a fix this PR pins Node.JS to the last version that this repo works with

* [Last passing build on main](https://app.circleci.com/pipelines/github/ampproject/amphtml/29172/workflows/77e14143-a503-4bdb-baec-5876506ad33f), when `nvm install --lts` installed v18.17.1
* [First failing build on main](https://app.circleci.com/pipelines/github/ampproject/amphtml/29178/workflows/9a7a34c2-c4d1-407a-89a5-d023c52263e2), when `nvm install --lts` installed v18.18.0