### PR TITLE
❄️ Increase timeout for e2e test `amp-social-share > clicking > opens a new window on click`

### DIFF
--- a/extensions/amp-social-share/1.0/test-e2e/test-amp-social-share.js
+++ b/extensions/amp-social-share/1.0/test-e2e/test-amp-social-share.js
@@ -86,7 +86,9 @@ describes.endtoend(
     });
 
     describe('clicking', () => {
-      it('opens a new window on click', async () => {
+      it('opens a new window on click', async function () {
+        this.timeout(5000);
+
         const host = await controller.findElement('#two');
 
         let windows = await controller.getAllWindows();


### PR DESCRIPTION
This test often fails due to taking longer than the default timeout. Increasing the timeout to 5,000ms should hopefully fix it