### PR TITLE
🏗 Partial updates for core devDependencies

### DIFF
--- a/build-system/release-tagger/index.js
+++ b/build-system/release-tagger/index.js
@@ -8,7 +8,7 @@
  * 4. channel (beta-percent|stable|lts)
  */
 
-const dedent = require('dedent');
+const {default: dedent} = require('dedent');
 const {action, base, channel, head, sha} = require('minimist')(
   process.argv.slice(2),
   {

--- a/build-system/release-tagger/make-release.js
+++ b/build-system/release-tagger/make-release.js
@@ -3,7 +3,7 @@
  * Make release for the release tagger.
  */
 
-const dedent = require('dedent');
+const {default: dedent} = require('dedent');
 const {GitHubApi} = require('./utils');
 
 /** @typedef {import('@octokit/graphql').GraphQlQueryResponseData} GraphQlQueryResponseData */

--- a/build-system/release-tagger/utils.js
+++ b/build-system/release-tagger/utils.js
@@ -3,7 +3,7 @@
  * GitHub API util functions.
  */
 
-const dedent = require('dedent');
+const {default: dedent} = require('dedent');
 const {graphql} = require('@octokit/graphql');
 const {Octokit} = require('@octokit/rest');
 

--- a/build-system/task-runner/amp-task-runner.js
+++ b/build-system/task-runner/amp-task-runner.js
@@ -4,7 +4,7 @@
  */
 
 const argv = require('minimist')(process.argv.slice(2));
-const commander = require('commander');
+const {program} = require('commander');
 const esprima = require('esprima');
 const fs = require('fs-extra');
 const os = require('os');
@@ -218,7 +218,7 @@ function createTask(
     argv._.length === 0 && taskName == 'default' && !isHelpTask; // `amp`
 
   if (isHelpTask) {
-    const task = commander.command(cyan(taskName));
+    const task = program.command(cyan(taskName));
     const description = getTaskDescription(taskSourceFileName, taskFuncName);
     task.description(description);
   }
@@ -226,7 +226,7 @@ function createTask(
     startAtRepoRoot();
     ensureUpdatedPackages(taskSourceFileName);
     const taskFunc = getTaskFunc(taskSourceFileName, taskFuncName);
-    const task = commander.command(taskName, {isDefault: isDefaultTask});
+    const task = program.command(taskName, {isDefault: isDefaultTask});
     task.description(green(taskFunc.description));
     task.allowUnknownOption(); // Fall through to validateUsage()
     task.helpOption('--help', 'Print this list of flags');
@@ -267,18 +267,18 @@ function validateUsage(task, taskName, taskFunc) {
  * was called.
  */
 function finalizeRunner() {
-  commander.addHelpCommand(false); // We already have `amp --help` and `amp <task> --help`
+  program.addHelpCommand(false); // We already have `amp --help` and `amp <task> --help`
   if (isHelpTask) {
-    commander.helpOption('--help', 'Print this list of tasks');
-    commander.usage('<task> <flags>');
+    program.helpOption('--help', 'Print this list of tasks');
+    program.usage('<task> <flags>');
   }
-  commander.on('command:*', (args) => {
+  program.on('command:*', (args) => {
     log(red('ERROR:'), 'Unknown task', cyan(args.join(' ')));
     log('⤷ Run', cyan('amp --help'), 'for a full list of tasks.');
     log('⤷ Run', cyan('amp <task> --help'), 'for help with a specific task.');
     process.exitCode = 1;
   });
-  commander.parse();
+  program.parse();
 }
 
 module.exports = {

--- a/build-system/tasks/unit.js
+++ b/build-system/tasks/unit.js
@@ -10,10 +10,6 @@ const {compileJison} = require('./compile-jison');
 const {css} = require('./css');
 const {getUnitTestsToRun} = require('./runtime-test/helpers-unit');
 const {maybePrintArgvMessages} = require('./runtime-test/helpers');
-const {log} = require('../common/logging');
-const whyIsNodeRunning = require('why-is-node-running');
-const {red} = require('kleur/colors');
-const {isCircleciBuild} = require('../common/ci');
 
 class Runner extends RuntimeTestRunner {
   /**
@@ -45,26 +41,8 @@ async function unit() {
   const runner = new Runner(config);
 
   await runner.setup();
-  // TODO(danielrozenberg): temporary debugging output.
-  const timeoutHandler = isCircleciBuild()
-    ? setTimeout(() => {
-        log(red('[TEMPORARY DEBUGGING STATEMENT]'), 'See #39501 for details.');
-        log(
-          'Unit tests on CircleCI are still running after 7 minutes, probably indicating that the tests are stuck. The following output indicates which handles are still live in Node:'
-        );
-        console./*OK*/ groupCollapsed('why-is-node-running');
-        whyIsNodeRunning();
-        console./*OK*/ groupEnd();
-        process.exit(1);
-      }, 420_000)
-    : null;
-
   await runner.run();
   await runner.teardown();
-
-  if (timeoutHandler) {
-    clearTimeout(timeoutHandler);
-  }
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -174,7 +174,7 @@
         "tempy": "1.0.1",
         "terser": "5.14.2",
         "traverse": "0.6.6",
-        "typescript": "4.9.5",
+        "typescript": "5.3.3",
         "util": "0.12.4"
       }
     },
@@ -21832,16 +21832,16 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -38155,9 +38155,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "chai-as-promised": "7.1.1",
         "check-dependencies": "2.0.0",
         "chokidar": "3.5.3",
-        "commander": "7.2.0",
+        "commander": "11.1.0",
         "connect-header": "0.0.5",
         "css-imports": "0.3.1",
         "css-what": "6.1.0",
@@ -6244,6 +6244,15 @@
         "amphtml-validator": "cli.js"
       }
     },
+    "node_modules/amphtml-validator/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "dev": true,
@@ -8202,11 +8211,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "7.2.0",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">=16"
       }
     },
     "node_modules/comment-parser": {
@@ -21156,6 +21166,15 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/svgo/node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -27082,6 +27101,14 @@
         "colors": "1.4.0",
         "commander": "7.2.0",
         "promise": "8.1.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        }
       }
     },
     "ansi-colors": {
@@ -28448,7 +28475,9 @@
       }
     },
     "commander": {
-      "version": "7.2.0",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true
     },
     "comment-parser": {
@@ -37629,6 +37658,12 @@
         "picocolors": "^1.0.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+          "dev": true
+        },
         "css-select": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -175,8 +175,7 @@
         "terser": "5.14.2",
         "traverse": "0.6.6",
         "typescript": "4.9.5",
-        "util": "0.12.4",
-        "why-is-node-running": "2.2.2"
+        "util": "0.12.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4507,9 +4506,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -4530,6 +4529,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
     },
     "node_modules/@kristoferbaxter/async": {
       "version": "1.0.0",
@@ -11404,20 +11409,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -20245,8 +20236,9 @@
     },
     "node_modules/semver": {
       "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -20522,12 +20514,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -20741,8 +20727,10 @@
     },
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
     },
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
@@ -20799,12 +20787,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -21284,8 +21266,9 @@
     },
     "node_modules/tar": {
       "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -21654,8 +21637,9 @@
     },
     "node_modules/traverse": {
       "version": "0.6.6",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
+      "dev": true
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.1",
@@ -22015,8 +21999,9 @@
     },
     "node_modules/util": {
       "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -22300,22 +22285,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/why-is-node-running": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
-      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
-      "dev": true,
-      "dependencies": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
-      },
-      "bin": {
-        "why-is-node-running": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wide-align": {
@@ -25754,9 +25723,9 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
     "@jridgewell/trace-mapping": {
@@ -25773,6 +25742,12 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
           "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+          "dev": true
+        },
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
           "dev": true
         }
       }
@@ -30770,13 +30745,6 @@
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.2",
@@ -36980,6 +36948,8 @@
     },
     "semver": {
       "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -37195,12 +37165,6 @@
         "object-inspect": "^1.9.0"
       }
     },
-    "siginfo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -37350,6 +37314,8 @@
     },
     "sourcemap-codec": {
       "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spdx-exceptions": {
@@ -37395,12 +37361,6 @@
           "dev": true
         }
       }
-    },
-    "stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
     },
     "statuses": {
       "version": "1.5.0",
@@ -37749,6 +37709,8 @@
     },
     "tar": {
       "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",
@@ -38026,6 +37988,8 @@
     },
     "traverse": {
       "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw==",
       "dev": true
     },
     "ts-api-utils": {
@@ -38252,6 +38216,8 @@
     },
     "util": {
       "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -38467,16 +38433,6 @@
         "for-each": "^0.3.3",
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
-      }
-    },
-    "why-is-node-running": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.2.2.tgz",
-      "integrity": "sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==",
-      "dev": true,
-      "requires": {
-        "siginfo": "^2.0.0",
-        "stackback": "0.0.2"
       }
     },
     "wide-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "css-imports": "0.3.1",
         "css-what": "6.1.0",
         "cssnano": "6.0.3",
-        "dedent": "0.7.0",
+        "dedent": "1.5.1",
         "del": "6.0.0",
         "enzyme": "3.11.0",
         "enzyme-adapter-preact-pure": "4.1.0",
@@ -8902,9 +8902,18 @@
       "dev": true
     },
     "node_modules/dedent": {
-      "version": "0.7.0",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
-      "license": "MIT"
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
     },
     "node_modules/deep-eql": {
       "version": "3.0.1",
@@ -28972,8 +28981,11 @@
       "dev": true
     },
     "dedent": {
-      "version": "0.7.0",
-      "dev": true
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "requires": {}
     },
     "deep-eql": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "chai-as-promised": "7.1.1",
     "check-dependencies": "2.0.0",
     "chokidar": "3.5.3",
-    "commander": "7.2.0",
+    "commander": "11.1.0",
     "connect-header": "0.0.5",
     "css-imports": "0.3.1",
     "css-what": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
     "terser": "5.14.2",
     "traverse": "0.6.6",
     "typescript": "4.9.5",
-    "util": "0.12.4",
-    "why-is-node-running": "2.2.2"
+    "util": "0.12.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "tempy": "1.0.1",
     "terser": "5.14.2",
     "traverse": "0.6.6",
-    "typescript": "4.9.5",
+    "typescript": "5.3.3",
     "util": "0.12.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "css-imports": "0.3.1",
     "css-what": "6.1.0",
     "cssnano": "6.0.3",
-    "dedent": "0.7.0",
+    "dedent": "1.5.1",
     "del": "6.0.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-preact-pure": "4.1.0",

--- a/src/preact/component/types.d.ts
+++ b/src/preact/component/types.d.ts
@@ -19,7 +19,7 @@ export interface WrapperComponentProps {
  */
 export interface ContainerWrapperComponentProps {
   as?: FunctionComponent | any;
-  contentAs?: string | FunctionComponent;
+  contentAs?: FunctionComponent | any;
   contentProps?: any;
   style?: Preact.JSX.CSSProperties;
   size?: boolean;


### PR DESCRIPTION
This PR updates code devDependencies that require non-trivial changes to the codebase:

* `dedent` - explicitly requires that we import its `default`
* `commander` - requires that we import `Program` instead of the default export
* `typescript` - requires a minor type definition change in `src/preact/component/types.d.ts`

This PR also removes the `why-is-node-running` package and the debugging code that used it, which should fix the broken `amp --help` command