### PR TITLE
🐛 [Connatix Player] - Fix player not unmuting while docking

### DIFF
--- a/extensions/amp-connatix-player/0.1/amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/amp-connatix-player.js
@@ -28,7 +28,11 @@ import {
   getConsentPolicySharedData,
   getConsentPolicyState,
 } from '../../../src/consent';
-import {mutedOrUnmutedEvent, redispatch} from '../../../src/iframe-video';
+import {
+  addUnsafeAllowAutoplay,
+  mutedOrUnmutedEvent,
+  redispatch,
+} from '../../../src/iframe-video';
 import {addParamsToUrl} from '../../../src/url';
 import {
   VideoEvents_Enum,
@@ -321,6 +325,7 @@ export class AmpConnatixPlayer extends AMP.BaseElement {
 
     // applyFillContent so that frame covers the entire component.
     applyFillContent(iframe, /* replacedContent */ true);
+    addUnsafeAllowAutoplay(iframe);
 
     // append child iframe for element
     element.appendChild(iframe);

--- a/extensions/amp-connatix-player/0.1/amp-connatix-player.js
+++ b/extensions/amp-connatix-player/0.1/amp-connatix-player.js
@@ -183,6 +183,14 @@ export class AmpConnatixPlayer extends AMP.BaseElement {
           this.isFullscreen_ = !this.isFullscreen_;
           break;
         }
+        case 'cnxVolumeChanged': {
+          const newVolume = dataJSON['args'];
+
+          this.muted_ = newVolume === 0;
+          dispatchCustomEvent(this.element, mutedOrUnmutedEvent(this.muted_));
+
+          break;
+        }
       }
 
       redispatch(this.element, dataJSON['func'].toString(), {
@@ -437,15 +445,11 @@ export class AmpConnatixPlayer extends AMP.BaseElement {
 
   /** @override */
   mute() {
-    this.muted_ = true;
-    dispatchCustomEvent(this.element, mutedOrUnmutedEvent(this.muted_));
     this.sendCommand_('mute');
   }
 
   /** @override */
   unmute() {
-    this.muted_ = false;
-    dispatchCustomEvent(this.element, mutedOrUnmutedEvent(this.muted_));
     this.sendCommand_('unmute');
   }
 


### PR DESCRIPTION
The current PR fixes two issues:
1. Player could not be muted/unmuted through docking UI controls if user hadn't interacted with the player while it was embedded. This was solved by using the `addUnsafeAllowAutoplay` method.
2. Desyncing between the player volume and the docking UI mute/unmute button icon. This was solved by only updating mute/unmute status after the volumeChanged command has been received.