### PR TITLE
♻️ [WEB-313] Refactor MoEngage amp-analytics vendor to v2 reporting API

### DIFF
--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -1197,7 +1197,7 @@ For complete documentation and additional examples please see: https://marketing
         "clickTrigger": {
           "on": "click",
           "selector": "#test1",
-          "request": "event",
+          "request": "eventV2",
           "extraUrlParams": {
             "viewsCount": 1,
             "viewsInfo": [

--- a/examples/analytics-vendors.amp.html
+++ b/examples/analytics-vendors.amp.html
@@ -1199,10 +1199,17 @@ For complete documentation and additional examples please see: https://marketing
           "selector": "#test1",
           "request": "event",
           "extraUrlParams": {
-            "a": {
-              "title": "${title}"
-            },
-            "e": "AMP example button click"
+            "viewsCount": 1,
+            "viewsInfo": [
+              {
+                "EVENT_ACTION": "AMP_BUTTON_CLICK",
+                "EVENT_ATTRS": {
+                  "button_title": "${title}"
+                },
+                "EVENT_G_TIME": "${timestamp}",
+                "EVENT_L_TIME": "${timestamp}"
+              }
+            ]
           }
         }
       }

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -339,8 +339,8 @@
     "pagedcl": "https://engagement-collector.mobify.net/s.gif?slug=mobify-project-id&timestamp_local=_timestamp_&channel=web&dimensions=%7b%22platform%22%3a%22AMP%22%2c%22client_id%22%3a%22_client_id(sandy-client-id)_%22%2c%22title%22%3a%22_title_%22%2c%22location%22%3a%22_source_url_%22%2c%22page%22%3a%22_source_path_%22%2c%22src_location%22%3a%22_ampdoc_url_%22%2c%22referrer%22%3a%22_document_referrer_%22%2c%22templateName%22%3a%22page-type%22%7d&data=%7b%22category%22%3a%22timing%22%2c%22action%22%3a%22DOMContentLoaded%22%2c%22value%22%3a_content_load_time_%7d"
   },
   "moengage": {
-    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true",
-    "event": "https://sdk-01.moengage.com/v2/sdk/report/!appId?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_"
+    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true&identifiers=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D",
+    "event": "https://sdk-01.moengage.com/v2/sdk/report/!appId?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&identifiers=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D"
   },
   "mparticle": {
     "host": "https://pixels.mparticle.com",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -339,8 +339,8 @@
     "pagedcl": "https://engagement-collector.mobify.net/s.gif?slug=mobify-project-id&timestamp_local=_timestamp_&channel=web&dimensions=%7b%22platform%22%3a%22AMP%22%2c%22client_id%22%3a%22_client_id(sandy-client-id)_%22%2c%22title%22%3a%22_title_%22%2c%22location%22%3a%22_source_url_%22%2c%22page%22%3a%22_source_path_%22%2c%22src_location%22%3a%22_ampdoc_url_%22%2c%22referrer%22%3a%22_document_referrer_%22%2c%22templateName%22%3a%22page-type%22%7d&data=%7b%22category%22%3a%22timing%22%2c%22action%22%3a%22DOMContentLoaded%22%2c%22value%22%3a_content_load_time_%7d"
   },
   "moengage": {
-    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true&a=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D&url=_ampdoc_url_",
-    "event": "https://sdk-01.moengage.com/v2/report/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&a=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D&url=_ampdoc_url_"
+    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true",
+    "event": "https://sdk-01.moengage.com/v2/sdk/report/!appId?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_"
   },
   "mparticle": {
     "host": "https://pixels.mparticle.com",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -339,9 +339,9 @@
     "pagedcl": "https://engagement-collector.mobify.net/s.gif?slug=mobify-project-id&timestamp_local=_timestamp_&channel=web&dimensions=%7b%22platform%22%3a%22AMP%22%2c%22client_id%22%3a%22_client_id(sandy-client-id)_%22%2c%22title%22%3a%22_title_%22%2c%22location%22%3a%22_source_url_%22%2c%22page%22%3a%22_source_path_%22%2c%22src_location%22%3a%22_ampdoc_url_%22%2c%22referrer%22%3a%22_document_referrer_%22%2c%22templateName%22%3a%22page-type%22%7d&data=%7b%22category%22%3a%22timing%22%2c%22action%22%3a%22DOMContentLoaded%22%2c%22value%22%3a_content_load_time_%7d"
   },
   "moengage": {
-    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true",
-    "event": "https://sdk-01.moengage.com/v2/report/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_",
-    "eventV2": "https://sdk-01.moengage.com/v2/sdk/report/!appId?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_"
+    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true&identifiers=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D",
+    "event": "https://sdk-01.moengage.com/v2/report/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&identifiers=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D",
+    "eventV2": "https://sdk-01.moengage.com/v2/sdk/report/!appId?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&identifiers=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D"
   },
   "mparticle": {
     "host": "https://pixels.mparticle.com",

--- a/extensions/amp-analytics/0.1/test/vendor-requests.json
+++ b/extensions/amp-analytics/0.1/test/vendor-requests.json
@@ -339,8 +339,9 @@
     "pagedcl": "https://engagement-collector.mobify.net/s.gif?slug=mobify-project-id&timestamp_local=_timestamp_&channel=web&dimensions=%7b%22platform%22%3a%22AMP%22%2c%22client_id%22%3a%22_client_id(sandy-client-id)_%22%2c%22title%22%3a%22_title_%22%2c%22location%22%3a%22_source_url_%22%2c%22page%22%3a%22_source_path_%22%2c%22src_location%22%3a%22_ampdoc_url_%22%2c%22referrer%22%3a%22_document_referrer_%22%2c%22templateName%22%3a%22page-type%22%7d&data=%7b%22category%22%3a%22timing%22%2c%22action%22%3a%22DOMContentLoaded%22%2c%22value%22%3a_content_load_time_%7d"
   },
   "moengage": {
-    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true&identifiers=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D",
-    "event": "https://sdk-01.moengage.com/v2/sdk/report/!appId?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&identifiers=%5Bobject%20Object%5D&meta=%5Bobject%20Object%5D"
+    "addDevice": "https://sdk-01.moengage.com/v2/device/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_&isAmp=true",
+    "event": "https://sdk-01.moengage.com/v2/report/add?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_",
+    "eventV2": "https://sdk-01.moengage.com/v2/sdk/report/!appId?os=mweb&app_id=!appId&sdk_ver=0.0.0&app_ver=1.0&device_tz=_timezone_&os_platform=_user_agent_&unique_id=_client_id(moe_uuid)_&device_ts=_timestamp_"
   },
   "mparticle": {
     "host": "https://pixels.mparticle.com",

--- a/extensions/amp-analytics/0.1/vendors/moengage.json
+++ b/extensions/amp-analytics/0.1/vendors/moengage.json
@@ -1,7 +1,8 @@
 {
   "requests": {
     "addDevice": "https://${dataCenter}.moengage.com/v2/device/add?os=${os}&app_id=${appId}&sdk_ver=${sdk_ver}&app_ver=${app_ver}&device_tz=${device_tz}&os_platform=${os_platform}&unique_id=${unique_id}&device_ts=${timestamp}&isAmp=true",
-    "event": "https://${dataCenter}.moengage.com/v2/sdk/report/${appId}?os=${os}&app_id=${appId}&sdk_ver=${sdk_ver}&app_ver=${app_ver}&device_tz=${device_tz}&os_platform=${os_platform}&unique_id=${unique_id}&device_ts=${timestamp}"
+    "event": "https://${dataCenter}.moengage.com/v2/report/add?os=${os}&app_id=${appId}&sdk_ver=${sdk_ver}&app_ver=${app_ver}&device_tz=${device_tz}&os_platform=${os_platform}&unique_id=${unique_id}&device_ts=${timestamp}",
+    "eventV2": "https://${dataCenter}.moengage.com/v2/sdk/report/${appId}?os=${os}&app_id=${appId}&sdk_ver=${sdk_ver}&app_ver=${app_ver}&device_tz=${device_tz}&os_platform=${os_platform}&unique_id=${unique_id}&device_ts=${timestamp}"
   },
   "vars": {
     "os": "mweb",
@@ -14,17 +15,22 @@
     "integration_type": "AMP"
   },
   "extraUrlParams": {
+    "a": {
+      "timestamp": "${timestamp}",
+      "URL": "${ampdocUrl}"
+    },
     "identifiers": {},
     "meta": {
       "bid": "${random}",
       "request_time": "${timestamp}",
       "integration_type": "${integration_type}"
-    }
+    },
+    "url": "${ampdocUrl}"
   },
   "triggers": {
     "pageViewed": {
       "on": "visible",
-      "request": "event",
+      "request": "eventV2",
       "extraUrlParams": {
         "viewsCount": 1,
         "viewsInfo": [
@@ -49,6 +55,7 @@
   },
   "transport": {
     "xhrpost": true,
+    "beacon": true,
     "useBody": true
   }
 }

--- a/extensions/amp-analytics/0.1/vendors/moengage.json
+++ b/extensions/amp-analytics/0.1/vendors/moengage.json
@@ -15,17 +15,12 @@
     "integration_type": "AMP"
   },
   "extraUrlParams": {
-    "a": {
-      "timestamp": "${timestamp}",
-      "URL": "${ampdocUrl}"
-    },
     "identifiers": {},
     "meta": {
       "bid": "${random}",
       "request_time": "${timestamp}",
       "integration_type": "${integration_type}"
-    },
-    "url": "${ampdocUrl}"
+    }
   },
   "triggers": {
     "pageViewed": {

--- a/extensions/amp-analytics/0.1/vendors/moengage.json
+++ b/extensions/amp-analytics/0.1/vendors/moengage.json
@@ -1,7 +1,7 @@
 {
   "requests": {
     "addDevice": "https://${dataCenter}.moengage.com/v2/device/add?os=${os}&app_id=${appId}&sdk_ver=${sdk_ver}&app_ver=${app_ver}&device_tz=${device_tz}&os_platform=${os_platform}&unique_id=${unique_id}&device_ts=${timestamp}&isAmp=true",
-    "event": "https://${dataCenter}.moengage.com/v2/report/add?os=${os}&app_id=${appId}&sdk_ver=${sdk_ver}&app_ver=${app_ver}&device_tz=${device_tz}&os_platform=${os_platform}&unique_id=${unique_id}&device_ts=${timestamp}"
+    "event": "https://${dataCenter}.moengage.com/v2/sdk/report/${appId}?os=${os}&app_id=${appId}&sdk_ver=${sdk_ver}&app_ver=${app_ver}&device_tz=${device_tz}&os_platform=${os_platform}&unique_id=${unique_id}&device_ts=${timestamp}"
   },
   "vars": {
     "os": "mweb",
@@ -10,24 +10,46 @@
     "device_tz": "${timezone}",
     "os_platform": "${userAgent}",
     "unique_id": "${clientId(moe_uuid)}",
-    "dataCenter": "sdk-01"
-  },
-  "extraUrlParams": {
-    "a": {
-      "timestamp": "${timestamp}",
-      "URL": "${ampdocUrl}"
-    },
-    "meta": {
-      "bid": "${random}"
-    },
-    "url": "${ampdocUrl}"
+    "dataCenter": "sdk-01",
+    "integration_type": "AMP"
   },
   "triggers": {
     "pageViewed": {
       "on": "visible",
-      "request": ["addDevice", "event"],
+      "request": "event",
       "extraUrlParams": {
-        "e": "MOE_PAGE_VIEWED"
+        "identifiers": {},
+        "meta": {
+          "bid": "${random}",
+          "request_time": "${timestamp}",
+          "integration_type": "${integration_type}"
+        },
+        "viewsCount": 1,
+        "viewsInfo": [
+          {
+            "EVENT_ACTION": "MOE_PAGE_VIEWED",
+            "EVENT_ATTRS": {
+              "timestamp": "${timestamp}",
+              "moe_logged_in_status": false,
+              "moe_first_visit": false,
+              "URL": "${sourceUrl}"
+            },
+            "EVENT_G_TIME": "${timestamp}",
+            "EVENT_L_TIME": "${timestamp}"
+          }
+        ]
+      }
+    },
+    "deviceRegister": {
+      "on": "visible",
+      "request": "addDevice",
+      "extraUrlParams": {
+        "identifiers": {},
+        "meta": {
+          "bid": "${random}",
+          "request_time": "${timestamp}",
+          "integration_type": "${integration_type}"
+        }
       }
     }
   },

--- a/extensions/amp-analytics/0.1/vendors/moengage.json
+++ b/extensions/amp-analytics/0.1/vendors/moengage.json
@@ -6,24 +6,26 @@
   "vars": {
     "os": "mweb",
     "sdk_ver": "0.0.0",
-    "app_ver": "1",
+    "app_ver": "1.0",
     "device_tz": "${timezone}",
     "os_platform": "${userAgent}",
     "unique_id": "${clientId(moe_uuid)}",
     "dataCenter": "sdk-01",
     "integration_type": "AMP"
   },
+  "extraUrlParams": {
+    "identifiers": {},
+    "meta": {
+      "bid": "${random}",
+      "request_time": "${timestamp}",
+      "integration_type": "${integration_type}"
+    }
+  },
   "triggers": {
     "pageViewed": {
       "on": "visible",
       "request": "event",
       "extraUrlParams": {
-        "identifiers": {},
-        "meta": {
-          "bid": "${random}",
-          "request_time": "${timestamp}",
-          "integration_type": "${integration_type}"
-        },
         "viewsCount": 1,
         "viewsInfo": [
           {
@@ -42,15 +44,7 @@
     },
     "deviceRegister": {
       "on": "visible",
-      "request": "addDevice",
-      "extraUrlParams": {
-        "identifiers": {},
-        "meta": {
-          "bid": "${random}",
-          "request_time": "${timestamp}",
-          "integration_type": "${integration_type}"
-        }
-      }
+      "request": "addDevice"
     }
   },
   "transport": {


### PR DESCRIPTION
♻️ Refactor

The MoEngage `amp-analytics` integration previously sent events to a single legacy `event` endpoint using a flat `a`/`e`/`meta`/`url` parameter shape that no longer matches MoEngage's v2 reporting API. This PR migrates AMP event reporting to the v2 contract so AMP-sourced data aligns with the rest of the MoEngage SDK (richer event metadata + dedicated device registration), while keeping the legacy endpoint working for existing integrations.


## What this does
- **`extensions/amp-analytics/0.1/vendors/moengage.json`**
  - Adds a new `eventV2` request routing to `/v2/sdk/report/${appId}`.
  - Adds an `addDevice` request and a new `deviceRegister` trigger for device registration.
  - Repoints the `pageViewed` trigger to use `eventV2`.
  - Restructures `extraUrlParams` from the flat `a`/`e`/`meta`/`url` shape to a nested `viewsCount` / `viewsInfo` structure carrying `EVENT_ACTION`, `EVENT_ATTRS`, `EVENT_G_TIME`, and `EVENT_L_TIME`.
  - Introduces an `identifiers` object and a new `integration_type: "AMP"` variable.
  - Bumps `app_ver` from `"1"` to `"1.0"`.
  - Extends transport config with `beacon: true` (alongside existing `xhrpost` and `useBody`).
- **`extensions/amp-analytics/0.1/test/vendor-requests.json`** — Updates expected request URLs/params to match the new `eventV2` endpoint and parameter structure.
- **`examples/analytics-vendors.amp.html`** — Updates the MoEngage example to use `eventV2` and the new `extraUrlParams` format.

## Backward compatibility
The legacy `event` endpoint is retained, so existing integrations keep working. The move to `eventV2` is additive and can be adopted gradually.

## Testing
- Updated `vendor-requests.json` expectations pass for the new request shapes.
- Verified the example in `examples/analytics-vendors.amp.html` sends the expected `eventV2` and `deviceRegister` requests.