### PR TITLE
🏗 Configure CircleCI to keep using the `full` checkout method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,8 @@ commands:
             - git-cache-{{ arch }}-v3-main-{{ .Revision }}
             - git-cache-{{ arch }}-v3-main-
             - git-cache-{{ arch }}-v3-
-      - checkout
+      - checkout:
+          method: full
       - when:
           condition:
             equal: ['main', << pipeline.git.branch >>]


### PR DESCRIPTION
CircleCI are [changing their default Git checkout method to `blobless`](https://circleci.com/changelog/introducing-a-faster-checkout-option/), which would break our builds as we have several checks that access the Git history

This PR explicitly sets the previous (`full`) checkout method in our CircleCI config