### PR TITLE
VS code config: Insert EOF newline

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,8 @@
     "*.schema.json": "jsonc"
   },
 
+  "files.insertFinalNewline": true,
+
   // Auto-fix JS files with ESLint using amphtml's custom settings. Needs
   // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
A few people are having issues since VSCode does not automatically insert a newline at EOF. This change intends to set it for project.