### PR TITLE
📖 Fix typo in component validator rules documentation

### DIFF
--- a/docs/component-validator-rules.md
+++ b/docs/component-validator-rules.md
@@ -410,7 +410,7 @@ In the document `<head>` section, add the extension `<script>` tag used by this 
 
 <pre>
 &lt;script async custom-element='<b>amp-cat</b>'
-     src='https://cdn.ampproject.org/v0/<b>amp-cat</b>-0.1.js'&gt;&lt;/scrip&gt;
+     src='https://cdn.ampproject.org/v0/<b>amp-cat</b>-0.1.js'&gt;&lt;/script&gt;
 </pre>
 
 **Add a working example of your tag**


### PR DESCRIPTION
📖 Fix typo in component validator rules documentation

## Summary
This PR fixes a simple typo in the component validator rules documentation where 'scrip' was incorrectly written instead of 'script' on line 413.

## Changes
- Fixed typo in `docs/component-validator-rules.md` line 413: changed `'scrip'` to `'script'`

## Why this change is needed
The typo could confuse developers reading the documentation about validator rules for AMP extended components. Ensuring accurate documentation helps maintain clarity for contributors working with AMP validator rules.

## Additional Note
This is my first contribution to this project, but I wanted to make a small contribution by fixing this typo to help improve the project.😊