### PR TITLE
fix: correct CSS error column numbers when `<style>` and content are on the same line

### DIFF
--- a/validator/cpp/engine/validator-internal.cc
+++ b/validator/cpp/engine/validator-internal.cc
@@ -3113,9 +3113,12 @@ void CdataMatcher::MatchCss(string_view cdata, const CssSpec& css_spec,
   vector<unique_ptr<htmlparser::css::ErrorToken>> css_warnings;
   vector<char32_t> codepoints =
       htmlparser::Strings::Utf8ToCodepoints(cdata.data());
+  // Use the tag's line (line_col_) to preserve correct line numbering, but
+  // use the content's column (content_line_col) so that when the CSS is on
+  // the same line as the <style> tag, column offsets are correct. For
+  // multi-line content, the first newline resets the column to 0 anyway.
   vector<unique_ptr<htmlparser::css::Token>> tokens = htmlparser::css::Tokenize(
-      &codepoints, content_line_col.line(), content_line_col.col(),
-      &css_errors);
+      &codepoints, line_col_.line(), content_line_col.col(), &css_errors);
   unique_ptr<htmlparser::css::Stylesheet> stylesheet =
       htmlparser::css::ParseAStylesheet(
           &tokens, parsed_cdata_spec_->css_parsing_config(), &css_errors);

--- a/validator/cpp/engine/validator-internal.cc
+++ b/validator/cpp/engine/validator-internal.cc
@@ -1953,8 +1953,12 @@ class CdataMatcher {
                         const LineCol& line_col);
 
   // Matches |cdata| against what this CdataMatcher expects.
+  // |content_line_col| is the position of the actual text content (e.g., the
+  // text node inside <style>), which may differ from the opening tag position
+  // when the tag and content are on the same line.
   void Match(string_view cdata, Context* context,
-             ValidationResult* result) const;
+             ValidationResult* result,
+             const LineCol& content_line_col) const;
 
  private:
   // Matches the provided cdata against a CSS specification. Helper
@@ -1962,7 +1966,8 @@ class CdataMatcher {
   // in the CSS string which were measured as URLs. In some validation types,
   // these bytes are not counted against byte limits.
   void MatchCss(string_view cdata, const CssSpec& css_spec, int* url_bytes,
-                Context* context, ValidationResult* result) const;
+                Context* context, ValidationResult* result,
+                const LineCol& content_line_col) const;
 
   // Matches the provided stylesheet against a MediaQuery specification.
   // Helper routine for MatchCss.
@@ -2896,7 +2901,8 @@ class InvalidDeclVisitor : public htmlparser::css::RuleVisitor {
 };
 
 void CdataMatcher::Match(string_view cdata, Context* context,
-                         ValidationResult* result) const {
+                         ValidationResult* result,
+                         const LineCol& content_line_col) const {
   if (!parsed_cdata_spec_) return;
   if (context->Progress(*result).complete) return;
 
@@ -2932,7 +2938,8 @@ void CdataMatcher::Match(string_view cdata, Context* context,
       return;
     }
   } else if (cdata_spec.has_css_spec()) {
-    MatchCss(cdata, cdata_spec.css_spec(), &url_bytes, context, result);
+    MatchCss(cdata, cdata_spec.css_spec(), &url_bytes, context, result,
+             content_line_col);
   } else if (cdata_spec.whitespace_only()) {
     static LazyRE2 ws_only = {"^\\s*$"};
     if (!RE2::FullMatch(cdata, *ws_only)) {
@@ -3100,13 +3107,15 @@ void CdataMatcher::MatchSelectors(
 
 void CdataMatcher::MatchCss(string_view cdata, const CssSpec& css_spec,
                             int* url_bytes, Context* context,
-                            ValidationResult* result) const {
+                            ValidationResult* result,
+                            const LineCol& content_line_col) const {
   vector<unique_ptr<htmlparser::css::ErrorToken>> css_errors;
   vector<unique_ptr<htmlparser::css::ErrorToken>> css_warnings;
   vector<char32_t> codepoints =
       htmlparser::Strings::Utf8ToCodepoints(cdata.data());
   vector<unique_ptr<htmlparser::css::Token>> tokens = htmlparser::css::Tokenize(
-      &codepoints, line_col_.line(), line_col_.col(), &css_errors);
+      &codepoints, content_line_col.line(), content_line_col.col(),
+      &css_errors);
   unique_ptr<htmlparser::css::Stylesheet> stylesheet =
       htmlparser::css::ParseAStylesheet(
           &tokens, parsed_cdata_spec_->css_parsing_config(), &css_errors);
@@ -5843,9 +5852,19 @@ class Validator {
         const CdataMatcher* cdata_matcher =
             context_.tag_stack().cdata_matcher();
         if (cdata_matcher) {
+          LineCol content_lc = context_.line_col();
+          if (auto pos = node->FirstChild()->LineColInHtmlSrc();
+              pos.has_value()) {
+            // LineColInHtmlSrc() returns 1-indexed columns; convert to
+            // 0-indexed to match the convention used by the CSS tokenizer.
+            int line_no = pos.value().first;
+            int col_no = pos.value().second;
+            content_lc = LineCol(line_no >= 0 ? line_no : line_no + 1,
+                                 col_no > 0 ? col_no - 1 : col_no);
+          }
           cdata_matcher->Match(string_view(node->FirstChild()->Data().data(),
                                            node->FirstChild()->Data().size()),
-                               &context_, &result_);
+                               &context_, &result_, content_lc);
         }
       }
     }

--- a/validator/testdata/feature_tests/css_error_column_same_line.html
+++ b/validator/testdata/feature_tests/css_error_column_same_line.html
@@ -1,0 +1,19 @@
+<!--
+  Test Description:
+  Tests that CSS error column numbers are correct when the style tag and CSS
+  content appear on the same line.
+-->
+<!doctype html>
+<html ⚡>
+<head>
+  <meta charset="utf-8">
+  <link rel="canonical" href="./regular-html-version.html">
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+  <style amp-custom>a{b{c:d}}</style>
+</head>
+<body>
+Hello, world.
+</body>
+</html>

--- a/validator/testdata/feature_tests/css_error_column_same_line.out
+++ b/validator/testdata/feature_tests/css_error_column_same_line.out
@@ -13,10 +13,8 @@ FAIL
 |    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 |    <script async src="https://cdn.ampproject.org/v0.js"></script>
 |    <style amp-custom>a{b{c:d}}</style>
->>                       ^~~~~~~~~
-feature_tests/css_error_column_same_line.html:14:22 CSS syntax error in tag 'style amp-custom' - incomplete declaration.
->>                            ^~~~~~~~~
-feature_tests/css_error_column_same_line.html:14:27 CSS syntax error in tag 'style amp-custom' - invalid declaration.
+>>                      ^~~~~~~~~
+feature_tests/css_error_column_same_line.html:14:21 CSS syntax error in tag 'style amp-custom' - incomplete declaration.
 |  </head>
 |  <body>
 |  Hello, world.

--- a/validator/testdata/feature_tests/css_error_column_same_line.out
+++ b/validator/testdata/feature_tests/css_error_column_same_line.out
@@ -1,0 +1,24 @@
+FAIL
+|  <!--
+|    Test Description:
+|    Tests that CSS error column numbers are correct when the style tag and CSS
+|    content appear on the same line.
+|  -->
+|  <!doctype html>
+|  <html ⚡>
+|  <head>
+|    <meta charset="utf-8">
+|    <link rel="canonical" href="./regular-html-version.html">
+|    <meta name="viewport" content="width=device-width,minimum-scale=1">
+|    <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+|    <script async src="https://cdn.ampproject.org/v0.js"></script>
+|    <style amp-custom>a{b{c:d}}</style>
+>>                       ^~~~~~~~~
+feature_tests/css_error_column_same_line.html:14:22 CSS syntax error in tag 'style amp-custom' - incomplete declaration.
+>>                            ^~~~~~~~~
+feature_tests/css_error_column_same_line.html:14:27 CSS syntax error in tag 'style amp-custom' - invalid declaration.
+|  </head>
+|  <body>
+|  Hello, world.
+|  </body>
+|  </html>


### PR DESCRIPTION
Fixes #40424

When `<style amp-custom>` and its CSS are on the same line (e.g. `<style amp-custom>body{bad:css}</style>`), CSS error column numbers point to the opening tag instead of the actual CSS content. This is because `CdataMatcher` passes the tag's position to the CSS tokenizer, and when everything's on one line the column offset is wrong. When they're on separate lines it doesn't matter since the newline resets the column.

The fix plumbs the text node's actual position (`node->FirstChild()->LineColInHtmlSrc()`) through to the CSS tokenizer, with a fallback to the existing behavior if unavailable. Same approach that's already used for JSON content error positions a few lines above.

Includes a test case with style tag and CSS on the same line.