### PR TITLE
🏗 Replace CircleCI's MacOS resource class to `macos.m1.medium.gen1`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.4.8
   codecov: codecov/codecov@4.1.0
+  macos: circleci/macos@2.4.1
   node: circleci/node@5.2.0
 
 push_and_pr_builds: &push_and_pr_builds
@@ -183,11 +184,6 @@ commands:
       - run:
           name: '💿 Install Microsoft Edge'
           command: ./.circleci/install_microsoft_edge.sh
-  enable_safari_automation:
-    steps:
-      - run:
-          name: '⚙️ Enable Safari Automation'
-          command: sudo /usr/bin/safaridriver --enable
   store_test_output:
     steps:
       - store_test_results:
@@ -409,7 +405,8 @@ jobs:
     <<: *test_types_job
     steps:
       - setup_vm
-      - enable_safari_automation
+      - macos/install-rosetta
+      - macos/add-safari-permissions
       - run:
           name: '⭐⭐⭐ << parameters.test_type >> Tests (Safari) ⭐⭐⭐'
           command: node build-system/pr-check/browser-tests.js --browser=safari --type=<< parameters.test_type >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   browser-tools: circleci/browser-tools@1.4.8
   codecov: codecov/codecov@4.1.0
-  macos: circleci/macos@2.4.1
+  macos: circleci/macos@2.5.0
   node: circleci/node@5.2.0
 
 push_and_pr_builds: &push_and_pr_builds
@@ -69,7 +69,7 @@ executors:
     resource_class: 2xlarge
   macos-medium:
     macos:
-      xcode: 14.3.1
+      xcode: 15.3.0
     resource_class: macos.m1.medium.gen1
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ executors:
   macos-medium:
     macos:
       xcode: 14.3.1
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
 
 commands:
   checkout_repo:


### PR DESCRIPTION
Per https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

Also updates `xcode` to 15.3.0 (Safari 17), replaces our custom `Enable Safari Automation` step with the recommended `macos` Orb's step, and installs Rosetta to enable compatibility with the new CPU.

The existing resource class we're using (`macos.x86.medium.gen2`) is being deprecated in June.