### PR TITLE
✨ Add a Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are applied only to the latest release.
+
+## Reporting a Vulnerability
+
+If you have discovered a security vulnerability in this project, please report it privately. **Do not disclose it as a public issue.** This gives us time to work with you to fix the issue before public exposure, reducing the chance that the exploit will be used before a patch is released.
+
+Please disclose it at [security advisory](https://github.com/ampproject/amphtml/security/advisories/new).
+
+This project is maintained by a team on a best effort basis. As such, vulnerability reports will be investigated and fixed or disclosed as soon as possible.


### PR DESCRIPTION
Resolves https://github.com/ampproject/amphtml/issues/39712

This PR adds a suggestion of a Security Policy for the repository.

Please mind that the link suggested for reporting vulnerabilities uses GitHub's Security Advisories [report vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability) feature. You would need to enable the feature for it to work.

Let me know if this security policy makes sense for the repository or how can we work it better to reflect how team would like to handle vulnerability reports.