### PR TITLE
validate exit url protocol in amp-ad-exit

### DIFF
--- a/extensions/amp-ad-exit/0.1/amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/amp-ad-exit.js
@@ -145,6 +145,10 @@ export class AmpAdExit extends AMP.BaseElement {
         .map(substituteVariables)
         .forEach((url) => this.pingTrackingUrl_(url));
     }
+    if (!Services.urlForDoc(this.element).isProtocolValid(target.finalUrl)) {
+      user().error(TAG, 'Invalid exit URL protocol: ' + target.finalUrl);
+      return;
+    }
     const finalUrl = substituteVariables(target.finalUrl);
     // TODO(wg-monetization): clean up unused HostServices.
     if (HostServices.isAvailable(this.getAmpDoc())) {

--- a/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
+++ b/extensions/amp-ad-exit/0.1/test/test-amp-ad-exit.js
@@ -349,6 +349,37 @@ describes.realWin(
       );
     });
 
+    it('should reject exit URLs with an invalid protocol', async () => {
+      const el = await makeElementWithConfig({
+        targets: {
+          js: {'finalUrl': /* eslint no-script-url: 0 */ 'javascript:alert(1)'},
+          data: {'finalUrl': 'data:text/html,<script>alert(1)</script>'},
+        },
+      });
+      const open = env.sandbox.stub(win, 'open');
+      const impl = await el.getImpl();
+
+      allowConsoleError(() =>
+        impl.executeAction({
+          method: 'exit',
+          args: {target: 'js'},
+          event: makeClickEvent(1001),
+          satisfiesTrust: () => true,
+        })
+      );
+      allowConsoleError(() =>
+        impl.executeAction({
+          method: 'exit',
+          args: {target: 'data'},
+          event: makeClickEvent(1001),
+          satisfiesTrust: () => true,
+        })
+      );
+
+      expect(open).to.not.have.been.called;
+      win.document.body.removeChild(el);
+    });
+
     it('should enable attribution tracking when given `browserAdConversion`', async () => {
       env.sandbox
         .stub(AmpAdExit.prototype, 'detectAttributionReportingSupport')


### PR DESCRIPTION
the `exit()` handler navigates to a creative-controlled `finalUrl` through `win.open`/`HostServices.openUrl` without a scheme check, so a creative configuring `finalUrl` (or a substituted var) as `javascript:`/`data:` reaches navigation while every other nav path goes through `Navigation.navigateTo` and rejects it via `isProtocolValid`; this validates the substituted `finalUrl` before any exit, found while comparing amp-ad-exit's direct `win.open` against navigation.js.