### PR TITLE
Add build/setup instructions to README.md (#40431)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,20 @@ AMP is an open source project, and we'd love your help making it better!
 -   [AMP's roadmap](https://amp.dev/community/roadmap) provides details on some of the significant projects we are working on.
 -   The [AMP meta repository](https://github.com/ampproject/meta) has information _about_ the AMP open source project, including AMP's [governance](https://github.com/ampproject/meta/blob/main/GOVERNANCE.md).
 -   [AMP's code of conduct](https://github.com/ampproject/meta/blob/main/CODE_OF_CONDUCT.md) documents how all members, committers and volunteers in the community are required to act. AMP strives for a positive and growing project community that provides a safe environment for everyone.
+
+## Building AMP Locally
+
+To build and run AMP locally:
+
+1. Install dependencies:
+   ```bash
+   npm install
+
+2. Build the runtime:
+    ```bash
+    npx amp build
+
+3. Start local server:
+    ```bash
+    npx amp serve
+


### PR DESCRIPTION
📖 Documentation

Closes #40431  

Added a new “Building AMP Locally” section to `README.md` to help new contributors set up their environment.  
This section explains how to install dependencies and use AMP’s task runner commands:

- `npm install` — install project dependencies  
- `npx amp build` — build the runtime  
- `npx amp serve` — run a local development server  

This improves onboarding clarity for first-time contributors and replaces missing build/setup context that was previously undocumented.

---

🆕 First-time contributor: Please let me know if the formatting, section placement, or command descriptions need adjustment.