### PR TITLE
🏗 Fix for Percy changes on handling missing snapshots

### DIFF
--- a/build-system/tasks/visual-diff/index.js
+++ b/build-system/tasks/visual-diff/index.js
@@ -106,6 +106,9 @@ function maybeOverridePercyEnvironmentVariables() {
       process.env[variable.toUpperCase()] = argv[variable];
     }
   });
+  if (argv.empty) {
+    process.env['PERCY_PARTIAL_BUILD'] = '1';
+  }
 }
 
 /**
@@ -571,7 +574,7 @@ function setDebuggingLevel() {
  * @return {Promise<void>}
  */
 async function createEmptyBuild(browser) {
-  log('info', 'Skipping visual diff tests and generating a blank Percy build');
+  log('info', 'Generating the blank page snapshot');
 
   const page = await newPage(browser);
 
@@ -642,9 +645,7 @@ async function performVisualTests(executablePath) {
   );
 
   try {
-    if (argv.empty) {
-      await createEmptyBuild(browser);
-    } else {
+    if (!argv.empty) {
       // Load and parse the config. Use JSON5 due to JSON comments in file.
       const visualTestsConfig = JSON5.parse(
         fs.readFileSync(
@@ -657,6 +658,7 @@ async function performVisualTests(executablePath) {
       );
       await runVisualTests(browser, visualTestsConfig.webpages);
     }
+    await createEmptyBuild(browser);
   } finally {
     await browser.close();
     exitCtrlcHandler(handlerProcess);


### PR DESCRIPTION
Percy recently introduced changes that make it so that missing snapshots now trigger an error. When we create a build on Percy we either just generate a build with a single, blank page (e.g., for docs-only changes), or we generate a build with all the visual tests _except_ the blank page - this means that now every PR fails on Percy (blank page PRs are missing 146 snapshots, and regular PRs are missing 1 snapshot)

This PR makes two changes:
1. It sets `PERCY_PARTIAL_BUILD` (introduced [a while ago](https://docs.percy.io/docs/partial-builds), but wasn't required until recently) on blank page-only PRs
2. Generates the blank page snapshot on full PRs too