### PR TITLE
✨ Adskeeper website attribute

### DIFF
--- a/ads/vendors/adskeeper.js
+++ b/ads/vendors/adskeeper.js
@@ -21,41 +21,60 @@ import {loadScript, validateData} from '#3p/3p';
  * @param {!Object} data
  */
 export function adskeeper(global, data) {
-  validateData(data, ['publisher', 'widget', 'container'], ['url', 'options']);
-
-  const scriptRoot = global.document.createElement('div');
-  scriptRoot.id = data.container;
-
-  global.document.body.appendChild(scriptRoot);
-
-  /**
-   * Returns path for provided js filename
-   * @param {string} publisher js filename
-   * @return {string} Path to provided filename.
-   */
-  function getResourceFilePath(publisher) {
-    const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
-    return `${publisherStr[0]}/${publisherStr[1]}`;
-  }
-
-  const url =
-    `https://jsc.adskeeper.com/${getResourceFilePath(data.publisher)}/` +
-    `${encodeURIComponent(data.publisher)}.` +
-    `${encodeURIComponent(data.widget)}.js`;
+  validateData(
+    data,
+    [['publisher', 'website'], ['container', 'website'], 'widget'],
+    ['url', 'options']
+  );
 
   global.uniqId = (
     '00000' + Math.round(Math.random() * 100000).toString(16)
   ).slice(-5);
-  global['ampOptions' + data.widget + '_' + global.uniqId] = data.options;
+  window['ampOptions' + data.widget + '_' + global.uniqId] = data.options;
 
   global.context.observeIntersection(function (changes) {
     /** @type {!Array} */ (changes).forEach(function (c) {
-      global['intersectionRect' + data.widget + '_' + global.uniqId] =
+      window['intersectionRect' + data.widget + '_' + global.uniqId] =
         c.intersectionRect;
-      global['boundingClientRect' + data.widget + '_' + global.uniqId] =
+      window['boundingClientRect' + data.widget + '_' + global.uniqId] =
         c.boundingClientRect;
     });
   });
 
-  loadScript(global, data.url || url);
+  if (data.website) {
+    const widgetContainer = document.createElement('div');
+    widgetContainer.dataset.type = '_mgwidget';
+    widgetContainer.dataset.widgetId = data.widget;
+    document.body.appendChild(widgetContainer);
+
+    const url =
+      `https://jsc.adskeeper.com/site/` +
+      `${encodeURIComponent(data.website)}.js?t=` +
+      Math.floor(Date.now() / 36e5);
+
+    loadScript(global, data.url || url);
+  } else {
+    const scriptRoot = document.createElement('div');
+    scriptRoot.id = data.container;
+
+    document.body.appendChild(scriptRoot);
+
+    /**
+     * Returns path for provided js filename
+     * @param {string} publisher js filename
+     * @return {string} Path to provided filename.
+     */
+    function getResourceFilePath(publisher) {
+      const publisherStr = publisher.replace(/[^a-zA-Z0-9]/g, '');
+      return `${publisherStr[0]}/${publisherStr[1]}`;
+    }
+
+    const url =
+      `https://jsc.adskeeper.com/${getResourceFilePath(data.publisher)}/` +
+      `${encodeURIComponent(data.publisher)}.` +
+      `${encodeURIComponent(data.widget)}.js?t=` +
+      Math.floor(Date.now() / 36e5);
+
+    loadScript(global, data.url || url);
+  }
 }

--- a/ads/vendors/adskeeper.md
+++ b/ads/vendors/adskeeper.md
@@ -20,6 +20,19 @@ limitations under the License.
 
 ### Basic
 
+Latest version:
+```html
+<amp-embed
+  width="100"
+  height="283"
+  type="adskeeper"
+  data-website="98765"
+  data-widget="12345"
+>
+</amp-embed>
+```
+
+Legacy version:
 ```html
 <amp-embed
   width="100"
@@ -38,8 +51,13 @@ For details on the configuration semantics, please contact the ad network or ref
 
 ### Required parameters
 
--   `data-publisher`
+Latest version:
 -   `data-widget`
+-   `data-website`
+
+Legacy version:
+-   `data-widget`
+-   `data-publisher`
 -   `data-container`
 
 ### Optional parameters

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -679,8 +679,7 @@
   </amp-ad>
 
   <h2>AdsKeeper</h2>
-  <amp-embed width="600" height="320" type="adskeeper" data-publisher="example.adskeeper.com" data-widget="1126814"
-    data-container="M707443ScriptRootC1126814">
+  <amp-embed width="600" height="320" type="adskeeper" data-website="107894" data-widget="1629491">
   </amp-embed>
 
   <h2>AdsLoom</h2>


### PR DESCRIPTION
We adding new attribute "website" to adskeeper ad component. It could be used instead legacy attributes "publisher" and "container" (they are still supported, but are not encouraged to use)