### PR TITLE
🐛 purify item template output in bento-autocomplete

### DIFF
--- a/src/bento/components/bento-autocomplete/1.0/base-element.js
+++ b/src/bento/components/bento-autocomplete/1.0/base-element.js
@@ -8,6 +8,8 @@ import {tryParseJson} from '#core/types/object/json';
 import * as Preact from '#preact';
 import {PreactBaseElement} from '#preact/base-element';
 
+import {Purifier} from '#purifier';
+
 import {BentoAutocomplete} from './component';
 import {CSS as COMPONENT_CSS} from './component.jss';
 
@@ -71,10 +73,16 @@ export class BaseElement extends PreactBaseElement {
       return;
     }
 
+    // Mustache only escapes interpolated values; its output is not a security
+    // boundary. Suggestion data can come from a remote `src`, so run the
+    // rendered markup through the AMP Purifier before it reaches the DOM, the
+    // same way amp-mustache and amp-autocomplete sanitize template output.
+    const purifier = new Purifier(this.win.document);
     this.mutateProps({
       'itemTemplate': (data) => {
         const html = mustache.render(template./*OK*/ innerHTML, data);
-        return <div dangerouslySetInnerHTML={{__html: html}} />;
+        const sanitized = purifier.purifyHtml(html)./*OK*/ innerHTML;
+        return <div dangerouslySetInnerHTML={{__html: sanitized}} />;
       },
     });
   }


### PR DESCRIPTION
checkPropsPostMutations renders each suggestion with mustache and writes the result into the DOM through dangerouslySetInnerHTML, but mustache only escapes interpolated values so its output is not a sanitization boundary, and the suggestion data can come from a remote src fetch. A response item like {"name": "<img src=x onerror=alert(document.domain)>"} rendered through a {{{name}}} template runs its handler in the component shadow root. This routes the rendered markup through the AMP Purifier before insertion, the same way amp-mustache and amp-autocomplete sanitize template output.