### PR TITLE
fix: add missing title in amp-consent iframe element

### DIFF
--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -1035,7 +1035,7 @@ export class AmpConsent extends AMP.BaseElement {
 
     // Set up the __tcfApiLocator window to signal postMessage support
     const iframe = this.element.ownerDocument.createElement('iframe');
-    iframe.setAttribute('title', this.element.title || 'AMP Consent');
+    iframe.setAttribute('title', this.element.title || 'Consent Banner');
     iframe.setAttribute('name', TCF_API_LOCATOR);
     iframe.setAttribute('aria-hidden', 'true');
     toggle(iframe, false);

--- a/extensions/amp-consent/0.1/amp-consent.js
+++ b/extensions/amp-consent/0.1/amp-consent.js
@@ -1035,6 +1035,7 @@ export class AmpConsent extends AMP.BaseElement {
 
     // Set up the __tcfApiLocator window to signal postMessage support
     const iframe = this.element.ownerDocument.createElement('iframe');
+    iframe.setAttribute('title', this.element.title || 'AMP Consent');
     iframe.setAttribute('name', TCF_API_LOCATOR);
     iframe.setAttribute('aria-hidden', 'true');
     toggle(iframe, false);


### PR DESCRIPTION
Added basic title to internal iframe of the AMP consent component. Following same logic applied in https://github.com/ampproject/amphtml/pull/30834.