### PR TITLE
🏗 Only run package-lock.json sync check on PRs

### DIFF
--- a/build-system/common/update-packages.js
+++ b/build-system/common/update-packages.js
@@ -6,7 +6,7 @@ const path = require('path');
 const {cyan, red} = require('kleur/colors');
 const {execOrDie} = require('./exec');
 const {getOutput} = require('./process');
-const {isCiBuild} = require('./ci');
+const {isCiBuild, isPullRequestBuild} = require('./ci');
 const {log, logLocalDev} = require('./logging');
 const {runNpmChecks} = require('./npm-checks');
 
@@ -213,7 +213,7 @@ function updatePackages() {
   patchIntersectionObserver();
   patchResizeObserver();
   patchShadowDom();
-  if (isCiBuild()) {
+  if (isPullRequestBuild()) {
     runNpmChecks();
   }
 }
@@ -244,7 +244,7 @@ function updateSubpackages(dir, skipNpmChecks = false) {
       throw new Error('Installation failed');
     }
   }
-  if (isCiBuild() && !skipNpmChecks) {
+  if (isPullRequestBuild() && !skipNpmChecks) {
     runNpmChecks(dir);
   }
 }


### PR DESCRIPTION
The code that verifies that `package-lock.json` has been synced correctly occasionally break on different environments (e.g., CircleCI vs. GitHub Actions) because those envs have different versions of npm, e.g. [this recent breakage](https://github.com/ampproject/amphtml/issues/40488). In hindsight it doesn't seem to make sense to run this test on push builds - it should only ever be cause at the PR level