### PR TITLE
✨ Add channelid Attribute to <amp-youtube> Component

### DIFF
--- a/extensions/amp-youtube/0.1/amp-youtube.js
+++ b/extensions/amp-youtube/0.1/amp-youtube.js
@@ -379,7 +379,7 @@ class AmpYoutube extends AMP.BaseElement {
 
     userAssert(
       numSources === 1,
-      'Exactly one of data-videoid, data-live-channelid, or data-channelid should be present for <amp-youtube> %s',
+      'Exactly one of data-videoid, data-live-channelid or data-channelid should be present for <amp-youtube> %s',
       this.element
     );
   }

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -8,8 +8,10 @@ import {installResizeObserverStub} from '#testing/resize-observer-stub';
 import {VideoEvents_Enum} from '../../../../src/video-interface';
 
 const EXAMPLE_VIDEOID = 'mGENRKrdoGY';
+const EXAMPLE_CHANNELID = 'UU5Tmo6TCGnc9FioXnzzPJ5A';
 const EXAMPLE_LIVE_CHANNELID = 'UCB8Kb4pxYzsDsHxzBfnid4Q';
 const EXAMPLE_VIDEOID_URL = `https://www.youtube.com/embed/${EXAMPLE_VIDEOID}?enablejsapi=1&amp=1&playsinline=1`;
+const EXAMPLE_CHANNELID_URL = `https://www.youtube.com/embed/?listType=playlist&list=${EXAMPLE_CHANNELID}`;
 const EXAMPLE_LIVE_CHANNELID_URL = `https://www.youtube.com/embed/live_stream?channel=${EXAMPLE_LIVE_CHANNELID}&enablejsapi=1&amp=1&playsinline=1`;
 const EXAMPLE_NO_COOKIE_VIDEOID_URL = `https://www.youtube-nocookie.com/embed/${EXAMPLE_VIDEOID}?enablejsapi=1&amp=1&playsinline=1`;
 
@@ -61,6 +63,10 @@ describes.realWin(
 
     describe('with data-videoid', function () {
       runTestsForDatasource(EXAMPLE_VIDEOID);
+    });
+
+    describe('with data-channelid', function () {
+      runTestsForDatasource(EXAMPLE_CHANNELID);
     });
 
     describe('with data-live-channelid', function () {
@@ -254,6 +260,15 @@ describes.realWin(
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
       expect(iframe.src).to.equal(EXAMPLE_LIVE_CHANNELID_URL);
+    });
+
+    it('renders for channel ids', async () => {
+      const yt = await getYt({'data-channelid': EXAMPLE_CHANNELID});
+      const iframe = yt.querySelector('iframe');
+      expect(iframe).to.not.be.null;
+      expect(iframe.tagName).to.equal('IFRAME');
+      console.log(iframe.src + ' ' + EXAMPLE_CHANNELID_URL);
+      expect(iframe.src).to.include(EXAMPLE_CHANNELID_URL);
     });
 
     it('uses privacy-enhanced mode', async () => {

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -281,10 +281,10 @@ describes.realWin(
       expect(iframe.src).to.equal(EXAMPLE_NO_COOKIE_VIDEOID_URL);
     });
 
-    it('requires exactly one of data-videoid, data-live-channelid, or data-channelid', () => {
+    it('requires exactly one of data-videoid, data-live-channelid or data-channelid', () => {
       return allowConsoleError(() => {
         return getYt({}).should.eventually.be.rejectedWith(
-          /Exactly one of data-videoid, data-live-channelid, or data-channelid should be present/
+          /Exactly one of data-videoid, data-live-channelid or data-channelid should be present/
         );
       });
     });

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -267,7 +267,6 @@ describes.realWin(
       const iframe = yt.querySelector('iframe');
       expect(iframe).to.not.be.null;
       expect(iframe.tagName).to.equal('IFRAME');
-      console.log(iframe.src + ' ' + EXAMPLE_CHANNELID_URL);
       expect(iframe.src).to.include(EXAMPLE_CHANNELID_URL);
     });
 

--- a/extensions/amp-youtube/0.1/test/test-amp-youtube.js
+++ b/extensions/amp-youtube/0.1/test/test-amp-youtube.js
@@ -267,10 +267,10 @@ describes.realWin(
       expect(iframe.src).to.equal(EXAMPLE_NO_COOKIE_VIDEOID_URL);
     });
 
-    it('requires data-videoid or data-live-channelid', () => {
+    it('requires exactly one of data-videoid, data-live-channelid, or data-channelid', () => {
       return allowConsoleError(() => {
         return getYt({}).should.eventually.be.rejectedWith(
-          /Exactly one of data-videoid or data-live-channelid should/
+          /Exactly one of data-videoid, data-live-channelid, or data-channelid should be present/
         );
       });
     });

--- a/src/bento/components/bento-youtube/1.0/component.js
+++ b/src/bento/components/bento-youtube/1.0/component.js
@@ -85,7 +85,7 @@ function BentoYoutubeWithRef(
 
   if (!datasourceExists) {
     throw new Error(
-      'Exactly one of data-videoid, data-live-channelid, or data-channelid should be present for <amp-youtube>'
+      'Exactly one of data-videoid, data-live-channelid or data-channelid should be present for <amp-youtube>'
     );
   }
 

--- a/src/bento/components/bento-youtube/1.0/component.js
+++ b/src/bento/components/bento-youtube/1.0/component.js
@@ -71,6 +71,7 @@ function BentoYoutubeWithRef(
     autoplay,
     credentials,
     liveChannelid,
+    channelid,
     loop,
     onLoad,
     params = {},
@@ -80,15 +81,15 @@ function BentoYoutubeWithRef(
   ref
 ) {
   const datasourceExists =
-    !(videoid && liveChannelid) && (videoid || liveChannelid);
+    (videoid ? 1 : 0) + (liveChannelid ? 1 : 0) + (channelid ? 1 : 0) === 1;
 
   if (!datasourceExists) {
     throw new Error(
-      'Exactly one of data-videoid or data-live-channelid should be present for <amp-youtube>'
+      'Exactly one of data-videoid, data-live-channelid, or data-channelid should be present for <amp-youtube>'
     );
   }
 
-  let src = getEmbedUrl(credentials, videoid, liveChannelid);
+  let src = getEmbedUrl(credentials, videoid, liveChannelid, channelid);
   if (!('playsinline' in params)) {
     params['playsinline'] = '1';
   }
@@ -101,8 +102,6 @@ function BentoYoutubeWithRef(
     if (!('iv_load_policy' in params)) {
       params['iv_load_policy'] = `${PlayerFlags.HIDE_ANNOTATION}`;
     }
-
-    // Inline play must be set for autoplay regardless of original value.
     params['playsinline'] = '1';
   }
 
@@ -121,7 +120,6 @@ function BentoYoutubeWithRef(
 
   src = addParamsToUrl(src, params);
 
-  // Player state. Includes `currentTime` and `duration`.
   const playerStateRef = useRef();
   if (!playerStateRef.current) {
     playerStateRef.current = createDefaultInfo();

--- a/src/bento/components/bento-youtube/1.0/component.js
+++ b/src/bento/components/bento-youtube/1.0/component.js
@@ -69,9 +69,9 @@ function createDefaultInfo() {
 function BentoYoutubeWithRef(
   {
     autoplay,
+    channelid,
     credentials,
     liveChannelid,
-    channelid,
     loop,
     onLoad,
     params = {},

--- a/test/fixtures/errors.html
+++ b/test/fixtures/errors.html
@@ -24,7 +24,7 @@
 
 <amp-youtube
     id="yt0"
-    data-expectederror="Exactly one of data-videoid, data-live-channelid or data-channelid be"
+    data-expectederror="Exactly one of data-videoid, data-live-channelid or data-channelid should be present for <amp-youtube>"
     YYYYYY="mGENRKrdoGY"
     layout="responsive"
     width="480" height="270"></amp-youtube>

--- a/test/fixtures/errors.html
+++ b/test/fixtures/errors.html
@@ -24,7 +24,7 @@
 
 <amp-youtube
     id="yt0"
-    data-expectederror="Exactly one of data-videoi, data-live-channelid or data-channelid be"
+    data-expectederror="Exactly one of data-videoid, data-live-channelid or data-channelid be"
     YYYYYY="mGENRKrdoGY"
     layout="responsive"
     width="480" height="270"></amp-youtube>

--- a/test/fixtures/errors.html
+++ b/test/fixtures/errors.html
@@ -24,7 +24,7 @@
 
 <amp-youtube
     id="yt0"
-    data-expectederror="Exactly one of data-videoid or data-live-channelid should be"
+    data-expectederror="Exactly one of data-videoi, data-live-channelid or data-channelid be"
     YYYYYY="mGENRKrdoGY"
     layout="responsive"
     width="480" height="270"></amp-youtube>


### PR DESCRIPTION
issue https://github.com/ampproject/amphtml/issues/26304

**Summary**
This PR adds support for the channelid attribute in the component, allowing users to embed the latest video from a specified YouTube channel.

Currently, supports embedding individual videos and playlists but does not allow embedding a channel’s latest video dynamically. This update enables users to specify a channelid, which will automatically load and display the most recent video from that channel.

**Changes Introduced**
- Added a channelid attribute
- Implemented logic to construct the correct embed URL for displaying the latest video from the channel.

**Testing**
Manually tested with different channelid values to ensure the latest video loads correctly.
Updated automated tests to validate expected behaviour.
