### PR TITLE
🐛 Fix: Clickio amp-ad vendor: enhanced Page URL Handling for Cached AMP Pages

### DIFF
--- a/ads/vendors/clickio.js
+++ b/ads/vendors/clickio.js
@@ -28,7 +28,11 @@ export function clickio(global, data) {
 
       // base config
       clickioGlobal.ampMode = context.isMaster ? 1 : 2;
-      clickioGlobal.pageUrl = global.context.location.href;
+      clickioGlobal.ampContext = global.context;
+
+      // page url params
+      clickioGlobal.pageUrl =
+        global.context.sourceUrl || global.context.location.href;
       clickioGlobal.sendPageUrl = true;
 
       // ad container


### PR DESCRIPTION
### Problem Description

On cached AMP pages, the Clickio ad unit was sending incorrect URLs. The issue occurred because the ad was using `global.context.location.href` which returns the cached URL instead of the original canonical URL.

### Root Cause

- AMP Cache serves pages through CDN URLs that don't represent the actual page URL
- The previous implementation only used `global.context.location.href` which points to the cached URL

### Changes Made

1. **Added fallback URL resolution**: Now checks `global.context.sourceUrl` first, falling back to `global.context.location.href` if not available
2. **Improved context access**: Added `clickioGlobal.ampContext = global.context` for better access to the global context