### PR TITLE
Fix google cookie expiration date setting.

### DIFF
--- a/ads/google/a4a/cookie-utils.js
+++ b/ads/google/a4a/cookie-utils.js
@@ -46,7 +46,7 @@ export function maybeSetCookieFromAdResponse(win, fetchResponse) {
     // On proxy origin, we want cookies to be partitioned by subdomain to
     // prevent sharing across unrelated publishers, so we don't set a domain.
     const domain = getProxySafeDomain(win, cookieInfo['domain']);
-    const expiration = Math.max(cookieInfo['expiration'], 0);
+    const expiration = Math.max(cookieInfo['expires'], 0);
     setCookie(win, cookieName, value, expiration, {
       domain,
       secure: false,

--- a/ads/google/a4a/test/test-cookie-utils.js
+++ b/ads/google/a4a/test/test-cookie-utils.js
@@ -24,13 +24,13 @@ describes.fakeWin('#maybeSetCookieFromAdResponse', {amp: true}, (env) => {
                 'version': 1,
                 'value': 'val1',
                 'domain': 'foo.com',
-                'expiration': Date.now() + 100_000,
+                'expires': Date.now() + 100_000,
               },
               {
                 'version': 2,
                 'value': 'val2',
                 'domain': 'foo.com',
-                'expiration': Date.now() + 100_000,
+                'expires': Date.now() + 100_000,
               },
             ],
           });


### PR DESCRIPTION
Fixes issue in which we were incorrectly reading 'expiration' from the cookie header rather than the correct field 'expires'.