### PR TITLE
✨ [amp-story-player] Re-emit captions state to host page

### DIFF
--- a/docs/spec/amp-story-player.md
+++ b/docs/spec/amp-story-player.md
@@ -663,6 +663,16 @@ player.addEventListener('amp-story-muted-state', (event) => {
 })
 ```
 
+#### amp-story-captions-state
+
+Fired when the story's captions are turned on/off. This event provides a `captions` property.
+
+```javascript
+player.addEventListener('amp-story-captions-state', (event) => {
+  console.log('captions state', event.detail.captions);
+})
+```
+
 #### navigation
 
 Fired when the player changes to a new story and provides the `index`, the player's story after changing, and `remaining`, the number of stories left.

--- a/src/amp-story-player/amp-story-player-impl.js
+++ b/src/amp-story-player/amp-story-player-impl.js
@@ -100,6 +100,7 @@ const STORY_MESSAGE_STATE_TYPE_ENUM = {
   PAGE_ATTACHMENT_STATE: 'PAGE_ATTACHMENT_STATE',
   UI_STATE: 'UI_STATE',
   MUTED_STATE: 'MUTED_STATE',
+  CAPTIONS_STATE: 'CAPTIONS_STATE',
   CURRENT_PAGE_ID: 'CURRENT_PAGE_ID',
   STORY_PROGRESS: 'STORY_PROGRESS',
   DESKTOP_ASPECT_RATIO: 'DESKTOP_ASPECT_RATIO',
@@ -643,6 +644,10 @@ export class AmpStoryPlayer {
 
           messaging.sendRequest('onDocumentState', {
             'state': STORY_MESSAGE_STATE_TYPE_ENUM.MUTED_STATE,
+          });
+
+          messaging.sendRequest('onDocumentState', {
+            'state': STORY_MESSAGE_STATE_TYPE_ENUM.CAPTIONS_STATE,
           });
 
           messaging.sendRequest('onDocumentState', {
@@ -1596,6 +1601,9 @@ export class AmpStoryPlayer {
       case STORY_MESSAGE_STATE_TYPE_ENUM.MUTED_STATE:
         this.onMutedStateUpdate_(/** @type {string} */ (data.value));
         break;
+      case STORY_MESSAGE_STATE_TYPE_ENUM.CAPTIONS_STATE:
+        this.onCaptionsStateUpdate_(/** @type {string} */ (data.value));
+        break;
       case STORY_MESSAGE_STATE_TYPE_ENUM.UI_STATE:
         // Handles UI state updates on window resize.
         this.onUiStateUpdate_(/** @type {number} */ (data.value));
@@ -1668,6 +1676,17 @@ export class AmpStoryPlayer {
   onMutedStateUpdate_(muted) {
     this.element_.dispatchEvent(
       createCustomEvent(this.win_, 'amp-story-muted-state', {muted})
+    );
+  }
+
+  /**
+   * Reacts to captions on/off events coming from the story.
+   * @param {string} captions
+   * @private
+   */
+  onCaptionsStateUpdate_(captions) {
+    this.element_.dispatchEvent(
+      createCustomEvent(this.win_, 'amp-story-captions-state', {captions})
     );
   }
 

--- a/test/unit/test-amp-story-player.js
+++ b/test/unit/test-amp-story-player.js
@@ -1460,6 +1460,56 @@ describes.realWin('AmpStoryPlayer', {amp: false}, (env) => {
       });
     });
 
+    it('should dispatch amp-story-captions-state when story captions are turned on', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      attachPlayerWithStories(playerEl, 1);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      await player.load();
+      await macroTask();
+
+      const spy = env.sandbox.spy();
+      playerEl.addEventListener('amp-story-captions-state', spy);
+
+      const fakeData = {state: 'CAPTIONS_STATE', value: true};
+      fireHandler['documentStateUpdate']('documentStateUpdate', fakeData);
+
+      await macroTask();
+
+      expect(spy).to.have.been.calledWithMatch({
+        type: 'amp-story-captions-state',
+        detail: {
+          captions: true,
+        },
+      });
+    });
+
+    it('should dispatch amp-story-captions-state when story captions are turned off', async () => {
+      const playerEl = win.document.createElement('amp-story-player');
+      attachPlayerWithStories(playerEl, 1);
+
+      const player = new AmpStoryPlayer(win, playerEl);
+
+      await player.load();
+      await macroTask();
+
+      const spy = env.sandbox.spy();
+      playerEl.addEventListener('amp-story-captions-state', spy);
+
+      const fakeData = {state: 'CAPTIONS_STATE', value: false};
+      fireHandler['documentStateUpdate']('documentStateUpdate', fakeData);
+
+      await macroTask();
+
+      expect(spy).to.have.been.calledWithMatch({
+        type: 'amp-story-captions-state',
+        detail: {
+          captions: false,
+        },
+      });
+    });
+
     it('should react to CURRENT_PAGE_ID events', async () => {
       const playerEl = win.document.createElement('amp-story-player');
       attachPlayerWithStories(playerEl, 1);


### PR DESCRIPTION
Adds `<amp-story-player>` re-emit of caption-state changes so host pages embedding a story can listen for caption toggles, mirroring the existing `amp-story-muted-state` event. The player already bridges muted-state from the embedded story to the host element via `onMutedStateUpdate_`; this PR adds the captions-state equivalent.

Changes to `src/amp-story-player/amp-story-player-impl.js`, mirroring the muted-state plumbing:
1. New `CAPTIONS_STATE: 'CAPTIONS_STATE'` entry in `STORY_MESSAGE_STATE_TYPE_ENUM`.
2. New `messaging.sendRequest('onDocumentState', ...)` subscription on handshake.
3. New `case` in the `onDocumentStateUpdate_` switch.
4. New `onCaptionsStateUpdate_(captions)` handler that dispatches an `amp-story-captions-state` `CustomEvent` on the player element with `{captions}` detail.

Also updates `docs/spec/amp-story-player.md` and adds two unit tests in `test/unit/test-amp-story-player.js` mirroring the existing muted-state tests.

Host page usage:

```js
player.addEventListener('amp-story-captions-state', (event) => {
  console.log('captions on?', event.detail.captions);
});
```

Detail key is `captions` (not `captionsState`) to match the muted-state external API, which drops the `_STATE` suffix (`MUTED_STATE` → `event.detail.muted`). This PR is story-to-host re-emit only; a host-to-story push direction analogous to `player.mute()` / `player.unmute()` can be added in a follow-up if wanted.
