### PR TITLE
Launch INP metrics on amp-analytics

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -18,5 +18,5 @@
   "amp-sticky-ad-to-amp-ad-v4": 0,
   "story-video-cache-apply-audio": 0,
   "amp-story-subscriptions": 1,
-  "interaction-to-next-paint": 0.1
+  "interaction-to-next-paint": 1
 }

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -15,5 +15,6 @@
   "story-load-inactive-outside-viewport": 1,
   "amp-sticky-ad-to-amp-ad-v4": 0,
   "story-video-cache-apply-audio": 0,
-  "amp-story-subscriptions": 1
+  "amp-story-subscriptions": 1,
+  "interaction-to-next-paint": 1
 }


### PR DESCRIPTION
Does not appear to be breaking anything. INP is also not appearing in Google-specific dashboards. Therefore we should be able to safely launch it to 100%.