### PR TITLE
🐛 escape verify-response field name in form verifier selector

### DIFF
--- a/extensions/amp-form/0.1/form-verifiers.js
+++ b/extensions/amp-form/0.1/form-verifiers.js
@@ -1,5 +1,6 @@
 import {LastAddedResolver} from '#core/data-structures/promise';
 import {iterateCursor} from '#core/dom';
+import {escapeCssSelectorIdent} from '#core/dom/css-selectors';
 import {isFieldDefault} from '#core/dom/form';
 
 import {user} from '#utils/log';
@@ -214,7 +215,9 @@ export class AsyncVerifier extends FormVerifier {
       // If multiple elements share the same name, the first should be selected.
       // This matches the behavior of HTML5 validation, e.g. with radio buttons.
       const element = user().assertElement(
-        this.form_./*OK*/ querySelector(`[name="${name}"]`),
+        this.form_./*OK*/ querySelector(
+          `[name="${escapeCssSelectorIdent(name)}"]`
+        ),
         'Verification error name property must match a field name'
       );
 
@@ -232,7 +235,11 @@ export class AsyncVerifier extends FormVerifier {
       errors.every((error) => previousError.name !== error.name);
     const fixedElements = previousErrors
       .filter(isFixed)
-      .map((e) => this.form_./*OK*/ querySelector(`[name="${e.name}"]`));
+      .map((e) =>
+        this.form_./*OK*/ querySelector(
+          `[name="${escapeCssSelectorIdent(e.name)}"]`
+        )
+      );
 
     return /** @type {!UpdatedErrorsDef} */ ({
       updatedElements: errorElements.concat(fixedElements),

--- a/extensions/amp-form/0.1/test/test-form-verifiers.js
+++ b/extensions/amp-form/0.1/test/test-form-verifiers.js
@@ -230,5 +230,30 @@ describes.fakeWin('amp-form async verification', {}, (env) => {
         });
       }
     );
+
+    it('does not let a server-supplied name break out of the selector', () => {
+      // Name closes the [name="..."] selector and appends [name="email"],
+      // which would re-target the error onto the email field if unescaped.
+      const injected = 'nomatch"], [name="email';
+      const errorResponse = {
+        json() {
+          return Promise.resolve({
+            verifyErrors: [{name: injected, message: 'injected'}],
+          });
+        },
+      };
+      const xhrSpy = env.sandbox.spy(() =>
+        Promise.reject({response: errorResponse})
+      );
+      const form = getForm(env.win.document);
+      const verifier = getFormVerifier(form, xhrSpy);
+
+      form.email.value = 'test@example.com';
+      const assertEmailClean = () => {
+        expect(form.email.validity.customError).to.be.false;
+        expect(form.email.validationMessage).to.not.equal('injected');
+      };
+      return verifier.onCommit().then(assertEmailClean, assertEmailClean);
+    });
   });
 });


### PR DESCRIPTION
applyErrors_ builds a `[name="..."]` selector from the field name in a verify-xhr response without escaping, so a verify endpoint can return a name like `nomatch"], [name="email` that closes the selector and moves the error onto an unrelated field, or a stray quote that throws and aborts verification. Escape the name with escapeCssSelectorIdent, the same way navigation.js and shadow-embed.js build selectors from untrusted ids. Added a regression test asserting an injected name cannot re-target another field.