### PR TITLE
🚮 Stop loading pv endpoint from MGID AMP stories

### DIFF
--- a/extensions/amp-ad-network-mgid-impl/0.1/amp-ad-network-mgid-impl.js
+++ b/extensions/amp-ad-network-mgid-impl/0.1/amp-ad-network-mgid-impl.js
@@ -15,7 +15,6 @@ import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
 const TAG = 'amp-ad-network-mgid-impl';
 
 const BASE_URL_ = 'https://servicer.mgid.com/';
-const PV_URL_ = 'https://c.mgid.com/pv/';
 
 export class AmpAdNetworkMgidImpl extends AmpA4A {
   /**
@@ -74,19 +73,6 @@ export class AmpAdNetworkMgidImpl extends AmpA4A {
       params.forEach((result) => data.push(result.value));
       const joinedParams = '?' + data.join('&');
       servicerUrl += joinedParams;
-
-      if (!hasOwn(this.win, '_mgAmpStoryPV')) {
-        this.getAmpDoc()
-          .getBody()
-          .appendChild(
-            createElementWithAttributes(this.win.document, 'amp-pixel', {
-              'src': PV_URL_ + joinedParams,
-            })
-          );
-
-        this.win['_mgAmpStoryPV'] = 1;
-      }
-
       return servicerUrl;
     });
   }

--- a/extensions/amp-ad-network-mgid-impl/0.1/amp-ad-network-mgid-impl.js
+++ b/extensions/amp-ad-network-mgid-impl/0.1/amp-ad-network-mgid-impl.js
@@ -2,8 +2,7 @@ import {
   CONSENT_POLICY_STATE,
   CONSENT_STRING_TYPE,
 } from '#core/constants/consent-state';
-import {createElementWithAttributes, removeElement} from '#core/dom';
-import {hasOwn} from '#core/types/object';
+import {removeElement} from '#core/dom';
 
 import {Services} from '#service';
 


### PR DESCRIPTION
We no longer need to call amp-pixel with https://c.mgid.com/pv/, so it should be removed.