### PR TITLE
🐛 Prevent prototype pollution in amp-analytics mergeObjects

### DIFF
--- a/extensions/amp-analytics/0.1/config.js
+++ b/extensions/amp-analytics/0.1/config.js
@@ -495,6 +495,16 @@ export function mergeObjects(from, to, opt_predefinedVendorConfig) {
   );
 
   for (const property in from) {
+    // Never merge keys that can reach Object.prototype. A remote or inline
+    // config returning {"__proto__": {...}} would otherwise recurse into the
+    // prototype and pollute it for every object on the page.
+    if (
+      property === '__proto__' ||
+      property === 'constructor' ||
+      property === 'prototype'
+    ) {
+      continue;
+    }
     userAssert(
       opt_predefinedVendorConfig || property != 'iframePing',
       'iframePing config is only available to vendor config.'

--- a/extensions/amp-analytics/0.1/test/test-config.js
+++ b/extensions/amp-analytics/0.1/test/test-config.js
@@ -338,6 +338,13 @@ describes.realWin(
           'foobar': {'foobar': ['abc', 'def']},
         });
       });
+
+      it('does not pollute Object.prototype via __proto__', function () {
+        // JSON.parse produces a real own "__proto__" key, matching a remote
+        // config response.
+        mergeObjects(JSON.parse('{"__proto__": {"polluted": "yes"}}'), {});
+        expect({}.polluted).to.be.undefined;
+      });
     });
 
     describe('vendor only configs', () => {


### PR DESCRIPTION
mergeObjects merges a remote analytics config fetched via res.json() (and the inline config) into the page config, but it never skips the `__proto__` key. A config endpoint returning `{"__proto__": {...}}` makes the recursive merge read `to['__proto__']`, which resolves to Object.prototype, and the following assignments pollute it for every object on the page. Skip `__proto__`, `constructor` and `prototype` inside the merge loop so untrusted config can't reach the prototype chain. Added a regression test under the existing `mergeObjects` block.