### PR TITLE
🏗 Override Chrome binary in e2e tests with `CHROME_BIN` env variable

### DIFF
--- a/build-system/tasks/e2e/describes-e2e.js
+++ b/build-system/tasks/e2e/describes-e2e.js
@@ -133,6 +133,9 @@ function createDriver(browserName, args, deviceName) {
     case 'chrome':
       const chromeOptions = new chrome.Options(capabilities);
       chromeOptions.addArguments(args);
+      if (process.env.CHROME_BIN) {
+        chromeOptions.setChromeBinaryPath(process.env.CHROME_BIN);
+      }
       if (deviceName) {
         chromeOptions.setMobileEmulation({deviceName});
       }


### PR DESCRIPTION
e2e tests use Selenium to control the testing browser, whereas unit/integration tests use Karma. Karma overrides which Chrome binary to use for tests when the `CHROME_BIN` env variable is set, so this PR brings e2e tests on par, which would make it easier for us to test breakages on browser version changes

e.g., I can now run `CHROME_BIN=$HOME/Downloads/chrome-stable-114/opt/google/chrome/google-chrome amp e2e --nobuild --headless --minified` when debugging e2e tests that break between Chrome 113 and 114