### PR TITLE
🏗 Nicer format for test names when reporting to CircleCI

### DIFF
--- a/build-system/tasks/runtime-test/runtime-test-base.js
+++ b/build-system/tasks/runtime-test/runtime-test-base.js
@@ -133,6 +133,15 @@ class RuntimeTestConfig {
       this.junitReporter = {
         outputFile: `result-reports/${this.testType}.xml`,
         useBrowserName: false,
+        nameFormatter(_, result) {
+          return result.description.trim();
+        },
+        classNameFormatter(_, result) {
+          return result.suite
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .join(' » ');
+        },
       };
     }
 


### PR DESCRIPTION
This PR reduces the full name of tests to only be the text in the `it('...')` spec, and adds delimiters to different `describes` texts for the `classname`. Also removes empty strings in the middle (which happens as a side-effect of how we implemented some of the test runners)

| Before | After |
| --- | --- |
| ![image](https://github.com/ampproject/amphtml/assets/1839738/3a76f1e1-71c7-4c77-9b6a-6171c1ea230a) | ![image](https://github.com/ampproject/amphtml/assets/1839738/47cae073-3c28-4a88-afb8-d26468afe323) |
| ![image](https://github.com/ampproject/amphtml/assets/1839738/fa10b225-d0fb-4902-9b32-ae27ccef3597) | ![image](https://github.com/ampproject/amphtml/assets/1839738/8ead6fc9-5577-4006-a33c-2648c21f235d) |