### PR TITLE
🐛 Fix cache-origin check bypass in amp-ad-template-helper

### DIFF
--- a/extensions/amp-a4a/0.1/amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/amp-ad-template-helper.js
@@ -12,7 +12,7 @@ import {
   getServiceForDoc,
   registerServiceBuilderForDoc,
 } from '../../../src/service-helpers';
-import {parseUrlDeprecated} from '../../../src/url';
+import {isProxyOrigin, parseUrlDeprecated} from '../../../src/url';
 
 /** @private {!{[key: string]: string|boolean}} */
 const TEMPLATE_CORS_CONFIG = {
@@ -114,7 +114,7 @@ export class AmpAdTemplateHelper {
   getTemplateProxyUrl_(url) {
     const cdnUrlSuffix = urls.cdn.slice(8);
     const loc = parseUrlDeprecated(url);
-    return loc.origin.indexOf(cdnUrlSuffix) > 0
+    return isProxyOrigin(loc)
       ? url
       : 'https://' +
           loc.hostname.replace(/-/g, '--').replace(/\./g, '-') +

--- a/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
+++ b/extensions/amp-a4a/0.1/test/test-amp-ad-template-helper.js
@@ -59,6 +59,15 @@ describes.fakeWin('AmpAdTemplateHelper', {amp: true}, (env) => {
     );
   });
 
+  it('should proxy a host that only embeds the CDN name as a substring', () => {
+    const lookalikeUrl =
+      'https://cdn.ampproject.org.evil.example/amp_template_1';
+    expect(ampAdTemplateHelper.getTemplateProxyUrl_(lookalikeUrl)).to.equal(
+      'https://cdn-ampproject-org-evil-example.cdn.ampproject.org/ad/s/' +
+        'cdn.ampproject.org.evil.example/amp_template_1'
+    );
+  });
+
   it('should render a template with correct values', () => {
     const parentDiv = doc.createElement('div');
     parentDiv./*OK*/ innerHTML =


### PR DESCRIPTION
getTemplateProxyUrl_ decides whether a template URL is already an AMP cache URL with loc.origin.indexOf('cdn.ampproject.org') > 0, which is a substring test rather than an origin match. The templateUrl comes from the ad XHR response parsed in template-validator.js, so a value like https://cdn.ampproject.org.evil.example/x passes the check and the template is fetched and rendered straight from the attacker origin instead of being routed through the cache. Switch to isProxyOrigin(loc), which tests the anchored cdnProxyRegex against the whole origin so only real cdn.ampproject.org hosts are treated as already-proxied.