### PR TITLE
Don't focus on the current story until the animation ends

### DIFF
--- a/examples/amp-story/player.html
+++ b/examples/amp-story/player.html
@@ -81,36 +81,28 @@
       <amp-story-player style="width: 360px; height: 600px;">
         <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
             class="story">
-          <img data-amp-story-player-poster-img src="https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/promo3x4.jpg" width="360" height="600" loading="lazy">
-          <span class="title">A local’s guide to what to eat and do in New York City</span>
+          <span class="title">New York City local guide</span>
+        </a>
+        <a href="https://wp.stories.google/stories/a-taste-of-new-york-pizza-history/">
+          <span class="title">Pizza Pizza Pizza</span>
         </a>
         <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/">
-          <img data-amp-story-player-poster-img src="https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/img/promo3x4.jpg" width="360" height="600" loading="lazy">
-          <span class="title">A local’s guide to what to eat and do in Miami</span>
-        </a>
-        <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/">
-          <img data-amp-story-player-poster-img src="https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/img/promo3x4.jpg" width="360" height="600" loading="lazy">
-          <span class="title">A local’s guide to what to eat and do in Mexico City</span>
+          <span class="title">Miami local guide</span>
         </a>
         <a href="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/">
-          <img data-amp-story-player-poster-img src="https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/img/promo3x4.jpg" width="360" height="600" loading="lazy">
-          <span class="title">A local’s guide to what to eat and do in Rome</span>
+          <span class="title">Rome local guide</span>
         </a>
       </amp-story-player>
 
       <div class="actions">
         <div class="circle active"
-            data-story="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/"
-            style="background-image: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/img/42a59562-834d-11e9-b585-e36b16a531aa.jpg')">New York</div>
+            data-story="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-new-york-city/">New York</div>
         <div class="circle"
-            data-story="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/"
-            style="background-image: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/img/9f1d2656-6b7a-11e9-bbe7-1c798fb80536.jpg')">Miami</div>
+            data-story="https://wp.stories.google/stories/a-taste-of-new-york-pizza-history/">Pizza</div>
         <div class="circle"
-            data-story="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/"
-            style="background-image: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-mexico-city/img/2e0f5178-746c-11e9-9331-30bc5836f48e.jpg')">Mexico City</div>
+            data-story="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-miami/">Miami</div>
         <div class="circle"
-            data-story="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/"
-            style="background-image: url('https://www-washingtonpost-com.cdn.ampproject.org/i/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/img/f5903e2e-86fa-11e9-9d73-e2ba6bbf1b9b.jpg')">Rome</div>
+            data-story="https://www-washingtonpost-com.cdn.ampproject.org/v/s/www.washingtonpost.com/graphics/2019/lifestyle/travel/amp-stories/a-locals-guide-to-what-to-eat-and-do-in-rome/">Rome</div>
       </div>
     </div>
     <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras viverra neque ex, sit amet varius sem maximus sed. Suspendisse potenti. Donec erat purus, sagittis sit amet tincidunt ut, maximus sit amet massa. Maecenas venenatis fringilla dui vitae vestibulum. Fusce imperdiet euismod lobortis. Nullam sagittis nunc at tristique mattis. In sodales consectetur mollis. Maecenas sollicitudin, ex vel tempor rutrum, turpis eros interdum enim, sit amet volutpat tortor dolor at ipsum. Nam posuere velit vel urna vulputate interdum. Aenean eu vulputate lorem. Praesent nec nunc sodales, egestas orci sed, hendrerit mauris. Ut blandit turpis non erat sagittis, quis fermentum odio feugiat.</div>

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -49,7 +49,7 @@ const STORY_POSITION_ENUM = {
 };
 
 /** @const @type {!Array<string>} */
-const SUPPORTED_CACHES = ['cdn.ampproject.org', 'www.bing-amp.com'];
+const SUPPORTED_CACHES = ['cdn.ampproject.org', 'www.bing-amp.com']; // eslint-disable-line local/no-forbidden-terms
 
 /** @const @type {!Array<string>} */
 const SANDBOX_MIN_LIST = ['allow-top-navigation'];
@@ -1142,8 +1142,8 @@ export class AmpStoryPlayer {
       story.distance === 0
         ? STORY_POSITION_ENUM.CURRENT
         : story.idx > this.currentIdx_
-        ? STORY_POSITION_ENUM.NEXT
-        : STORY_POSITION_ENUM.PREVIOUS;
+          ? STORY_POSITION_ENUM.NEXT
+          : STORY_POSITION_ENUM.PREVIOUS;
 
     requestAnimationFrame(() => {
       const {iframe} = story;

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -49,7 +49,7 @@ const STORY_POSITION_ENUM = {
 };
 
 /** @const @type {!Array<string>} */
-const SUPPORTED_CACHES = ['cdn.ampproject.org', 'www.bing-amp.com']; // eslint-disable-line local/no-forbidden-terms
+const SUPPORTED_CACHES = ['cdn.ampproject.org', 'www.bing-amp.com'];
 
 /** @const @type {!Array<string>} */
 const SANDBOX_MIN_LIST = ['allow-top-navigation'];
@@ -1142,8 +1142,8 @@ export class AmpStoryPlayer {
       story.distance === 0
         ? STORY_POSITION_ENUM.CURRENT
         : story.idx > this.currentIdx_
-          ? STORY_POSITION_ENUM.NEXT
-          : STORY_POSITION_ENUM.PREVIOUS;
+        ? STORY_POSITION_ENUM.NEXT
+        : STORY_POSITION_ENUM.PREVIOUS;
 
     requestAnimationFrame(() => {
       const {iframe} = story;
@@ -1287,7 +1287,10 @@ export class AmpStoryPlayer {
             this.updatePosition_(story);
 
             if (story.distance === 0) {
-              tryFocus(story.iframe);
+              // Focus on the current story iframe after the animation ends.
+              story.iframe.addEventListener('animationend', () => {
+                tryFocus(story.iframe);
+              });
             }
           })
           .catch((err) => {


### PR DESCRIPTION
Context:
In Firefox, when player.show() is called, the transition animation of iframes(that host stories) cause the final position to be wrong. More specifically, it only happens when you show the 2nd story(not any other stories), where after the animation the story with index 1 is at the position 0, and all stories with index n is at the position n-1. Basically, the entire array of stories shift left by one.

This bug only happens in Firefox. I agree with Corey that focus() and transition animation running at the same time somehow cause the bug. This PR fixes it by first waiting for the transition animation to end, and then call focus() to focus on the current story's iframe element.

#38634