### PR TITLE
🐛 Escape attribute values and text content in getHtml

### DIFF
--- a/src/core/dom/get-html.js
+++ b/src/core/dom/get-html.js
@@ -1,3 +1,4 @@
+import {escapeHtml} from '#core/dom';
 import {isElement, isString} from '#core/types';
 
 /** @type {Array<string>} */
@@ -70,7 +71,7 @@ function appendToResult(rootNode, attrs, result) {
     if (isString(node)) {
       result.push(node);
     } else if (node.nodeType === Node.TEXT_NODE) {
-      result.push(node.textContent ?? '');
+      result.push(escapeHtml(node.textContent ?? ''));
     } else if (isElement(node) && isApplicableNode(node)) {
       appendOpenTag(node, allowedAttrs, result);
       stack.push(`</${node.tagName.toLowerCase()}>`);
@@ -108,7 +109,7 @@ function appendOpenTag(node, attrs, result) {
 
   attrs.forEach((attr) => {
     if (node.hasAttribute(attr)) {
-      result.push(` ${attr}="${node.getAttribute(attr)}"`);
+      result.push(` ${attr}="${escapeHtml(node.getAttribute(attr))}"`);
     }
   });
 

--- a/src/core/dom/get-html.js
+++ b/src/core/dom/get-html.js
@@ -109,7 +109,7 @@ function appendOpenTag(node, attrs, result) {
 
   attrs.forEach((attr) => {
     if (node.hasAttribute(attr)) {
-      result.push(` ${attr}="${escapeHtml(node.getAttribute(attr))}"`);
+      result.push(` ${attr}="${escapeHtml(node.getAttribute(attr) ?? '')}"`);
     }
   });
 

--- a/test/unit/core/dom/test-get-html.js
+++ b/test/unit/core/dom/test-get-html.js
@@ -53,4 +53,21 @@ describes.sandboxed('DOM - getHtml', {}, () => {
     const result = getHtml(window, '.no-such-class', ['class', 'id']);
     expect(result).to.equal('');
   });
+
+  it('should escape quotes in attribute values', () => {
+    element.innerHTML =
+      '<div id="wrapper">' +
+      '<a class="c" title="x&quot; onmouseover=&quot;evil()">t</a>' +
+      '</div>';
+    const result = getHtml(window, '#wrapper', ['class', 'title']);
+    expect(result).to.not.include('onmouseover="evil()"');
+    expect(result).to.include('title="x&quot; onmouseover=&quot;evil()"');
+  });
+
+  it('should escape markup in text content', () => {
+    element.innerHTML =
+      '<div id="wrapper">&lt;img src=x onerror=alert(1)&gt;</div>';
+    const result = getHtml(window, '#wrapper', []);
+    expect(result).to.equal('<div>&lt;img src=x onerror=alert(1)&gt;</div>');
+  });
 });


### PR DESCRIPTION
getHtml assembles an HTML string by hand and writes attribute values and text nodes into it unescaped, so any host-page value carrying a quote or angle bracket escapes the markup it is serialized into: a title of x" onmouseover="evil() comes back as a live event handler, and a text node holding <img src=x onerror=alert(1)> comes back as real markup. An ad iframe reaches this through the GET_HTML message when the slot sets data-html-access-allowed, and the serialized string is returned to that frame. Escaping both sinks with escapeHtml matches what the friendly-iframe-embed serializer already does and leaves plain values untouched, so the existing tests are unaffected.