### PR TITLE
docs: Fix documentation links and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ AMP is an open source project, and we'd love your help making it better!
 
 -   The [amp.dev Support page](https://amp.dev/support/) has resources for getting help.
 -   Use [Stack Overflow](http://stackoverflow.com/questions/tagged/amp-html) to ask questions about using AMP and find answers to questions others have asked.
--   [Let us know about bugs](https://github.com/ampproject/amphtml/blob/main/docs/contributing.md#report-a-bug), and [file feature requests](https://github.com/ampproject/amphtml/blob/main/docs/contributing.md#make-a-suggestion) to suggest improvements.
+-   [Let us know about bugs](docs/contributing.md#report-a-bug), and [file feature requests](docs/contributing.md#make-a-suggestion) to suggest improvements.
 -   AMP accepts responsible security disclosures through the [Google Application Security program](https://www.google.com/about/appsecurity/).
 
 ## Want to help make AMP better?
 
--   [docs/contributing.md](https://github.com/ampproject/amphtml/blob/main/docs/contributing.md) has information on how you can help improve AMP, including [ongoing participation](https://github.com/ampproject/amphtml/blob/main/docs/contributing.md#ongoing-participation) through Slack, weekly design reviews, etc.
--   We strongly encourage [code contributions](https://github.com/ampproject/amphtml/blob/main/docs/contributing-code.md)!
--   **We enthusiastically welcome new contributors to AMP _even if you have no experience being part of an open source project_**. We've made it easy to [get started contributing](https://github.com/ampproject/amphtml/blob/main/docs/contributing.md#get-started-with-open-source).
+-   [docs/contributing.md](docs/contributing.md) has information on how you can help improve AMP, including [ongoing participation](docs/contributing.md#ongoing-participation) through Slack, weekly design reviews, etc.
+-   We strongly encourage [code contributions](docs/contributing-code.md)!
+-   **We enthusiastically welcome new contributors to AMP _even if you have no experience being part of an open source project_**. We've made it easy to [get started contributing](docs/contributing.md#get-started-with-open-source).
 -   Consider joining one of AMP's [Working Groups](https://github.com/ampproject/meta/tree/main/working-groups), where most of the day-to-day work in AMP gets done.
 
 ## Other useful information

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,7 +21,7 @@ How would you like to help?
 -   [Get started with open source](#get-started-with-open-source)
 -   [Ongoing participation](#ongoing-participation)
 
-If you have questions about _using_ AMP or are _encountering problems using AMP_ on your site please visit our [support page](./support.md) for help.
+If you have questions about _using_ AMP or are _encountering problems using AMP_ on your site please visit our [support page](https://amp.dev/support/) for help.
 
 ## Report a bug
 


### PR DESCRIPTION
- Replace absolute GitHub URLs with relative paths in README.md
- Fix dead support page link in contributing.md
- Improve documentation maintainability

This PR fixes documentation issues by:
- Converting absolute GitHub URLs to relative paths for better maintainability
- Updating the broken support page link to point to amp.dev/support
- Ensuring consistent link formats throughout the documentation