### PR TITLE
ci: add AI Moderator workflow for issue and comment detection

### DIFF
--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -1,0 +1,28 @@
+name: AI Moderator
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  spam-detection:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      models: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/ai-moderator@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          spam-label: 'spam'
+          ai-label: 'ai-generated'
+          minimize-detected-comments: true
+          enable-spam-detection: true
+          enable-link-spam-detection: true
+          enable-ai-detection: true


### PR DESCRIPTION
Hey @erwinmombay and @rafaelGSS. Here is a proposal to start solving the AI generated comments, issues, PRs, etc..

I created an small feedback issue to the GitHub team asking for additional features https://github.com/github/ai-moderator/issues/22, but in the meantime this is what we can achieve:

- ✅ Hide spam comments on PRs and issues
- ✅ Include the tag `ai-generated` when a new comment has been moderated in a issue.
- ✅ The execution time is fast (unless for the first execution) like few seconds and there is no need for additional GH PAT tokens
- ❌ Moderate PR description
- ❌ Moderate Issue description
- ❌ Auto-close or lock issues and PRs

### Demo
- https://github.com/UlisesGascon/amphtml/issues/3
- https://github.com/UlisesGascon/amphtml/pull/2

### Additional things:

We can add a separate workflow that can close issues tagged as `ai-generated` but that will close any issue where a random AI comment is added, so probably is not something that we want