### PR TITLE
🧪 Allow doc opt in for `story-ad-allow-fullbleed`

### DIFF
--- a/build-system/global-configs/canary-config.json
+++ b/build-system/global-configs/canary-config.json
@@ -1,6 +1,7 @@
 {
   "allow-doc-opt-in": [
-    "amp-next-page"
+    "amp-next-page",
+    "story-ad-allow-fullbleed"
   ],
   "allow-url-opt-in": [],
   "canary": 1,

--- a/build-system/global-configs/prod-config.json
+++ b/build-system/global-configs/prod-config.json
@@ -1,6 +1,7 @@
 {
   "allow-doc-opt-in": [
-    "amp-next-page"
+    "amp-next-page",
+    "story-ad-allow-fullbleed"
   ],
   "allow-url-opt-in": [],
   "canary": 0,


### PR DESCRIPTION
Related to: https://github.com/ampproject/amphtml/issues/40183

This PR will allow opting into the experiment `story-ad-allow-fullbleed` (https://github.com/ampproject/amphtml/pull/40264) via the `<meta>` tag:

`<meta name="amp-experiments-opt-in" content="story-ad-allow-fullbleed">`