### PR TITLE
Bugfix: Fix AMP_CONTEXT_DATA parsing

### DIFF
--- a/3p/ampcontext.js
+++ b/3p/ampcontext.js
@@ -326,7 +326,7 @@ export class AbstractAmpContext {
   /**
    *  Parse the metadata attributes from the name and add them to
    *  the class instance.
-   *  @param {!Object|string} data
+   *  @param {string} data
    *  @private
    */
   setupMetadata_(data) {
@@ -346,6 +346,17 @@ export class AbstractAmpContext {
       delete this.data['_context'];
     }
 
+    this.setupMetadataFromContext_(context);
+
+    this.embedType_ = dataObject.type || null;
+  }
+
+  /**
+   *  Set the metadata attributes from the "context" instance directly.
+   *  @param {!Object} context
+   *  @private
+   */
+  setupMetadataFromContext_(context) {
     this.canary = context.canary;
     this.canonicalUrl = context.canonicalUrl;
     this.clientId = context.clientId;
@@ -367,8 +378,6 @@ export class AbstractAmpContext {
     this.sourceUrl = context.sourceUrl;
     this.startTime = context.startTime;
     this.tagName = context.tagName;
-
-    this.embedType_ = dataObject.type || null;
   }
 
   /**
@@ -403,8 +412,11 @@ export class AbstractAmpContext {
     } else if (this.win_.AMP_CONTEXT_DATA) {
       if (typeof this.win_.AMP_CONTEXT_DATA == 'string') {
         this.sentinel = this.win_.AMP_CONTEXT_DATA;
+        // If AMP_CONTEXT_DATA is an Object, Assume that it is the Context Object
+        // and not inside the attributes._context which is the structure
+        // parsed from "name" on other instances.
       } else if (isObject(this.win_.AMP_CONTEXT_DATA)) {
-        this.setupMetadata_(this.win_.AMP_CONTEXT_DATA);
+        this.setupMetadataFromContext_(this.win_.AMP_CONTEXT_DATA);
       }
     } else {
       this.setupMetadata_(this.win_.name);

--- a/test/unit/test-amp-context.js
+++ b/test/unit/test-amp-context.js
@@ -103,8 +103,8 @@ describes.sandboxed('3p ampcontext.js', {}, (env) => {
     expect(context.referrer).to.equal('baz.net');
   });
 
-  it('should add metadata to window.context using window var.', () => {
-    win.AMP_CONTEXT_DATA = generateAttributes();
+  it('should add metadata to window.context using window global.', () => {
+    win.AMP_CONTEXT_DATA = generateAMPConfigObject();
     const context = new AmpContext(win);
     expect(context.location).to.deep.equal({
       'hash': '',
@@ -392,6 +392,20 @@ describes.sandboxed('3p ampcontext.js', {}, (env) => {
     expect(successCallbackSpy).to.not.be.called;
   });
 });
+
+function generateAMPConfigObject() {
+  return {
+    location: {
+      href: 'https://foo.com/a?b=c',
+    },
+    canonicalUrl: 'https://bar.com',
+    pageViewId: '1',
+    pageViewId64: 'abcdef',
+    sentinel: '1-291921',
+    startTime: 0,
+    referrer: 'baz.net',
+  };
+}
 
 function generateSerializedAttributes(opt_sentinel) {
   return JSON.stringify(generateAttributes(opt_sentinel));


### PR DESCRIPTION
The `setupMetadata_`  is currently passed in a context object that comes from ads safeframe code. The current code assumes that the context object is nested inside the passed in parameter which causes a parsing error that is silently caught by the wrapping top level try/catch in https://github.com/ampproject/amphtml/blob/6a610ba7734d8bfced751644876e9f72e9108725/3p/ampcontext-lib.js#L19-L27

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
