### PR TITLE
🐛 frame.html: generate the script tag securely

### DIFF
--- a/3p/frame.max.html
+++ b/3p/frame.max.html
@@ -7,7 +7,9 @@ var url = './integration.js';
 try {
   url = JSON.parse(window.name).bootstrap;
 } catch (e) {}
-document.write('<script src="' + url + '"><' + '/script>');
+var script = document.createElement('script');
+script.src = url;
+document.write(script.outerHTML);
 </script>
 </head>
 <body style="margin:0">


### PR DESCRIPTION
In order to remove the possibility of generating arbitrary HTML code using the URL argument.