### PR TITLE
fix(amp-slikeplayer): add amp param to video URL and fullscreen/GDPR support

### DIFF
--- a/examples/slikeplayer.amp.html
+++ b/examples/slikeplayer.amp.html
@@ -74,6 +74,16 @@
       custom-element="amp-slikeplayer"
       src="https://cdn.ampproject.org/v0/amp-slikeplayer-0.1.js"
     ></script>
+    <script
+      async
+      custom-element="amp-consent"
+      src="https://cdn.ampproject.org/v0/amp-consent-0.1.js"
+    ></script>
+    <script
+      async
+      custom-element="amp-geo"
+      src="https://cdn.ampproject.org/v0/amp-geo-0.1.js"
+    ></script>
 
     <style amp-custom>
       body {
@@ -249,6 +259,67 @@
         font-weight: 600;
       }
 
+      .consent-ui {
+        background: #333;
+        color: white;
+        padding: 16px 24px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 12px;
+        font-size: 0.95rem;
+      }
+
+      .consent-ui p {
+        margin: 0;
+        flex: 1;
+        min-width: 200px;
+      }
+
+      .consent-ui .btn-group {
+        display: flex;
+        gap: 8px;
+      }
+
+      .consent-ui button {
+        border: none;
+        border-radius: 4px;
+        padding: 8px 20px;
+        font-size: 0.9rem;
+        cursor: pointer;
+        font-weight: 600;
+      }
+
+      .consent-ui .btn-accept {
+        background: #4facfe;
+        color: white;
+      }
+
+      .consent-ui .btn-reject {
+        background: #666;
+        color: white;
+      }
+
+      .post-consent-ui {
+        background: #e8f5e9;
+        padding: 8px 16px;
+        text-align: center;
+        font-size: 0.85rem;
+        color: #333;
+      }
+
+      .post-consent-ui button {
+        border: none;
+        background: #667eea;
+        color: white;
+        border-radius: 4px;
+        padding: 4px 12px;
+        margin-left: 8px;
+        cursor: pointer;
+        font-size: 0.85rem;
+      }
+
       @media (max-width: 768px) {
         .header h1 {
           font-size: 2rem;
@@ -267,6 +338,50 @@
   </head>
 
   <body>
+    <!-- Geo detection for consent -->
+    <amp-geo layout="nodisplay">
+      <script type="application/json">
+        {
+          "ISOCountryGroups": {
+            "eea": ["at", "be", "bg", "hr", "cy", "cz", "dk", "ee", "fi", "fr",
+                     "de", "gr", "hu", "ie", "it", "lv", "lt", "lu", "mt", "nl",
+                     "pl", "pt", "ro", "sk", "si", "es", "se", "gb", "is", "li",
+                     "no", "ch"]
+          }
+        }
+      </script>
+    </amp-geo>
+
+    <!-- Consent management -->
+    <amp-consent id="slike-consent" layout="nodisplay">
+      <script type="application/json">
+        {
+          "consentInstanceId": "slike-player-consent",
+          "consentRequired": true,
+          "promptUI": "consent-prompt",
+          "postPromptUI": "post-consent-prompt"
+        }
+      </script>
+      <div id="consent-prompt" class="consent-ui">
+        <p>
+          We use cookies and data to deliver and improve our services. By
+          accepting, you agree to personalized content and ads.
+        </p>
+        <div class="btn-group">
+          <button class="btn-accept" on="tap:slike-consent.accept">
+            Accept
+          </button>
+          <button class="btn-reject" on="tap:slike-consent.reject">
+            Reject
+          </button>
+        </div>
+      </div>
+      <div id="post-consent-prompt" class="post-consent-ui">
+        Consent preference saved.
+        <button on="tap:slike-consent.prompt">Manage</button>
+      </div>
+    </amp-consent>
+
     <!-- Header Section -->
     <div class="header">
       <div class="container">

--- a/extensions/amp-slikeplayer/0.1/amp-slikeplayer.js
+++ b/extensions/amp-slikeplayer/0.1/amp-slikeplayer.js
@@ -10,6 +10,7 @@ import {installVideoManagerForDoc} from '#service/video-manager-impl';
 import {getData, listen} from '#utils/event-helper';
 import {userAssert} from '#utils/log';
 
+import {getConsentDataToForward} from '../../../src/consent';
 import {disableScrollingOnIframe} from '../../../src/iframe-helper';
 import {
   addUnsafeAllowAutoplay,
@@ -266,12 +267,20 @@ export class AmpSlikeplayer extends AMP.BaseElement {
     }
 
     const data = objOrParseJson(messageData);
+
+    // Handle consent request from iframe (sent as raw object with type field)
+    if (data['type'] === 'send-consent-data') {
+      this.sendConsentData_();
+      return;
+    }
+
     const event = data['event'];
     const detail = data['detail'];
     if (event === 'ready') {
       detail && this.onReadyOnce_(detail);
       return;
     }
+
     const {element} = this;
     if (redispatch(element, event, CleoEvent)) {
       return;
@@ -336,6 +345,29 @@ export class AmpSlikeplayer extends AMP.BaseElement {
    */
   handleViewportPlayPause(inViewport) {
     this.postMessage_('handleViewport', inViewport);
+  }
+
+  /**
+   * Fetches consent data from AMP consent service
+   * and forwards it to the iframe via postMessage.
+   * @private
+   */
+  sendConsentData_() {
+    getConsentDataToForward(this.element, this.getConsentPolicy()).then(
+      (consents) => {
+        if (!this.iframe_ || !this.iframe_.contentWindow) {
+          return;
+        }
+        this.iframe_.contentWindow./*OK*/ postMessage(
+          {
+            'sentinel': 'amp',
+            'type': 'consent-data',
+            ...consents,
+          },
+          this.targetOrigin_
+        );
+      }
+    );
   }
 
   /**

--- a/extensions/amp-slikeplayer/0.1/amp-slikeplayer.js
+++ b/extensions/amp-slikeplayer/0.1/amp-slikeplayer.js
@@ -1,5 +1,10 @@
 import {Deferred} from '#core/data-structures/promise';
 import {dispatchCustomEvent} from '#core/dom';
+import {
+  fullscreenEnter,
+  fullscreenExit,
+  isFullscreenElement,
+} from '#core/dom/fullscreen';
 import {isLayoutSizeDefined} from '#core/dom/layout';
 import {observeIntersections} from '#core/dom/layout/viewport-observer';
 import {once} from '#core/types/function';
@@ -8,7 +13,7 @@ import {Services} from '#service';
 import {installVideoManagerForDoc} from '#service/video-manager-impl';
 
 import {getData, listen} from '#utils/event-helper';
-import {userAssert} from '#utils/log';
+import {dev, userAssert} from '#utils/log';
 
 import {getConsentDataToForward} from '../../../src/consent';
 import {disableScrollingOnIframe} from '../../../src/iframe-helper';
@@ -87,6 +92,9 @@ export class AmpSlikeplayer extends AMP.BaseElement {
     /** @private {string} */
     this.baseUrl_ = 'https://tvid.in/player/amp.html';
 
+    /** @private {string} Origin of the player iframe; target for postMessage. */
+    this.targetOrigin_ = '*';
+
     /** @private {number} */
     this.duration_ = 1;
 
@@ -126,6 +134,16 @@ export class AmpSlikeplayer extends AMP.BaseElement {
     this.baseUrl_ = element.getAttribute('data-iframe-src') || this.baseUrl_;
     this.config_ = element.getAttribute('data-config') || '';
     this.poster_ = element.getAttribute('poster') || '';
+
+    // Resolve the player origin so messages target it explicitly rather than '*'.
+    try {
+      this.targetOrigin_ = new URL(
+        this.baseUrl_,
+        this.win.location.href
+      ).origin;
+    } catch {
+      this.targetOrigin_ = '*';
+    }
 
     // Read optional viewport visibility threshold from data-config
     if (this.config_) {
@@ -181,10 +199,10 @@ export class AmpSlikeplayer extends AMP.BaseElement {
 
   /** @override */
   layoutCallback() {
-    let src = `${this.baseUrl_}#apikey=${this.apikey_}&videoid=${this.videoid_}&baseurl=${this.win.location.origin}`;
+    let src = `${this.baseUrl_}#apikey=${this.apikey_}&videoid=${this.videoid_}&amp=1&baseurl=${this.win.location.origin}`;
 
     if (this.config_) {
-      src = `${this.baseUrl_}#apikey=${this.apikey_}&videoid=${this.videoid_}&${this.config_}&baseurl=${this.win.location.origin}`;
+      src = `${this.baseUrl_}#apikey=${this.apikey_}&videoid=${this.videoid_}&${this.config_}&amp=1&baseurl=${this.win.location.origin}`;
     }
 
     const frame = disableScrollingOnIframe(
@@ -241,6 +259,40 @@ export class AmpSlikeplayer extends AMP.BaseElement {
     return false;
   }
 
+  /** @override */
+  fullscreenEnter() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenEnter(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  fullscreenExit() {
+    if (!this.iframe_) {
+      return;
+    }
+    fullscreenExit(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  isFullscreen() {
+    if (!this.iframe_) {
+      return false;
+    }
+    return isFullscreenElement(dev().assertElement(this.iframe_));
+  }
+
+  /** @override */
+  showControls() {
+    this.postMessage_('showControls', '');
+  }
+
+  /** @override */
+  hideControls() {
+    this.postMessage_('hideControls', '');
+  }
+
   /** @private */
   onReady_() {
     const {element} = this;
@@ -257,6 +309,15 @@ export class AmpSlikeplayer extends AMP.BaseElement {
       !this.iframe_ ||
       !messageEvent ||
       messageEvent.source != this.iframe_.contentWindow
+    ) {
+      return;
+    }
+
+    // Defense-in-depth: ignore messages from an unexpected origin when known.
+    if (
+      this.targetOrigin_ !== '*' &&
+      messageEvent.origin &&
+      messageEvent.origin !== this.targetOrigin_
     ) {
       return;
     }
@@ -290,6 +351,9 @@ export class AmpSlikeplayer extends AMP.BaseElement {
         case 'fullscreen':
           break;
         case 'meta':
+          if (detail.duration) {
+            this.duration_ = detail.duration;
+          }
           break;
         case 'mute':
           break;
@@ -298,6 +362,9 @@ export class AmpSlikeplayer extends AMP.BaseElement {
         case 'time':
           const {currentTime} = detail;
           this.currentTime_ = currentTime;
+          if (detail.duration) {
+            this.duration_ = detail.duration;
+          }
           break;
         case 'adTime':
           const {position} = detail;
@@ -429,7 +496,7 @@ export class AmpSlikeplayer extends AMP.BaseElement {
           'method': method,
           'optParams': optParams,
         }),
-        '*'
+        this.targetOrigin_
       );
     });
   }

--- a/extensions/amp-slikeplayer/0.1/test/test-amp-slikeplayer.js
+++ b/extensions/amp-slikeplayer/0.1/test/test-amp-slikeplayer.js
@@ -77,6 +77,25 @@ describes.realWin(
       expect(src).to.contain('viewport=50');
     });
 
+    it('adds amp=1 to iframe src with and without data-config', async () => {
+      const {el: noConfig} = await buildPlayer({
+        'data-apikey': 'a',
+        'data-videoid': 'b',
+      });
+      expect(noConfig.querySelector('iframe').getAttribute('src')).to.contain(
+        'amp=1'
+      );
+
+      const {el: withConfig} = await buildPlayer({
+        'data-apikey': 'a',
+        'data-videoid': 'b',
+        'data-config': 'autoplay=true',
+      });
+      expect(withConfig.querySelector('iframe').getAttribute('src')).to.contain(
+        'amp=1'
+      );
+    });
+
     it('parses viewport threshold from percent and ratio', async () => {
       const {impl: implPct} = await buildPlayer({
         'data-config': 'viewport=150',
@@ -212,6 +231,78 @@ describes.realWin(
       expect(removed).to.be.true;
       // Subsequent layout should be possible
       await el.layoutCallback();
+    });
+
+    it('fullscreenEnter/Exit delegate to the iframe, guarded by null', async () => {
+      const {iframe, impl} = await buildPlayer();
+      const enterSpy = (iframe.requestFullscreen = env.sandbox.spy());
+      const exitSpy = (iframe.exitFullscreen = env.sandbox.spy());
+
+      impl.fullscreenEnter();
+      expect(enterSpy).to.have.been.calledOnce;
+
+      impl.fullscreenExit();
+      expect(exitSpy).to.have.been.calledOnce;
+
+      // No iframe: methods are no-ops and must not throw.
+      impl.iframe_ = null;
+      expect(() => impl.fullscreenEnter()).to.not.throw();
+      expect(() => impl.fullscreenExit()).to.not.throw();
+    });
+
+    it('isFullscreen returns false without an iframe and by default', async () => {
+      const {impl} = await buildPlayer();
+      expect(impl.isFullscreen()).to.be.false;
+      impl.iframe_ = null;
+      expect(impl.isFullscreen()).to.be.false;
+    });
+
+    it('showControls/hideControls post the matching methods', async () => {
+      const {impl} = await buildPlayer();
+      const postSpy = env.sandbox.spy(impl, 'postMessage_');
+      impl.showControls();
+      impl.hideControls();
+      await Promise.resolve();
+      const methods = postSpy.getCalls().map((c) => c.args[0]);
+      expect(methods).to.include('showControls');
+      expect(methods).to.include('hideControls');
+    });
+
+    it('updates duration from meta and time events', async () => {
+      const {iframe, impl} = await buildPlayer();
+      impl.onMessage_({
+        source: iframe.contentWindow,
+        data: JSON.stringify({event: 'meta', detail: {duration: 120}}),
+      });
+      expect(impl.getDuration()).to.equal(120);
+
+      impl.onMessage_({
+        source: iframe.contentWindow,
+        data: JSON.stringify({
+          event: 'time',
+          detail: {currentTime: 5, duration: 200},
+        }),
+      });
+      expect(impl.getDuration()).to.equal(200);
+    });
+
+    it('ignores messages from an unexpected origin', async () => {
+      const {iframe, impl} = await buildPlayer();
+      const initial = impl.getCurrentTime();
+      impl.onMessage_({
+        source: iframe.contentWindow,
+        origin: 'https://evil.example.com',
+        data: JSON.stringify({event: 'time', detail: {currentTime: 77}}),
+      });
+      expect(impl.getCurrentTime()).to.equal(initial);
+
+      // Matching origin is accepted.
+      impl.onMessage_({
+        source: iframe.contentWindow,
+        origin: 'https://tvid.in',
+        data: JSON.stringify({event: 'time', detail: {currentTime: 88}}),
+      });
+      expect(impl.getCurrentTime()).to.equal(88);
     });
 
     it('calls sendConsentData_ on send-consent-data message', async () => {


### PR DESCRIPTION
## Summary
Updates the `amp-slikeplayer` extension:

- Append `&amp=1` to the player iframe `src` in `layoutCallback()` (both default and config code paths) so the player can detect it is running inside an AMP context.
- Resolve the player iframe origin and use it as an explicit `postMessage` target instead of `'*'`.
- Implement `fullscreenEnter()` / `fullscreenExit()` overrides using `#core/dom/fullscreen`.
- Add GDPR/consent support to `amp-slikeplayer`.

## Files
- `extensions/amp-slikeplayer/0.1/amp-slikeplayer.js`

## Test
- Verified the player loads inside AMP with the `amp=1` parameter present in the iframe URL.