### PR TITLE
🏗 Automatically create an issue to request a validator rollup

### DIFF
--- a/.github/create_validator_rollup_issue.md
+++ b/.github/create_validator_rollup_issue.md
@@ -1,0 +1,7 @@
+---
+title: 'Rollup updated AMP Validator code on the AMP cache'
+---
+
+AMP Validator code has been updated, and requires a rollup on the cdn.ampproject.org AMP cache.
+
+// {{ env.MENTION }} — please triage and resolve this issue.

--- a/.github/workflows/request-validator-rollup.yml
+++ b/.github/workflows/request-validator-rollup.yml
@@ -1,0 +1,27 @@
+name: Request Validator Rollup
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'validator/**'
+      - 'extensions/**/validator-*.*'
+
+permissions:
+  issues: write
+
+jobs:
+  rollup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
+        with:
+          filename: .github/create_validator_rollup_issue.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MENTION: '@ampproject/wg-caching'


### PR DESCRIPTION
This PR adds a GitHub Action that will notify @ampproject/wg-caching when a validator change has been merged to `main`, and create an issue to roll it up on the AMP cache

Example of these can be found on my fork: https://github.com/danielrozenberg/amphtml/actions/workflows/request-validator-rollup.yml