### PR TITLE
fix: allow 'expanded' attribute in Purifier

### DIFF
--- a/src/purifier/sanitation.js
+++ b/src/purifier/sanitation.js
@@ -235,6 +235,7 @@ export const ALLOWLISTED_ATTRS = [
   'max-font-size',
   'on',
   'option',
+  'expanded',
   'placeholder',
   // Attributes related to amp-form.
   'submitting',

--- a/src/purifier/sanitation.js
+++ b/src/purifier/sanitation.js
@@ -235,7 +235,6 @@ export const ALLOWLISTED_ATTRS = [
   'max-font-size',
   'on',
   'option',
-  'expanded',
   'placeholder',
   // Attributes related to amp-form.
   'submitting',

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -194,13 +194,8 @@ describes.sandboxed('DOMPurify-based', {}, (env) => {
     });
 
     it('should output "expanded" attribute', () => {
-<<<<<<< HEAD
-      expect(purify('<section expanded>Header</section>')).to.match(
-        /<section expanded i-amphtml-key="(\d+)">Header<\/section>/
-=======
       expect(purify('<section expanded>Header</section>')).to.equal(
         '<section expanded="">Header</section>'
->>>>>>> a6e8549e7d (fix: allow 'expanded' attribute in Purifier)
       );
     });
 

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -193,6 +193,12 @@ describes.sandboxed('DOMPurify-based', {}, (env) => {
       expect(rewriteAttributeValueSpy.callCount).to.be.equal(1);
     });
 
+    it('should output "expanded" attribute', () => {
+      expect(purify('<section expanded>Header</section>')).to.match(
+        /<section expanded i-amphtml-key="(\d+)">Header<\/section>/
+      );
+    });
+
     it('should default target to _top with href', () => {
       // Can't use string equality since DOMPurify will reorder attributes.
       const actual = serialize(

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -194,8 +194,13 @@ describes.sandboxed('DOMPurify-based', {}, (env) => {
     });
 
     it('should output "expanded" attribute', () => {
+<<<<<<< HEAD
       expect(purify('<section expanded>Header</section>')).to.match(
         /<section expanded i-amphtml-key="(\d+)">Header<\/section>/
+=======
+      expect(purify('<section expanded>Header</section>')).to.equal(
+        '<section expanded="">Header</section>'
+>>>>>>> a6e8549e7d (fix: allow 'expanded' attribute in Purifier)
       );
     });
 


### PR DESCRIPTION
Allow 'expanded' to be preserved during HTML sanitization. This is needed for amp-accordion

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
