### PR TITLE
✨ Google Ad Manager Publisher first-party IDs

### DIFF
--- a/ads/google/a4a/cookie-utils.js
+++ b/ads/google/a4a/cookie-utils.js
@@ -1,0 +1,59 @@
+import {setCookie} from 'src/cookies';
+
+/** @type {string} */
+export const AMP_GFP_SET_COOKIES_HEADER_NAME = 'amp-ff-set-cookies';
+
+/**
+ * @param {!Window} win
+ * @param {!Response} fetchResponse
+ */
+export function maybeSetCookieFromAdResponse(win, fetchResponse) {
+  if (!fetchResponse.headers.has(AMP_GFP_SET_COOKIES_HEADER_NAME)) {
+    return;
+  }
+  let cookiesToSet = /** @type {!Array<!Object>} */ [];
+  try {
+    cookiesToSet = JSON.parse(
+      fetchResponse.headers.get(AMP_GFP_SET_COOKIES_HEADER_NAME)
+    );
+  } catch {}
+  for (const cookieInfo of cookiesToSet) {
+    const cookieName =
+      (cookieInfo['_version_'] ?? 1) === 2 ? '__gpi' : '__gads';
+    const value = cookieInfo['_value_'];
+    const domain = cookieInfo['_domain_'];
+    const expiration = Math.max(cookieInfo['_expiration_'], 0);
+    setCookie(win, cookieName, value, expiration, {
+      domain,
+      secure: false,
+    });
+  }
+}
+
+/**
+ * Sets up postmessage listener for cookie opt out signal.
+ * @param {!Window} win
+ * @param {!Event} event
+ */
+export function handleCookieOptOutPostMessage(win, event) {
+  try {
+    const message = JSON.parse(event.data);
+    if (message['googMsgType'] === 'gpi-uoo') {
+      const userOptOut = !!message['userOptOut'];
+      const clearAdsData = !!message['clearAdsData'];
+      const domain = win.location.hostname;
+      setCookie(
+        win,
+        '__gpi_opt_out',
+        userOptOut ? '1' : '0',
+        // Last valid date for 32-bit browsers; 2038-01-19
+        2147483646 * 1000,
+        {domain}
+      );
+      if (userOptOut || clearAdsData) {
+        setCookie(win, '__gads', 'delete', Date.now() - 1000, {domain});
+        setCookie(win, '__gpi', 'delete', Date.now() - 1000, {domain});
+      }
+    }
+  } catch {}
+}

--- a/ads/google/a4a/test/test-cookie-utils.js
+++ b/ads/google/a4a/test/test-cookie-utils.js
@@ -41,7 +41,7 @@ describes.fakeWin('#maybeSetCookieFromAdResponse', {amp: true}, (env) => {
   });
 
   it('should not set cookies on proxy origin', () => {
-    env.win.location = 'https://cdn.ampproject.org';
+    env.win.location = 'https://foo-com.cdn.ampproject.org';
     maybeSetCookieFromAdResponse(env.win, {
       headers: {
         has: (header) => {
@@ -138,7 +138,7 @@ describes.fakeWin('#handleCookieOptOutPostMessage', {amp: true}, (env) => {
     setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
     expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
     expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
-    env.win.location = 'https://cdn.ampproject.org';
+    env.win.location = 'https://foo-com.cdn.ampproject.org';
 
     handleCookieOptOutPostMessage(env.win, {
       data: JSON.stringify({

--- a/ads/google/a4a/test/test-cookie-utils.js
+++ b/ads/google/a4a/test/test-cookie-utils.js
@@ -1,0 +1,101 @@
+import {
+  AMP_GFP_SET_COOKIES_HEADER_NAME,
+  handleCookieOptOutPostMessage,
+  maybeSetCookieFromAdResponse,
+} from '#ads/google/a4a/cookie-utils';
+
+import {getCookie, setCookie} from 'src/cookies';
+
+describes.fakeWin('#maybeSetCookieFromAdResponse', {amp: true}, (env) => {
+  it('should set cookies based on ad response header', () => {
+    maybeSetCookieFromAdResponse(env.win, {
+      headers: {
+        has: (header) => {
+          return header === AMP_GFP_SET_COOKIES_HEADER_NAME;
+        },
+        get: (header) => {
+          if (header !== AMP_GFP_SET_COOKIES_HEADER_NAME) {
+            return;
+          }
+
+          return JSON.stringify([
+            {
+              '_version_': 1,
+              '_value_': 'val1',
+              '_domain_': 'foo.com',
+              '_expiration_': Date.now() + 100_000,
+            },
+            {
+              '_version_': 2,
+              '_value_': 'val2',
+              '_domain_': 'foo.com',
+              '_expiration_': Date.now() + 100_000,
+            },
+          ]);
+        },
+      },
+    });
+
+    expect(getCookie(env.win, '__gads')).to.equal('val1');
+    expect(getCookie(env.win, '__gpi')).to.equal('val2');
+  });
+});
+
+describes.fakeWin('#handleCookieOptOutPostMessage', {amp: true}, (env) => {
+  it('should clear cookies as specified in creative response, with opt out', () => {
+    setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+    setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+    handleCookieOptOutPostMessage(env.win, {
+      data: JSON.stringify({
+        googMsgType: 'gpi-uoo',
+        userOptOut: true,
+        clearAdsData: true,
+      }),
+    });
+
+    expect(getCookie(env.win, '__gpi_opt_out')).to.equal('1');
+    expect(getCookie(env.win, '__gads')).to.be.null;
+    expect(getCookie(env.win, '__gpi')).to.be.null;
+  });
+
+  it('should clear cookies as specified in creative response, without opt out', () => {
+    setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+    setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+    handleCookieOptOutPostMessage(env.win, {
+      data: JSON.stringify({
+        googMsgType: 'gpi-uoo',
+        userOptOut: false,
+        clearAdsData: true,
+      }),
+    });
+
+    expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
+    expect(getCookie(env.win, '__gads')).to.be.null;
+    expect(getCookie(env.win, '__gpi')).to.be.null;
+  });
+
+  it('should not clear cookies as specified in creative response, without opt out or clear ads', () => {
+    setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+    setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+    handleCookieOptOutPostMessage(env.win, {
+      data: JSON.stringify({
+        googMsgType: 'gpi-uoo',
+        userOptOut: false,
+        clearAdsData: false,
+      }),
+    });
+
+    expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
+    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+  });
+});

--- a/ads/google/a4a/test/test-cookie-utils.js
+++ b/ads/google/a4a/test/test-cookie-utils.js
@@ -39,6 +39,40 @@ describes.fakeWin('#maybeSetCookieFromAdResponse', {amp: true}, (env) => {
     expect(getCookie(env.win, '__gads')).to.equal('val1');
     expect(getCookie(env.win, '__gpi')).to.equal('val2');
   });
+
+  it('should not set cookies on proxy origin', () => {
+    env.win.location = 'https://cdn.ampproject.org';
+    maybeSetCookieFromAdResponse(env.win, {
+      headers: {
+        has: (header) => {
+          return header === AMP_GFP_SET_COOKIES_HEADER_NAME;
+        },
+        get: (header) => {
+          if (header !== AMP_GFP_SET_COOKIES_HEADER_NAME) {
+            return;
+          }
+
+          return JSON.stringify([
+            {
+              '_version_': 1,
+              '_value_': 'val1',
+              '_domain_': 'foo.com',
+              '_expiration_': Date.now() + 100_000,
+            },
+            {
+              '_version_': 2,
+              '_value_': 'val2',
+              '_domain_': 'foo.com',
+              '_expiration_': Date.now() + 100_000,
+            },
+          ]);
+        },
+      },
+    });
+
+    expect(getCookie(env.win, '__gads')).to.be.null;
+    expect(getCookie(env.win, '__gpi')).to.be.null;
+  });
 });
 
 describes.fakeWin('#handleCookieOptOutPostMessage', {amp: true}, (env) => {
@@ -95,6 +129,26 @@ describes.fakeWin('#handleCookieOptOutPostMessage', {amp: true}, (env) => {
     });
 
     expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
+    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+  });
+
+  it('should not clear cookies as specified in creative response, due to proxy origin', () => {
+    setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+    setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+    env.win.location = 'https://cdn.ampproject.org';
+
+    handleCookieOptOutPostMessage(env.win, {
+      data: JSON.stringify({
+        googMsgType: 'gpi-uoo',
+        userOptOut: false,
+        clearAdsData: false,
+      }),
+    });
+
+    expect(getCookie(env.win, '__gpi_opt_out')).to.be.null;
     expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
     expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
   });

--- a/ads/google/a4a/test/test-cookie-utils.js
+++ b/ads/google/a4a/test/test-cookie-utils.js
@@ -39,40 +39,6 @@ describes.fakeWin('#maybeSetCookieFromAdResponse', {amp: true}, (env) => {
     expect(getCookie(env.win, '__gads')).to.equal('val1');
     expect(getCookie(env.win, '__gpi')).to.equal('val2');
   });
-
-  it('should not set cookies on proxy origin', () => {
-    env.win.location = 'https://foo-com.cdn.ampproject.org';
-    maybeSetCookieFromAdResponse(env.win, {
-      headers: {
-        has: (header) => {
-          return header === AMP_GFP_SET_COOKIES_HEADER_NAME;
-        },
-        get: (header) => {
-          if (header !== AMP_GFP_SET_COOKIES_HEADER_NAME) {
-            return;
-          }
-
-          return JSON.stringify([
-            {
-              '_version_': 1,
-              '_value_': 'val1',
-              '_domain_': 'foo.com',
-              '_expiration_': Date.now() + 100_000,
-            },
-            {
-              '_version_': 2,
-              '_value_': 'val2',
-              '_domain_': 'foo.com',
-              '_expiration_': Date.now() + 100_000,
-            },
-          ]);
-        },
-      },
-    });
-
-    expect(getCookie(env.win, '__gads')).to.be.null;
-    expect(getCookie(env.win, '__gpi')).to.be.null;
-  });
 });
 
 describes.fakeWin('#handleCookieOptOutPostMessage', {amp: true}, (env) => {
@@ -129,26 +95,6 @@ describes.fakeWin('#handleCookieOptOutPostMessage', {amp: true}, (env) => {
     });
 
     expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
-    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
-    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
-  });
-
-  it('should not clear cookies as specified in creative response, due to proxy origin', () => {
-    setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
-    setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
-    expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
-    expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
-    env.win.location = 'https://foo-com.cdn.ampproject.org';
-
-    handleCookieOptOutPostMessage(env.win, {
-      data: JSON.stringify({
-        googMsgType: 'gpi-uoo',
-        userOptOut: false,
-        clearAdsData: false,
-      }),
-    });
-
-    expect(getCookie(env.win, '__gpi_opt_out')).to.be.null;
     expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
     expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
   });

--- a/build-system/test-configs/dep-check-config.js
+++ b/build-system/test-configs/dep-check-config.js
@@ -108,6 +108,7 @@ exports.rules = [
       'ads/google/a4a/**->src/ad-cid.js',
       'ads/google/a4a/**->src/experiments/index.js',
       'ads/google/a4a/**->src/service/index.js',
+      'ads/google/a4a/cookie-utils.js->src/cookies.js',
       'ads/google/a4a/utils.js->src/service/variable-source.js',
       'ads/google/a4a/utils.js->src/ini-load.js',
       // IMA, similar to other non-Ad 3Ps above, needs access to event-helper

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -109,6 +109,9 @@ export const INVALID_SPSA_RESPONSE = 'INVALID-SPSA-RESPONSE';
 /** @type {string} */
 export const IFRAME_GET = 'IFRAME-GET';
 
+/** @type {string} */
+export const AMP_GFP_SET_COOKIES_HEADER_NAME = 'amp-ff-set-cookies';
+
 /** @enum {string} */
 export const XORIGIN_MODE = {
   CLIENT_CACHE: 'client_cache',
@@ -842,6 +845,15 @@ export class AmpA4A extends AMP.BaseElement {
       // response is empty.
       /** @return {!Promise<!Response>} */
       .then((fetchResponse) => {
+        protectFunctionWrapper(this.onAdResponse, this, (err) => {
+          dev().error(
+            TAG,
+            this.element.getAttribute('type'),
+            'Error executing onAdResponse',
+            err
+          );
+        })(fetchResponse);
+
         checkStillCurrent();
         this.maybeTriggerAnalyticsEvent_('adRequestEnd');
         // If the response is null (can occur for non-200 responses)  or
@@ -1673,6 +1685,12 @@ export class AmpA4A extends AMP.BaseElement {
       creativeMetaData ? 'renderFriendlyEnd' : 'renderCrossDomainEnd'
     );
   }
+
+  /**
+   * To be overridden by implementing subclasses.
+   * @param {!Response} unusedFetchResponse
+   */
+  onAdResponse(unusedFetchResponse) {}
 
   /**
    * @param {!Element} iframe that was just created.  To be overridden for

--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -109,9 +109,6 @@ export const INVALID_SPSA_RESPONSE = 'INVALID-SPSA-RESPONSE';
 /** @type {string} */
 export const IFRAME_GET = 'IFRAME-GET';
 
-/** @type {string} */
-export const AMP_GFP_SET_COOKIES_HEADER_NAME = 'amp-ff-set-cookies';
-
 /** @enum {string} */
 export const XORIGIN_MODE = {
   CLIENT_CACHE: 'client_cache',

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a-cookies.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a-cookies.js
@@ -12,12 +12,8 @@ describes.fakeWin('amp-a4a: cookies', {amp: true}, (env) => {
   });
 
   function setCookies() {
-    setCookie(win, '__gads', '_gads_value', Date.now() + 100_000, {
-      secure: 'true',
-    });
-    setCookie(win, '__gpi', '_gpi_value', Date.now() + 100_000, {
-      secure: 'true',
-    });
+    setCookie(win, '__gads', '_gads_value', Date.now() + 100_000);
+    setCookie(win, '__gpi', '_gpi_value', Date.now() + 100_000);
   }
 
   it('does not add cookies without consent tuple', () => {

--- a/extensions/amp-a4a/0.1/test/test-amp-a4a-cookies.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-a4a-cookies.js
@@ -1,0 +1,172 @@
+import {CONSENT_POLICY_STATE} from '#core/constants/consent-state';
+
+import {setCookie} from 'src/cookies';
+
+import {tryAddingCookieParams} from '../amp-a4a';
+
+describes.fakeWin('amp-a4a: cookies', {amp: true}, (env) => {
+  let win;
+
+  beforeEach(() => {
+    win = env.win;
+  });
+
+  function setCookies() {
+    setCookie(win, '__gads', '_gads_value', Date.now() + 100_000, {
+      secure: 'true',
+    });
+    setCookie(win, '__gpi', '_gpi_value', Date.now() + 100_000, {
+      secure: 'true',
+    });
+  }
+
+  it('does not add cookies without consent tuple', () => {
+    setCookies();
+    const params = {};
+
+    tryAddingCookieParams(null, win, params);
+
+    expect(params.cookie).to.be.undefined;
+    expect(params.gpic).to.be.undefined;
+    expect(params.cookie_enabled).to.be.undefined;
+  });
+
+  it('does not add cookies with unknown consent policy state', () => {
+    setCookies();
+    const params = {};
+
+    tryAddingCookieParams(
+      {
+        consentState: CONSENT_POLICY_STATE.UNKNOWN,
+        gdprApplies: true,
+        consentString: 'consent',
+        purposeOne: true,
+      },
+      win,
+      params
+    );
+
+    expect(params.cookie).to.be.undefined;
+    expect(params.gpic).to.be.undefined;
+    expect(params.cookie_enabled).to.be.undefined;
+  });
+
+  it('does not add cookies with insufficient consent policy state', () => {
+    setCookies();
+    const params = {};
+
+    tryAddingCookieParams(
+      {
+        consentState: CONSENT_POLICY_STATE.INSUFFICIENT,
+        gdprApplies: true,
+        consentString: 'consent',
+        purposeOne: true,
+      },
+      win,
+      params
+    );
+
+    expect(params.cookie).to.be.undefined;
+    expect(params.gpic).to.be.undefined;
+    expect(params.cookie_enabled).to.be.undefined;
+  });
+
+  it('does not add cookies when when GDPR applies and no consent string', () => {
+    setCookies();
+    const params = {};
+
+    tryAddingCookieParams(
+      {
+        consentState: CONSENT_POLICY_STATE.SUFFICIENT,
+        gdprApplies: true,
+        consentString: '',
+        purposeOne: true,
+      },
+      win,
+      params
+    );
+
+    expect(params.cookie).to.be.undefined;
+    expect(params.gpic).to.be.undefined;
+    expect(params.cookie_enabled).to.be.undefined;
+  });
+
+  it('does not add cookie params when GDPR applies and not purposeOne', () => {
+    setCookies();
+    const params = {};
+
+    tryAddingCookieParams(
+      {
+        consentState: CONSENT_POLICY_STATE.SUFFICIENT,
+        gdprApplies: true,
+        consentString: 'consent',
+        purposeOne: false,
+      },
+      win,
+      params
+    );
+
+    expect(params.cookie).to.be.undefined;
+    expect(params.gpic).to.be.undefined;
+    expect(params.cookie_enabled).to.be.undefined;
+  });
+
+  it('adds cookie params when GDPR applies and consentString present with purposeOne', () => {
+    setCookies();
+    const params = {};
+
+    tryAddingCookieParams(
+      {
+        consentState: CONSENT_POLICY_STATE.SUFFICIENT,
+        gdprApplies: true,
+        consentString: 'consent',
+        purposeOne: true,
+      },
+      win,
+      params
+    );
+
+    expect(params.cookie).to.equal('_gads_value');
+    expect(params.gpic).to.equal('_gpi_value');
+    expect(params.cookie_enabled).to.be.undefined;
+  });
+
+  it('adds cookie params when GDPR does not apply regardless of other properties', () => {
+    setCookies();
+    const params = {};
+
+    tryAddingCookieParams(
+      {
+        consentState: CONSENT_POLICY_STATE.SUFFICIENT,
+        gdprApplies: false,
+        consentString: '',
+        purposeOne: false,
+      },
+      win,
+      params
+    );
+
+    expect(params.cookie).to.equal('_gads_value');
+    expect(params.gpic).to.equal('_gpi_value');
+    expect(params.cookie_enabled).to.be.undefined;
+  });
+
+  it('adds cookie_enabled when consent allows and no current cookie exists', () => {
+    const params = {};
+
+    tryAddingCookieParams(
+      {
+        consentState: CONSENT_POLICY_STATE.SUFFICIENT,
+        gdprApplies: false,
+        consentString: '',
+        purposeOne: false,
+      },
+      win,
+      params
+    );
+
+    expect(params.cookie).to.be.null;
+    expect(params.gpic).to.be.null;
+    expect(params.cookie_enabled).to.equal('1');
+  });
+});

--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -585,7 +585,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    * iframe. Exposed as own function to ease unit testing. (It's near
    * impossible to simulate the postmessage coming from the creative iframe in
    * unit test environments).
-   * @param {Event} event
+   * @param {!Event} event
    * @return {boolean} True if the source of the message matches the ad iframe.
    */
   checkIfClearCookiePostMessageHasValidSource_(event) {

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -3,6 +3,8 @@
 // always available for them. However, when we test an impl in isolation,
 // AmpAd is not loaded already, so we need to load it separately.
 import '../../../amp-ad/0.1/amp-ad';
+import {AMP_GFP_SET_COOKIES_HEADER_NAME} from '#ads/google/a4a/cookie-utils';
+
 import {
   CONSENT_POLICY_STATE,
   CONSENT_STRING_TYPE,
@@ -16,6 +18,8 @@ import {forceExperimentBranch, toggleExperiment} from '#experiments';
 import * as experiments from '#experiments';
 
 import {Services} from '#service';
+
+import {getCookie, setCookie} from 'src/cookies';
 
 import {AmpA4A} from '../../../amp-a4a/0.1/amp-a4a';
 import {AmpAd} from '../../../amp-ad/0.1/amp-ad';
@@ -477,6 +481,90 @@ describes.realWin(
         await savePromise;
 
         expect(storageContent).to.deep.equal({'aas-ca-adsense': true});
+      });
+
+      it('should clear cookies as specified in creative response, with opt out', () => {
+        setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+        setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+        expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+        expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+        impl.size_ = {width: 123, height: 456};
+        impl.iframe = {
+          contentWindow: window,
+          nodeType: 1,
+          style: {setProperty: () => {}},
+        };
+        impl.onCreativeRender(false);
+        impl.checkIfClearCookiePostMessageHasValidSource_ = () => true;
+        env.win.postMessage(
+          JSON.stringify({
+            googMsgType: 'gpi-uoo',
+            userOptOut: true,
+            clearAdsData: true,
+          }),
+          '*'
+        );
+
+        expect(getCookie(env.win, '__gpi_opt_out')).to.equal('1');
+        expect(getCookie(env.win, '__gads')).to.be.null;
+        expect(getCookie(env.win, '__gpi')).to.be.null;
+      });
+
+      it('should clear cookies as specified in creative response, without opt out', () => {
+        setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+        setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+        expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+        expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+        impl.size_ = {width: 123, height: 456};
+        impl.iframe = {
+          contentWindow: window,
+          nodeType: 1,
+          style: {setProperty: () => {}},
+        };
+        impl.onCreativeRender(false);
+        impl.checkIfClearCookiePostMessageHasValidSource_ = () => true;
+        env.win.postMessage(
+          JSON.stringify({
+            googMsgType: 'gpi-uoo',
+            userOptOut: false,
+            clearAdsData: true,
+          }),
+          '*'
+        );
+
+        expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
+        expect(getCookie(env.win, '__gads')).to.be.null;
+        expect(getCookie(env.win, '__gpi')).to.be.null;
+      });
+
+      it('should not clear cookies as specified in creative response, without opt out or clear ads', () => {
+        setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+        setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+        expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+        expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+        impl.size_ = {width: 123, height: 456};
+        impl.iframe = {
+          contentWindow: window,
+          nodeType: 1,
+          style: {setProperty: () => {}},
+        };
+        impl.onCreativeRender(false);
+        impl.checkIfClearCookiePostMessageHasValidSource_ = () => true;
+        env.win.postMessage(
+          JSON.stringify({
+            googMsgType: 'gpi-uoo',
+            userOptOut: false,
+            clearAdsData: false,
+          }),
+          '*'
+        );
+
+        expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
+        expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+        expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
       });
     });
 
@@ -1603,6 +1691,59 @@ describes.realWin(
           branches.forEach((branch) => expect(branch).to.be.a('string'));
         });
       });
+    });
+  }
+);
+
+// Separate from main describe function because of difficulty testing cookie setting with real window.
+describes.fakeWin(
+  'amp-ad-network-adsense-impl#onAdResponse',
+  {amp: true},
+  (env) => {
+    let element;
+    let impl;
+    beforeEach(() => {
+      element = env.win.document.createElement('amp-ad');
+      element.setAttribute('type', 'adsense');
+      env.win.document.body.appendChild(element);
+      impl = new AmpAdNetworkAdsenseImpl(element);
+    });
+
+    afterEach(() => {
+      env.win.document.body.removeChild(element);
+    });
+
+    it('sets cookies as specified on the ad response', () => {
+      impl.onAdResponse({
+        headers: {
+          has: (header) => {
+            return header === AMP_GFP_SET_COOKIES_HEADER_NAME;
+          },
+          get: (header) => {
+            if (header !== AMP_GFP_SET_COOKIES_HEADER_NAME) {
+              return;
+            }
+
+            return JSON.stringify([
+              {
+                '_version_': 1,
+                '_value_': 'val1',
+                '_domain_': 'foo.com',
+                '_expiration_': Date.now() + 100_000,
+              },
+              {
+                '_version_': 2,
+                '_value_': 'val2',
+                '_domain_': 'foo.com',
+                '_expiration_': Date.now() + 100_000,
+              },
+            ]);
+          },
+        },
+      });
+
+      expect(getCookie(env.win, '__gads')).to.equal('val1');
+      expect(getCookie(env.win, '__gpi')).to.equal('val2');
     });
   }
 );

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1415,7 +1415,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * iframe. Exposed as own function to ease unit testing. (It's near
    * impossible to simulate the postmessage coming from the creative iframe in
    * unit test environments).
-   * @param {Event} event
+   * @param {!Event} event
    * @return {boolean} True if the source of the message matches the ad iframe.
    */
   checkIfClearCookiePostMessageHasValidSource_(event) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -2059,7 +2059,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
       '__gpi_opt_out',
       userOptOut ? '1' : '0',
       // Last valid date for 32-bit browsers; 2038-01-19
-      2147483647,
+      2147483646 * 1000,
       {domain}
     );
     if (userOptOut || clearAdsData) {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1401,7 +1401,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
     // Add listener for GPID cookie optout.
     this.win.addEventListener('message', (event) => {
-      if (event.source != devAssert(this.iframe.contentWindow)) {
+      if (!this.checkIfClearCookiePostMessageHasValidSource_(event)) {
         return;
       }
       try {
@@ -1416,6 +1416,16 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
     });
 
     this.postTroubleshootMessage();
+  }
+
+  /**
+   * Checks whether the postMessage event's source corresponds to the ad
+   * iframe. Exposed as own function to ease unit testing.
+   * @param {Event} event
+   * @return {boolean} True if the source of the message matches the ad iframe.
+   */
+  checkIfClearCookiePostMessageHasValidSource_(event) {
+    return event.source == devAssert(this.iframe.contentWindow);
   }
 
   /**

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -2015,7 +2015,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
 
   /** @param {!Response} fetchResponse */
   onAdResponse(fetchResponse) {
-    if (!fetchResponse.header.has(AMP_GFP_SET_COOKIES_HEADER_NAME)) {
+    if (!fetchResponse.headers.has(AMP_GFP_SET_COOKIES_HEADER_NAME)) {
       return;
     }
     let cookiesToSet = /** @type {!Array<!Object>} */ [];

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1855,13 +1855,13 @@ for (const {config, name} of [
 
                 return JSON.stringify([
                   {
-                    '_version_': '1',
+                    '_version_': 1,
                     '_value_': 'val1',
                     '_domain_': 'foo.com',
                     '_expiration_': Date.now() + 100_000,
                   },
                   {
-                    '_version_': '2',
+                    '_version_': 2,
                     '_value_': 'val2',
                     '_domain_': 'foo.com',
                     '_expiration_': Date.now() + 100_000,
@@ -1871,8 +1871,8 @@ for (const {config, name} of [
             },
           });
 
-          expect(getCookie('__gads')).to.equal('val1');
-          expect(getCookie('__gpi')).to.equal('val2');
+          expect(getCookie(env.win, '__gads')).to.equal('val1');
+          expect(getCookie(env.win, '__gpi')).to.equal('val2');
         });
       });
     }

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -558,7 +558,7 @@ for (const {config, name} of [
           );
         });
 
-        it('should clear cookies as specified in creative response', () => {
+        it('should clear cookies as specified in creative response, with opt out', () => {
           setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
           setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
           expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
@@ -575,8 +575,53 @@ for (const {config, name} of [
             '*'
           );
 
+          expect(getCookie(env.win, '__gpi_opt_out')).to.equal('1');
           expect(getCookie(env.win, '__gads')).to.be.null;
           expect(getCookie(env.win, '__gpi')).to.be.null;
+        });
+
+        it('should clear cookies as specified in creative response, without opt out', () => {
+          setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+          setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+          expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+          expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+          impl.onCreativeRender(false);
+          impl.checkIfClearCookiePostMessageHasValidSource_ = () => true;
+          env.win.postMessage(
+            JSON.stringify({
+              googMsgType: 'gpi-uoo',
+              userOptOut: false,
+              clearAdsData: true,
+            }),
+            '*'
+          );
+
+          expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
+          expect(getCookie(env.win, '__gads')).to.be.null;
+          expect(getCookie(env.win, '__gpi')).to.be.null;
+        });
+
+        it('should clear cookies as specified in creative response, without opt out or clear ads', () => {
+          setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+          setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+          expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+          expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
+
+          impl.onCreativeRender(false);
+          impl.checkIfClearCookiePostMessageHasValidSource_ = () => true;
+          env.win.postMessage(
+            JSON.stringify({
+              googMsgType: 'gpi-uoo',
+              userOptOut: false,
+              clearAdsData: false,
+            }),
+            '*'
+          );
+
+          expect(getCookie(env.win, '__gpi_opt_out')).to.equal('0');
+          expect(getCookie(env.win, '__gads')).to.equal('__gads_val');
+          expect(getCookie(env.win, '__gpi')).to.equal('__gpi_val');
         });
 
         it('should register click listener', () => {

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -3,6 +3,7 @@
 // always available for them. However, when we test an impl in isolation,
 // AmpAd is not loaded already, so we need to load it separately.
 import '../../../amp-ad/0.1/amp-ad';
+import {AMP_GFP_SET_COOKIES_HEADER_NAME} from '#ads/google/a4a/cookie-utils';
 import {AMP_EXPERIMENT_ATTRIBUTE, QQID_HEADER} from '#ads/google/a4a/utils';
 
 import {
@@ -22,7 +23,6 @@ import {getCookie, setCookie} from 'src/cookies';
 
 import {FriendlyIframeEmbed} from '../../../../src/friendly-iframe-embed';
 import {
-  AMP_GFP_SET_COOKIES_HEADER_NAME,
   AmpA4A,
   CREATIVE_SIZE_HEADER,
   XORIGIN_MODE,
@@ -602,7 +602,7 @@ for (const {config, name} of [
           expect(getCookie(env.win, '__gpi')).to.be.null;
         });
 
-        it('should clear cookies as specified in creative response, without opt out or clear ads', () => {
+        it('should not clear cookies as specified in creative response, without opt out or clear ads', () => {
           setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
           setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
           expect(getCookie(env.win, '__gads')).to.equal('__gads_val');

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/test/test-amp-ad-network-doubleclick-impl.js
@@ -1828,38 +1828,46 @@ for (const {config, name} of [
         });
       });
 
-      describe('onAdResponse', () => {
+      describes.fakeWin('onAdResponse', {amp: true}, (env) => {
+        let element;
+
         beforeEach(() => {
-          element = doc.createElement('amp-ad');
+          element = env.win.document.createElement('amp-ad');
           element.setAttribute('type', 'doubleclick');
-          doc.body.appendChild(element);
+          env.win.document.body.appendChild(element);
           impl = new AmpAdNetworkDoubleclickImpl(element);
+        });
+
+        afterEach(() => {
+          env.win.document.body.removeChild(element);
         });
 
         it('sets cookies', () => {
           impl.onAdResponse({
-            has: (header) => {
-              return header === AMP_GFP_SET_COOKIES_HEADER_NAME;
-            },
-            get: (header) => {
-              if (header !== AMP_GFP_SET_COOKIES_HEADER_NAME) {
-                return;
-              }
+            headers: {
+              has: (header) => {
+                return header === AMP_GFP_SET_COOKIES_HEADER_NAME;
+              },
+              get: (header) => {
+                if (header !== AMP_GFP_SET_COOKIES_HEADER_NAME) {
+                  return;
+                }
 
-              return JSON.stringify([
-                {
-                  '_version_': '1',
-                  '_value_': 'val1',
-                  '_domain_': 'foo.com',
-                  '_expiration_': Date.now() + 100_000,
-                },
-                {
-                  '_version_': '2',
-                  '_value_': 'val2',
-                  '_domain_': 'foo.com',
-                  '_expiration_': Date.now() + 100_000,
-                },
-              ]);
+                return JSON.stringify([
+                  {
+                    '_version_': '1',
+                    '_value_': 'val1',
+                    '_domain_': 'foo.com',
+                    '_expiration_': Date.now() + 100_000,
+                  },
+                  {
+                    '_version_': '2',
+                    '_value_': 'val2',
+                    '_domain_': 'foo.com',
+                    '_expiration_': Date.now() + 100_000,
+                  },
+                ]);
+              },
             },
           });
 

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -268,10 +268,10 @@ function checkOriginForSettingCookie(win, options, name) {
  */
 function getTempCookieName(win) {
   let testCookieName = TEST_COOKIE_NAME;
-  const counter = 0;
+  let counter = 0;
   while (getCookie(win, testCookieName)) {
     // test cookie name conflict, append counter to test cookie name
-    testCookieName = TEST_COOKIE_NAME + counter;
+    testCookieName = TEST_COOKIE_NAME + counter++;
   }
   return testCookieName;
 }

--- a/src/cookies.js
+++ b/src/cookies.js
@@ -275,3 +275,17 @@ function getTempCookieName(win) {
   }
   return testCookieName;
 }
+
+/**
+ * @param {!Window} win
+ * @return {boolean}
+ */
+export function canSetCookie(win) {
+  const testCookieName = getTempCookieName(win);
+  const testCookieValue = 'TESTCOOKIEVALUE';
+  try {
+    setCookie(win, testCookieName, testCookieValue, Date.now() + 1000);
+    return getCookie(win, testCookieName) === testCookieValue;
+  } catch {}
+  return false;
+}

--- a/test/unit/test-cookies.js
+++ b/test/unit/test-cookies.js
@@ -3,6 +3,7 @@ import * as fakeTimers from '@sinonjs/fake-timers';
 import {BASE_CID_MAX_AGE_MILLIS} from '#service/cid-impl';
 
 import {
+  canSetCookie,
   getCookie,
   getHighestAvailableDomain,
   setCookie,
@@ -230,5 +231,14 @@ describes.fakeWin('test-cookies', {amp: true}, (env) => {
         'expires=Thu, 01 Jan 1970 00:00:00 GMT'
     );
     expect(doc.cookie).to.equal('');
+  });
+
+  it('can set cookie', () => {
+    expect(canSetCookie(win)).to.be.true;
+  });
+
+  it('cannot set cookie for proxy domain', () => {
+    win.location = 'https://foo.cdn.ampproject.org/test.html';
+    expect(canSetCookie(win)).to.be.false;
   });
 });


### PR DESCRIPTION
Addresses #40248.

Implements both cookie writing and reading components described in the linked I2I. In particular, we will set the specified cookies on the ad response HTTP header, and add those cookies to ad requests when available. We also add here some ads utility functions for verifying user consent for cookies, and some global cookie utility functions for checking whether setting cookies is allowed.

This change on its own is mostly a no-op, as serving is not yet setup to send to the new HTTP cookie header. 
