### PR TITLE
🏗 Save nvm cache in CircleCI's cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,20 @@ commands:
                   - .git
   setup_node_environment:
     steps:
+      - restore_cache:
+          name: 'Restore nvm Cache'
+          keys:
+            - nvm-cache-{{ arch }}-v1-
       - node/install:
           node-version: 'lts'
+      - run:
+          name: 'Create nvm Cache Checksum File'
+          command: 'node -v > ~/.node-version'
+      - save_cache:
+          name: 'Save nvm Cache'
+          key: nvm-cache-{{ arch }}-v1-{{ checksum "~/.node-version" }}
+          paths:
+            - ~/.nvm/.cache
       - node/install-packages:
           with-cache: false
   setup_vm:


### PR DESCRIPTION
This shouldn't have any positive or negative effect on CI performance, but [on occasion a network hiccup causes a build to fail](https://app.circleci.com/pipelines/github/ampproject/amphtml/29413/workflows/4e17dd84-5c01-4be9-906c-ae5946c3c382/jobs/629561#:~:text=0s-,Install%20Node.js%20lts,-Explain%20this%20error) when downloading Node with nvm. This PR caches the nvm cache inside CircleCI so we can reuse it between builds.

Since the LTS version of Node changes once every few weeks, this is a pretty stable cache key!