### PR TITLE
✨ Add an attribute to amp-story in order to hide share story button

### DIFF
--- a/examples/amp-story/amp-story-social-share.html
+++ b/examples/amp-story/amp-story-social-share.html
@@ -125,7 +125,7 @@
 </head>
 
 <body>
-  <amp-story standalone>
+  <amp-story standalone hide-share-button>
     <amp-story-page id="fill-template-title">
       <amp-social-share class="rounded flex whatsapp i-amphtml-built i-amphtml-layout i-amphtml-element"
         aria-label="Share" type="whatsapp" i-amphtml-layout="fixed" role="button" tabindex="0">Share on

--- a/extensions/amp-story/1.0/amp-story-store-service.js
+++ b/extensions/amp-story/1.0/amp-story-store-service.js
@@ -247,6 +247,7 @@ const Action = mangleObjectValues({
   TOGGLE_PAGE_HAS_ELEMENT_WITH_PLAYBACK: 'togglePageHasElementWithPlayblack',
   TOGGLE_PAUSED: 'togglePaused',
   TOGGLE_RTL: 'toggleRtl',
+  TOGGLE_SHARE_BUTTON: 'toggleShareButton',
   TOGGLE_SHARE_MENU: 'toggleShareMenu',
   TOGGLE_STORY_HAS_BACKGROUND_AUDIO: 'toggleStoryHasBackgroundAudio',
   TOGGLE_STORY_HAS_PLAYBACK_UI: 'toggleStoryHasPlaybackUi',
@@ -419,6 +420,11 @@ const actions = (state, action, data) => {
       return /** @type {!State} */ ({
         ...state,
         [StateProperty.KEYBOARD_ACTIVE_STATE]: !!data,
+      });
+    case Action.TOGGLE_SHARE_BUTTON:
+      return /** @type {!State} */ ({
+        ...state,
+        [StateProperty.CAN_SHOW_SHARING_UIS]: !!data,
       });
     case Action.TOGGLE_SHARE_MENU:
       return /** @type {!State} */ ({

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -402,10 +402,9 @@ export class AmpStory extends AMP.BaseElement {
       );
     }
 
-    this.storeService_.dispatch(
-      Action.TOGGLE_SHARE_BUTTON,
-      !this.element.hasAttribute([Attributes.NO_SHARING])
-    );
+    if (this.element.hasAttribute([Attributes.NO_SHARING])) {
+      this.storeService_.dispatch(Action.TOGGLE_SHARE_BUTTON, false);
+    }
 
     // Removes title in order to prevent incorrect titles appearing on link
     // hover. (See 17654)

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -145,6 +145,7 @@ const Attributes = {
   ADVANCE_TO: 'i-amphtml-advance-to',
   AUTO_ADVANCE_AFTER: 'auto-advance-after',
   AUTO_ADVANCE_TO: 'auto-advance-to',
+  NO_SHARING: 'hide-share-button',
   MUTED: 'muted',
   ORIENTATION: 'orientation',
   PUBLIC_ADVANCE_TO: 'advance-to',
@@ -400,6 +401,11 @@ export class AmpStory extends AMP.BaseElement {
         ''
       );
     }
+
+    this.storeService_.dispatch(
+      Action.TOGGLE_SHARE_BUTTON,
+      !this.element.hasAttribute([Attributes.NO_SHARING])
+    );
 
     // Removes title in order to prevent incorrect titles appearing on link
     // hover. (See 17654)

--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -374,6 +374,10 @@ export class AmpStory extends AMP.BaseElement {
       this.initializeStandaloneStory_();
     }
 
+    if (this.isShareButtonHidden_()) {
+      this.initializeShareButton_(false);
+    }
+
     // buildCallback already runs in a mutate context. Calling another
     // mutateElement explicitly will force the runtime to remeasure the
     // amp-story element, fixing rendering bugs where the story is inactive
@@ -400,10 +404,6 @@ export class AmpStory extends AMP.BaseElement {
         'data-story-supports-landscape',
         ''
       );
-    }
-
-    if (this.element.hasAttribute([Attributes.NO_SHARING])) {
-      this.storeService_.dispatch(Action.TOGGLE_SHARE_BUTTON, false);
     }
 
     // Removes title in order to prevent incorrect titles appearing on link
@@ -579,6 +579,16 @@ export class AmpStory extends AMP.BaseElement {
     this.lockBody_();
     // Standalone CSS affects sizing of the entire page.
     this.onResizeDebounced();
+  }
+
+  /**
+   * Initializes the share button by toggling its visibility.
+   *
+   * @param {boolean} canShow - A boolean indicating whether the share button should be shown.
+   * @private
+   */
+  initializeShareButton_(canShow) {
+    this.storeService_.dispatch(Action.TOGGLE_SHARE_BUTTON, canShow);
   }
 
   /**
@@ -2025,6 +2035,15 @@ export class AmpStory extends AMP.BaseElement {
    */
   isLandscapeSupported_() {
     return this.element.hasAttribute(Attributes.SUPPORTS_LANDSCAPE);
+  }
+
+  /**
+   * Checks if the share button is hidden.
+   * @return {boolean} True if the share button is hidden, false otherwise.
+   * @private
+   */
+  isShareButtonHidden_() {
+    return this.element.hasAttribute(Attributes.NO_SHARING);
   }
 
   /**

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -492,6 +492,15 @@ describes.realWin(
       ]);
     });
 
+    it('should hide the share button', async () => {
+      await createStoryWithPages(2, ['cover', 'page-1']);
+      story.element.setAttribute('hide-share-button', '');
+      story.buildCallback();
+      await story.layoutCallback();
+      expect(story.storeService_.get(StateProperty.CAN_SHOW_SHARING_UIS)).to.be
+        .false;
+    });
+
     describe('amp-story consent', () => {
       it('should pause the story if there is a consent', async () => {
         await createStoryWithPages(2, ['cover', 'page-1']);


### PR DESCRIPTION
This PR introduces a new attribute for the <amp-story> component that allows developers to hide the share story button. 
This is particularly useful when using <amp-social-share>, as it prevents having two share buttons in the UI, improving consistency and user experience.

Added a new attribute (e.g., hide-share-button) to <amp-story>.
