### PR TITLE
Reenable flaky video test

### DIFF
--- a/test/integration/test-video-players-helper.js
+++ b/test/integration/test-video-players-helper.js
@@ -179,8 +179,7 @@ export function runVideoPlayerIntegrationTests(
           });
       });
 
-      // TODO(#40115): fix this flaky test
-      it.skip('should trigger pause analytics when the video pauses', function () {
+      it('should trigger pause analytics when the video pauses', function () {
         let pauseButton;
 
         return getVideoPlayer({
@@ -202,8 +201,7 @@ export function runVideoPlayerIntegrationTests(
           });
       });
 
-      // TODO(#40115): fix this flaky test
-      it.skip('should trigger session analytics when a session ends', function () {
+      it('should trigger session analytics when a session ends', function () {
         let pauseButton;
 
         return getVideoPlayer({
@@ -381,8 +379,7 @@ export function runVideoPlayerIntegrationTests(
     this.timeout(timeout);
 
     describe('play/pause', () => {
-      // TODO(#40115): fix this flaky test
-      it.skip('should play when in view port initially', () => {
+      it('should play when in view port initially', () => {
         return getVideoPlayer({outsideView: false, autoplay: true}).then(
           (r) => {
             return listenOncePromise(r.video, VideoEvents_Enum.PLAYING);
@@ -593,8 +590,8 @@ export function runVideoPlayerIntegrationTests(
         video.setAttribute('id', 'myVideo');
         video.setAttribute('controls', '');
         video.setAttribute('layout', 'fixed');
-        video.setAttribute('width', '300px');
-        video.setAttribute('height', '50vh');
+        video.setAttribute('width', '300');
+        video.setAttribute('height', '300');
 
         video.style.position = 'absolute';
         video.style.top = top;

--- a/test/integration/test-video-players.js
+++ b/test/integration/test-video-players.js
@@ -34,7 +34,8 @@ describes.sandboxed('amp-video-iframe', {}, (env) => {
   );
 });
 
-describes.sandboxed('amp-youtube', {}, (env) => {
+// TODO(#40181): Youtube tests not working on Circle.
+describes.sandboxed.skip('amp-youtube', {}, (env) => {
   runVideoPlayerIntegrationTests(
     env,
     (fixture) => {
@@ -60,8 +61,7 @@ describes.sandboxed('amp-dailymotion', {}, (env) => {
   );
 });
 
-// TODO(#39857): Unskip when integration is fixed.
-describes.sandboxed.skip('amp-3q-player', {}, (env) => {
+describes.sandboxed('amp-3q-player', {}, (env) => {
   runVideoPlayerIntegrationTests(
     env,
     (fixture) => {


### PR DESCRIPTION
Turns out it's because amp-youtube integration tests are failing on circle only. It works fine locally. Suspect it is some network issue on circle or Youtube actively blocking access from a cloud machine. https://github.com/ampproject/amphtml/issues/40181

This PR reenables relevant tests, but disables amp-youtube

Fixes #39857 