### PR TITLE
chore: consolidate image serving for examples and tests

### DIFF
--- a/examples/ad-lightbox.amp.html
+++ b/examples/ad-lightbox.amp.html
@@ -34,7 +34,7 @@
      role="button"
      class="button button-secondary play"
      tabindex="0">
-    <amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n"
+    <amp-img src="img/hero@1x.jpg"
              width="400"
              height="300"
              layout="responsive">
@@ -49,12 +49,12 @@
     <amp-carousel type="slides"
                   height="300"
                   layout="fixed-height">
-      <amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n"
+      <amp-img src="img/sea@1x.jpg"
                width="400"
                height="300"
                layout="responsive">
       </amp-img>
-      <amp-img src="https://amp.dev/static/samples/img/amp.jpg"
+      <amp-img src="img/sample.jpg"
                layout="responsive"
                width="1080"
                height="610">

--- a/examples/amp-video.amp.html
+++ b/examples/amp-video.amp.html
@@ -65,7 +65,7 @@
     autoplay
     title="Big Buck Bunny"
     artist="Blender Foundation"
-    poster="https://peach.blender.org/wp-content/uploads/bbb-splash.png"
+    poster="img/bigbuckbunny.jpg"
     artwork="img/bigbuckbunny.jpg"
     album="The Peach Open Movie Project"
     src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
@@ -90,7 +90,7 @@
   <amp-video
     title="Big Buck Bunny"
     artist="Blender Foundation"
-    poster="https://peach.blender.org/wp-content/uploads/bbb-splash.png"
+    poster="img/bigbuckbunny.jpg"
     artwork="img/bigbuckbunny.jpg"
     album="The Peach Open Movie Project"
     src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"

--- a/examples/amp-youtube.amp.html
+++ b/examples/amp-youtube.amp.html
@@ -65,7 +65,7 @@
       height="204"
       layout="responsive">
     <amp-img
-      src="https://i.ytimg.com/vi/Wm1fWz-7nLQ/hqdefault_live.jpg"
+      src="img/sample.jpg"
       placeholder
       layout="fill"
       />

--- a/examples/images.json
+++ b/examples/images.json
@@ -2,122 +2,92 @@
   "images": [
     {
       "id": "0",
-      "author": "Alejandro Escamilla",
-      "width": 5616,
-      "height": 3744,
+      "author": "Local Example",
+      "width": 300,
+      "height": 300,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/yC-Yzbqy7PY",
-        "picsum": "https://picsum.photos/id/0/5616/3744"
+        "local": "./img/sample.jpg"
       }
     },
     {
       "id": "1",
-      "author": "Alejandro Escamilla",
-      "width": 5616,
-      "height": 3744,
+      "author": "Local Example",
+      "width": 720,
+      "height": 405,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/LNRyGwIJr5c",
-        "picsum": "https://picsum.photos/id/1/5616/3744"
+        "local": "./img/bigbuckbunny.jpg"
       }
     },
     {
-      "id": "10",
-      "author": "Paul Jarvis",
-      "width": 2500,
-      "height": 1667,
+      "id": "2",
+      "author": "Local Example",
+      "width": 640,
+      "height": 360,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/6J--NXulQCs",
-        "picsum": "https://picsum.photos/id/10/2500/1667"
+        "local": "./img/hero@1x.jpg"
       }
     },
     {
-      "id": "100",
-      "author": "Tina Rataj",
-      "width": 2500,
-      "height": 1656,
+      "id": "3",
+      "author": "Local Example",
+      "width": 300,
+      "height": 300,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/pwaaqfoMibI",
-        "picsum": "https://picsum.photos/id/100/2500/1656"
+        "local": "./img/sea@1x.jpg"
       }
     },
     {
-      "id": "1000",
-      "author": "Lukas Budimaier",
-      "width": 5626,
-      "height": 3635,
+      "id": "4",
+      "author": "Local Example",
+      "width": 300,
+      "height": 300,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/6cY-FvMlmkQ",
-        "picsum": "https://picsum.photos/id/1000/5626/3635"
+        "local": "./img/sea@2x.jpg"
       }
     },
     {
-      "id": "1001",
-      "author": "Danielle MacInnes",
-      "width": 5616,
-      "height": 3744,
+      "id": "5",
+      "author": "Local Example",
+      "width": 640,
+      "height": 360,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/1DkWWN1dr-s",
-        "picsum": "https://picsum.photos/id/1001/5616/3744"
+        "local": "./img/hero@2x.jpg"
       }
     },
     {
-      "id": "1002",
-      "author": "NASA",
-      "width": 4312,
-      "height": 2868,
+      "id": "6",
+      "author": "Local Example",
+      "width": 200,
+      "height": 200,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/6-jTZysYY_U",
-        "picsum": "https://picsum.photos/id/1002/4312/2868"
+        "local": "./img/clock.jpg"
       }
     },
     {
-      "id": "1003",
-      "author": "E+N Photographies",
-      "width": 1181,
-      "height": 1772,
+      "id": "7",
+      "author": "Local Example",
+      "width": 100,
+      "height": 100,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/GYumuBnTqKc",
-        "picsum": "https://picsum.photos/id/1003/1181/1772"
+        "local": "./img/cats-anim.gif"
       }
     },
     {
-      "id": "1004",
-      "author": "Greg Rakozy",
-      "width": 5616,
-      "height": 3744,
+      "id": "8",
+      "author": "Local Example",
+      "width": 100,
+      "height": 100,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/SSxIGsySh8o",
-        "picsum": "https://picsum.photos/id/1004/5616/3744"
+        "local": "./img/cats-anim-placeholder.gif"
       }
     },
     {
-      "id": "1005",
-      "author": "Matthew Wiebe",
-      "width": 5760,
-      "height": 3840,
+      "id": "9",
+      "author": "Local Example",
+      "width": 100,
+      "height": 100,
       "urls": {
-        "unsplash": "https://unsplash.com/photos/tBtuxtLvAZs",
-        "picsum": "https://picsum.photos/id/1005/5760/3840"
-      }
-    },
-    {
-      "id": "1006",
-      "author": "Vladimir Kudinov",
-      "width": 3000,
-      "height": 2000,
-      "urls": {
-        "unsplash": "https://unsplash.com/photos/-wWRHIUklxM",
-        "picsum": "https://picsum.photos/id/1006/3000/2000"
-      }
-    },
-    {
-      "id": "1008",
-      "author": "Benjamin Combs",
-      "width": 5616,
-      "height": 3744,
-      "urls": {
-        "unsplash": "https://unsplash.com/photos/5L4XAgMSno0",
-        "picsum": "https://picsum.photos/id/1008/5616/3744"
+        "local": "./img/stars.png"
       }
     }
   ]


### PR DESCRIPTION
✨ [Examples] Consolidate image serving in examples and tests

## Description

This pull request consolidates image serving for AMPHTML examples and test files, addressing [issue #25045](https://github.com/ampproject/amphtml/issues/25045).

- **Why:** 
  - Ensures all image references in examples and tests point to local assets within the repository, improving reliability, reproducibility, and self-containment of AMPHTML development and demos.

- **What:**
  - Replaced all external image URLs (Picsum, Unsplash, Googleusercontent, amp.dev) in example HTML files with local images from `examples/img`.
  - Updated `examples/images.json` to reference only included images.
  - Verified that all examples use repo-hosted images for static demonstrations.

- **How to verify:**  
  - Open affected example files and confirm that all images render correctly.
  - Check that no image references use external URLs.

Closes #25045

<!--
# Instructions:
1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.
# References:
- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started
# Emojis for categorizing pull requests (copy-paste emoji into description):
✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
