### PR TITLE
🐛 amp-analytics failing in some cases when using amp shadow

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-transport.js
+++ b/extensions/amp-analytics/0.1/test/test-transport.js
@@ -40,6 +40,8 @@ describes.realWin(
       sendXhrStub = env.sandbox.stub();
       sendBeaconStub = env.sandbox.stub();
 
+      env.sandbox.spy(Services, 'urlReplacementsForDoc');
+
       // Needed for PreconnectService.
       installDocService(win, true);
     });
@@ -578,6 +580,7 @@ describes.realWin(
 
     function expectImagePixel(url, referrerPolicy, attributionSrc) {
       imagePixelVerifier.verifyRequest(url, referrerPolicy, attributionSrc);
+      expect(Services.urlReplacementsForDoc).to.be.calledWith(ampdoc);
     }
 
     function expectNoImagePixel() {

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -141,7 +141,8 @@ export class Transport {
         getRequest(false),
         suppressWarnings,
         /** @type {string|undefined} */ (this.referrerPolicy_),
-        /** @type {string|undefined} */ (this.attributionSrc_)
+        /** @type {string|undefined} */ (this.attributionSrc_),
+        this.ampdoc_
       );
       return;
     }
@@ -248,18 +249,27 @@ export class Transport {
    * @param {boolean} suppressWarnings
    * @param {string|undefined} referrerPolicy
    * @param {string|undefined} attributionSrc
+   * @param {(Element|./service/ampdoc-impl.AmpDoc)=} opt_elementOrAmpDoc Whether services are provided by an
+   *     element.
    */
   static sendRequestUsingImage(
     win,
     request,
     suppressWarnings,
     referrerPolicy,
-    attributionSrc
+    attributionSrc,
+    opt_elementOrAmpDoc
   ) {
     if (!win) {
       return;
     }
-    const image = createPixel(win, request.url, referrerPolicy, attributionSrc);
+    const image = createPixel(
+      win,
+      request.url,
+      referrerPolicy,
+      attributionSrc,
+      opt_elementOrAmpDoc
+    );
     loadPromise(image)
       .then(() => {
         dev().fine(TAG_, 'Sent image request', request.url);

--- a/extensions/amp-analytics/0.1/transport.js
+++ b/extensions/amp-analytics/0.1/transport.js
@@ -249,7 +249,7 @@ export class Transport {
    * @param {boolean} suppressWarnings
    * @param {string|undefined} referrerPolicy
    * @param {string|undefined} attributionSrc
-   * @param {(Element|./service/ampdoc-impl.AmpDoc)=} opt_elementOrAmpDoc Whether services are provided by an
+   * @param {!Element|!./service/ampdoc-impl.AmpDoc} elementOrAmpDoc Whether services are provided by an
    *     element.
    */
   static sendRequestUsingImage(
@@ -258,7 +258,7 @@ export class Transport {
     suppressWarnings,
     referrerPolicy,
     attributionSrc,
-    opt_elementOrAmpDoc
+    elementOrAmpDoc
   ) {
     if (!win) {
       return;
@@ -268,7 +268,7 @@ export class Transport {
       request.url,
       referrerPolicy,
       attributionSrc,
-      opt_elementOrAmpDoc
+      elementOrAmpDoc
     );
     loadPromise(image)
       .then(() => {

--- a/src/builtins/amp-pixel/amp-pixel.js
+++ b/src/builtins/amp-pixel/amp-pixel.js
@@ -85,7 +85,8 @@ export class AmpPixel extends BaseElement {
               this.win,
               src,
               this.referrerPolicy_,
-              this.element.getAttribute('attributionsrc')
+              this.element.getAttribute('attributionsrc'),
+              this.element
             );
             dev().info(TAG, 'pixel triggered: ', src);
             return pixel;

--- a/test/unit/builtins/test-amp-pixel.js
+++ b/test/unit/builtins/test-amp-pixel.js
@@ -1,3 +1,4 @@
+import {Services} from '#service';
 import {installUrlReplacementsForEmbed} from '#service/url-replacements-impl';
 import {VariableSource} from '#service/variable-source';
 
@@ -21,6 +22,7 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
     await createPixel(
       'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?'
     );
+    env.sandbox.spy(Services, 'urlReplacementsForDoc');
   });
 
   function createPixel(src, referrerPolicy) {
@@ -170,6 +172,7 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
         'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?ars=6'
       );
       expect(img.attributionSrc).to.equal('');
+      expect(Services.urlReplacementsForDoc).to.be.calledWith(pixel);
     });
   });
 
@@ -189,6 +192,7 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
         'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?ars=6'
       );
       expect(img.attributionSrc).to.equal('https://adtech.example?ars=6');
+      expect(Services.urlReplacementsForDoc).to.be.calledWith(pixel);
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/39284, using the extension element for retrieving the proper service instead of forcing window.document. Same approach followed by most of other extensions.