### PR TITLE
🔥 Update Fairground network to not be an open proxy

### DIFF
--- a/ads/vendors/fairground.js
+++ b/ads/vendors/fairground.js
@@ -1,10 +1,15 @@
-import {loadScript, validateData} from '#3p/3p';
+import {validateData} from '#3p/3p';
 
 /**
  * @param {!Window} global
  * @param {!Object} data
  */
 export function fairground(global, data) {
-  validateData(data, ['src']);
-  loadScript(global, data['src']);
+  validateData(data, ['project', 'hash'])
+
+  const c = document.createElement('script');
+  c.src = "https://amp.thefairground.com/" + data.project + "/" + data.hash + "/amp.script.js";
+  c.type = 'text/javascript';
+
+  global.document.getElementsByTagName('body')[0].append(c);
 }

--- a/ads/vendors/fairground.md
+++ b/ads/vendors/fairground.md
@@ -4,12 +4,13 @@ Provides support for Fairground ads.
 
 ### Required parameters
 
--   `src`
+-   `project`
+-   `hash`
 
 ## Example
 
 ```html
 <amp-ad width="320" height="100" layout="fixed" type="fairground"
-        src="https://amp.thefairground.com/campaigns/4189dd42-f853-4535-aedd-7130ea601fd8/amp.script.js">
+        data-project="campaigns" data-hash="4189dd42-f853-4535-aedd-7130ea601fd8">
 </amp-ad>
 ```

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -1068,7 +1068,7 @@
 
   <h2>Fairground</h2>
   <amp-ad width="320" height="100" layout="fixed" type="fairground"
-          src="https://amp.thefairground.com/campaigns/4189dd42-f853-4535-aedd-7130ea601fd8/amp.script.js">
+          data-project="campaigns" data-hash="4189dd42-f853-4535-aedd-7130ea601fd8">
   </amp-ad>
 
   <h2>FlexOneELEPHANT</h2>


### PR DESCRIPTION
The Fairground network is acting as an open proxy that may be used with any script, so this PR fixes that!

I've updated it so that it will only load scripts from `amp.thefairground.com`

The original PR: #39007

cc ampproject/wg-monetization