### PR TITLE
Quick fix to the interval/timeout namespace conflict

### DIFF
--- a/3p/environment.js
+++ b/3p/environment.js
@@ -18,7 +18,11 @@ export function setInViewportForTesting(inV) {
 // Active intervals. Must be global, because people clear intervals
 // with clearInterval from a different window.
 const intervals = {};
-let intervalId = 1;
+
+// TODO(40235): This is so we avoid the ID range of setTimeout. We
+// should also patch setTimeout and clearTimeout to avoid having to
+// use this.
+let intervalId = 10000000;
 
 /**
  * Add instrumentation to a window and all child iframes.


### PR DESCRIPTION
As a fix to the timeout/interval space conflict problem: https://github.com/ampproject/amphtml/issues/40235

This does not guarantee that there is no conflict, but at least it will become highly unlikely. Because the way we implement setInterval, we are not able to use the js engine's namespace. The only way to resolve this is to we also generate the ids for timeouts, which is a bit more involved.