### PR TITLE
✨ Update Neodata amp-analytics vendor config with GDPR support and conditional cookie-match

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -1266,7 +1266,10 @@ For complete documentation and additional examples please see: https://marketing
       "vars": {
         "sysId": "999",
         "tagId": "12321",
-        "advId": "56785"
+        "advId": "56785",
+        "enableCmDbm": "true",
+        "enableCmAdform": "",
+        "enableCmMediamath": ""
       }
     }
   </script>

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -360,10 +360,10 @@
     "sysId": "999",
     "tagId": "12321",
     "advId": "56785",
-    "pageview": "https://tra.neodatagroup.com/pv?sid=!sysId&rnd=_random_&id=!tagId&ad=!advId&gdpr_consent=_consent_string_&rs=_screen_width_x_screen_height_&lg=_browser_language_&tz=_timezone_&re=_document_referrer_&co=_screen_color_depth_&ur=_ampdoc_url_",
+    "pageview": "https://tra.neodatagroup.com/pv?sid=!sysId&rnd=_random_&id=!tagId&ad=!advId&gdpr=_if(_equals(_consent_metadata(gdprApplies)_%2Ctrue)_%2C1)__if(_equals(_consent_metadata(gdprApplies)_%2Cfalse)_%2C0)_&gdpr_consent=_consent_string_&rs=_screen_width_x_screen_height_&lg=_browser_language_&tz=_timezone_&re=_document_referrer_&co=_screen_color_depth_&ur=_ampdoc_url_",
     "cmDbm": "https://cm.g.doubleclick.net/pixel?google_nid=neodata_dmp&google_cm&pv=dbm&sid=!sysId&rt=img&rnd=_random_",
-    "ADFORM": "https://dmp.adform.net/serving/cookie/match?party=1056&rt=img&rnd=_random_",
-    "MEDIAMATH": "https://pixel.mathtag.com/sync/js?sync=auto&mt_exid=10082&exsync=https://tra.neodatagroup.com/cm?sid=!sysId&pv=MEDIAMATH&eid=[MM_UUID]&rt=img&rnd=_random_"
+    "cmAdform": "https://dmp.adform.net/serving/cookie/match?party=1056&rt=img&rnd=_random_",
+    "cmMediamath": "https://pixel.mathtag.com/sync/js?sync=auto&mt_exid=10082&exsync=https://tra.neodatagroup.com/cm?sid=!sysId&pv=MEDIAMATH&eid=[MM_UUID]&rt=img&rnd=_random_"
   },
   "newrelic": {
     "pageview": "https://bam.nr-data.net/amp?appId=!appId&licenseKey=!licenseKey&ampUrl=_ampdoc_url_&canonicalUrl=_canonical_url_&timeToDomContentLoadedEventEnd=_nav_timing(domContentLoadedEventEnd)_&timeToDomInteractive=_nav_timing(domInteractive)_&timeToDomComplete=_nav_timing(domComplete)_&timeToDomLoading=_nav_timing(domLoading)_&timeToResponseStart=_nav_timing(responseStart)_&timeToResponseEnd=_nav_timing(responseEnd)_&timeToLoadEventStart=_nav_timing(loadEventStart)_&timeToLoadEventEnd=_nav_timing(loadEventEnd)_&timeToConnectStart=_nav_timing(connectStart)_&timeToConnectEnd=_nav_timing(connectEnd)_&timeToFetchStart=_nav_timing(fetchStart)_&timeToRequestStart=_nav_timing(requestStart)_&timeToUnloadEventStart=_nav_timing(unloadEventStart)_&timeToUnloadEventEnd=_nav_timing(unloadEventEnd)_&timeToDomainLookupStart=_nav_timing(domainLookupStart)_&timeToDomainLookupEnd=_nav_timing(domainLookupEnd)_&timeToRedirectStart=_nav_timing(redirectStart)_&timeToRedirectEnd=_nav_timing(redirectEnd)_&timeToSecureConnection=_nav_timing(secureConnectionStart)_&timestamp=_timestamp_&ampVersion=_amp_version_&pageLoadTime=_page_load_time_"

--- a/extensions/amp-analytics/0.1/vendors/neodata.json
+++ b/extensions/amp-analytics/0.1/vendors/neodata.json
@@ -1,19 +1,36 @@
 {
+  "vars": {
+    "gdprAppliesFlag": "$IF($EQUALS(CONSENT_METADATA(gdprApplies), true), 1)$IF($EQUALS(CONSENT_METADATA(gdprApplies), false), 0)",
+    "enableCmDbm": "",
+    "enableCmAdform": "",
+    "enableCmMediamath": ""
+  },
   "requests": {
     "base": "https://tra.neodatagroup.com",
-    "pageview": "${base}/pv?sid=${sysId}&rnd=${random}&id=${tagId}&ad=${advId}&gdpr_consent=${consentString}&rs=${screenWidth}x${screenHeight}&lg=${browserLanguage}&tz=${timezone}&re=${documentReferrer}&co=${screenColorDepth}&ur=${ampdocUrl}",
+    "pageview": "${base}/pv?sid=${sysId}&rnd=${random}&id=${tagId}&ad=${advId}&gdpr=${gdprAppliesFlag}&gdpr_consent=${consentString}&rs=${screenWidth}x${screenHeight}&lg=${browserLanguage}&tz=${timezone}&re=${documentReferrer}&co=${screenColorDepth}&ur=${ampdocUrl}",
     "cmDbm": "https://cm.g.doubleclick.net/pixel?google_nid=neodata_dmp&google_cm&pv=dbm&sid=${sysId}&rt=img&rnd=${random}",
-    "ADFORM": "https://dmp.adform.net/serving/cookie/match?party=1056&rt=img&rnd=${random}",
-    "MEDIAMATH" :"https://pixel.mathtag.com/sync/js?sync=auto&mt_exid=10082&exsync=${base}/cm?sid=${sysId}&pv=MEDIAMATH&eid=[MM_UUID]&rt=img&rnd=${random}"
+    "cmAdform": "https://dmp.adform.net/serving/cookie/match?party=1056&rt=img&rnd=${random}",
+    "cmMediamath": "https://pixel.mathtag.com/sync/js?sync=auto&mt_exid=10082&exsync=${base}/cm?sid=${sysId}&pv=MEDIAMATH&eid=[MM_UUID]&rt=img&rnd=${random}"
   },
   "triggers": {
     "trackPageview": {
       "on": "visible",
       "request": ["pageview"]
     },
-    "trackCookieMatch":{
-      "on":"visible",
-      "request": ["cmDbm", "ADFORM", "MEDIAMATH"]
+    "trackCmDbm": {
+      "on": "visible",
+      "enabled": "${enableCmDbm}",
+      "request": "cmDbm"
+    },
+    "trackCmAdform": {
+      "on": "visible",
+      "enabled": "${enableCmAdform}",
+      "request": "cmAdform"
+    },
+    "trackCmMediamath": {
+      "on": "visible",
+      "enabled": "${enableCmMediamath}",
+      "request": "cmMediamath"
     }
   },
   "transport": {


### PR DESCRIPTION
The Neodata vendor config was missing the gdpr=0|1 flag required by the IAB TCF standard, and cookie-match triggers were always active with no way for publishers to control which partners to enable.

Changes:

- Add gdpr=0|1 parameter to the pageview URL, derived from CONSENT_METADATA(gdprApplies) via a gdprAppliesFlag variable in the vars section
- Split the single trackCookieMatch trigger into three separate triggers (trackCmDbm, trackCmAdform, trackCmMediamath), each controlled by a publisher-overridable enableCm* variable that defaults to "" (disabled); publishers opt-in to individual partners from the in-page tag
- Rename requests ADFORM→cmAdform and MEDIAMATH→cmMediamath for naming consistency with cmDbm
- Update vendor-requests.json test fixture and examples/analytics-vendors.amp.html accordingly