### PR TITLE
✨ Add new attribute to mgid and idealmedia ad components

### DIFF
--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -27,7 +27,9 @@ export function getA4ARegistry() {
       'dianomi': () => true,
       'doubleclick': () => true,
       'fake': () => true,
-      'mgid': (win, adTag) => !adTag.hasAttribute('data-container') && !adTag.hasAttribute('data-website'),
+      'mgid': (win, adTag) =>
+        !adTag.hasAttribute('data-container') &&
+        !adTag.hasAttribute('data-website'),
       'nws': () => true,
       'smartadserver': () => true,
       'valueimpression': () => true,

--- a/ads/_a4a-config.js
+++ b/ads/_a4a-config.js
@@ -27,7 +27,7 @@ export function getA4ARegistry() {
       'dianomi': () => true,
       'doubleclick': () => true,
       'fake': () => true,
-      'mgid': (win, adTag) => !adTag.hasAttribute('data-container'),
+      'mgid': (win, adTag) => !adTag.hasAttribute('data-container') && !adTag.hasAttribute('data-website'),
       'nws': () => true,
       'smartadserver': () => true,
       'valueimpression': () => true,

--- a/ads/vendors/idealmedia.js
+++ b/ads/vendors/idealmedia.js
@@ -5,7 +5,11 @@ import {loadScript, validateData} from '#3p/3p';
  * @param {!Object} data
  */
 export function idealmedia(global, data) {
-  validateData(data, [['publisher', 'website'], ['container', 'website'], 'widget'], ['url', 'options']);
+  validateData(
+    data,
+    [['publisher', 'website'], ['container', 'website'], 'widget'],
+    ['url', 'options']
+  );
 
   global.uniqId = (
     '00000' + Math.round(Math.random() * 100000).toString(16)

--- a/ads/vendors/idealmedia.js
+++ b/ads/vendors/idealmedia.js
@@ -5,28 +5,7 @@ import {loadScript, validateData} from '#3p/3p';
  * @param {!Object} data
  */
 export function idealmedia(global, data) {
-  validateData(data, ['publisher', 'widget', 'container'], ['url', 'options']);
-
-  const scriptRoot = document.createElement('div');
-  scriptRoot.id = data.container;
-
-  document.body.appendChild(scriptRoot);
-
-  /**
-   * Returns path for provided js filename
-   * @param {string} publisher The first number.
-   * @return {string} Path to provided filename.
-   */
-  function getResourceFilePath(publisher) {
-    const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
-    return `${publisherStr[0]}/${publisherStr[1]}`;
-  }
-
-  const url =
-    `https://jsc.idealmedia.io/${getResourceFilePath(data.publisher)}/` +
-    `${encodeURIComponent(data.publisher)}.` +
-    `${encodeURIComponent(data.widget)}.js?t=` +
-    Math.floor(Date.now() / 36e5);
+  validateData(data, [['publisher', 'website'], ['container', 'website'], 'widget'], ['url', 'options']);
 
   global.uniqId = (
     '00000' + Math.round(Math.random() * 100000).toString(16)
@@ -42,5 +21,40 @@ export function idealmedia(global, data) {
     });
   });
 
-  loadScript(global, data.url || url);
+  if (data.website) {
+    const widgetContainer = document.createElement('div');
+    widgetContainer.dataset.type = '_mgwidget';
+    widgetContainer.dataset.widgetId = data.widget;
+    document.body.appendChild(widgetContainer);
+
+    const url =
+      `https://jsc.idealmedia.io/site/` +
+      `${encodeURIComponent(data.website)}.js?t=` +
+      Math.floor(Date.now() / 36e5);
+
+    loadScript(global, data.url || url);
+  } else {
+    const scriptRoot = document.createElement('div');
+    scriptRoot.id = data.container;
+
+    document.body.appendChild(scriptRoot);
+
+    /**
+     * Returns path for provided js filename
+     * @param {string} publisher js filename
+     * @return {string} Path to provided filename.
+     */
+    function getResourceFilePath(publisher) {
+      const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
+      return `${publisherStr[0]}/${publisherStr[1]}`;
+    }
+
+    const url =
+      `https://jsc.idealmedia.io/${getResourceFilePath(data.publisher)}/` +
+      `${encodeURIComponent(data.publisher)}.` +
+      `${encodeURIComponent(data.widget)}.js?t=` +
+      Math.floor(Date.now() / 36e5);
+
+    loadScript(global, data.url || url);
+  }
 }

--- a/ads/vendors/idealmedia.md
+++ b/ads/vendors/idealmedia.md
@@ -4,6 +4,19 @@
 
 ### Basic
 
+Latest version:
+```html
+<amp-embed
+  width="100"
+  height="283"
+  type="idealmedia"
+  data-website="98765"
+  data-widget="12345"
+>
+</amp-embed>
+```
+
+Legacy version:
 ```html
 <amp-embed
   width="100"
@@ -22,8 +35,13 @@ For details on the configuration semantics, please contact the ad network or ref
 
 ### Required parameters
 
--   `data-publisher`
+Latest version:
 -   `data-widget`
+-   `data-website`
+
+Legacy version:
+-   `data-widget`
+-   `data-publisher`
 -   `data-container`
 
 ### Optional parameters

--- a/ads/vendors/mgid.js
+++ b/ads/vendors/mgid.js
@@ -5,7 +5,11 @@ import {loadScript, validateData} from '#3p/3p';
  * @param {!Object} data
  */
 export function mgid(global, data) {
-  validateData(data, [['publisher', 'website'], ['container', 'website'], 'widget'], ['url', 'options']);
+  validateData(
+    data,
+    [['publisher', 'website'], ['container', 'website'], 'widget'],
+    ['url', 'options']
+  );
 
   global.uniqId = (
     '00000' + Math.round(Math.random() * 100000).toString(16)

--- a/ads/vendors/mgid.js
+++ b/ads/vendors/mgid.js
@@ -5,28 +5,7 @@ import {loadScript, validateData} from '#3p/3p';
  * @param {!Object} data
  */
 export function mgid(global, data) {
-  validateData(data, ['publisher', 'widget', 'container'], ['url', 'options']);
-
-  const scriptRoot = document.createElement('div');
-  scriptRoot.id = data.container;
-
-  document.body.appendChild(scriptRoot);
-
-  /**
-   * Returns path for provided js filename
-   * @param {string} publisher js filename
-   * @return {string} Path to provided filename.
-   */
-  function getResourceFilePath(publisher) {
-    const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
-    return `${publisherStr[0]}/${publisherStr[1]}`;
-  }
-
-  const url =
-    `https://jsc.mgid.com/${getResourceFilePath(data.publisher)}/` +
-    `${encodeURIComponent(data.publisher)}.` +
-    `${encodeURIComponent(data.widget)}.js?t=` +
-    Math.floor(Date.now() / 36e5);
+  validateData(data, [['publisher', 'website'], ['container', 'website'], 'widget'], ['url', 'options']);
 
   global.uniqId = (
     '00000' + Math.round(Math.random() * 100000).toString(16)
@@ -42,5 +21,40 @@ export function mgid(global, data) {
     });
   });
 
-  loadScript(global, data.url || url);
+  if (data.website) {
+    const widgetContainer = document.createElement('div');
+    widgetContainer.dataset.type = '_mgwidget';
+    widgetContainer.dataset.widgetId = data.widget;
+    document.body.appendChild(widgetContainer);
+
+    const url =
+      `https://jsc.mgid.com/site/` +
+      `${encodeURIComponent(data.website)}.js?t=` +
+      Math.floor(Date.now() / 36e5);
+
+    loadScript(global, data.url || url);
+  } else {
+    const scriptRoot = document.createElement('div');
+    scriptRoot.id = data.container;
+
+    document.body.appendChild(scriptRoot);
+
+    /**
+     * Returns path for provided js filename
+     * @param {string} publisher js filename
+     * @return {string} Path to provided filename.
+     */
+    function getResourceFilePath(publisher) {
+      const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
+      return `${publisherStr[0]}/${publisherStr[1]}`;
+    }
+
+    const url =
+      `https://jsc.mgid.com/${getResourceFilePath(data.publisher)}/` +
+      `${encodeURIComponent(data.publisher)}.` +
+      `${encodeURIComponent(data.widget)}.js?t=` +
+      Math.floor(Date.now() / 36e5);
+
+    loadScript(global, data.url || url);
+  }
 }

--- a/ads/vendors/mgid.md
+++ b/ads/vendors/mgid.md
@@ -4,6 +4,19 @@
 
 ### Basic
 
+Latest version:
+```html
+<amp-embed
+  width="100"
+  height="283"
+  type="mgid"
+  data-website="98765"
+  data-widget="12345"
+>
+</amp-embed>
+```
+
+Legacy version:
 ```html
 <amp-embed
   width="100"
@@ -22,8 +35,13 @@ For details on the configuration semantics, please contact the ad network or ref
 
 ### Required parameters
 
--   `data-publisher`
+Latest version:
 -   `data-widget`
+-   `data-website`
+
+Legacy version:
+-   `data-widget`
+-   `data-publisher`
 -   `data-container`
 
 ### Optional parameters

--- a/examples/amp-ad/ads.amp.esm.html
+++ b/examples/amp-ad/ads.amp.esm.html
@@ -1315,9 +1315,8 @@
   <h2>Idealmedia</h2>
   <amp-ad width="600" height="320"
           type="idealmedia"
-          data-publisher="test_20190314_vt-24403_appr1.com"
-          data-widget="689384"
-          data-container="M416878ScriptRootC689384">
+          data-website="416878"
+          data-widget="689384">
   </amp-ad>
 
   <h2>I-Mobile 320x50 banner</h2>
@@ -1538,9 +1537,8 @@
   <h2>Mgid</h2>
   <amp-ad width="600" height="320"
           type="mgid"
-          data-publisher="barada.com"
-          data-widget="353317"
-          data-container="M207275ScriptRootC353317">
+          data-website="207275"
+          data-widget="353317">
   </amp-ad>
 
   <h2>MicroAd 320x50 banner</h2>

--- a/examples/amp-ad/ads.amp.esm.html
+++ b/examples/amp-ad/ads.amp.esm.html
@@ -1315,8 +1315,8 @@
   <h2>Idealmedia</h2>
   <amp-ad width="600" height="320"
           type="idealmedia"
-          data-website="416878"
-          data-widget="689384">
+          data-website="473218"
+          data-widget="1629484">
   </amp-ad>
 
   <h2>I-Mobile 320x50 banner</h2>
@@ -1537,8 +1537,8 @@
   <h2>Mgid</h2>
   <amp-ad width="600" height="320"
           type="mgid"
-          data-website="207275"
-          data-widget="353317">
+          data-website="579198"
+          data-widget="996801">
   </amp-ad>
 
   <h2>MicroAd 320x50 banner</h2>

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -1190,8 +1190,7 @@
   </amp-ad>
 
   <h2>Idealmedia</h2>
-  <amp-ad width="600" height="320" type="idealmedia" data-publisher="testsok150917-d1.com" data-widget="167018"
-    data-container="M278974ScriptRootC167018">
+  <amp-ad width="600" height="320" type="idealmedia" data-website="278974" data-widget="167018">
   </amp-ad>
 
   <h2>I-Mobile 320x50 banner</h2>
@@ -1365,8 +1364,7 @@
   </amp-ad>
 
   <h2>Mgid</h2>
-  <amp-ad width="600" height="320" type="mgid" data-publisher="barada.com" data-widget="353317"
-    data-container="M207275ScriptRootC353317">
+  <amp-ad width="600" height="320" type="mgid" data-website="207275" data-widget="353317">
   </amp-ad>
 
   <h2>MicroAd 320x50 banner</h2>

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -1190,7 +1190,7 @@
   </amp-ad>
 
   <h2>Idealmedia</h2>
-  <amp-ad width="600" height="320" type="idealmedia" data-website="278974" data-widget="167018">
+  <amp-ad width="600" height="320" type="idealmedia" data-website="473218" data-widget="1629484">
   </amp-ad>
 
   <h2>I-Mobile 320x50 banner</h2>
@@ -1364,7 +1364,7 @@
   </amp-ad>
 
   <h2>Mgid</h2>
-  <amp-ad width="600" height="320" type="mgid" data-website="207275" data-widget="353317">
+  <amp-ad width="600" height="320" type="mgid" data-website="579198" data-widget="996801">
   </amp-ad>
 
   <h2>MicroAd 320x50 banner</h2>


### PR DESCRIPTION
We adding new attribute "website" to mgid and idealmedia ad components. It could be used instead legacy attributes "publisher" and "container" (they are still supported, but are not encouraged to use)
