### PR TITLE
guard mergeObjects against prototype-polluting keys

### DIFF
--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -499,8 +499,14 @@ export function mergeObjects(from, to, opt_predefinedVendorConfig) {
       opt_predefinedVendorConfig || property != 'iframePing',
       'iframePing config is only available to vendor config.'
     );
-    // Only deal with own properties.
-    if (hasOwn(from, property)) {
+    // Only deal with own properties, and never let a key reach the prototype
+    // chain (remote/inline config is attacker reachable).
+    if (
+      hasOwn(from, property) &&
+      property != '__proto__' &&
+      property != 'constructor' &&
+      property != 'prototype'
+    ) {
       if (isArray(from[property])) {
         if (!isArray(to[property])) {
           to[property] = [];

--- a/extensions/amp-analytics/0.1/test/test-config.js
+++ b/extensions/amp-analytics/0.1/test/test-config.js
@@ -338,6 +338,20 @@ describes.realWin(
           'foobar': {'foobar': ['abc', 'def']},
         });
       });
+
+      it('does not pollute the prototype via __proto__', () => {
+        const from = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+        mergeObjects(from, {});
+        expect({}.polluted).to.be.undefined;
+      });
+
+      it('does not pollute the prototype via constructor', () => {
+        const from = JSON.parse(
+          '{"constructor": {"prototype": {"polluted": "yes"}}}'
+        );
+        mergeObjects(from, {});
+        expect({}.polluted).to.be.undefined;
+      });
     });
 
     describe('vendor only configs', () => {


### PR DESCRIPTION
mergeObjects merges fetched/inline analytics config into a plain object and recurses into the destination when both sides are objects.
- a remote `config` response with a `__proto__` key walks the recursion onto Object.prototype and writes nested keys there, so `{}.whatever` is polluted page-wide
- `mergeObjects(this.remoteConfig_, config)` in processConfigs_ feeds the fetched JSON straight in, so the source is whatever the analytics endpoint returns
- what happens if a vendor or a compromised endpoint returns `{"__proto__": {"...": ...}}`? right now every object on the page inherits it
Skipping `__proto__`/`constructor`/`prototype` in the loop, same shape storage-impl already uses for its keys.