### PR TITLE
🐛 Fix videojs amp-video-iframe intergration on ios

### DIFF
--- a/src/video-iframe-integration.js
+++ b/src/video-iframe-integration.js
@@ -278,7 +278,10 @@ export class AmpVideoIntegration {
       });
 
       // in case `canplay` fires before this script loads
-      if (player.readyState() >= /* HAVE_FUTURE_DATA */ 3) {
+      if (
+        player.readyState() >= /* HAVE_FUTURE_DATA */ 3 ||
+        /iPhone|iPad|iPod/i.test(this.win_.navigator.userAgent) // iOS 12+ no longer fires `canplay`, this is a workaround
+      ) {
         this.postEvent(canplay);
       } else {
         player.on(canplay, () => this.postEvent(canplay));

--- a/test/unit/test-video-iframe-integration.js
+++ b/test/unit/test-video-iframe-integration.js
@@ -268,7 +268,7 @@ describes.realWin('video-iframe-integration', {amp: false}, (env) => {
 
           const player = mockVideoJsPlayer();
 
-          const integration = new AmpVideoIntegration();
+          const integration = new AmpVideoIntegration(env.win);
 
           const listenToOnce = env.sandbox.stub(integration, 'listenToOnce_');
           const methodSpy = env.sandbox.spy(integration, 'method');


### PR DESCRIPTION
Fixes https://github.com/ampproject/amphtml/issues/39676

For unknown reason, iOS refuses to send `canplay` event when the video player is in ready state.

https://html.spec.whatwg.org/multipage/media.html#mediaevents This appears to be contrary to the spec, which state that it should do so when `readyState` becomes >=3, which was AMP's implementation.

Therefore, we have to apply this nasty patch to make it work. Since `platform service` is not available here, I do user agent check directly instead of using `isIos()` function.