### PR TITLE
Update docs for dock support

### DIFF
--- a/examples/connatix-player.amp.html
+++ b/examples/connatix-player.amp.html
@@ -12,6 +12,7 @@
         padding: 12px;
       }
     </style>
+  <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"></script>
   <script async custom-element="amp-connatix-player" src="https://cdn.ampproject.org/v0/amp-connatix-player-0.1.js"></script>
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 </head>
@@ -39,6 +40,13 @@
     width="480"
     height="270">
   </amp-connatix-player>
-
+  <h3>Connatix Player With Docking</h3>
+  <amp-connatix-player
+    dock
+    data-player-id="f721b0d8-7a79-42b6-b637-fa4e86138ed9"
+    layout="fixed"
+    width="640"
+    height="360">
+  </amp-connatix-player>
 </body>
 </html>

--- a/extensions/amp-video-docking/amp-video-docking.md
+++ b/extensions/amp-video-docking/amp-video-docking.md
@@ -29,6 +29,7 @@ Currently, the supported players are:
 
 -   [`amp-brid-player`](https://amp.dev/documentation/components/amp-brid-player)
 -   [`amp-brightcove`](https://amp.dev/documentation/components/amp-brightcove)
+-   [`amp-connatix-player`](https://amp.dev/documentation/components/amp-connatix-player)
 -   [`amp-dailymotion`](https://amp.dev/documentation/components/amp-dailymotion)
 -   [`amp-delight-player`](https://github.com/ampproject/amphtml/blob/main/extensions/amp-delight-player/amp-delight-player.md)
 -   [`amp-ima-video`](https://amp.dev/documentation/components/amp-ima-video)


### PR DESCRIPTION
The purpose of this PR is to add the necessary documentation to accompany our latest changes that enable docking to be used in conjunction with the Connatix Player component.