### PR TITLE
🐛 clear window.opener on story ad attribution click

### DIFF
--- a/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/story-ad-ui.js
@@ -204,7 +204,17 @@ export function maybeCreateAttribution(win, metadata, container) {
  * @param {string} href
  */
 export function handleAttributionClick(win, href) {
-  openWindowDialog(win, href, '_blank');
+  // `win` is the host story document, so the opened landing page must not keep
+  // a reference back to it (reverse tabnabbing). Mirror the Navigation service:
+  // pass `noopener` where nulling `opener` afterwards is unreliable (iOS/Safari,
+  // non-Chrome), otherwise clear the returned window's `opener` so Chrome still
+  // opens a tab rather than a detached window.
+  const platform = Services.platformFor(win);
+  const features = platform.isIos() || !platform.isChrome() ? 'noopener' : '';
+  const newWin = openWindowDialog(win, href, '_blank', features);
+  if (newWin) {
+    newWin.opener = null;
+  }
 }
 
 /**

--- a/extensions/amp-story-auto-ads/0.1/test/test-story-ad-ui.js
+++ b/extensions/amp-story-auto-ads/0.1/test/test-story-ad-ui.js
@@ -9,6 +9,7 @@ import {
   getStoryAdMetaTags,
   getStoryAdMetadataFromDoc,
   getStoryAdMetadataFromElement,
+  handleAttributionClick,
   maybeCreateAttribution,
   validateCtaMetadata,
 } from '../story-ad-ui';
@@ -182,6 +183,19 @@ describes.realWin('story-ad-ui', {amp: true}, (env) => {
         expect(element).to.be.null;
         expect(doc.querySelector('.i-amphtml-attribution-host')).not.to.exist;
       });
+    });
+  });
+
+  describe('handleAttributionClick', () => {
+    it('opens the url in a new context without leaking window.opener', () => {
+      const fakeWin = {opener: {}};
+      const openStub = env.sandbox.stub(win, 'open').returns(fakeWin);
+      handleAttributionClick(win, 'https://www.kittens.com/moreinfo');
+      expect(openStub).to.have.been.calledOnce;
+      const [url, target] = openStub.firstCall.args;
+      expect(url).to.equal('https://www.kittens.com/moreinfo');
+      expect(target).to.equal('_blank');
+      expect(fakeWin.opener).to.be.null;
     });
   });
 


### PR DESCRIPTION
1. `handleAttributionClick` opens the creative-supplied `attribution-url` with `win.open(href, '_blank')`, and `win` here is the host story document.
2. because that is a programmatic `window.open`, the anchor `target=_blank` implies-`noopener` default does not apply, so the advertiser landing page keeps a live `window.opener` to the story page and can navigate it.

Pass `noopener` where nulling `opener` afterwards is unreliable (iOS/Safari, non-Chrome) and clear the returned window's `opener` otherwise, matching `Navigation` `openWindow`.