### PR TITLE
Fix chrome 131 amp-ad-exit test

### DIFF
--- a/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test-e2e/test-amp-ad-exit.js
@@ -62,8 +62,7 @@ describes.endtoend(
       );
     });
 
-    // TODO(#40214): fix flaky test.
-    it.skip('product2 ad opened', async () => {
+    it('product2 ad opened', async () => {
       const adDiv = await controller.findElement('#product2');
       await setTime(Number.MAX_VALUE);
       await controller.click(adDiv);
@@ -76,9 +75,11 @@ describes.endtoend(
         /^http:\/\/localhost:8000\/\?product2&r=0\.\d+$/
       );
 
-      await expect(
-        'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking'
-      ).to.have.sentCount(1);
+      const response = await fetch(
+        'http://localhost:8000/amp4test/request-bank/e2e/withdraw/tracking',
+        {signal: AbortSignal.timeout(500)}
+      );
+      await response.json();
     });
 
     it('variable target "current" should point to product1 by default', async () => {
@@ -95,8 +96,7 @@ describes.endtoend(
       );
     });
 
-    // TODO(#40214): fix flaky test.
-    it.skip('should open product2 after setting varible target', async () => {
+    it('should open product2 after setting varible target', async () => {
       const headline = await controller.findElement('h1');
       const nextButton = await controller.findElement('#next-btn');
       await setTime(Number.MAX_VALUE);
@@ -110,9 +110,11 @@ describes.endtoend(
       await expect(await controller.getCurrentUrl()).to.match(
         /^http:\/\/localhost:8000\/\?product2&r=0\.\d+$/
       );
-      await expect(
-        'http://localhost:8000/amp4test/request-bank/e2e/deposit/tracking'
-      ).to.have.sentCount(1);
+      const response = await fetch(
+        'http://localhost:8000/amp4test/request-bank/e2e/withdraw/tracking',
+        {signal: AbortSignal.timeout(500)}
+      );
+      await response.json();
     });
   }
 );


### PR DESCRIPTION
The reason it fails is that we use performance events to find out requests being made, and that it fails when being within a cross domain iframe (but works within a friendly iframe). No ideas why it worked before though. This PR changes to verify that the request is sent using request bank directly. 

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
