### PR TITLE
🐛 Add close button to responsive menu sidebar

### DIFF
--- a/examples/responsive-menu.amp.html
+++ b/examples/responsive-menu.amp.html
@@ -83,9 +83,44 @@
     }
     #sidebar {
       width: 350px;
+      position: relative;
+      background: white;
+      padding-top: 60px;
+    }
+    #sidebar amp-list {
+      position: relative;
+      z-index: 1;
     }
     #sidebar section[expanded] {
       background: white;
+    }
+    #sidebar .close-button {
+      position: absolute;
+      top: 10px;
+      right: 10px;
+      padding: 10px 15px;
+      font-size: 2em;
+      line-height: 1;
+      background: rgba(255, 255, 255, 0.95);
+      border: 2px solid #333;
+      border-radius: 4px;
+      color: #333;
+      cursor: pointer;
+      z-index: 9999;
+      min-width: 40px;
+      min-height: 40px;
+      display: block;
+      text-align: center;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    }
+    #sidebar .close-button:hover {
+      color: #000;
+      background: #fff;
+      border-color: #000;
+    }
+    #sidebar .close-button:focus {
+      outline: 2px solid #005fcc;
+      outline-offset: 2px;
     }
     @media (max-width: 1024px) {
       #megamenu {
@@ -144,6 +179,12 @@
   </header>
 
   <amp-sidebar id="sidebar" layout="nodisplay">
+    <button
+        class="close-button"
+        on="tap:sidebar.close"
+        aria-label="Click to close sidebar">
+      ×
+    </button>
     <amp-list layout="fill" src="https://api.myjson.com/bins/11znw2" items="." single-item>
       <template type="amp-mustache">
         <amp-accordion layout="container" expand-single-section>


### PR DESCRIPTION
## Description
Adds a close button (×) inside the `amp-sidebar` component in the responsive menu example to improve user experience. Previously, users could only close the sidebar by clicking the hamburger button again, which wasn't intuitive. Now there's a dedicated, clearly visible close button inside the sidebar.

## Changes
- Added close button with × symbol inside the `amp-sidebar` element
- Positioned absolutely at top-right corner with proper styling
- Button uses `on="tap:sidebar.close"` to close the sidebar
- Added CSS styling for better visibility:
  - White background with border and shadow for contrast
  - Hover states for better UX
  - Focus outline for accessibility
  - Proper z-index to ensure visibility above content
- Added padding-top to sidebar to prevent content overlap with close button

## Testing
- Tested locally at `http://localhost:8000/examples/responsive-menu.amp.html`
- Verified button appears correctly in the top-right corner of the sidebar
- Verified button closes the sidebar when clicked
- Verified button is visible and accessible with proper styling
- Tested on responsive viewport sizes

## Screenshots
<img width="1887" height="872" alt="image" src="https://github.com/user-attachments/assets/7a5c20b1-c336-472c-8351-2d79d4d0721f" />
