### PR TITLE
📖 Document dark mode support for amp-img via media attribute

### DIFF
--- a/src/builtins/amp-img/amp-img.md
+++ b/src/builtins/amp-img/amp-img.md
@@ -210,6 +210,46 @@ for more details.
 
 [/filter]<!-- formats="email" -->
 
+### Show a different image for dark mode
+
+The [`media`](#common-attributes) attribute accepts any valid
+[media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries),
+not just screen widths. This means it can also be used with the
+[`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+media feature to show a different image depending on whether the user has
+requested a light or dark color scheme. To do this, use two sibling
+`amp-img` elements, each with a `media` attribute that matches one of the
+color schemes:
+
+[example preview="inline" playground="true"]
+
+```html
+<amp-img
+  alt="A view of the sea"
+  src="{{server_for_email}}/static/inline-examples/images/sea.jpg"
+  width="900"
+  height="675"
+  layout="responsive"
+  media="(prefers-color-scheme: light)"
+>
+</amp-img>
+<amp-img
+  alt="A view of the sea"
+  src="{{server_for_email}}/static/inline-examples/images/sea-dark.jpg"
+  width="900"
+  height="675"
+  layout="responsive"
+  media="(prefers-color-scheme: dark)"
+>
+</amp-img>
+```
+
+[/example]
+
+Since browsers that don't support the `prefers-color-scheme` media feature
+won't match either query, always include a `light` variant so that those
+browsers still have an image to display.
+
 [filter formats="websites, stories, ads"]
 
 ### Maintain the aspect ratio for images with unknown dimensions

--- a/test/manual/amp-img-dark-mode.amp.html
+++ b/test/manual/amp-img-dark-mode.amp.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html ⚡ lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AMP #0</title>
+  <link rel="canonical" href="amps.html" >
+  <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <style amp-custom>
+    amp-img img {
+      margin: 30px;
+      padding: 30px;
+      border: 10px solid red;
+    }
+  </style>
+  <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+  <h1>amp-img with prefers-color-scheme</h1>
+  <p>
+    Toggle your OS/browser color scheme (e.g. Chrome DevTools &rarr;
+    Rendering &rarr; "Emulate CSS media feature prefers-color-scheme")
+    to see the image below switch.
+  </p>
+
+  <amp-img alt="Clock (light mode)" src="/examples/img/clock.jpg" width="400"
+      height="300" layout="responsive" media="(prefers-color-scheme: light)">
+  </amp-img>
+  <amp-img alt="Stars (dark mode)" src="/examples/img/stars.png" width="400"
+      height="300" layout="responsive" media="(prefers-color-scheme: dark)">
+  </amp-img>
+</body>
+</html>

--- a/test/unit/test-custom-element.js
+++ b/test/unit/test-custom-element.js
@@ -1385,6 +1385,23 @@ describes.realWin('CustomElement', {amp: true}, (env) => {
         expect(requestMeasureStub).to.be.calledTwice;
       });
 
+      it('should apply media condition for non-viewport media features', () => {
+        matchMedia
+          .withArgs('(prefers-color-scheme: dark)')
+          .returns({matches: true, onchange: null});
+        matchMedia
+          .withArgs('(prefers-color-scheme: light)')
+          .returns({matches: false, onchange: null});
+
+        element1.setAttribute('media', '(prefers-color-scheme: dark)');
+        doc.body.appendChild(element1);
+        expect(element1).to.not.have.class('i-amphtml-hidden-by-media-query');
+
+        element2.setAttribute('media', '(prefers-color-scheme: light)');
+        doc.body.appendChild(element2);
+        expect(element2).to.have.class('i-amphtml-hidden-by-media-query');
+      });
+
       it('should re-apply media condition', () => {
         element1.setAttribute('media', '(min-width: 1px)');
         doc.body.appendChild(element1);


### PR DESCRIPTION
Issue #40515 asks for amp-img to support prefers-color-scheme for dark-mode images. AMP's existing media attribute (see custom-element.js#initMediaAttrs_) already shows/hides any AMP element based on an arbitrary window.matchMedia() query, with no validator restriction on the query string, so prefers-color-scheme already works today using two sibling amp-img elements.

- Document the pattern in amp-img.md with a runnable example
- Add unit test coverage for non-viewport media features (matchMedia is not restricted to width-based queries)
- Add a manual test page to visually verify the behavior

Fixes #40515

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
