### PR TITLE
✨ [amp-target-video-player] Adds support for TargetVideo player

### DIFF
--- a/build-system/compile/bundles.config.extensions.json
+++ b/build-system/compile/bundles.config.extensions.json
@@ -1161,6 +1161,11 @@
     }
   },
   {
+    "name": "amp-target-video-player",
+    "version": "0.1",
+    "latestVersion": "0.1"
+  },
+  {
     "name": "amp-tiktok",
     "version": "0.1",
     "latestVersion": "0.1",

--- a/build-system/compile/bundles.legacy-latest-versions.jsonc
+++ b/build-system/compile/bundles.legacy-latest-versions.jsonc
@@ -144,6 +144,7 @@
   "amp-stream-gallery": "0.1",
   "amp-subscriptions-google": "0.1",
   "amp-subscriptions": "0.1",
+  "amp-target-video-player": "0.1",
   "amp-tiktok": "0.1",
   "amp-timeago": "0.1",
   "amp-truncate-text": "0.1",

--- a/build-system/server/app-video-testbench.js
+++ b/build-system/server/app-video-testbench.js
@@ -47,6 +47,11 @@ const requiredAttrs = {
     'data-playerid': '26e2e3c1049c4e70ae08a242638b5c40',
     'data-playerversion': 'v4',
   },
+  'amp-target-video-player': {
+    'data-partner': '264',
+    'data-player': '4144',
+    'data-video': '13663',
+  },
   'amp-video-iframe': {
     'src': '/examples/amp-video-iframe/frame.html',
     'poster': 'https://placekitten.com/g/1600/900',

--- a/examples/target-video-player.amp.html
+++ b/examples/target-video-player.amp.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>TargetVideo Player Example</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <link href='https://fonts.googleapis.com/css?family=Georgia|Open+Sans|Roboto' rel='stylesheet' type='text/css'>
+  <script async custom-element="amp-video-docking" src="https://cdn.ampproject.org/v0/amp-video-docking-0.1.js"></script>
+  <script async custom-element="amp-target-video-player" src="https://cdn.ampproject.org/v0/amp-target-video-player-0.1.js"></script>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <style amp-custom>
+    body { font-family:Roboto,sans-serif; padding: 0.5em; }
+    h4 { margin: 0.5em 0; }
+    .spacer { height: 100vh; }
+  </style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+
+  <h2>TargetVideo Player</h2>
+  <amp-target-video-player
+      id="myVideo"
+      data-partner="264"
+      data-player="4144"
+      data-video="13663"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <h4>Actions</h4>
+  <button on="tap:myVideo.play">Play</button>
+  <button on="tap:myVideo.pause">Pause</button>
+  <button on="tap:myVideo.mute">Mute</button>
+  <button on="tap:myVideo.unmute">Unmute</button>
+  <button on="tap:myVideo.fullscreen">Fullscreen</button>
+
+  <h2>Autoplay</h2>
+  <amp-target-video-player
+      autoplay
+      data-partner="264"
+      data-player="4144"
+      data-video="13663"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+
+  <h2>Outstream</h2>
+  <amp-target-video-player
+      autoplay
+      data-partner="6205"
+      data-player="0"
+      data-outstream="3828"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+
+  <h2>Carousel</h2>
+  <amp-target-video-player
+      data-partner="17402"
+      data-player="26145"
+      data-carousel="459"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+
+  <h2>Dock</h2>
+  <amp-target-video-player
+      dock
+      data-partner="264"
+      data-player="4144"
+      data-video="13663"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+
+  <div class="spacer"></div>
+
+</body>
+</html>

--- a/extensions/amp-target-video-player/0.1/amp-target-video-player.js
+++ b/extensions/amp-target-video-player/0.1/amp-target-video-player.js
@@ -1,0 +1,499 @@
+import {CONSENT_POLICY_STATE} from '#core/constants/consent-state';
+import {Deferred} from '#core/data-structures/promise';
+import {
+  dispatchCustomEvent,
+  getChildJsonConfig,
+  removeElement,
+} from '#core/dom';
+import {
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '#core/dom/fullscreen';
+import {applyFillContent, isLayoutSizeDefined} from '#core/dom/layout';
+import {propagateAttributes} from '#core/dom/propagate-attributes';
+import {htmlFor} from '#core/dom/static-template';
+import {PauseHelper} from '#core/dom/video/pause-helper';
+
+import {Services} from '#service';
+import {installVideoManagerForDoc} from '#service/video-manager-impl';
+
+import {getData, listen} from '#utils/event-helper';
+import {dev, userAssert} from '#utils/log';
+
+import {
+  getConsentPolicyInfo,
+  getConsentPolicyState,
+} from '../../../src/consent';
+import {
+  createFrameFor,
+  mutedOrUnmutedEvent,
+  originMatches,
+  redispatch,
+} from '../../../src/iframe-video';
+import {assertAbsoluteHttpOrHttpsUrl} from '../../../src/url';
+import {VideoEvents_Enum} from '../../../src/video-interface';
+
+const TAG = 'amp-target-video-player';
+
+/**
+ * @implements {../../../src/video-interface.VideoInterface}
+ */
+class AmpTargetVideoPlayer extends AMP.BaseElement {
+  /** @param {!AmpElement} element */
+  constructor(element) {
+    super(element);
+
+    /** @private {string} */
+    this.partnerID_ = '';
+
+    /** @private {string} */
+    this.feedID_ = '';
+
+    /** @private {string} */
+    this.playerID_ = '';
+
+    /** @private {?number}  */
+    this.currentTime_ = 0;
+
+    /** @private {?number}  */
+    this.duration_ = 0;
+
+    /** @private {?HTMLIFrameElement} */
+    this.iframe_ = null;
+
+    /** @private {?Promise} */
+    this.playerReadyPromise_ = null;
+
+    /** @private {?Function} */
+    this.playerReadyResolver_ = null;
+
+    /** @private {?string} */
+    this.videoIframeSrc_ = null;
+
+    /** @private {?number} */
+    this.volume_ = null;
+
+    /** @private {?Function} */
+    this.unlistenMessage_ = null;
+
+    /** @private @const */
+    this.pauseHelper_ = new PauseHelper(this.element);
+  }
+
+  /**
+   * @param {boolean=} opt_onLayout
+   * @override
+   */
+  preconnectCallback(opt_onLayout) {
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://player.target-video.com',
+      opt_onLayout
+    );
+    Services.preconnectFor(this.win).url(
+      this.getAmpDoc(),
+      'https://cdn.target-video.com',
+      opt_onLayout
+    );
+  }
+
+  /** @override */
+  isLayoutSupported(layout) {
+    return isLayoutSizeDefined(layout);
+  }
+
+  /**
+   * Gets the source of video
+   *
+   * @return {string}
+   */
+  getVideoIframeSrc_() {
+    if (this.videoIframeSrc_) {
+      return this.videoIframeSrc_;
+    }
+
+    let feedType = '';
+    const itemsNum = this.element.hasAttribute('data-dynamic') ? '10' : '1';
+
+    if (this.element.hasAttribute('data-video')) {
+      feedType = 'video';
+    } else if (this.element.hasAttribute('data-dynamic')) {
+      feedType = this.element.getAttribute('data-dynamic');
+    } else if (this.element.hasAttribute('data-playlist')) {
+      feedType = 'playlist';
+    } else if (this.element.hasAttribute('data-carousel')) {
+      feedType = 'carousel';
+    } else if (this.element.hasAttribute('data-outstream')) {
+      feedType = 'outstream';
+    }
+
+    // Create iframe
+    let src =
+      'https://player.target-video.com/services/iframe/' +
+      encodeURIComponent(feedType) +
+      '/' +
+      encodeURIComponent(this.feedID_) +
+      '/' +
+      encodeURIComponent(this.partnerID_) +
+      '/' +
+      encodeURIComponent(this.playerID_) +
+      '/0/' +
+      itemsNum +
+      '/?amp=1';
+
+    // Append child JSON config if supplied
+    try {
+      const customConfig = getChildJsonConfig(this.element);
+      src += '&cust_config=' + JSON.stringify(customConfig);
+    } catch (e) {}
+
+    this.videoIframeSrc_ = assertAbsoluteHttpOrHttpsUrl(src);
+
+    return this.videoIframeSrc_;
+  }
+
+  /** @override */
+  buildCallback() {
+    const {element} = this;
+
+    this.partnerID_ = userAssert(
+      element.getAttribute('data-partner'),
+      'The data-partner attribute is required for <amp-target-video-player> %s',
+      element
+    );
+
+    this.playerID_ = userAssert(
+      element.getAttribute('data-player'),
+      'The data-player attribute is required for <amp-target-video-player> %s',
+      element
+    );
+
+    this.feedID_ = userAssert(
+      element.getAttribute('data-video') ||
+        element.getAttribute('data-playlist') ||
+        element.getAttribute('data-carousel') ||
+        element.getAttribute('data-outstream'),
+      'Either the data-video, data-playlist, data-carousel or data-outstream ' +
+        'attributes must be specified for <amp-target-video-player> %s',
+      element
+    );
+
+    const deferred = new Deferred();
+    this.playerReadyPromise_ = deferred.promise;
+    this.playerReadyResolver_ = deferred.resolve;
+
+    installVideoManagerForDoc(element);
+    Services.videoManagerForDoc(element).register(this);
+  }
+
+  /** @override */
+  layoutCallback() {
+    const iframe = createFrameFor(this, this.getVideoIframeSrc_());
+
+    this.iframe_ = /** @type {HTMLIFrameElement} */ (iframe);
+
+    this.unlistenMessage_ = listen(
+      this.win,
+      'message',
+      this.handleTargetVideoMessage_.bind(this)
+    );
+
+    return this.loadPromise(iframe).then(() => this.playerReadyPromise_);
+  }
+
+  /** @override */
+  unlayoutCallback() {
+    if (this.iframe_) {
+      removeElement(this.iframe_);
+      this.iframe_ = null;
+    }
+    if (this.unlistenMessage_) {
+      this.unlistenMessage_();
+    }
+
+    const deferred = new Deferred();
+    this.playerReadyPromise_ = deferred.promise;
+    this.playerReadyResolver_ = deferred.resolve;
+
+    this.pauseHelper_.updatePlaying(false);
+
+    return true; // Call layoutCallback again.
+  }
+
+  /** @override */
+  pauseCallback() {
+    this.pause();
+  }
+
+  /** @override */
+  createPlaceholderCallback() {
+    const {element} = this;
+
+    if (
+      !element.hasAttribute('data-video') &&
+      !element.hasAttribute('data-playlist')
+    ) {
+      return;
+    }
+
+    const {feedID_: feedID, partnerID_: partnerID} = this;
+
+    const html = htmlFor(element);
+    const placeholder = html`
+      <img placeholder referrerpolicy="origin" loading="lazy" />
+    `;
+
+    propagateAttributes(['aria-label'], this.element, placeholder);
+    applyFillContent(placeholder);
+
+    const altText = placeholder.hasAttribute('aria-label')
+      ? 'Loading video - ' + placeholder.getAttribute('aria-label')
+      : 'Loading video';
+
+    placeholder.setAttribute('alt', altText);
+
+    placeholder.setAttribute(
+      'src',
+      `https://cdn.target-video.com/live/partners/${encodeURIComponent(partnerID)}` +
+        `/snapshot/${encodeURIComponent(feedID)}.jpg`
+    );
+
+    this.loadPromise(placeholder).catch(() => {
+      placeholder.src = 'https://cdn.target-video.com/live/default/defaultSnapshot.png';
+    });
+
+    return placeholder;
+  }
+
+  /**
+   * Sends a command to the player through postMessage.
+   * @param {string} command
+   * @param {*=} opt_arg
+   * @private
+   * */
+  sendCommand_(command, opt_arg) {
+    this.playerReadyPromise_.then(() => {
+      if (this.iframe_ && this.iframe_.contentWindow) {
+        const args = opt_arg === undefined ? '' : '|' + opt_arg;
+        const message = 'BPLR|' + command + args;
+        console.log({message});
+        this.iframe_.contentWindow./*OK*/ postMessage(message, '*');
+      }
+    });
+  }
+
+  /**
+   * Requests consent data from consent module
+   * and forwards information to player
+   * @private
+   */
+  getConsentData_() {
+    const consentPolicy = this.getConsentPolicy() || 'default';
+    const consentStatePromise = getConsentPolicyState(
+      this.element,
+      consentPolicy
+    );
+    const consentStringPromise = getConsentPolicyInfo(
+      this.element,
+      consentPolicy
+    );
+
+    return Promise.all([consentStatePromise, consentStringPromise]).then(
+      (consents) => {
+        let consentData;
+        switch (consents[0]) {
+          case CONSENT_POLICY_STATE.SUFFICIENT:
+            consentData = {
+              'gdprApplies': true,
+              'userConsent': 1,
+              'gdprString': consents[1],
+            };
+            break;
+          case CONSENT_POLICY_STATE.INSUFFICIENT:
+          case CONSENT_POLICY_STATE.UNKNOWN:
+            consentData = {
+              'gdprApplies': true,
+              'userConsent': 0,
+              'gdprString': consents[1],
+            };
+            break;
+          case CONSENT_POLICY_STATE.UNKNOWN_NOT_REQUIRED:
+          default:
+            consentData = {
+              'gdprApplies': false,
+            };
+        }
+        this.sendCommand_('setAMPGDPR', JSON.stringify(consentData));
+      }
+    );
+  }
+
+  /**
+   * @param {!Event} event
+   * @private
+   */
+  handleTargetVideoMessage_(event) {
+    if (!originMatches(event, this.iframe_, 'https://player.target-video.com')) {
+      return;
+    }
+
+    const eventData = /** @type {?string|undefined} */ (getData(event));
+    if (typeof eventData !== 'string' || eventData.indexOf('BPLR') !== 0) {
+      return;
+    }
+
+    const {element} = this;
+    const params = eventData.split('|');
+
+    if (params[2] == 'trigger') {
+      switch (params[3]) {
+        case 'ready':
+          this.playerReadyResolver_(this.iframe_);
+          break;
+        case 'requestAMPGDPR':
+          this.getConsentData_();
+          break;
+        case 'play':
+          this.pauseHelper_.updatePlaying(true);
+          break;
+        case 'pause':
+        case 'ended':
+          this.pauseHelper_.updatePlaying(false);
+          break;
+      }
+      redispatch(element, params[3], {
+        'ready': VideoEvents_Enum.LOAD,
+        'play': VideoEvents_Enum.PLAYING,
+        'pause': VideoEvents_Enum.PAUSE,
+        'ended': VideoEvents_Enum.ENDED,
+        'adStart': VideoEvents_Enum.AD_START,
+        'adEnd': VideoEvents_Enum.AD_END,
+        'loadedmetadata': VideoEvents_Enum.LOADEDMETADATA,
+      });
+    }
+
+    if (params[2] == 'volume') {
+      this.volume_ = parseFloat(params[3]);
+      dispatchCustomEvent(element, mutedOrUnmutedEvent(this.volume_ <= 0));
+    }
+
+    if (params[2] == 'currentTime') {
+      this.currentTime_ = parseFloat(params[3]);
+    }
+
+    if (params[2] == 'duration') {
+      this.duration_ = parseFloat(params[3]);
+    }
+  }
+
+  /** @override */
+  supportsPlatform() {
+    return true;
+  }
+
+  /** @override */
+  isInteractive() {
+    return true;
+  }
+
+  /** @override */
+  play(isAutoplay) {
+    this.sendCommand_('play', isAutoplay ? 'auto' : '');
+  }
+
+  /** @override */
+  pause() {
+    this.sendCommand_('pause');
+  }
+
+  /** @override */
+  mute() {
+    this.sendCommand_('muted', 1);
+    this.sendCommand_('volume', 0);
+  }
+
+  /** @override */
+  unmute() {
+    this.sendCommand_('muted', 0);
+    this.sendCommand_('volume', 1);
+  }
+
+  /** @override */
+  showControls() {
+    // Not supported.
+  }
+
+  /** @override */
+  hideControls() {
+    // Not supported.
+  }
+
+  /**
+   * @override
+   */
+  fullscreenEnter() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenEnter(dev().assertElement(this.iframe_));
+  }
+
+  /**
+   * @override
+   */
+  fullscreenExit() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    if (!this.iframe_) {
+      return false;
+    }
+    return isFullscreenElement(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  getMetadata() {
+    // Not implemented
+  }
+
+  /** @override */
+  preimplementsMediaSessionAPI() {
+    return false;
+  }
+
+  /** @override */
+  preimplementsAutoFullscreen() {
+    return false;
+  }
+
+  /** @override */
+  getCurrentTime() {
+    return /** @type {number} */ (this.currentTime_);
+  }
+
+  /** @override */
+  getDuration() {
+    return /** @type {number} */ (this.duration_);
+  }
+
+  /** @override */
+  getPlayedRanges() {
+    // Not supported.
+    return [];
+  }
+
+  /** @override */
+  seekTo(unusedTimeSeconds) {
+    this.user().error(TAG, '`seekTo` not supported.');
+  }
+}
+
+AMP.extension(TAG, '0.1', (AMP) => {
+  AMP.registerElement(TAG, AmpTargetVideoPlayer);
+});

--- a/extensions/amp-target-video-player/0.1/test/test-amp-target-video-player.js
+++ b/extensions/amp-target-video-player/0.1/test/test-amp-target-video-player.js
@@ -1,0 +1,265 @@
+import '../amp-target-video-player';
+import {Services} from '#service';
+
+import {listenOncePromise} from '#utils/event-helper';
+
+import {VideoEvents_Enum} from '../../../../src/video-interface';
+
+describes.realWin(
+  'amp-target-video-player',
+  {
+    amp: {
+      extensions: ['amp-target-video-player'],
+    },
+  },
+  (env) => {
+    let win, doc;
+    let timer;
+
+    beforeEach(() => {
+      win = env.win;
+      doc = win.document;
+      timer = Services.timerFor(win);
+    });
+
+    function getTargetVideoPlayer(attributes, opt_responsive, config) {
+      const bc = doc.createElement('amp-target-video-player');
+
+      for (const key in attributes) {
+        bc.setAttribute(key, attributes[key]);
+      }
+      bc.setAttribute('width', '640');
+      bc.setAttribute('height', '360');
+      if (opt_responsive) {
+        bc.setAttribute('layout', 'responsive');
+      }
+
+      // create config element if provided
+      if (config) {
+        const configElement = doc.createElement('script');
+        configElement.setAttribute('type', 'application/json');
+        if (typeof config == 'string') {
+          configElement.textContent = config;
+        } else {
+          configElement.textContent = JSON.stringify(config);
+        }
+        bc.appendChild(configElement);
+      }
+
+      // see yt test implementation
+      timer
+        .promise(50)
+        .then(() => bc.getImpl())
+        .then((impl) => {
+          const targetVideoTimerIframe = bc.querySelector('iframe');
+
+          impl.handleTargetVideoMessage_({
+            origin: 'https://player.target-video.com',
+            source: targetVideoTimerIframe.contentWindow,
+            data: 'BPLR|0|trigger|ready',
+          });
+        });
+      doc.body.appendChild(bc);
+      return bc
+        .buildInternal()
+        .then(() => {
+          bc.layoutCallback();
+        })
+        .then(() => bc);
+    }
+
+    it('renders', () => {
+      return getTargetVideoPlayer({
+        'data-partner': '264',
+        'data-player': '4144',
+        'data-video': '13663',
+      }).then((bc) => {
+        const iframe = bc.querySelector('iframe');
+        expect(iframe).to.not.be.null;
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.src).to.equal(
+          'https://player.target-video.com/services/iframe/video/13663/264/4144/0/1/?amp=1'
+        );
+      });
+    });
+
+    it('renders responsively', () => {
+      return getTargetVideoPlayer(
+        {
+          'data-partner': '1177',
+          'data-player': '979',
+          'data-video': '5204',
+        },
+        true
+      ).then((bc) => {
+        const iframe = bc.querySelector('iframe');
+        expect(iframe).to.not.be.null;
+        expect(iframe.className).to.match(/i-amphtml-fill-content/);
+      });
+    });
+
+    it('requires data-partner', () => {
+      return allowConsoleError(() => {
+        return getTargetVideoPlayer({
+          'data-player': '4144',
+          'data-video': '13663',
+        }).should.eventually.be.rejectedWith(
+          /The data-partner attribute is required for/
+        );
+      });
+    });
+
+    it('requires data-player', () => {
+      return allowConsoleError(() => {
+        return getTargetVideoPlayer({
+          'data-partner': '264',
+          'data-video': '13663',
+        }).should.eventually.be.rejectedWith(
+          /The data-player attribute is required for/
+        );
+      });
+    });
+
+    it('requires data-partner for playlists', () => {
+      return allowConsoleError(() => {
+        return getTargetVideoPlayer({
+          'data-player': '4144',
+          'data-playlist': '13663',
+        }).should.eventually.be.rejectedWith(
+          /The data-partner attribute is required for/
+        );
+      });
+    });
+
+    it('requires data-player for playlists', () => {
+      return allowConsoleError(() => {
+        return getTargetVideoPlayer({
+          'data-partner': '264',
+          'data-playlist': '13663',
+        }).should.eventually.be.rejectedWith(
+          /The data-player attribute is required for/
+        );
+      });
+    });
+
+    it('requires data-partner for carousels', () => {
+      return allowConsoleError(() => {
+        return getTargetVideoPlayer({
+          'data-player': '4144',
+          'data-carousel': '459',
+        }).should.eventually.be.rejectedWith(
+          /The data-partner attribute is required for/
+        );
+      });
+    });
+
+    it('requires data-player for carousels', () => {
+      return allowConsoleError(() => {
+        return getTargetVideoPlayer({
+          'data-partner': '264',
+          'data-carousel': '459',
+        }).should.eventually.be.rejectedWith(
+          /The data-player attribute is required for/
+        );
+      });
+    });
+
+    it('config is passed', () => {
+      return getTargetVideoPlayer(
+        {
+          'data-partner': '264',
+          'data-player': '4144',
+          'data-video': '13663',
+        },
+        null,
+        {
+          'debug': 1,
+        }
+      ).then((bc) => {
+        const iframe = bc.querySelector('iframe');
+        expect(iframe).to.not.be.null;
+        expect(iframe.tagName).to.equal('IFRAME');
+        expect(iframe.src).to.equal(
+          'https://player.target-video.com/services/iframe/video/13663/264/4144/0/1/?amp=1&cust_config={%22debug%22:1}'
+        );
+      });
+    });
+
+    it('should forward events from target-video-player to the amp element', async () => {
+      const bc = await getTargetVideoPlayer(
+        {
+          'data-partner': '1177',
+          'data-player': '979',
+          'data-video': '5204',
+        },
+        true
+      );
+      const impl = await bc.getImpl();
+
+      const iframe = bc.querySelector('iframe');
+      return Promise.resolve()
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents_Enum.PLAYING);
+          sendFakeMessage(impl, iframe, 'trigger|play');
+          return p;
+        })
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents_Enum.MUTED);
+          sendFakeMessage(impl, iframe, 'volume|0');
+          return p;
+        })
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents_Enum.PAUSE);
+          sendFakeMessage(impl, iframe, 'trigger|pause');
+          return p;
+        })
+        .then(() => {
+          const p = listenOncePromise(bc, VideoEvents_Enum.UNMUTED);
+          sendFakeMessage(impl, iframe, 'volume|1');
+          return p;
+        });
+    });
+
+    function sendFakeMessage(impl, iframe, command) {
+      impl.handleTargetVideoMessage_({
+        origin: 'https://player.target-video.com',
+        source: iframe.contentWindow,
+        data: 'BPLR|0|' + command,
+      });
+    }
+
+    describe('createPlaceholderCallback', () => {
+      it('should create a placeholder image', () => {
+        return getTargetVideoPlayer({
+          'data-partner': '264',
+          'data-player': '979',
+          'data-video': '13663',
+        }).then((targetVideo) => {
+          const img = targetVideo.querySelector('img');
+          expect(img).to.not.be.null;
+          expect(img.getAttribute('src')).to.equal(
+            'https://cdn.target-video.com/live/partners/264/snapshot/13663.jpg'
+          );
+          expect(img).to.have.class('i-amphtml-fill-content');
+          expect(img).to.have.attribute('placeholder');
+          expect(img.getAttribute('alt')).to.equal('Loading video');
+          expect(img.getAttribute('referrerpolicy')).to.equal('origin');
+        });
+      });
+      it('should propagate aria label for placeholder image', () => {
+        return getTargetVideoPlayer({
+          'data-partner': '264',
+          'data-player': '979',
+          'data-video': '13663',
+          'aria-label': 'great video',
+        }).then((targetVideo) => {
+          const img = targetVideo.querySelector('img');
+          expect(img).to.not.be.null;
+          expect(img.getAttribute('alt')).to.equal(
+            'Loading video - great video'
+          );
+        });
+      });
+    });
+  }
+);

--- a/extensions/amp-target-video-player/0.1/test/validator-amp-target-video-player.html
+++ b/extensions/amp-target-video-player/0.1/test/validator-amp-target-video-player.html
@@ -1,0 +1,81 @@
+<!--
+  Test Description:
+  Tests support for the amp-target-video-player tag.
+-->
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <script async custom-element="amp-target-video-player" src="https://cdn.ampproject.org/v0/amp-target-video-player-0.1.js"></script>
+</head>
+<body>
+  <!-- Example of a valid amp-target-video-player. -->
+  <amp-target-video-player
+      data-partner="264"
+      data-player="4144"
+      data-video="13663"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <!-- Alternate valid example using a playlist. -->
+  <amp-target-video-player
+      data-partner="264"
+      data-player="4144"
+      data-playlist="13663"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <!-- Alternate valid example using a dynamic playlist. -->
+  <amp-target-video-player
+      data-partner="264"
+      data-player="4144"
+      data-playlist="test tag"
+      data-dynamic="tag"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <!-- Alternate valid example using a carousel. -->
+  <amp-target-video-player
+      data-partner="264"
+      data-player="4144"
+      data-carousel="255"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <!-- Alternate valid example using a outstream. -->
+  <amp-target-video-player
+      data-partner="6205"
+      data-player="0"
+      data-outstream="3828"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <!-- Invalid example missing a player id. -->
+  <amp-target-video-player
+      data-partner="264"
+      data-video="13663"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <!-- Invalid example missing video, playlist and outstream. -->
+  <amp-target-video-player
+      data-partner="264"
+      data-player="4144"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+  <!-- Invalid: `dock` without `amp-video-docking` extension. -->
+  <amp-target-video-player
+      dock
+      data-partner="264"
+      data-player="4144"
+      data-video="13663"
+      layout="responsive"
+      width="480" height="270">
+  </amp-target-video-player>
+</body>
+</html>

--- a/extensions/amp-target-video-player/0.1/test/validator-amp-target-video-player.out
+++ b/extensions/amp-target-video-player/0.1/test/validator-amp-target-video-player.out
@@ -1,0 +1,88 @@
+FAIL
+|  <!--
+|    Test Description:
+|    Tests support for the amp-target-video-player tag.
+|  -->
+|  <!doctype html>
+|  <html ⚡ lang="en">
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <script async custom-element="amp-target-video-player" src="https://cdn.ampproject.org/v0/amp-target-video-player-0.1.js"></script>
+|  </head>
+|  <body>
+|    <!-- Example of a valid amp-target-video-player. -->
+|    <amp-target-video-player
+|        data-partner="264"
+|        data-player="4144"
+|        data-video="13663"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|    <!-- Alternate valid example using a playlist. -->
+|    <amp-target-video-player
+|        data-partner="264"
+|        data-player="4144"
+|        data-playlist="13663"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|    <!-- Alternate valid example using a dynamic playlist. -->
+|    <amp-target-video-player
+|        data-partner="264"
+|        data-player="4144"
+|        data-playlist="test tag"
+|        data-dynamic="tag"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|    <!-- Alternate valid example using a carousel. -->
+|    <amp-target-video-player
+|        data-partner="264"
+|        data-player="4144"
+|        data-carousel="255"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|    <!-- Alternate valid example using a outstream. -->
+|    <amp-target-video-player
+|        data-partner="6205"
+|        data-player="0"
+|        data-outstream="3828"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|    <!-- Invalid example missing a player id. -->
+|    <amp-target-video-player
+>>   ^~~~~~~~~
+amp-target-video-player/0.1/test/validator-amp-target-video-player.html:58:2 The mandatory attribute 'data-player' is missing in tag 'amp-target-video-player'. (see https://amp.dev/documentation/components/amp-target-video-player/)
+|        data-partner="264"
+|        data-video="13663"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|    <!-- Invalid example missing video, playlist and outstream. -->
+|    <amp-target-video-player
+>>   ^~~~~~~~~
+amp-target-video-player/0.1/test/validator-amp-target-video-player.html:65:2 The tag 'amp-target-video-player' is missing a mandatory attribute - pick one of ['data-carousel', 'data-outstream', 'data-playlist', 'data-video']. (see https://amp.dev/documentation/components/amp-target-video-player/)
+|        data-partner="264"
+|        data-player="4144"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|    <!-- Invalid: `dock` without `amp-video-docking` extension. -->
+|    <amp-target-video-player
+>>   ^~~~~~~~~
+amp-target-video-player/0.1/test/validator-amp-target-video-player.html:72:2 The attribute 'dock' requires including the 'amp-video-docking' extension JavaScript.
+|        dock
+|        data-partner="264"
+|        data-player="4144"
+|        data-video="13663"
+|        layout="responsive"
+|        width="480" height="270">
+|    </amp-target-video-player>
+|  </body>
+|  </html>

--- a/extensions/amp-target-video-player/OWNERS
+++ b/extensions/amp-target-video-player/OWNERS
@@ -1,0 +1,10 @@
+// For an explanation of the OWNERS rules and syntax, see:
+// https://github.com/ampproject/amp-github-apps/blob/main/owners/OWNERS.example
+
+{
+  rules: [
+    {
+      owners: [{name: 'pedjoni8'}, {name: 'grajzer'}, {name: 'danijel-ristic'}, {name: 'ampproject/wg-components'}],
+    },
+  ],
+}

--- a/extensions/amp-target-video-player/amp-target-video-player.md
+++ b/extensions/amp-target-video-player/amp-target-video-player.md
@@ -1,0 +1,110 @@
+---
+$category@: media
+formats:
+  - websites
+teaser:
+  text: Displays a TargetVideo player.
+---
+
+# amp-target-video-player
+
+An `amp-target-video-player` displays the TargetVideo Player used in [TargetVideo](https://www.target-video.com/) Video Platform.
+
+The `width` and `height` attributes determine the aspect ratio of the player embedded in responsive layouts.
+
+```html
+<amp-target-video-player
+  data-partner="264"
+  data-player="4144"
+  data-video="13663"
+  layout="responsive"
+  width="480"
+  height="270"
+>
+</amp-target-video-player>
+```
+
+### `autoplay`
+
+If this attribute is present, and the browser supports autoplay:
+
+-   the video is automatically muted before autoplay starts
+-   when the video is scrolled out of view, the video is paused
+-   when the video is scrolled into view, the video resumes playback
+-   when the user taps the video, the video is unmuted
+-   if the user has interacted with the video (e.g., mutes/unmutes,
+    pauses/resumes, etc.), and the video is scrolled in or out of view, the
+    state of the video remains as how the user left it. For example, if the user
+    pauses the video, then scrolls the video out of view and returns to the
+    video, the video is still paused.
+
+### `data-partner`
+
+The TargetVideo partner ID.
+
+### `data-player`
+
+The TargetVideo player ID. Specific to every partner.
+
+### `data-video`
+
+The TargetVideo video ID. Embed code must either have `video`, `playlist`, `carousel`
+or `outstream` attribute.
+
+### `data-playlist`
+
+The TargetVideo playlist ID or custom string value for dynamic playlists. Embed code
+must either have `video`, `playlist`, `carousel` or `outstream` attribute.
+
+### `data-carousel`
+
+The TargetVideo carousel ID. Embed code must either have `video`, `playlist`, `carousel`
+or `outstream` attribute.
+
+### `data-outstream`
+
+The TargetVideo outstream unit ID. Embed code must either have `video`, `playlist`, `carousel`
+or `outstream` attribute.
+
+### `data-dynamic`
+
+Parameter used to specify type of dynamic playlist, e.g. latest, channel, tag.
+
+### `dock`
+
+**Requires `amp-video-docking` extension.** If this attribute is present and the
+video is playing manually, the video will be "minimized" and fixed to a corner
+or an element when the user scrolls out of the video component's visual area.
+
+For more details, see [documentation on the docking extension itself](https://amp.dev/documentation/components/amp-video-docking).
+
+### Common attributes
+
+This element includes [common attributes](https://amp.dev/documentation/guides-and-tutorials/learn/common_attributes)
+extended to AMP components.
+
+## Actions
+
+### `play`
+
+Plays the video.
+
+### `pause`
+
+Pauses the video.
+
+### `mute`
+
+Mutes the video.
+
+### `unmute`
+
+Unmutes the video.
+
+### `fullscreenenter`
+
+Takes the video to fullscreen.
+
+## Validation
+
+See [amp-target-video-player rules](https://github.com/ampproject/amphtml/blob/main/extensions/amp-target-video-player/validator-amp-target-video-player.protoascii) in the AMP validator specification.

--- a/extensions/amp-target-video-player/validator-amp-target-video-player.protoascii
+++ b/extensions/amp-target-video-player/validator-amp-target-video-player.protoascii
@@ -1,0 +1,66 @@
+tags: {  # amp-target-video-player
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-target-video-player"
+    version: "0.1"
+    version: "latest"
+    requires_usage: EXEMPTED
+    deprecated_allow_duplicates: true
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-target-video-player>
+  html_format: AMP
+  tag_name: "AMP-target-video-PLAYER"
+  requires_extension: "amp-target-video-player"
+  attrs: { name: "autoplay" }
+  attrs: {
+    name: "data-dynamic"
+    value_regex: "[a-z]+"
+  }
+  attrs: {
+    name: "data-outstream"
+    mandatory_oneof: "['data-carousel', 'data-outstream', 'data-playlist', 'data-video']"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "data-partner"
+    mandatory: true
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "data-player"
+    mandatory: true
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "data-playlist"
+    mandatory_oneof: "['data-carousel', 'data-outstream', 'data-playlist', 'data-video']"
+    value_regex: ".+"
+  }
+  attrs: {
+    name: "data-video"
+    mandatory_oneof: "['data-carousel', 'data-outstream', 'data-playlist', 'data-video']"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "data-carousel"
+    mandatory_oneof: "['data-carousel', 'data-outstream', 'data-playlist', 'data-video']"
+    value_regex: "[0-9]+"
+  }
+  attrs: {
+    name: "dock"
+    requires_extension: "amp-video-docking"
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-target-video-player/"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}


### PR DESCRIPTION
This PR adds TargetVideo player which will replace Brid player.
For now we need to keep Brid player for compatibility reasons until we migrate everything to TargetVideo.