### PR TITLE
🐛 allow ampshadow to be root for ContextNode

### DIFF
--- a/src/core/context/node.js
+++ b/src/core/context/node.js
@@ -15,6 +15,7 @@ import {Values} from './values';
 const NODE_PROP = '__AMP_NODE';
 const ASSIGNED_SLOT_PROP = '__AMP_ASSIGNED_SLOT';
 const AMP_PREFIX = 'AMP-';
+const AMPDOC_PROP = '__AMPDOC';
 
 // Relevant node types.
 // See https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType.
@@ -192,14 +193,14 @@ export class ContextNode {
     this.name = name;
 
     /**
-     * Whether this node is a root. The Document DOM nodes are automatically
+     * Whether this node is a root. The Document DOM nodes and ampdoc roots are automatically
      * considered as roots. But other nodes can become roots as well
      * (e.g. shadow roots) via `setIsRoot()` API.
      *
      * @package
      * @type {boolean}
      */
-    this.isRoot = node.nodeType == DOCUMENT_NODE;
+    this.isRoot = node.nodeType == DOCUMENT_NODE || !!node[AMPDOC_PROP];
 
     /**
      * The root context node. Always available for a DOM node connected to a

--- a/src/core/context/types.d.ts
+++ b/src/core/context/types.d.ts
@@ -1,4 +1,5 @@
 import {ContextNode} from './node';
+
 export interface IContextProp<T, DEP> {
   /**
    * A globally unique key. Extensions must use a fully qualified name such
@@ -92,5 +93,7 @@ declare global {
 
     // Used to map a Node to its assigned slot.
     __AMP_ASSIGNED_SLOT?: Node;
+
+    __AMPDOC: import('../../service/ampdoc-impl').AmpDoc;
   }
 }

--- a/src/core/context/types.d.ts
+++ b/src/core/context/types.d.ts
@@ -94,6 +94,6 @@ declare global {
     // Used to map a Node to its assigned slot.
     __AMP_ASSIGNED_SLOT?: Node;
 
-    __AMPDOC: import('../../service/ampdoc-impl').AmpDoc;
+    __AMPDOC?: import('../../service/ampdoc-impl').AmpDoc;
   }
 }

--- a/test/unit/core/context/test-node-discover.js
+++ b/test/unit/core/context/test-node-discover.js
@@ -161,6 +161,23 @@ describes.realWin('ContextNode', {}, (env) => {
       });
     });
 
+    it('should create a ampdoc holder shadow root', () => {
+      const frag = doc.createDocumentFragment();
+
+      frag.__AMPDOC = {};
+
+      const cn = ContextNode.get(frag);
+      expect(cn.node).to.equal(frag);
+      // Parent always starts as null.
+      expectContext(cn, {
+        parent: null,
+        isRoot: false,
+        root: frag,
+        children: [],
+        discoverable: true,
+      });
+    });
+
     it('should create a document node', () => {
       const cn = ContextNode.get(doc);
       expect(cn.node).to.equal(doc);

--- a/test/unit/core/context/test-node-discover.js
+++ b/test/unit/core/context/test-node-discover.js
@@ -171,10 +171,10 @@ describes.realWin('ContextNode', {}, (env) => {
       // Parent always starts as null.
       expectContext(cn, {
         parent: null,
-        isRoot: false,
+        isRoot: true,
         root: frag,
         children: [],
-        discoverable: true,
+        discoverable: false,
       });
     });
 


### PR DESCRIPTION
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->

amp-render components inside ampshadows are not being rendered beucase ContextNode is not able to find a proper root. 

Amp component constructors are working properly, scheduling renders for preact, however this callback is never executed 
https://github.com/ampproject/amphtml/blob/main/src/preact/base-element.js#L432 because subscriber thinks the element is not connected https://github.com/ampproject/amphtml/blob/main/src/core/context/subscriber.js#L181.

ampshadow root should be treated like document for normal ampdocs, what do you think?

