### PR TITLE
✨ [Story analytics] Add caption state analytics events

### DIFF
--- a/extensions/amp-story/1.0/amp-story.js
+++ b/extensions/amp-story/1.0/amp-story.js
@@ -689,6 +689,20 @@ export class AmpStory extends AMP.BaseElement {
       false /** callToInitialize */
     );
 
+    this.storeService_.subscribe(
+      StateProperty.CAPTIONS_STATE,
+      (captionsState) => {
+        // We do not want to trigger an analytics event for the initialization of
+        // the captions state.
+        this.analyticsService_.triggerEvent(
+          captionsState
+            ? StoryAnalyticsEvent.STORY_CAPTIONS_ON
+            : StoryAnalyticsEvent.STORY_CAPTIONS_OFF
+        );
+      },
+      false /** callToInitialize */
+    );
+
     this.storeService_.subscribe(StateProperty.ADVANCEMENT_MODE, (mode) => {
       this.variableService_.onVariableUpdate(
         AnalyticsVariable.STORY_ADVANCEMENT_MODE,

--- a/extensions/amp-story/1.0/story-analytics.js
+++ b/extensions/amp-story/1.0/story-analytics.js
@@ -27,6 +27,8 @@ export const StoryAnalyticsEvent = {
   STORY_CONTENT_LOADED: 'story-content-loaded',
   STORY_MUTED: 'story-audio-muted',
   STORY_UNMUTED: 'story-audio-unmuted',
+  STORY_CAPTIONS_ON: 'story-captions-on',
+  STORY_CAPTIONS_OFF: 'story-captions-off',
   SHOPPING_BUY_NOW_CLICK: 'story-shopping-buy-now-click',
   SHOPPING_PLP_VIEW: 'story-shopping-plp-view',
   SHOPPING_PDP_VIEW: 'story-shopping-pdp-view',

--- a/extensions/amp-story/1.0/test/test-amp-story.js
+++ b/extensions/amp-story/1.0/test/test-amp-story.js
@@ -34,7 +34,7 @@ import {
 } from '../amp-story-store-service';
 import {EventType, dispatch} from '../events';
 import {MediaType_Enum} from '../media-pool';
-import {AdvancementMode} from '../story-analytics';
+import {AdvancementMode, StoryAnalyticsEvent} from '../story-analytics';
 import * as utils from '../utils';
 
 // Represents the correct value of KeyboardEvent.which for the Right Arrow
@@ -993,6 +993,27 @@ describes.realWin(
 
         story.storeService_.dispatch(Action.TOGGLE_MUTED, true);
         expect(story.element.hasAttribute('muted')).to.be.true;
+      });
+
+      it('should trigger analytics event on captions toggle', async () => {
+        await createStoryWithPages(2, ['cover', 'page-1']);
+
+        const triggerSpy = env.sandbox.spy(
+          story.analyticsService_,
+          'triggerEvent'
+        );
+
+        await story.layoutCallback();
+
+        story.storeService_.dispatch(Action.TOGGLE_CAPTIONS, false);
+        expect(triggerSpy).to.have.been.calledWith(
+          StoryAnalyticsEvent.STORY_CAPTIONS_OFF
+        );
+
+        story.storeService_.dispatch(Action.TOGGLE_CAPTIONS, true);
+        expect(triggerSpy).to.have.been.calledWith(
+          StoryAnalyticsEvent.STORY_CAPTIONS_ON
+        );
       });
 
       describe('#getMaxMediaElementCounts', () => {

--- a/extensions/amp-story/amp-story-analytics.md
+++ b/extensions/amp-story/amp-story-analytics.md
@@ -145,6 +145,14 @@ The `story-audio-muted` trigger is fired when the user initiates an interaction 
 
 The `story-audio-unmuted` trigger is fired when the user initiates an interaction to unmute the audio for the current story.
 
+### Captions on trigger (`"on": "story-captions-on"`)
+
+The `story-captions-on` trigger is fired when the user initiates an interaction to turn captions on for the current story.
+
+### Captions off trigger (`"on": "story-captions-off"`)
+
+The `story-captions-off` trigger is fired when the user initiates an interaction to turn captions off for the current story.
+
 ### Page attachment enter trigger (`"on": "story-page-attachment-enter"`)
 
 The `story-page-attachment-enter` trigger is fired when a page attachment is opened by the user.


### PR DESCRIPTION
Adds analytics dispatch for `StateProperty.CAPTIONS_STATE` so publishers can track when users toggle captions on or off, mirroring the existing `STORY_MUTED` / `STORY_UNMUTED` events. Captions are a parallel user-toggleable media state but have no analytics surface today.

Changes:
- `story-analytics.js`: adds `STORY_CAPTIONS_ON: 'story-captions-on'` and `STORY_CAPTIONS_OFF: 'story-captions-off'` to the `StoryAnalyticsEvent` enum.
- `amp-story.js`: subscribes to `StateProperty.CAPTIONS_STATE` next to the existing muted-state analytics subscriber, with `callToInitialize: false` so only user toggles fire events.
- `amp-story-analytics.md`: documents the two new triggers in the same voice as the existing mute/unmute entries.

Verb choice `on` / `off` matches the `captions-on` host attribute on the system layer; audio uses `muted` / `unmuted` and captions uses `on` / `off`, each following its own vocabulary. The audio analytics dispatch in `amp-story.js` is itself untested, so this PR follows the same pattern; happy to add coverage for both in a follow-up if preferred.
