### PR TITLE
✅ Temporary debugging output for unit tests running on CircleCI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -176,7 +176,8 @@
         "terser": "5.14.2",
         "traverse": "0.6.6",
         "typescript": "4.9.5",
-        "util": "0.12.4"
+        "util": "0.12.4",
+        "why-is-node-running": "2.2.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -21912,6 +21913,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -22315,6 +22322,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
     },
     "node_modules/static-extend": {
       "version": "0.1.2",
@@ -23882,6 +23895,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -39662,6 +39691,12 @@
         "object-inspect": "^1.9.0"
       }
     },
+    "siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -39955,6 +39990,12 @@
           "dev": true
         }
       }
+    },
+    "stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
@@ -41082,6 +41123,16 @@
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "why-is-node-running": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
+      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
+      "dev": true,
+      "requires": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "terser": "5.14.2",
     "traverse": "0.6.6",
     "typescript": "4.9.5",
-    "util": "0.12.4"
+    "util": "0.12.4",
+    "why-is-node-running": "2.2.2"
   }
 }


### PR DESCRIPTION
We often see unit tests failing on CircleCI on `main` with a silent timeout (recent examples: [[1]](https://app.circleci.com/pipelines/github/ampproject/amphtml/29231/workflows/19e044c0-d243-42c6-a3cb-4cb5d39ede9c/jobs/624647) [[2]](https://app.circleci.com/pipelines/github/ampproject/amphtml/29221/workflows/f2a3b97d-04d1-4ea1-a318-e17d0f3b8539/jobs/624397) [[3]](https://app.circleci.com/pipelines/github/ampproject/amphtml/29206/workflows/ab2a730f-fe82-4b88-a053-866c903f3aff/jobs/623971)), _after_ they pass on the related PR. I can't seem to be able to reproduce these failures directly on the PR, so I want to add this debugging statement that will automatically fail the PR if the unit test is running for longer than 7 minutes (these usually resolve within 4 minutes, so I think it's a safe margin)