### PR TITLE
❄️ Skip flaky tests

### DIFF
--- a/extensions/amp-analytics/0.1/test/test-events.js
+++ b/extensions/amp-analytics/0.1/test/test-events.js
@@ -1150,7 +1150,8 @@ describes.realWin('Events', {amp: 1}, (env) => {
     });
   });
 
-  describe('TimerEventTracker', () => {
+  // TODO(#39879): fix flaky tests.
+  describe.skip('TimerEventTracker', () => {
     let clock;
     let tracker;
 
@@ -1394,8 +1395,7 @@ describes.realWin('Events', {amp: 1}, (env) => {
       });
     });
 
-    // TODO(#39879): fix this flaky test.
-    it.skip(
+    it(
       'timers started and stopped by the same event on the same target' +
         ' do not have race condition problems',
       () => {

--- a/extensions/amp-consent/0.1/test/test-amp-consent.js
+++ b/extensions/amp-consent/0.1/test/test-amp-consent.js
@@ -4,7 +4,7 @@ import {xhrServiceForTesting} from '#service/xhr-impl';
 
 import {dev, user} from '#utils/log';
 
-import {macroTask, sleep} from '#testing/helpers';
+import {macroTask} from '#testing/helpers';
 
 import {
   registerServiceBuilder,
@@ -1156,12 +1156,13 @@ describes.realWin(
         );
       });
 
-      describe('granularConsentExp', () => {
+      // TODO(#39886): Fix flaky tests.
+      describe.skip('granularConsentExp', () => {
         let managerSpy;
 
         beforeEach(async () => {
           ampConsent.buildCallback();
-          await sleep(50);
+          await macroTask();
           managerSpy = env.sandbox.spy(
             ampConsent.consentStateManager_,
             'updateConsentInstancePurposes'


### PR DESCRIPTION
My attempt at fixing these flaky tests in #39877 failed. I'm trying to figure out exactly which tests are being flaky here. What happens often is that when we get the esbuild goroutines problem pop up it happens at the point where the tests I'm disabling in this PR are expected to run:

| When `All Unit Tests` flake | When `All Unit Tests` pass |
| --- | --- |
| ![image](https://github.com/ampproject/amphtml/assets/1839738/836816f0-8d86-4fa3-a5bf-50c72f57ad42) | ![image](https://github.com/ampproject/amphtml/assets/1839738/a9992224-0f9f-4f93-b7b9-d275cb3c7a39) |

I'll rerun these tests multiple times and see if these fail again :shrug: 

Tag-along change:
- Revert the unsuccessful "fix" from #39877