### PR TITLE
🏗🐛 Install Chrome in CircleCI `Module 3p Build (Test)` job, for empty visual-diff edge-case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,14 @@ jobs:
     <<: *dist_job
     steps:
       - setup_vm
+      - when:
+          condition:
+            and:
+              - equal: ['Module', <<parameters.module >>]
+              - equal: ['Test', <<parameters.purpose >>]
+          steps:
+            # Required in the edge case where we need to run `amp visual-diff --empty` in this step. See build-system/pr-check/dist.js for details.
+            - install_chrome
       - run:
           name: '⭐⭐⭐ << parameters.module >> 3p Build (<< parameters.purpose >>) ⭐⭐⭐'
           command: node build-system/pr-check/dist.js --type "<< parameters.module >> 3p Build (<< parameters.purpose >>)"


### PR DESCRIPTION
Example of where this fails as of now: https://app.circleci.com/pipelines/github/ampproject/amphtml/30407/workflows/7b9680ee-501d-4f56-a871-7682b9781fd3/jobs/653480

Example of how this PR fixes this: https://app.circleci.com/pipelines/github/ampproject/amphtml/30408/workflows/7b455776-e6aa-4cd4-af41-dc13937836f0/jobs/653511