### PR TITLE
🐛 Escape dot in trusted referrer host regex

### DIFF
--- a/src/impression.js
+++ b/src/impression.js
@@ -31,7 +31,7 @@ const TRUSTED_REFERRER_HOSTS = [
    * Twitter's link wrapper domains:
    * - t.co
    */
-  /^t.co$/,
+  /^t\.co$/,
 ];
 
 /**

--- a/test/unit/test-impression.js
+++ b/test/unit/test-impression.js
@@ -481,5 +481,11 @@ describes.realWin('impression', {amp: true}, (env) => {
       test('https://t.com/asdf', false);
       test('https://t.cn/asdf', false);
     });
+
+    it('should not trust lookalike hosts that match an unescaped dot', () => {
+      test('https://taco/asdf', false);
+      test('https://txco/asdf', false);
+      test('https://t-co/asdf', false);
+    });
   });
 });


### PR DESCRIPTION
isTrustedReferrer in src/impression.js gates the credentialed click-tracking fetch and the history.replaceState in handleReplaceUrl on whether the document referrer host is in TRUSTED_REFERRER_HOSTS. The only entry is `/^t.co$/`, where the unescaped dot acts as a wildcard, so it also matches unrelated single-label hosts like `taco` or `txco` rather than just Twitter's `t.co`. Escaping the dot keeps `t.co` matching while dropping the lookalikes.