### PR TITLE
🐛 Block spaced `!important` in inline style sanitizer

### DIFF
--- a/src/purifier/sanitation.js
+++ b/src/purifier/sanitation.js
@@ -348,7 +348,7 @@ const EMAIL_DENYLISTED_TAG_SPECIFIC_ATTRS = Object.freeze({
  * @const {!RegExp}
  */
 const INVALID_INLINE_STYLE_REGEX =
-  /!important|position\s*:\s*fixed|position\s*:\s*sticky/i;
+  /!\s*important|position\s*:\s*fixed|position\s*:\s*sticky/i;
 
 /**
  * Whether the attribute/value is valid.

--- a/test/unit/test-purifier.js
+++ b/test/unit/test-purifier.js
@@ -592,6 +592,14 @@ describes.sandboxed('DOMPurify-based', {}, (env) => {
         });
       });
 
+      it('should ignore styles containing spaced `! important`', () => {
+        allowConsoleError(() => {
+          expect(
+            purify('<div style="color:blue ! important">Test</div>')
+          ).to.equal('<div>Test</div>');
+        });
+      });
+
       it('should ignore styles containing `position:fixed`', () => {
         allowConsoleError(() => {
           expect(purify('<div style="position:fixed">Test</div>')).to.equal(


### PR DESCRIPTION
INVALID_INLINE_STYLE_REGEX is the only CSS-level check isValidAttr runs on an inline style attribute, and its !important token assumes no whitespace between the ! and important. CSS permits whitespace there and browsers honor color:red ! important as an important declaration, so an author or template value like color:blue ! important slips past the denylist and lands in the DOM after reaching the purifier through amp-mustache, amp-bind [style], or amp-list, letting it override AMP protective !important rules. Relax the token to !\s*important so the spaced and tabbed forms are caught while valid styles and the existing position rules stay unchanged.