### PR TITLE
Add Neuwo ad vendor

### DIFF
--- a/3p/vendors/neuwo.js
+++ b/3p/vendors/neuwo.js
@@ -1,0 +1,12 @@
+// src/polyfills.js must be the first import.
+import '#3p/polyfills';
+
+import {register} from '#3p/3p';
+import {draw3p, init} from '#3p/integration-lib';
+
+import {neuwo} from '#ads/vendors/neuwo';
+
+init(window);
+register('neuwo', neuwo);
+
+window.draw3p = draw3p;

--- a/ads/_config.js
+++ b/ads/_config.js
@@ -976,6 +976,10 @@ const adConfig = jsonConfiguration({
     renderStartImplemented: true,
   },
 
+  'neuwo': {
+    renderStartImplemented: true,
+  },
+
   'noddus': {
     prefetch: 'https://noddus.com/amp_loader.js',
     renderStartImplemented: true,

--- a/ads/vendors/neuwo.js
+++ b/ads/vendors/neuwo.js
@@ -1,0 +1,23 @@
+import {validateData, writeScript} from '#3p/3p';
+
+/**
+ * Neuwo Monetisation Platform.
+ * @param {!Window} global
+ * @param {!Object} data
+ */
+export function neuwo(global, data) {
+  validateData(data, ['scriptid'], []);
+
+  // The Neuwo SDK dispatches these custom events on the 3p-iframe window when a
+  // placement renders (fill) or has no fill. Bridge them to the AMP ad
+  // lifecycle so AMP can start rendering / fall back to the next slot.
+  global.addEventListener('neuwoAdRender', () => global.context.renderStart());
+  global.addEventListener('neuwoAdNoFill', () =>
+    global.context.noContentAvailable()
+  );
+
+  writeScript(
+    global,
+    'https://ads.neuwo.ai/loader/neuwo-ad.js?staticTagId=' + data['scriptid']
+  );
+}

--- a/ads/vendors/neuwo.md
+++ b/ads/vendors/neuwo.md
@@ -1,0 +1,19 @@
+# Neuwo
+
+Neuwo Monetisation Platform.
+
+## Example
+
+```html
+<amp-ad width="300" height="250" type="neuwo" data-scriptid="91"> </amp-ad>
+```
+
+## Configuration
+
+You need to get a `scriptid` (static tag ID) from your Neuwo account manager.
+
+For testing purposes you can use `data-scriptid="91"`.
+
+### Required parameters
+
+-   `data-scriptid`

--- a/examples/amp-ad/ads.amp.esm.html
+++ b/examples/amp-ad/ads.amp.esm.html
@@ -206,6 +206,7 @@
         <option>navegg</option>
         <option>nend</option>
         <option>netletix</option>
+        <option>neuwo</option>
         <option>noddus</option>
         <option>nokta</option>
         <option>nws</option>
@@ -1640,6 +1641,10 @@
       data-nxunit='/60343726/netzathleten_.de'
       data-nxwidth='300'
       data-nxheight='250'>
+  </amp-ad>
+
+  <h2>Neuwo</h2>
+  <amp-ad width="300" height="250" type="neuwo" data-scriptid="91">
   </amp-ad>
 
   <h2>Noddus</h2>

--- a/examples/amp-ad/ads.amp.html
+++ b/examples/amp-ad/ads.amp.html
@@ -339,6 +339,7 @@
         <option>navegg</option>
         <option>nend</option>
         <option>netletix</option>
+        <option>neuwo</option>
         <option>noddus</option>
         <option>nokta</option>
         <option>nws</option>
@@ -1484,6 +1485,10 @@
   <h2>NETLETIX</h2>
   <amp-ad width='300' height='250' type='netletix' data-nxkey='b5f0c5d4-c2b8-4989-a7b9-130ad4417102'
     data-nxunit='/60343726/netzathleten_.de' data-nxwidth='300' data-nxheight='250'>
+  </amp-ad>
+
+  <h2>Neuwo</h2>
+  <amp-ad width="300" height="250" type="neuwo" data-scriptid="91">
   </amp-ad>
 
   <h2>Noddus</h2>

--- a/extensions/amp-ad/amp-ad.md
+++ b/extensions/amp-ad/amp-ad.md
@@ -418,6 +418,7 @@ See [amp-ad rules](validator-amp-ad.protoascii) in the AMP validator specificati
 -   [Navegg](../../ads/vendors/navegg.md)
 -   [Nend](../../ads/vendors/nend.md)
 -   [NETLETIX](../../ads/vendors/netletix.md)
+-   [Neuwo](../../ads/vendors/neuwo.md)
 -   [Noddus](../../ads/vendors/noddus.md)
 -   [Nokta](../../ads/vendors/nokta.md)
 -   [Newsroom AI](../../ads/vendors/nws.md)

--- a/test/unit/ads/test-neuwo.js
+++ b/test/unit/ads/test-neuwo.js
@@ -1,0 +1,53 @@
+import * as _3p from '#3p/3p';
+
+import {neuwo} from '#ads/vendors/neuwo';
+
+import {createIframePromise} from '#testing/iframe';
+
+describes.fakeWin('amp-ad-neuwo', {}, (env) => {
+  let sandbox;
+  let win;
+
+  beforeEach(() => {
+    sandbox = env.sandbox;
+
+    return createIframePromise(true).then((iframe) => {
+      // Simulate the iframe that neuwo will be called inside.
+      win = iframe.win;
+      win.context = {
+        renderStart: sandbox.spy(),
+        noContentAvailable: sandbox.spy(),
+        referrer: null,
+      };
+    });
+  });
+
+  it('should require the scriptid parameter', () => {
+    allowConsoleError(() => {
+      expect(() => neuwo(win, {})).to.throw(/scriptid/);
+    });
+  });
+
+  it('should load the Neuwo static loader with the given scriptid', () => {
+    const writeScript = sandbox.stub(_3p, 'writeScript');
+    neuwo(win, {'scriptid': '91'});
+    expect(writeScript).to.be.calledOnce;
+    expect(writeScript.firstCall.args[1]).to.contain(
+      'ads.neuwo.ai/loader/neuwo-ad.js?staticTagId=91'
+    );
+  });
+
+  it('should bridge neuwoAdRender to renderStart()', () => {
+    sandbox.stub(_3p, 'writeScript');
+    neuwo(win, {'scriptid': '91'});
+    win.dispatchEvent(new win.Event('neuwoAdRender'));
+    expect(win.context.renderStart).to.be.calledOnce;
+  });
+
+  it('should bridge neuwoAdNoFill to noContentAvailable()', () => {
+    sandbox.stub(_3p, 'writeScript');
+    neuwo(win, {'scriptid': '91'});
+    win.dispatchEvent(new win.Event('neuwoAdNoFill'));
+    expect(win.context.noContentAvailable).to.be.calledOnce;
+  });
+});


### PR DESCRIPTION
Adds the Neuwo Monetisation Platform as a third-party ad vendor.

cc @ampproject/wg-monetization