### PR TITLE
Optimize shopping cart page to avoid flash of unavailable sizes(#40455)

### DIFF
--- a/examples/bind/ecommerce.amp.html
+++ b/examples/bind/ecommerce.amp.html
@@ -264,21 +264,21 @@
       <amp-selector on="select:AMP.setState({selectedSize: event.targetOption})">
         <table>
           <tr>
-            <td [class]="!shirts[selected.id].sizes['XS'] ? 'unavailable' : ''">
+            <td [class]="shirts[selected.id].sizes && !shirts[selected.id].sizes['XS'] ? 'unavailable' : ''">
               <div option="XS">XS</div>
             </td>
-            <td [class]="!shirts[selected.id].sizes['S'] ? 'unavailable' : ''">
+            <td [class]="shirts[selected.id].sizes && !shirts[selected.id].sizes['S'] ? 'unavailable' : ''">
               <div option="S">S</div>
             </td>
-            <td [class]="!shirts[selected.id].sizes['M'] ? 'unavailable' : ''"
+            <td [class]="shirts[selected.id].sizes && !shirts[selected.id].sizes['M'] ? 'unavailable' : ''"
                 class="unavailable">
               <div option="M">M</div>
             </td>
-            <td [class]="!shirts[selected.id].sizes['L'] ? 'unavailable' : ''"
+            <td [class]="shirts[selected.id].sizes && !shirts[selected.id].sizes['L'] ? 'unavailable' : ''"
                 class="unavailable">
               <div option="L">L</div>
             </td>
-            <td [class]="!shirts[selected.id].sizes['XL'] ? 'unavailable' : ''"
+            <td [class]="shirts[selected.id].sizes && !shirts[selected.id].sizes['XL'] ? 'unavailable' : ''"
                 class="unavailable">
               <div option="XL">XL</div>
             </td>


### PR DESCRIPTION
**Fixes #40455**

**Description**
This PR fixes a UI issue in the e-commerce example where all size options would momentarily flash as "unavailable" (crossed out) when switching between shirt colors.

**Motivation**
When a user selects a different color, the application fetches the size data for that color asynchronously. During this network request, the `sizes `object is `undefined`. The previous logic `!shirts[selected.id].sizes['SIZE']` evaluated to `true `during this loading and undefined state, causing the UI to incorrectly mark all sizes as unavailable.

**Changes**
Updated the `[class] `binding logic for all size options in 
_examples/bind/ecommerce.amp.html_.

- **Old Logic**: Checked only for the absence of the specific size.
- **New Logic**: Adds a guard check `shirts[selected.id].sizes && ...`  to ensure the `sizes `data exists before determining if a specific size is unavailable.

**Verification**
1.Open 
_examples/bind/ecommerce.amp.html_ .

2. Select a different color (e.g., "Brown").

3. Observe that size options remain in their neutral state during the fetch and update correctly once data is loaded, without flashing the "unavailable" style.

