### PR TITLE
🏗 Skip re-downloading `nvm`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,22 +108,24 @@ commands:
       - restore_cache:
           name: '♻️ Restore nvm Cache'
           keys:
-            - nvm-cache-{{ arch }}-v2-<< parameters.node-version >>-
+            - nvm-cache-{{ arch }}-vX_20240227.0-<< parameters.node-version >>-
       - run:
-          name: '♻️ Create .nvmrc file'
-          command: echo << parameters.node-version >> > .nvmrc
+          name: '⚙️ Configure nvm Installation'
+          command: |
+            echo << parameters.node-version >> > .nvmrc
+            if [[ -f ~/.nvm/install.sh ]]; then ~/.nvm/install.sh; fi
       - node/install
       - when:
           condition: << parameters.is-initializing-job >>
           steps:
             - run:
                 name: '⚙️ Create nvm Cache Checksum File'
-                command: node -v > ~/.node-version
+                command: echo nvm:$(nvm -v) node:$(node -v) > ~/.nvm-node-cache-key
             - save_cache:
                 name: '💾 Save nvm Cache'
-                key: nvm-cache-{{ arch }}-v2-<< parameters.node-version >>-{{ checksum "~/.node-version" }}
+                key: nvm-cache-{{ arch }}-vX_20240227.0-<< parameters.node-version >>-{{ checksum "~/.nvm-node-cache-key" }}
                 paths:
-                  - ~/.nvm/.cache
+                  - ~/.nvm
       - restore_cache:
           name: '♻️ Restore node_modules/ Cache'
           keys:


### PR DESCRIPTION
Since we're already restoring it from cache, skipping the download would shave a few seconds off each build, but more importantly it would not rely on the network to re-fetch an already installed binary.