### PR TITLE
♻️ Consolidate external placeholder images to local examples/img (#25045)

### DIFF
--- a/examples/amp-story/consent-geo.html
+++ b/examples/amp-story/consent-geo.html
@@ -55,7 +55,7 @@
   </head>
 
   <body>
-    <amp-story standalone publisher-logo-src="https://placekitten.com/g/64/64">
+    <amp-story standalone publisher-logo-src="../img/ampicon.png">
       <amp-geo layout="nodisplay">
         <script type="application/json">{
           "ISOCountryGroups": {

--- a/examples/amp-story/consent.html
+++ b/examples/amp-story/consent.html
@@ -53,7 +53,7 @@
   </head>
 
   <body>
-    <amp-story standalone publisher-logo-src="https://placekitten.com/g/64/64">
+    <amp-story standalone publisher-logo-src="../img/ampicon.png">
       <amp-consent id='ABC' layout='nodisplay'>
         <script type="application/json">{
           "consentInstanceId": "DEF",

--- a/examples/amp-story/helloworld.html
+++ b/examples/amp-story/helloworld.html
@@ -67,7 +67,7 @@
         <amp-story-grid-layer template="vertical">
           <h1>First Page</h1>
           <p>This is the first page of this story.</p>
-          <amp-img src="https://picsum.photos/1600/900?image=110"
+          <amp-img src="../img/sea@1x.jpg"
               width="400"
               height="225"></amp-img>
         </amp-story-grid-layer>


### PR DESCRIPTION
This PR is a first step toward consolidating external placeholder images (picsum.photos, placekitten.com) into locally-hosted images already available in `examples/img`, as tracked in #25045.

## Changes
- `examples/amp-story/helloworld.html`: replaced `picsum.photos` image with local `examples/img/sea@1x.jpg`
- `examples/amp-story/consent.html`: replaced `placekitten.com` publisher logo with local `examples/img/ampicon.png`
- `examples/amp-story/consent-geo.html`: replaced `placekitten.com` publisher logo with local `examples/img/ampicon.png`

Verified locally with `amp default` that all three pages render correctly with the local images.

This is a partial fix — I plan to follow up with additional files referencing external placeholder services in subsequent PRs.

Addresses #25045