### PR TITLE
🏗🐛 Fix incorrect condition for `headless` mode in visual-diff task

### DIFF
--- a/build-system/tasks/visual-diff/browser.js
+++ b/build-system/tasks/visual-diff/browser.js
@@ -57,7 +57,7 @@ async function launchBrowser() {
       '--no-startup-window',
     ],
     dumpio: argv.chrome_debug,
-    headless: !!argv.dev,
+    headless: !argv.dev,
     executablePath: locateChromeExecutablePath(),
     waitForInitialPage: false,
   };


### PR DESCRIPTION
`headless: !!argv.dev` means that visual diffs run in headless mode when we pass `--dev`, and with full UI when there's no `--dev` in the args list. This is the exact opposite of what we want 😅