### PR TITLE
Fix issue where GFP cookie is not being attached to AdSense ad requests.

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -61,7 +61,7 @@ import {ResponsiveState} from './responsive-state';
 import {getDefaultBootstrapBaseUrl} from '../../../src/3p-frame';
 import {insertAnalyticsElement} from '../../../src/extension-analytics';
 import {getMode} from '../../../src/mode';
-import {AmpA4A} from '../../amp-a4a/0.1/amp-a4a';
+import {AmpA4A, tryAddingCookieParams} from '../../amp-a4a/0.1/amp-a4a';
 import {AMP_SIGNATURE_HEADER} from '../../amp-a4a/0.1/signature-verifier';
 import {getAmpAdRenderOutsideViewport} from '../../amp-ad/0.1/concurrent-load';
 
@@ -423,6 +423,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
           ? gppSectionId
           : null,
     };
+    tryAddingCookieParams(consentTuple, this.win, parameters);
 
     const experimentIds = [];
     return googleAdUrl(

--- a/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/test/test-amp-ad-network-adsense-impl.js
@@ -652,6 +652,22 @@ describes.realWin(
         );
       });
 
+      it('should contain cookie params', () => {
+        setCookie(env.win, '__gads', '__gads_val', Date.now() + 100_000);
+        setCookie(env.win, '__gpi', '__gpi_val', Date.now() + 100_000);
+        const ampStickyAd = createElementWithAttributes(doc, 'amp-sticky-ad', {
+          'layout': 'nodisplay',
+        });
+        ampStickyAd.appendChild(element);
+        doc.body.appendChild(ampStickyAd);
+        return impl
+          .getAdUrl({consentState: CONSENT_POLICY_STATE.SUFFICIENT})
+          .then((adUrl) => {
+            expect(adUrl).to.contain('cookie=__gads_val');
+            expect(adUrl).to.contain('gpic=__gpi_val');
+          });
+      });
+
       it('should contain act', () => {
         const ampStickyAd = createElementWithAttributes(doc, 'amp-sticky-ad', {
           'layout': 'nodisplay',


### PR DESCRIPTION
Fixes an oversight in https://github.com/ampproject/amphtml/pull/40249.