### PR TITLE
✅ Fix amp-pixel attribution reporting test failure

### DIFF
--- a/test/unit/builtins/test-amp-pixel.js
+++ b/test/unit/builtins/test-amp-pixel.js
@@ -141,8 +141,10 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
     });
   });
 
-  // TODO(#40214): fix flaky test.
-  it.skip('should not allow attribution reporting', () => {
+  it('should not allow attribution reporting with a non-supporting browser', () => {
+    env.sandbox
+      .stub(privacySandboxUtils, 'isAttributionReportingAllowed')
+      .returns(false);
     const attributionSrc =
       '//pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=2';
     pixel.setAttribute(
@@ -154,7 +156,6 @@ describes.realWin('amp-pixel', {amp: true}, (env) => {
       expect(img.src).to.equal(
         'https://pubads.g.doubleclick.net/activity;dc_iu=1/abc;ord=1?ars=5'
       );
-      expect(img.attributionSrc).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
```
export function isAttributionReportingAllowed(doc) {
  return doc.featurePolicy?.allowedFeatures().includes('attribution-reporting');
}
```

Because isAttributionReportingAllowed is defined by whether the browser supports the attribution reporting api, with the new Chrome it flips to true. This PR fixes the test by no longer assuming it is off by default and forcing this test to test as if it is not supported. The supported case already exists.
