### PR TITLE
🏗 Temporarily pin Node to v18.* and fix nvm cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,19 +94,25 @@ commands:
                 paths:
                   - .git
   setup_node_environment:
+    parameters:
+      node-version:
+        type: string
+        default: '18' # TODO(wg-infra): restore this to 'lts' once #39510 is fixed.
     steps:
       - restore_cache:
           name: 'Restore nvm Cache'
           keys:
-            - nvm-cache-{{ arch }}-v1-
-      - node/install:
-          node-version: 'lts'
+            - nvm-cache-{{ arch }}-v2-<< parameters.node-version >>-
+      - run:
+          name: 'Create .nvmrc file'
+          command: echo << parameters.node-version >> > .nvmrc
+      - node/install
       - run:
           name: 'Create nvm Cache Checksum File'
-          command: 'node -v > ~/.node-version'
+          command: node -v > ~/.node-version
       - save_cache:
           name: 'Save nvm Cache'
-          key: nvm-cache-{{ arch }}-v1-{{ checksum "~/.node-version" }}
+          key: nvm-cache-{{ arch }}-v2-<< parameters.node-version >>-{{ checksum "~/.node-version" }}
           paths:
             - ~/.nvm/.cache
       - node/install-packages:


### PR DESCRIPTION
Because of #39510 

I've reworked the way we save/restore the nvm cache and determine which version to install: previously CircleCI would simply restore the latest cached version, which is not necessarily what we want, because that means the cache key that includes v18.18.2 was overtaken by v20.9.0, even once this PR is merged. With this PR, the major version we fix to becomes part of the cache key. Once we switch to back to 'lts' it'll simply continue to increment the cache key every time a new version comes out, but if we have to revert back to a fixed number again (like here) we can change the value of the `node-version` parameter and the cache will work out of the box

I also noticed that by default nvm tries to install Node twice - first immediately after nvm is unpacked it installs a fixed version number (v18.18.0), and then the one we asked it to install. By storing the version number/name we want it to install in a `.nvmrc` file it only installs it twice. This is a micro-optimization obviously, but the real reason is to avoid the previously encountered network issue that caused me to want to cache nvm artifacts in the first place