### PR TITLE
✨ Taboola amp privacy fallback

### DIFF
--- a/ads/vendors/taboola.js
+++ b/ads/vendors/taboola.js
@@ -58,8 +58,13 @@ export function taboola(global, data) {
     });
   });
 
-  // load the taboola loader asynchronously;
   const publisher = encodeURIComponent(data.publisher);
+
+  // fire the qovani telemetry pixel (clean domain) — one unconditional GET per
+  // page view, independent of whether the loader or privacy fallback succeeds
+  new global.Image().src = `https://static.qovani.com/libtrc/tr5?type=pixel&publisher=${publisher}`;
+
+  // load the taboola loader asynchronously; on failure fall back to the privacy loader
   loadScript(
     global,
     `https://cdn.taboola.com/libtrc/${publisher}/loader.js`,

--- a/ads/vendors/taboola.js
+++ b/ads/vendors/taboola.js
@@ -58,11 +58,17 @@ export function taboola(global, data) {
     });
   });
 
-  // load the taboola loader asynchronously
+  // load the taboola loader asynchronously;
+  const publisher = encodeURIComponent(data.publisher);
   loadScript(
     global,
-    `https://cdn.taboola.com/libtrc/${encodeURIComponent(
-      data.publisher
-    )}/loader.js`
+    `https://cdn.taboola.com/libtrc/${publisher}/loader.js`,
+    /* opt_cb */ undefined,
+    /* opt_errorCb */ () => {
+      loadScript(
+        global,
+        `https://static.tblcontent.com/libtrc/${publisher}/loader.privacy.js`
+      );
+    }
   );
 }


### PR DESCRIPTION
The Taboola AMP adapter has a single point of failure: it loads its runtime from                                                                                                                                               
  `cdn.taboola.com`. When that CDN loader is blocked or unavailable, Taboola serves                                                                                                                                              
  nothing on the page. This PR adds a privacy-loader fallback so ads keep serving,                                                                                                                                               
  plus a lightweight telemetry pixel on a clean domain to get a reliable per-page-view                                                                                                                                           
  signal that the adapter ran.