### PR TITLE
❄️ Fix flaky test `[v1.0] amp-social-share > chrome > Viewer environment > clicking tabs between multiple social-shares and opens on "enter" keypress`

### DIFF
--- a/extensions/amp-social-share/1.0/test-e2e/test-amp-social-share.js
+++ b/extensions/amp-social-share/1.0/test-e2e/test-amp-social-share.js
@@ -119,9 +119,7 @@ describes.endtoend(
         await expect(windows.length).to.equal(2);
         await controller.switchToWindow(windows[1]);
 
-        await expect(controller.getCurrentUrl()).to.equal(
-          'https://www.tumblr.com/login?redirect_to=https%3A%2F%2Fwww.tumblr.com%2Fwidgets%2Fshare%2Ftool%3FshareSource%3Dlegacy%26canonicalUrl%3D%26url%3Dhttp%253A%252F%252Fexample.com%252F%26posttype%3Dlink%26title%3Damp-social-share%26caption%3D%26content%3Dhttp%253A%252F%252Fexample.com%252F'
-        );
+        await expect(controller.getCurrentUrl()).to.contain('tumblr.com');
       });
     });
   }


### PR DESCRIPTION
Looks like a change in tumblr is breaking our tests on main. This is a quick fix that should be more forward-compatible: https://app.circleci.com/pipelines/github/ampproject/amphtml/31723/workflows/62b2cc4d-c419-4caf-950a-5831b6bbc9e4/jobs/695279
