### PR TITLE
🏗 Remove unused file `build-system/tasks/visual-diff/.npmrc`

### DIFF
--- a/build-system/tasks/visual-diff/.npmrc
+++ b/build-system/tasks/visual-diff/.npmrc
@@ -1,2 +1,0 @@
-puppeteer_skip_chrome_download=true
-puppeteer_skip_chromium_download=true


### PR DESCRIPTION
Puppeteer no longer force-downloads Chrome/Chromium, and `npm` is soon going to stop supporting custom configs anyways