### PR TITLE
🐛 Add canSetCookie check before attempting to set cookies

### DIFF
--- a/ads/google/a4a/cookie-utils.js
+++ b/ads/google/a4a/cookie-utils.js
@@ -1,4 +1,4 @@
-import {setCookie} from 'src/cookies';
+import {canSetCookie, setCookie} from 'src/cookies';
 import {isProxyOrigin} from 'src/url';
 
 /** @type {string} */
@@ -25,7 +25,10 @@ function getProxySafeDomain(win, domain) {
  * @param {!Response} fetchResponse
  */
 export function maybeSetCookieFromAdResponse(win, fetchResponse) {
-  if (!fetchResponse.headers.has(AMP_GFP_SET_COOKIES_HEADER_NAME)) {
+  if (
+    !fetchResponse.headers.has(AMP_GFP_SET_COOKIES_HEADER_NAME) ||
+    !canSetCookie(win)
+  ) {
     return;
   }
   let cookiesToSet = /** @type {!Array<!Object>} */ [];


### PR DESCRIPTION
Current behavior will attempt to set a cookie value indiscriminately, which may throw an error on some domains. This fix adds a `canSetCookie` check, which will ensure setting cookie is safe and will not result in a thrown error, before attempting to set cookies.