### PR TITLE
🐛 Anchor ALLOWED_FONT_REGEX in a4a head validation

### DIFF
--- a/extensions/amp-a4a/0.1/head-validation.js
+++ b/extensions/amp-a4a/0.1/head-validation.js
@@ -17,9 +17,13 @@ import {getMode} from '../../../src/mode';
  */
 export let ValidatedHeadDef;
 
-// From validator/validator-main.protoascii
+// From validator/validator-main.protoascii. The validator matches this against
+// the whole attribute value (RE2::FullMatch), so anchor it here too: RegExp.test
+// is a substring match, which would accept any href that merely contains an
+// allowed provider (e.g. https://evil.example/#https://fast.fonts.net/).
 const ALLOWED_FONT_REGEX = new RegExp(
-  'https://cdn\\.materialdesignicons\\.com/' +
+  '^(?:' +
+    'https://cdn\\.materialdesignicons\\.com/' +
     '([0-9]+\\.?)+/css/materialdesignicons\\.min\\.css|' +
     'https://cloud\\.typography\\.com/' +
     '[0-9]*/[0-9]*/css/fonts\\.css|' +
@@ -32,7 +36,8 @@ const ALLOWED_FONT_REGEX = new RegExp(
     'https://(use|pro)\\.fontawesome\\.com/releases/v([0-9]+\\.?)+' +
     '/css/[0-9a-zA-Z-]+\\.css|' +
     'https://(use|pro)\\.fontawesome\\.com/[0-9a-zA-Z-]+\\.css|' +
-    'https://use\\.typekit\\.net/[\\w\\p{L}\\p{N}_]+\\.css'
+    'https://use\\.typekit\\.net/[\\w\\p{L}\\p{N}_]+\\.css' +
+    ')$'
 );
 
 // If editing please also change:

--- a/extensions/amp-a4a/0.1/test/test-head-validation.js
+++ b/extensions/amp-a4a/0.1/test/test-head-validation.js
@@ -187,6 +187,19 @@ describes.realWin('head validation', {amp: true}, (env) => {
       expect(preloadStub).not.to.be.called;
     });
 
+    it('does not allow a foreign origin that embeds an allowlisted provider substring', () => {
+      const preloadStub = env.sandbox.stub(
+        Services.preconnectFor(env.win),
+        'preload'
+      );
+      head.innerHTML = `
+        <link href="https://evil.example/x.css#https://fast.fonts.net/" rel="stylesheet">
+      `;
+      const validated = processHead(env.win, adElement, head);
+      expect(validated.head.querySelector('link')).not.to.exist;
+      expect(preloadStub).not.to.be.called;
+    });
+
     it('keeps amp styles', () => {
       head.innerHTML = `
         <style amp-custom></style>


### PR DESCRIPTION
handleLink gates ad-creative `<link rel=stylesheet>` hrefs with `ALLOWED_FONT_REGEX.test(href)`, but the regex has no start/end anchors so test() succeeds on any href that merely contains an allowlisted provider, e.g. `https://evil.example/x.css#https://fast.fonts.net/`, which then survives head sanitization and gets preloaded from the host document. The validator that defines this allowlist (LINK_FONT_STYLESHEET in validator-main.protoascii) matches it with RE2::FullMatch against the whole value, so wrap the alternation in `^(?:...)$` to match that. Added a regression test for a foreign origin that embeds a provider substring.