### PR TITLE
For GFP cookie setting logic, fall back to reading purpose one directly from the consent string when explicit purpose one is not granted.

### DIFF
--- a/extensions/amp-a4a/0.1/amp-a4a.js
+++ b/extensions/amp-a4a/0.1/amp-a4a.js
@@ -2619,21 +2619,21 @@ export function hasStorageConsent(consentTuple) {
     return false;
   }
 
+  const {consentState, consentString, gdprApplies, purposeOne} = consentTuple;
+
   if (
     [CONSENT_POLICY_STATE.UNKNOWN, CONSENT_POLICY_STATE.INSUFFICIENT].includes(
-      consentTuple.consentState
+      consentState
     )
   ) {
     return false;
   }
 
-  const {consentString, gdprApplies, purposeOne} = consentTuple;
-
   if (!gdprApplies) {
     return true;
   }
 
-  return (
+  return !!(
     consentString &&
     (purposeOne ||
       // Fallback to checking purpose one from consent string, as there appear


### PR DESCRIPTION
There appear to be a number of cases where the AMP runtime fails to recognize purpose one being granted in the consent objects passed around internally, despite purpose one being granted in the TCF consent string.

This is a stopgap solution to ensure cookies are set when allowed. Possibly, and separate to this, we should investigate why the discrepancy between the runtime's internal representation of consent and the tcf consent string.