### PR TITLE
fix redos in amp-a4a font allowlist version matching

### DIFF
--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -20,7 +20,7 @@ export let ValidatedHeadDef;
 // From validator/validator-main.protoascii
 const ALLOWED_FONT_REGEX = new RegExp(
   'https://cdn\\.materialdesignicons\\.com/' +
-    '([0-9]+\\.?)+/css/materialdesignicons\\.min\\.css|' +
+    '[0-9]+(?:\\.[0-9]+)*\\.?/css/materialdesignicons\\.min\\.css|' +
     'https://cloud\\.typography\\.com/' +
     '[0-9]*/[0-9]*/css/fonts\\.css|' +
     'https://fast\\.fonts\\.net/.*|' +
@@ -28,8 +28,8 @@ const ALLOWED_FONT_REGEX = new RegExp(
     'https://fonts\\.googleapis\\.com/icon\\?.*|' +
     'https://fonts\\.googleapis\\.com/earlyaccess/.*\\.css|' +
     'https://maxcdn\\.bootstrapcdn\\.com/font-awesome/' +
-    '([0-9]+\\.?)+/css/font-awesome\\.min\\.css(\\?.*)?|' +
-    'https://(use|pro)\\.fontawesome\\.com/releases/v([0-9]+\\.?)+' +
+    '[0-9]+(?:\\.[0-9]+)*\\.?/css/font-awesome\\.min\\.css(\\?.*)?|' +
+    'https://(use|pro)\\.fontawesome\\.com/releases/v[0-9]+(?:\\.[0-9]+)*\\.?' +
     '/css/[0-9a-zA-Z-]+\\.css|' +
     'https://(use|pro)\\.fontawesome\\.com/[0-9a-zA-Z-]+\\.css|' +
     'https://use\\.typekit\\.net/[\\w\\p{L}\\p{N}_]+\\.css'

--- a/extensions/amp-a4a/0.1/test/test-head-validation.js
+++ b/extensions/amp-a4a/0.1/test/test-head-validation.js
@@ -174,6 +174,41 @@ describes.realWin('head validation', {amp: true}, (env) => {
       );
     });
 
+    it('keeps versioned material-design and font-awesome font links', () => {
+      const preloadStub = env.sandbox.stub(
+        Services.preconnectFor(env.win),
+        'preload'
+      );
+      const urls = [
+        'https://cdn.materialdesignicons.com/5.4.55/css/materialdesignicons.min.css',
+        'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css',
+        'https://use.fontawesome.com/releases/v5.15.4/css/all.css',
+      ];
+      head.innerHTML = urls
+        .map((href) => `<link href="${href}" rel="stylesheet">`)
+        .join('\n');
+      const validated = processHead(env.win, adElement, head);
+      expect(validated.head.querySelectorAll('link')).to.have.length(
+        urls.length
+      );
+      urls.forEach((href) =>
+        expect(preloadStub).calledWith(env.ampdoc, href)
+      );
+    });
+
+    it('rejects a font link with a long unterminated version run', () => {
+      const preloadStub = env.sandbox.stub(
+        Services.preconnectFor(env.win),
+        'preload'
+      );
+      const href =
+        'https://use.fontawesome.com/releases/v' + '9'.repeat(40) + '!';
+      head.innerHTML = `<link href="${href}" rel="stylesheet">`;
+      const validated = processHead(env.win, adElement, head);
+      expect(validated.head.querySelector('link')).not.to.exist;
+      expect(preloadStub).not.to.be.called;
+    });
+
     it('does not allow arbitrary font providers', () => {
       const preloadStub = env.sandbox.stub(
         Services.preconnectFor(env.win),


### PR DESCRIPTION
1. ALLOWED_FONT_REGEX in head-validation.js tests link[rel=stylesheet] href values pulled from third-party AMPHTML ad creative heads.
2. its version-number part uses ([0-9]+\.?)+, which backtracks catastrophically (ReDoS) on a long digit run followed by a tail that fails the rest of the alternative, so an ad creative can freeze the rendering page main thread.
3. swapped the three version sites to the linear [0-9]+(?:\.[0-9]+)*\.? form, which matches the same version strings.

have we considered the worst case here: on the .../releases/v path, 28 digits + a bad tail already costs ~30ms, 34 digits ~2s, and it doubles every extra two digits; the rewritten regex stays under 0.01ms even at 1000 digits while still accepting 5.4.55 / 4.7.0 / v5.15.4 style URLs.