### PR TITLE
append a `base` element to force the baseURI of the FakeWindow

### DIFF
--- a/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
+++ b/extensions/amp-skimlinks/0.1/test/test-affiliate-link-resolver.js
@@ -396,8 +396,7 @@ describes.fakeWin(
           expect(resolver.getAnchorDomain_(anchor)).to.equal('test.com');
         });
 
-        // TODO(#40214): fix flaky test.
-        it.skip('removes // protocol', () => {
+        it('removes // protocol', () => {
           const anchor = helpers.createAnchor('//test.com/');
           expect(resolver.getAnchorDomain_(anchor)).to.equal('test.com');
         });

--- a/extensions/amp-story-player/0.1/test/test-e2e/test-amp-story-player.js
+++ b/extensions/amp-story-player/0.1/test/test-e2e/test-amp-story-player.js
@@ -22,8 +22,7 @@ describes.endtoend(
       await expect(player);
     });
 
-    // TODO(#40214): fix flaky test.
-    it.skip('loads and displays first story on page load when player is visible in viewport', async () => {
+    it('loads and displays first story on page load when player is visible in viewport', async () => {
       const shadowHost = await controller.findElement(
         'div.i-amphtml-story-player-shadow-root-intermediary'
       );

--- a/extensions/amp-video/0.1/test/test-flexible-bitrate.js
+++ b/extensions/amp-video/0.1/test/test-flexible-bitrate.js
@@ -47,8 +47,7 @@ describes.fakeWin('amp-video flexible-bitrate', {}, (env) => {
       expect(currentBitrates(v0)[0]).to.equal(1000);
     });
 
-    // TODO(#40214): fix flaky test.
-    it.skip('should observe lower bandwidth on next sort', () => {
+    it('should observe lower bandwidth on next sort', () => {
       const m = getManager('4g');
       const v0 = getVideo([4000, 1000, 3000, 2000]);
       v0.id = 'v0';

--- a/testing/fake-dom.js
+++ b/testing/fake-dom.js
@@ -71,6 +71,14 @@ export class FakeWindow {
     // Document.
     /** @const {!HTMLDocument} */
     this.document = self.document.implementation.createHTMLDocument('');
+    // NOTE: There was a change between chrome 119 and 120 where the above
+    // self.document.implementation.createHTMLDocument no longer inherits
+    // the baseURI of self.document. We explicitly set and force it thru
+    // a `<base>` element.
+    const base = this.document.createElement('base');
+    base.href = self.document.baseURI;
+    this.document.head.appendChild(base);
+
     Object.defineProperty(this.document, 'defaultView', {
       get: () => this,
     });


### PR DESCRIPTION
This resolves some of the url issues we've been dealing with on the chromdriver 131 upgrade

there seems to have been a change between chrome 119 to chrome 131 on how the baseURI is inherited. We can force the baseURI of the FakeWindow by appending a `base` element on construction in fake-dom.js

See #40214 
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
