### PR TITLE
🏗 fix(circleci): update Bazel GPG key URL to releases.bazel.build

### DIFF
--- a/.circleci/install_validator_dependencies.sh
+++ b/.circleci/install_validator_dependencies.sh
@@ -8,7 +8,7 @@ set -e
 GREEN() { echo -e "\033[0;32m$1\033[0m"; }
 
 echo $(GREEN "Adding Bazel repo...")
-curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+curl -fsSL https://releases.bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
 sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
 echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 


### PR DESCRIPTION
URL is changed. The old one keeps throwing 404, failing all circle builds on main.