### PR TITLE
🐛 Add defensive check around ad iframe existence before checking contentWindow.

### DIFF
--- a/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
+++ b/extensions/amp-ad-network-adsense-impl/0.1/amp-ad-network-adsense-impl.js
@@ -589,7 +589,7 @@ export class AmpAdNetworkAdsenseImpl extends AmpA4A {
    * @return {boolean} True if the source of the message matches the ad iframe.
    */
   checkIfClearCookiePostMessageHasValidSource_(event) {
-    return event.source == devAssert(this.iframe.contentWindow);
+    return this.iframe && event.source == this.iframe.contentWindow;
   }
 
   /** @override */

--- a/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
+++ b/extensions/amp-ad-network-doubleclick-impl/0.1/amp-ad-network-doubleclick-impl.js
@@ -1419,7 +1419,7 @@ export class AmpAdNetworkDoubleclickImpl extends AmpA4A {
    * @return {boolean} True if the source of the message matches the ad iframe.
    */
   checkIfClearCookiePostMessageHasValidSource_(event) {
-    return event.source == devAssert(this.iframe.contentWindow);
+    return this.iframe && event.source == this.iframe.contentWindow;
   }
 
   /**


### PR DESCRIPTION
Fixes an issue wherein `this.iframe` may be destroyed by the time we attempt to process a postMessage from it resulting in a null access error.