### PR TITLE
🐛 match textarea pattern polyfill against the whole value

### DIFF
--- a/extensions/amp-form/0.1/form-validators.js
+++ b/extensions/amp-form/0.1/form-validators.js
@@ -122,7 +122,11 @@ export class FormValidator {
         input.validationMessage === CUSTOM_PATTERN_ERROR
       ) {
         const pattern = input.getAttribute('pattern');
-        const re = new RegExp(`^${pattern}$`, 'm');
+        // Match the whole value like a native <input pattern>: wrap the author
+        // pattern in a non-capturing group so a top-level alternation stays
+        // anchored, and drop the `m` flag so `^`/`$` don't match at internal
+        // line breaks.
+        const re = new RegExp(`^(?:${pattern})$`);
         const valid = re.test(input.value);
         input.setCustomValidity(valid ? '' : CUSTOM_PATTERN_ERROR);
       }

--- a/extensions/amp-form/0.1/test/test-form-validators.js
+++ b/extensions/amp-form/0.1/test/test-form-validators.js
@@ -210,6 +210,22 @@ describes.realWin('form-validators', {amp: true}, (env) => {
       validator.report();
       expect(textarea.checkValidity()).to.be.false;
     });
+
+    it('should match <textarea> pattern against the whole value', () => {
+      const textarea = form.querySelector('textarea');
+      textarea.setAttribute('pattern', '[a-z]+');
+
+      // A single-line value that fully matches the pattern is valid.
+      textarea.value = 'abc';
+      validator.report();
+      expect(textarea.checkValidity()).to.be.true;
+
+      // The pattern must apply to the entire value, not per line: a value
+      // whose first line matches but which carries extra content is invalid.
+      textarea.value = 'abc\nNOPE';
+      validator.report();
+      expect(textarea.checkValidity()).to.be.false;
+    });
   });
 
   describe('PolyfillDefaultValidator', () => {


### PR DESCRIPTION
The textarea `pattern` polyfill in `checkInputValidity` compiles the author pattern as `new RegExp('^' + pattern + '$', 'm')`, which does not match native `<input pattern>` semantics. The `m` flag lets `^` and `$` match at internal line breaks, and without a non-capturing group a top-level alternation such as `cat|dog` only anchors one branch, so a value whose first line matches (`abc\nanything` against `[a-z]+`) or that merely starts or ends with an alternative passes validation. Compiling as `^(?:pattern)$` with no flags applies the pattern to the whole value the way the browser does.